### PR TITLE
[go_router] Fix assertion failure when onException fires on initial navigation

### DIFF
--- a/packages/go_router/lib/src/parser.dart
+++ b/packages/go_router/lib/src/parser.dart
@@ -137,10 +137,19 @@ class GoRouteInformationParser extends RouteInformationParser<RouteMatchList> {
           ),
           extra: infoState.extra,
         );
-        final RouteMatchList resolved = onParserException != null
-            ? onParserException!(context, blocked)
-            : blocked;
-        return SynchronousFuture<RouteMatchList>(resolved);
+        if (onParserException != null) {
+          // Defer past this still-in-flight initial parse, so a recovery
+          // navigation (e.g. router.go()) made synchronously from
+          // onParserException/onException isn't discarded by the Router's
+          // intent-token churn (same reason as the microtask deferral
+          // below for the onEnter `then` callback).
+          scheduleMicrotask(() {
+            if (context.mounted) {
+              onParserException!(context, blocked);
+            }
+          });
+        }
+        return SynchronousFuture<RouteMatchList>(blocked);
       },
     );
   }

--- a/packages/go_router/lib/src/router.dart
+++ b/packages/go_router/lib/src/router.dart
@@ -271,8 +271,14 @@ class GoRouter implements RouterConfig<RouteMatchList> {
     if (onException != null) {
       parserExceptionHandler = (BuildContext context, RouteMatchList routeMatchList) {
         onException(context, configuration.buildTopLevelGoRouterState(routeMatchList), this);
-        // Avoid updating GoRouterDelegate if onException is provided.
-        return routerDelegate.currentConfiguration;
+        // Prefer the current configuration to avoid updating
+        // GoRouterDelegate with the error match list. Fall back to the
+        // error match list when there is no current configuration yet
+        // (e.g., initial deep link blocked by onEnter). This prevents
+        // an assertion failure in GoRouterDelegate.setNewRoutePath
+        // which requires configuration.isNotEmpty || configuration.isError.
+        final RouteMatchList current = routerDelegate.currentConfiguration;
+        return current.isNotEmpty ? current : routeMatchList;
       };
     } else {
       parserExceptionHandler = null;

--- a/packages/go_router/lib/src/router.dart
+++ b/packages/go_router/lib/src/router.dart
@@ -271,14 +271,15 @@ class GoRouter implements RouterConfig<RouteMatchList> {
     if (onException != null) {
       parserExceptionHandler = (BuildContext context, RouteMatchList routeMatchList) {
         onException(context, configuration.buildTopLevelGoRouterState(routeMatchList), this);
-        // Prefer the current configuration to avoid updating
+        // Prefer the current configuration whenever it is valid (non-empty
+        // or an already-installed error configuration), to avoid updating
         // GoRouterDelegate with the error match list. Fall back to the
-        // error match list when there is no current configuration yet
+        // error match list only when nothing has committed yet
         // (e.g., initial deep link blocked by onEnter). This prevents
         // an assertion failure in GoRouterDelegate.setNewRoutePath
         // which requires configuration.isNotEmpty || configuration.isError.
         final RouteMatchList current = routerDelegate.currentConfiguration;
-        return current.isNotEmpty ? current : routeMatchList;
+        return current.isNotEmpty || current.isError ? current : routeMatchList;
       };
     } else {
       parserExceptionHandler = null;

--- a/packages/go_router/pending_changelogs/change_2026_07_16_1784205172418.yaml
+++ b/packages/go_router/pending_changelogs/change_2026_07_16_1784205172418.yaml
@@ -1,0 +1,3 @@
+changelog: |
+  - Fixes an assertion failure when `onException` fires during a blocked initial navigation, and defers the call so a recovery navigation made inside it is no longer silently discarded
+version: patch

--- a/packages/go_router/test/exception_handling_test.dart
+++ b/packages/go_router/test/exception_handling_test.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
@@ -194,6 +196,69 @@ void main() {
       expect(exceptionCaught, isTrue);
       expect(find.text('generic error handled'), findsOneWidget);
       expect(find.text('should not reach here'), findsNothing);
+    });
+
+    testWidgets('recovers to the fallback route when onException defers router.go '
+        'during a blocked initial navigation', (WidgetTester tester) async {
+      final router = GoRouter(
+        initialLocation: '/protected',
+        onEnter: (_, GoRouterState current, GoRouterState next, GoRouter goRouter) {
+          if (next.matchedLocation == '/protected') {
+            return const Block.stop();
+          }
+          return const Allow();
+        },
+        onException: (_, GoRouterState state, GoRouter router) {
+          // Deferred to a microtask by the app itself: this should still
+          // work now that go_router also defers its own call to
+          // onException on the initial-navigation path (the sibling test
+          // below covers a router.go() called synchronously from
+          // onException).
+          scheduleMicrotask(() => router.go('/fallback'));
+        },
+        routes: <RouteBase>[
+          GoRoute(path: '/protected', builder: (_, _) => const Text('protected')),
+          GoRoute(path: '/fallback', builder: (_, _) => const Text('fallback')),
+        ],
+      );
+      addTearDown(router.dispose);
+
+      await tester.pumpWidget(MaterialApp.router(routerConfig: router));
+      await tester.pumpAndSettle();
+
+      expect(tester.takeException(), isNull);
+      expect(find.text('fallback'), findsOneWidget);
+      expect(find.text('protected'), findsNothing);
+      expect(router.state.uri.path, '/fallback');
+    });
+
+    testWidgets('recovers to the fallback route when onException calls router.go '
+        'synchronously during a blocked initial navigation', (WidgetTester tester) async {
+      final router = GoRouter(
+        initialLocation: '/protected',
+        onEnter: (_, GoRouterState current, GoRouterState next, GoRouter goRouter) {
+          if (next.matchedLocation == '/protected') {
+            return const Block.stop();
+          }
+          return const Allow();
+        },
+        onException: (_, GoRouterState state, GoRouter router) {
+          router.go('/fallback');
+        },
+        routes: <RouteBase>[
+          GoRoute(path: '/protected', builder: (_, _) => const Text('protected')),
+          GoRoute(path: '/fallback', builder: (_, _) => const Text('fallback')),
+        ],
+      );
+      addTearDown(router.dispose);
+
+      await tester.pumpWidget(MaterialApp.router(routerConfig: router));
+      await tester.pumpAndSettle();
+
+      expect(tester.takeException(), isNull);
+      expect(find.text('fallback'), findsOneWidget);
+      expect(find.text('protected'), findsNothing);
+      expect(router.state.uri.path, '/fallback');
     });
   });
 }

--- a/packages/go_router/test/exception_handling_test.dart
+++ b/packages/go_router/test/exception_handling_test.dart
@@ -260,5 +260,52 @@ void main() {
       expect(find.text('protected'), findsNothing);
       expect(router.state.uri.path, '/fallback');
     });
+
+    testWidgets('renders the default error screen for an unmatched initial navigation '
+        'when onException does not navigate', (WidgetTester tester) async {
+      var exceptionCaught = false;
+
+      await createRouter(
+        <RouteBase>[GoRoute(path: '/', builder: (_, GoRouterState state) => const Text('home'))],
+        tester,
+        initialLocation: '/unmatched-route',
+        onException: (_, _, _) {
+          exceptionCaught = true;
+        },
+      );
+
+      expect(tester.takeException(), isNull);
+      expect(exceptionCaught, isTrue);
+      expect(find.text('Page Not Found'), findsOneWidget);
+    });
+
+    testWidgets('preserves the first installed error configuration when a second '
+        'unmatched navigation also has onException not navigate', (WidgetTester tester) async {
+      final visited = <String>[];
+
+      final GoRouter router = await createRouter(
+        <RouteBase>[GoRoute(path: '/', builder: (_, GoRouterState state) => const Text('home'))],
+        tester,
+        initialLocation: '/first-unmatched',
+        onException: (_, GoRouterState state, _) {
+          visited.add(state.uri.toString());
+        },
+      );
+
+      expect(tester.takeException(), isNull);
+      expect(visited, <String>['/first-unmatched']);
+      expect(router.routerDelegate.currentConfiguration.uri.toString(), '/first-unmatched');
+
+      router.go('/second-unmatched');
+      await tester.pumpAndSettle();
+
+      // onException fires again for the second exception, but the
+      // already-installed error configuration from the first is
+      // preserved instead of being replaced by the second.
+      expect(tester.takeException(), isNull);
+      expect(visited, <String>['/first-unmatched', '/second-unmatched']);
+      expect(router.routerDelegate.currentConfiguration.uri.toString(), '/first-unmatched');
+      expect(find.text('Page Not Found'), findsOneWidget);
+    });
   });
 }


### PR DESCRIPTION
When `onException` is provided and fires during the initial navigation (e.g. a deep-linked route blocked by `onEnter` returning `Block.stop()`), `parserExceptionHandler` in `router.dart` returns `routerDelegate.currentConfiguration`. On the initial navigation nothing has committed yet, so that configuration is empty, and `GoRouterDelegate.setNewRoutePath` crashes on `assert(configuration.isNotEmpty || configuration.isError)`.

Crash sequence:

1. App starts with `initialLocation` pointing at a route.
2. `onEnter` returns `Block.stop()` for it.
3. The parser builds an error `RouteMatchList` (`isError == true`) and invokes `onException`.
4. `parserExceptionHandler` synchronously returns `routerDelegate.currentConfiguration` — still empty.
5. `setNewRoutePath` asserts `configuration.isNotEmpty || configuration.isError` — neither holds — crash.

The fix has two parts:

1. `router.dart`: fall back to the error match list when the current configuration is invalid — neither non-empty nor `isError` — satisfying the assertion's `isError` branch.
2. `parser.dart`: in the `onCanNotEnter` no-prior-route branch, defer the `onParserException` call to a microtask (the same pattern as the existing deferral for the `onEnter` `then` callback nearby). Without this, a recovery navigation made synchronously inside `onException` — e.g. `router.go('/fallback')`, as in the issue's repro — is silently discarded by the `Router`'s intent-token churn, leaving the app parked on the error state. Deferring past the in-flight parse lets synchronous recovery work the way `onException` normally does.

Behavior is unchanged everywhere else: non-initial navigations return the non-empty `currentConfiguration` as before, the plain unmatched-initial-route path keeps its fully synchronous `onException` call (existing redirect tests depend on it, and that path never drops the re-entrant navigation), and without `onException` neither code path is reached.

Tests in `exception_handling_test.dart`:

- One test calls `router.go('/fallback')` synchronously from inside `onException` and asserts full recovery (fallback rendered, protected absent, `router.state.uri.path == '/fallback'`); a second drives the app-side deferred-via-`scheduleMicrotask` pattern. Verified red/green for each half: without the `router.dart` fallback the delegate assertion fires at `delegate.dart:221`; without the `parser.dart` deferral the synchronous recovery is silently dropped and the fallback never renders.
- The `router.dart` fallback is also covered independently of the deferred path. An unmatched initial navigation with a non-navigating `onException` now renders the default error screen; before the fix the app just stayed blank, because the empty current configuration hit `setNewRoutePath`'s equality early-return. And a second unmatched navigation no longer replaces the first installed error configuration: the fallback preserves any valid current configuration, whether non-empty or `isError`.

Fixes flutter/flutter#189582

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under[^1].
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [x] All existing and new tests are passing.

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[the version and CHANGELOG instructions]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version-and-changelog-updates
[semantic versioning]: https://dart.dev/tools/pub/versioning#semantic-versions
[repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests