### PR TITLE
[go_router] Fix spurious onExit when refreshListenable re-parses a pushed route

### DIFF
--- a/packages/go_router/lib/src/match.dart
+++ b/packages/go_router/lib/src/match.dart
@@ -785,6 +785,56 @@ class RouteMatchList with Diagnosticable {
     );
   }
 
+  /// Returns a copy of this list where each [ImperativeRouteMatch] adopts the
+  /// completer of the live match with the same [pageKey] in [source].
+  ///
+  /// Decoding an encoded configuration (state restoration, browser
+  /// back/forward, or a `refreshListenable` re-parse) mints a fresh completer
+  /// per imperative match, since the push future cannot be serialized. Carrying
+  /// over the live completer keeps a re-decoded configuration equal to the one
+  /// already on screen, so the no-op fast path holds — no route spuriously
+  /// exits and the in-flight push future is preserved. A [pageKey] is unique
+  /// per push, so it identifies the live match unambiguously.
+  // TODO(loic-sharma): Remove meta library prefix.
+  // https://github.com/flutter/flutter/issues/171410
+  @meta.internal
+  RouteMatchList reconcileImperativeCompleters(RouteMatchList source) {
+    final liveCompleters = <ValueKey<String>, Completer<Object?>>{};
+    source.visitRouteMatches((RouteMatchBase match) {
+      if (match is ImperativeRouteMatch) {
+        liveCompleters[match.pageKey] = match.completer;
+      }
+      return true;
+    });
+    if (liveCompleters.isEmpty) {
+      return this;
+    }
+    return copyWith(matches: _reconcileMatches(matches, liveCompleters));
+  }
+
+  static List<RouteMatchBase> _reconcileMatches(
+    List<RouteMatchBase> matches,
+    Map<ValueKey<String>, Completer<Object?>> liveCompleters,
+  ) {
+    return matches.map<RouteMatchBase>((RouteMatchBase match) {
+      if (match is ImperativeRouteMatch) {
+        final Completer<Object?>? live = liveCompleters[match.pageKey];
+        if (live == null || live == match.completer) {
+          return match;
+        }
+        return ImperativeRouteMatch(
+          pageKey: match.pageKey,
+          matches: match.matches,
+          completer: live,
+        );
+      }
+      if (match is ShellRouteMatch) {
+        return match.copyWith(matches: _reconcileMatches(match.matches, liveCompleters));
+      }
+      return match;
+    }).toList();
+  }
+
   @override
   bool operator ==(Object other) {
     if (other.runtimeType != runtimeType) {

--- a/packages/go_router/lib/src/match.dart
+++ b/packages/go_router/lib/src/match.dart
@@ -995,7 +995,11 @@ class _RouteMatchListDecoder extends Converter<Map<Object?, Object?>, RouteMatch
         );
         final imperativeMatch = ImperativeRouteMatch(
           pageKey: pageKey,
-          // TODO(chunhtai): Figure out a way to preserve future.
+          // The push future cannot be serialized, so decoding mints a fresh
+          // completer. The route information parser swaps in the live completer
+          // by pageKey (reconcileImperativeCompleters) when re-decoding the
+          // current configuration. Across state restoration there is no live
+          // completer to adopt; see
           // https://github.com/flutter/flutter/issues/128122.
           completer: Completer<Object?>(),
           matches: imperativeMatchList,

--- a/packages/go_router/lib/src/parser.dart
+++ b/packages/go_router/lib/src/parser.dart
@@ -91,7 +91,12 @@ class GoRouteInformationParser extends RouteInformationParser<RouteMatchList> {
       incomingUri = routeInformation.uri;
     } else if (raw is! RouteInformationState) {
       // Restoration/back-forward: decode the stored match list and treat as restore.
-      final RouteMatchList decoded = _routeMatchListCodec.decode(raw as Map<Object?, Object?>);
+      // Decoding mints fresh completers for imperative matches; carry over the
+      // live ones so a re-parse of the current configuration stays a no-op
+      // instead of spuriously exiting a route or orphaning its push future.
+      final RouteMatchList decoded = _routeMatchListCodec
+          .decode(raw as Map<Object?, Object?>)
+          .reconcileImperativeCompleters(router.routerDelegate.currentConfiguration);
       infoState = RouteInformationState.restore(base: decoded);
       incomingUri = decoded.uri;
     } else {

--- a/packages/go_router/pending_changelogs/change_2026_07_16_1784204402825.yaml
+++ b/packages/go_router/pending_changelogs/change_2026_07_16_1784204402825.yaml
@@ -1,0 +1,3 @@
+changelog: |
+  - Fixes a spurious `onExit` call on a pushed route when `refreshListenable` fires (e.g. on tab refocus), by carrying over the live push completer when the current configuration is re-decoded.
+version: patch

--- a/packages/go_router/test/match_test.dart
+++ b/packages/go_router/test/match_test.dart
@@ -199,6 +199,48 @@ void main() {
       expect(match1 == match2, isFalse);
       expect(match1.hashCode == match2.hashCode, isFalse);
     });
+
+    test('reconcileImperativeCompleters adopts live completers by pageKey', () async {
+      // A decoded configuration carries fresh completers; reconciling against the
+      // live configuration must make the two lists equal again (completer
+      // included in identity), so the delegate's no-op fast path holds.
+      final live = RouteMatchList(
+        matches: <RouteMatchBase>[
+          matchList1.matches.first,
+          ImperativeRouteMatch(pageKey: key1, matches: matchList1, completer: completer1),
+        ],
+        uri: Uri.parse('/'),
+        pathParameters: const <String, String>{},
+      );
+      final decoded = RouteMatchList(
+        matches: <RouteMatchBase>[
+          matchList1.matches.first,
+          ImperativeRouteMatch(pageKey: key1, matches: matchList1, completer: completer2),
+        ],
+        uri: Uri.parse('/'),
+        pathParameters: const <String, String>{},
+      );
+
+      expect(decoded == live, isFalse);
+      final RouteMatchList reconciled = decoded.reconcileImperativeCompleters(live);
+      expect(reconciled == live, isTrue);
+      expect((reconciled.matches.last as ImperativeRouteMatch).completer, completer1);
+    });
+
+    test('reconcileImperativeCompleters keeps fresh completer when no live match', () async {
+      // Genuine state restoration (no live imperative match with that pageKey):
+      // the fresh completer is kept as-is.
+      final decoded = RouteMatchList(
+        matches: <RouteMatchBase>[
+          matchList1.matches.first,
+          ImperativeRouteMatch(pageKey: key1, matches: matchList1, completer: completer2),
+        ],
+        uri: Uri.parse('/'),
+        pathParameters: const <String, String>{},
+      );
+      final RouteMatchList reconciled = decoded.reconcileImperativeCompleters(RouteMatchList.empty);
+      expect((reconciled.matches.last as ImperativeRouteMatch).completer, completer2);
+    });
   });
 }
 

--- a/packages/go_router/test/on_exit_test.dart
+++ b/packages/go_router/test/on_exit_test.dart
@@ -606,4 +606,143 @@ void main() {
     await tester.pumpAndSettle();
     expect(find.byKey(home), findsOneWidget);
   });
+
+  testWidgets('onExit is not called when refreshListenable fires on a pushed route', (
+    WidgetTester tester,
+  ) async {
+    var onExitCount = 0;
+    final home = UniqueKey();
+    final form = UniqueKey();
+    final notifier = ValueNotifier<int>(0);
+    addTearDown(notifier.dispose);
+    final router = GoRouter(
+      initialLocation: '/',
+      refreshListenable: notifier,
+      routes: <GoRoute>[
+        GoRoute(
+          path: '/',
+          builder: (_, _) => DummyScreen(key: home),
+        ),
+        GoRoute(
+          path: '/form',
+          builder: (_, _) => DummyScreen(key: form),
+          onExit: (BuildContext context, GoRouterState state) {
+            onExitCount++;
+            return true;
+          },
+        ),
+      ],
+    );
+    addTearDown(router.dispose);
+    await tester.pumpWidget(MaterialApp.router(routerConfig: router));
+
+    unawaited(router.push('/form'));
+    await tester.pumpAndSettle();
+    expect(find.byKey(form), findsOneWidget);
+    expect(onExitCount, 0);
+
+    // A refreshListenable tick (e.g. a tab-focus claims refresh) re-parses the
+    // encoded current route. That round-trip must be a no-op: onExit fires only
+    // when a route actually leaves the stack, not on a refresh re-decode.
+    notifier.value++;
+    await tester.pumpAndSettle();
+
+    expect(onExitCount, 0);
+    expect(find.byKey(form), findsOneWidget);
+  });
+
+  testWidgets('live push completer is preserved across a refreshListenable tick', (
+    WidgetTester tester,
+  ) async {
+    final home = UniqueKey();
+    final form = UniqueKey();
+    final notifier = ValueNotifier<int>(0);
+    addTearDown(notifier.dispose);
+    final router = GoRouter(
+      initialLocation: '/',
+      refreshListenable: notifier,
+      routes: <GoRoute>[
+        GoRoute(
+          path: '/',
+          builder: (_, _) => DummyScreen(key: home),
+        ),
+        GoRoute(
+          path: '/form',
+          builder: (_, _) => DummyScreen(key: form),
+          onExit: (BuildContext context, GoRouterState state) => true,
+        ),
+      ],
+    );
+    addTearDown(router.dispose);
+    await tester.pumpWidget(MaterialApp.router(routerConfig: router));
+
+    // Capture completion via a flag rather than awaiting the future directly: if
+    // the refresh orphans the live completer (the bug), the future never completes
+    // and `completed` stays false — a synchronous, fail-fast assertion that cannot
+    // hang the suite.
+    var completed = false;
+    Object? completedWith;
+    unawaited(
+      router.push<String>('/form').then((Object? value) {
+        completed = true;
+        completedWith = value;
+      }),
+    );
+    await tester.pumpAndSettle();
+
+    notifier.value++;
+    await tester.pumpAndSettle();
+
+    router.pop<String>('result');
+    await tester.pumpAndSettle();
+
+    expect(completed, isTrue);
+    expect(completedWith, 'result');
+  });
+
+  testWidgets('replace() to the same location still completes its future', (
+    WidgetTester tester,
+  ) async {
+    final home = UniqueKey();
+    final form = UniqueKey();
+    final router = GoRouter(
+      initialLocation: '/',
+      routes: <GoRoute>[
+        GoRoute(
+          path: '/',
+          builder: (_, _) => DummyScreen(key: home),
+        ),
+        GoRoute(
+          path: '/form',
+          builder: (_, _) => DummyScreen(key: form),
+        ),
+      ],
+    );
+    addTearDown(router.dispose);
+    await tester.pumpWidget(MaterialApp.router(routerConfig: router));
+
+    unawaited(router.push<String>('/form'));
+    await tester.pumpAndSettle();
+    expect(find.byKey(form), findsOneWidget);
+
+    // replace() reuses the old match's pageKey and differs only by a new
+    // completer, so the completer must stay part of identity — otherwise the new
+    // configuration equals the current one, setNewRoutePath no-ops, and the
+    // returned future is orphaned.
+    var completed = false;
+    Object? completedWith;
+    unawaited(
+      router.replace<String>('/form').then((Object? value) {
+        completed = true;
+        completedWith = value;
+      }),
+    );
+    await tester.pumpAndSettle();
+
+    router.pop<String>('done');
+    await tester.pumpAndSettle();
+
+    expect(completed, isTrue);
+    expect(completedWith, 'done');
+  });
 }

--- a/packages/go_router/test/on_exit_test.dart
+++ b/packages/go_router/test/on_exit_test.dart
@@ -676,14 +676,17 @@ void main() {
     addTearDown(router.dispose);
     await tester.pumpWidget(MaterialApp.router(routerConfig: router));
 
-    // Capture completion via a flag rather than awaiting the future directly: if
-    // the refresh orphans the live completer (the bug), the future never completes
-    // and `completed` stays false — a synchronous, fail-fast assertion that cannot
-    // hang the suite.
+    // Capture completion via a flag first rather than awaiting the future
+    // directly: if the refresh orphans the live completer (the bug), the future
+    // never completes and `completed` stays false — a synchronous, fail-fast
+    // assertion that cannot hang the suite. Only after that fail-fast check do
+    // we also await the same future directly, since a Dart future accepts
+    // multiple listeners.
+    final Future<String?> result = router.push<String>('/form');
     var completed = false;
     Object? completedWith;
     unawaited(
-      router.push<String>('/form').then((Object? value) {
+      result.then((Object? value) {
         completed = true;
         completedWith = value;
       }),
@@ -698,6 +701,7 @@ void main() {
 
     expect(completed, isTrue);
     expect(completedWith, 'result');
+    expect(await result, 'result');
   });
 
   testWidgets('replace() to the same location still completes its future', (


### PR DESCRIPTION
`GoRoute.onExit` fires spuriously for a pushed route that never left the navigation stack whenever `refreshListenable` fires (auth refresh, a tab-refocus listener) while that route is on top. If the route uses `onExit` for a "discard unsaved changes?" prompt, the user sees it on every refresh tick.

Root cause: `ImperativeRouteMatch.completer` is the ephemeral result channel for `push(...).then(...)` and can't survive a codec round-trip — a `refreshListenable` re-parse (and state restoration) decodes a brand-new `Completer`. The re-decoded match list therefore compares unequal to the live one even though nothing changed, defeating `setNewRoutePath`'s no-op fast path; the router treats the re-parse as a real navigation change and runs `onExit`.

Fix: on the re-decode path only (the parser branch handling restoration, browser history, and refresh re-parses), carry over the live completer for each imperative match by `pageKey` (unique per push) via an internal `RouteMatchList.reconcileImperativeCompleters`. The re-decoded configuration then compares equal to the live one — completer included — so the fast path holds, `onExit` doesn't fire, and in-flight `push` futures are preserved. `operator==`/`hashCode` are untouched, and imperative navigations (`push`/`replace`/`pushReplacement`) never hit this path.

An earlier version of this PR excluded the completer from `ImperativeRouteMatch` equality instead. That regressed same-location `replace()` — whose match deliberately reuses `pageKey` and differs only by its new completer — orphaning the returned `Future`; see the PR thread for details.

Tests: no spurious `onExit` on a refresh tick; a live `push` future resolves across the tick; same-location `replace()` still completes its future; reconciliation contract tests in `match_test.dart`. Full go_router suite and analyzer green.

Fixes flutter/flutter#189578

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under[^1].
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [x] All existing and new tests are passing.

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[the version and CHANGELOG instructions]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version-and-changelog-updates
[semantic versioning]: https://dart.dev/tools/pub/versioning#semantic-versions
[repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests