### PR TITLE
[google_maps_flutter] Fix XCUITest on stable

### DIFF
--- a/packages/google_maps_flutter/google_maps_flutter_ios/example/ios/RunnerUITests/GoogleMapsUITests.swift
+++ b/packages/google_maps_flutter/google_maps_flutter_ios/example/ios/RunnerUITests/GoogleMapsUITests.swift
@@ -80,10 +80,26 @@ class GoogleMapsUITests: XCTestCase {
       XCTFail("Failed due to not able to find platform view")
     }
 
-    let titleBar = app.staticTexts["Map coordinates"]
-    if !titleBar.waitForExistence(timeout: kWaitTime) {
+    // The semantics type of this element changed between Flutter 3.44 and 3.47, so
+    // look for either one. Once 3.47 reaches stable, this can be simplified back
+    // down to just looking for the element in staticTexts.
+    let titleBarAsStaticText = app.staticTexts["Map coordinates"]
+    let titleBarAsOther = app.otherElements["Map coordinates"]
+    var titleBar: XCUIElement?
+    for _ in 0..<Int(kWaitTime) {
+      if titleBarAsStaticText.waitForExistence(timeout: 1) {
+        titleBar = titleBarAsStaticText
+        break
+      }
+      if titleBarAsOther.waitForExistence(timeout: 1) {
+        titleBar = titleBarAsOther
+        break
+      }
+    }
+    guard let titleBar = titleBar else {
       os_log("%@", log: .default, type: .error, app.debugDescription as NSString)
       XCTFail("Failed due to not able to find title bar")
+      return
     }
 
     let visibleRegionPredicate = NSPredicate(format: "label BEGINSWITH 'VisibleRegion'")

--- a/packages/google_maps_flutter/google_maps_flutter_ios/example/ios/RunnerUITests/GoogleMapsUITests.swift
+++ b/packages/google_maps_flutter/google_maps_flutter_ios/example/ios/RunnerUITests/GoogleMapsUITests.swift
@@ -80,26 +80,13 @@ class GoogleMapsUITests: XCTestCase {
       XCTFail("Failed due to not able to find platform view")
     }
 
-    // The semantics type of this element changed between Flutter 3.44 and 3.47, so
-    // look for either one. Once 3.47 reaches stable, this can be simplified back
-    // down to just looking for the element in staticTexts.
-    let titleBarAsStaticText = app.staticTexts["Map coordinates"]
-    let titleBarAsOther = app.otherElements["Map coordinates"]
-    var titleBar: XCUIElement?
-    for _ in 0..<Int(kWaitTime) {
-      if titleBarAsStaticText.waitForExistence(timeout: 1) {
-        titleBar = titleBarAsStaticText
-        break
-      }
-      if titleBarAsOther.waitForExistence(timeout: 1) {
-        titleBar = titleBarAsOther
-        break
-      }
-    }
-    guard let titleBar = titleBar else {
+    // The semantics type of this element changed between Flutter 3.44 and 3.47.
+    // Using descendants(matching: .any) allows finding it regardless of whether
+    // it is a staticText or otherElement.
+    let titleBar = app.descendants(matching: .any)["Map coordinates"]
+    if !titleBar.waitForExistence(timeout: kWaitTime) {
       os_log("%@", log: .default, type: .error, app.debugDescription as NSString)
       XCTFail("Failed due to not able to find title bar")
-      return
     }
 
     let visibleRegionPredicate = NSPredicate(format: "label BEGINSWITH 'VisibleRegion'")

--- a/packages/google_maps_flutter/google_maps_flutter_ios_sdk10/example/ios/RunnerUITests/GoogleMapsUITests.swift
+++ b/packages/google_maps_flutter/google_maps_flutter_ios_sdk10/example/ios/RunnerUITests/GoogleMapsUITests.swift
@@ -80,10 +80,26 @@ class GoogleMapsUITests: XCTestCase {
       XCTFail("Failed due to not able to find platform view")
     }
 
-    let titleBar = app.staticTexts["Map coordinates"]
-    if !titleBar.waitForExistence(timeout: kWaitTime) {
+    // The semantics type of this element changed between Flutter 3.44 and 3.47, so
+    // look for either one. Once 3.47 reaches stable, this can be simplified back
+    // down to just looking for the element in staticTexts.
+    let titleBarAsStaticText = app.staticTexts["Map coordinates"]
+    let titleBarAsOther = app.otherElements["Map coordinates"]
+    var titleBar: XCUIElement?
+    for _ in 0..<Int(kWaitTime) {
+      if titleBarAsStaticText.waitForExistence(timeout: 1) {
+        titleBar = titleBarAsStaticText
+        break
+      }
+      if titleBarAsOther.waitForExistence(timeout: 1) {
+        titleBar = titleBarAsOther
+        break
+      }
+    }
+    guard let titleBar = titleBar else {
       os_log("%@", log: .default, type: .error, app.debugDescription as NSString)
       XCTFail("Failed due to not able to find title bar")
+      return
     }
 
     let visibleRegionPredicate = NSPredicate(format: "label BEGINSWITH 'VisibleRegion'")

--- a/packages/google_maps_flutter/google_maps_flutter_ios_sdk10/example/ios/RunnerUITests/GoogleMapsUITests.swift
+++ b/packages/google_maps_flutter/google_maps_flutter_ios_sdk10/example/ios/RunnerUITests/GoogleMapsUITests.swift
@@ -80,26 +80,13 @@ class GoogleMapsUITests: XCTestCase {
       XCTFail("Failed due to not able to find platform view")
     }
 
-    // The semantics type of this element changed between Flutter 3.44 and 3.47, so
-    // look for either one. Once 3.47 reaches stable, this can be simplified back
-    // down to just looking for the element in staticTexts.
-    let titleBarAsStaticText = app.staticTexts["Map coordinates"]
-    let titleBarAsOther = app.otherElements["Map coordinates"]
-    var titleBar: XCUIElement?
-    for _ in 0..<Int(kWaitTime) {
-      if titleBarAsStaticText.waitForExistence(timeout: 1) {
-        titleBar = titleBarAsStaticText
-        break
-      }
-      if titleBarAsOther.waitForExistence(timeout: 1) {
-        titleBar = titleBarAsOther
-        break
-      }
-    }
-    guard let titleBar = titleBar else {
+    // The semantics type of this element changed between Flutter 3.44 and 3.47.
+    // Using descendants(matching: .any) allows finding it regardless of whether
+    // it is a staticText or otherElement.
+    let titleBar = app.descendants(matching: .any)["Map coordinates"]
+    if !titleBar.waitForExistence(timeout: kWaitTime) {
       os_log("%@", log: .default, type: .error, app.debugDescription as NSString)
       XCTFail("Failed due to not able to find title bar")
-      return
     }
 
     let visibleRegionPredicate = NSPredicate(format: "label BEGINSWITH 'VisibleRegion'")

--- a/packages/google_maps_flutter/google_maps_flutter_ios_sdk9/example/ios/RunnerUITests/GoogleMapsUITests.swift
+++ b/packages/google_maps_flutter/google_maps_flutter_ios_sdk9/example/ios/RunnerUITests/GoogleMapsUITests.swift
@@ -80,10 +80,26 @@ class GoogleMapsUITests: XCTestCase {
       XCTFail("Failed due to not able to find platform view")
     }
 
-    let titleBar = app.staticTexts["Map coordinates"]
-    if !titleBar.waitForExistence(timeout: kWaitTime) {
+    // The semantics type of this element changed between Flutter 3.44 and 3.47, so
+    // look for either one. Once 3.47 reaches stable, this can be simplified back
+    // down to just looking for the element in staticTexts.
+    let titleBarAsStaticText = app.staticTexts["Map coordinates"]
+    let titleBarAsOther = app.otherElements["Map coordinates"]
+    var titleBar: XCUIElement?
+    for _ in 0..<Int(kWaitTime) {
+      if titleBarAsStaticText.waitForExistence(timeout: 1) {
+        titleBar = titleBarAsStaticText
+        break
+      }
+      if titleBarAsOther.waitForExistence(timeout: 1) {
+        titleBar = titleBarAsOther
+        break
+      }
+    }
+    guard let titleBar = titleBar else {
       os_log("%@", log: .default, type: .error, app.debugDescription as NSString)
       XCTFail("Failed due to not able to find title bar")
+      return
     }
 
     let visibleRegionPredicate = NSPredicate(format: "label BEGINSWITH 'VisibleRegion'")

--- a/packages/google_maps_flutter/google_maps_flutter_ios_sdk9/example/ios/RunnerUITests/GoogleMapsUITests.swift
+++ b/packages/google_maps_flutter/google_maps_flutter_ios_sdk9/example/ios/RunnerUITests/GoogleMapsUITests.swift
@@ -80,26 +80,13 @@ class GoogleMapsUITests: XCTestCase {
       XCTFail("Failed due to not able to find platform view")
     }
 
-    // The semantics type of this element changed between Flutter 3.44 and 3.47, so
-    // look for either one. Once 3.47 reaches stable, this can be simplified back
-    // down to just looking for the element in staticTexts.
-    let titleBarAsStaticText = app.staticTexts["Map coordinates"]
-    let titleBarAsOther = app.otherElements["Map coordinates"]
-    var titleBar: XCUIElement?
-    for _ in 0..<Int(kWaitTime) {
-      if titleBarAsStaticText.waitForExistence(timeout: 1) {
-        titleBar = titleBarAsStaticText
-        break
-      }
-      if titleBarAsOther.waitForExistence(timeout: 1) {
-        titleBar = titleBarAsOther
-        break
-      }
-    }
-    guard let titleBar = titleBar else {
+    // The semantics type of this element changed between Flutter 3.44 and 3.47.
+    // Using descendants(matching: .any) allows finding it regardless of whether
+    // it is a staticText or otherElement.
+    let titleBar = app.descendants(matching: .any)["Map coordinates"]
+    if !titleBar.waitForExistence(timeout: kWaitTime) {
       os_log("%@", log: .default, type: .error, app.debugDescription as NSString)
       XCTFail("Failed due to not able to find title bar")
-      return
     }
 
     let visibleRegionPredicate = NSPredicate(format: "label BEGINSWITH 'VisibleRegion'")

--- a/packages/google_maps_flutter/google_maps_flutter_ios_shared_code/example/ios/RunnerUITests/GoogleMapsUITests.swift
+++ b/packages/google_maps_flutter/google_maps_flutter_ios_shared_code/example/ios/RunnerUITests/GoogleMapsUITests.swift
@@ -80,10 +80,26 @@ class GoogleMapsUITests: XCTestCase {
       XCTFail("Failed due to not able to find platform view")
     }
 
-    let titleBar = app.staticTexts["Map coordinates"]
-    if !titleBar.waitForExistence(timeout: kWaitTime) {
+    // The semantics type of this element changed between Flutter 3.44 and 3.47, so
+    // look for either one. Once 3.47 reaches stable, this can be simplified back
+    // down to just looking for the element in staticTexts.
+    let titleBarAsStaticText = app.staticTexts["Map coordinates"]
+    let titleBarAsOther = app.otherElements["Map coordinates"]
+    var titleBar: XCUIElement?
+    for _ in 0..<Int(kWaitTime) {
+      if titleBarAsStaticText.waitForExistence(timeout: 1) {
+        titleBar = titleBarAsStaticText
+        break
+      }
+      if titleBarAsOther.waitForExistence(timeout: 1) {
+        titleBar = titleBarAsOther
+        break
+      }
+    }
+    guard let titleBar = titleBar else {
       os_log("%@", log: .default, type: .error, app.debugDescription as NSString)
       XCTFail("Failed due to not able to find title bar")
+      return
     }
 
     let visibleRegionPredicate = NSPredicate(format: "label BEGINSWITH 'VisibleRegion'")

--- a/packages/google_maps_flutter/google_maps_flutter_ios_shared_code/example/ios/RunnerUITests/GoogleMapsUITests.swift
+++ b/packages/google_maps_flutter/google_maps_flutter_ios_shared_code/example/ios/RunnerUITests/GoogleMapsUITests.swift
@@ -80,26 +80,13 @@ class GoogleMapsUITests: XCTestCase {
       XCTFail("Failed due to not able to find platform view")
     }
 
-    // The semantics type of this element changed between Flutter 3.44 and 3.47, so
-    // look for either one. Once 3.47 reaches stable, this can be simplified back
-    // down to just looking for the element in staticTexts.
-    let titleBarAsStaticText = app.staticTexts["Map coordinates"]
-    let titleBarAsOther = app.otherElements["Map coordinates"]
-    var titleBar: XCUIElement?
-    for _ in 0..<Int(kWaitTime) {
-      if titleBarAsStaticText.waitForExistence(timeout: 1) {
-        titleBar = titleBarAsStaticText
-        break
-      }
-      if titleBarAsOther.waitForExistence(timeout: 1) {
-        titleBar = titleBarAsOther
-        break
-      }
-    }
-    guard let titleBar = titleBar else {
+    // The semantics type of this element changed between Flutter 3.44 and 3.47.
+    // Using descendants(matching: .any) allows finding it regardless of whether
+    // it is a staticText or otherElement.
+    let titleBar = app.descendants(matching: .any)["Map coordinates"]
+    if !titleBar.waitForExistence(timeout: kWaitTime) {
       os_log("%@", log: .default, type: .error, app.debugDescription as NSString)
       XCTFail("Failed due to not able to find title bar")
-      return
     }
 
     let visibleRegionPredicate = NSPredicate(format: "label BEGINSWITH 'VisibleRegion'")


### PR DESCRIPTION
https://github.com/flutter/packages/pull/12208 re-enabled these tests using new semantics types, but it turns out that the semantics type had not only changed several years ago when the test was first disabled, but again since the last stable, so the PR failed in post-submit where we run platform tests against stable as well as master.

This adjusts the test to look for the problematic element as any type, so that the test works on both stable and master. Validated locally with stable, since presubmit won't test it.

Part of https://github.com/flutter/flutter/issues/154641

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under[^1].
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [x] All existing and new tests are passing.

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[the version and CHANGELOG instructions]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version-and-changelog-updates
[semantic versioning]: https://dart.dev/tools/pub/versioning#semantic-versions
[repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
