### PR TITLE
[go_router] Add BlockedInitialNavigationException for blocked initial deep links

### DIFF
--- a/packages/go_router/lib/src/misc/errors.dart
+++ b/packages/go_router/lib/src/misc/errors.dart
@@ -26,7 +26,7 @@ class GoException implements Exception {
   String toString() => 'GoException: $message';
 }
 
-/// Raised when [Block] is returned from `onEnter` but there is no prior
+/// Raised when `Block` is returned from `onEnter` but there is no prior
 /// route configuration to restore (e.g., an initial deep link was blocked).
 ///
 /// Apps can check for this specific type in `onException` to recover

--- a/packages/go_router/lib/src/misc/errors.dart
+++ b/packages/go_router/lib/src/misc/errors.dart
@@ -25,3 +25,14 @@ class GoException implements Exception {
   @override
   String toString() => 'GoException: $message';
 }
+
+/// Raised when [Block] is returned from `onEnter` but there is no prior
+/// route configuration to restore (e.g., an initial deep link was blocked).
+///
+/// Apps can check for this specific type in `onException` to recover
+/// gracefully (e.g., redirect to a loading screen with the deep link
+/// preserved) instead of treating it as a generic routing error.
+class BlockedInitialNavigationException extends GoException {
+  /// Creates an exception for a blocked initial navigation attempt.
+  BlockedInitialNavigationException(super.message);
+}

--- a/packages/go_router/lib/src/parser.dart
+++ b/packages/go_router/lib/src/parser.dart
@@ -132,7 +132,7 @@ class GoRouteInformationParser extends RouteInformationParser<RouteMatchList> {
         // Surface an error so the app decides how to recover via onException.
         final RouteMatchList blocked = _OnEnterHandler._errorRouteMatchList(
           effectiveRoute.uri,
-          GoException(
+          BlockedInitialNavigationException(
             'Navigation to ${effectiveRoute.uri} was blocked by onEnter with no prior route to restore',
           ),
           extra: infoState.extra,

--- a/packages/go_router/pending_changelogs/change_2026_07_16_1784204325728.yaml
+++ b/packages/go_router/pending_changelogs/change_2026_07_16_1784204325728.yaml
@@ -1,0 +1,3 @@
+changelog: |
+  - Adds `BlockedInitialNavigationException` (a `GoException` subtype), raised when the initial navigation is blocked by `onEnter` with no prior route to restore, so apps can distinguish this case in `onException` without string matching.
+version: minor

--- a/packages/go_router/test/on_enter_test.dart
+++ b/packages/go_router/test/on_enter_test.dart
@@ -868,6 +868,37 @@ void main() {
       expect(find.text('Fallback Page'), findsOneWidget);
     });
 
+    testWidgets('Should raise BlockedInitialNavigationException when the initial navigation '
+        'is blocked by onEnter with no prior route to restore', (WidgetTester tester) async {
+      Object? capturedError;
+
+      router = GoRouter(
+        initialLocation: '/protected',
+        onEnter:
+            (
+              BuildContext context,
+              GoRouterState current,
+              GoRouterState next,
+              GoRouter goRouter,
+            ) async {
+              if (next.uri.path == '/protected') {
+                return const Block.stop();
+              }
+              return const Allow();
+            },
+        onException: (BuildContext context, GoRouterState state, GoRouter goRouter) {
+          capturedError = state.error;
+        },
+        routes: <GoRoute>[GoRoute(path: '/protected', builder: (_, _) => const Placeholder())],
+      );
+
+      await tester.pumpWidget(MaterialApp.router(routerConfig: router));
+      await tester.pumpAndSettle();
+
+      expect(capturedError, isA<BlockedInitialNavigationException>());
+      expect(capturedError, isA<GoException>());
+    });
+
     testWidgets('onEnter has priority over deprecated redirect', (WidgetTester tester) async {
       var redirectCallCount = 0;
       var onEnterCallCount = 0;


### PR DESCRIPTION
When `onEnter` returns `Block.stop()` on the very first navigation attempt (e.g. a deep link on web, before any route has been committed), the parser's `onCanNotEnter` path has no prior configuration to restore and reports a generic `GoException`. Apps handling this in `onException` can't tell "initial deep link blocked" apart from other routing errors (unmatched routes, redirect loops) without string matching on the exception message.

This adds `BlockedInitialNavigationException extends GoException`, raised specifically in that no-prior-route path. It only refines the exception type — no change to when or whether an exception is thrown, and existing `is GoException` checks keep working. Apps can now write `if (state.error is BlockedInitialNavigationException)` in `onException` and, for example, redirect to a loading screen with the deep link preserved instead of treating it as a 404.

Test: widget test in `on_enter_test.dart` — initial navigation blocked by `Block.stop()` with an `onException` handler; asserts the captured `state.error` is a `BlockedInitialNavigationException` (and still a `GoException`).

Fixes flutter/flutter#189581

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under[^1].
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [x] All existing and new tests are passing.

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[the version and CHANGELOG instructions]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version-and-changelog-updates
[semantic versioning]: https://dart.dev/tools/pub/versioning#semantic-versions
[repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests