### PR TITLE
[material_ui] Unpin material_color_utilities

### DIFF
--- a/packages/material_ui/pubspec.yaml
+++ b/packages/material_ui/pubspec.yaml
@@ -24,7 +24,7 @@ dependencies:
   intl: ^0.20.2
   # This is not unpinned currently.
   # See https://github.com/flutter/flutter/issues/185017
-  material_color_utilities: 0.13.0
+  material_color_utilities: ^0.13.0
   vector_math: ^2.2.0
 
 dev_dependencies:

--- a/packages/material_ui/pubspec.yaml
+++ b/packages/material_ui/pubspec.yaml
@@ -22,8 +22,6 @@ dependencies:
   flutter_localizations:
     sdk: flutter
   intl: ^0.20.2
-  # This is not unpinned currently.
-  # See https://github.com/flutter/flutter/issues/185017
   material_color_utilities: ^0.13.0
   vector_math: ^2.2.0
 


### PR DESCRIPTION
This was originally pinned in flutter/flutter, but we've been moving away from pinned dependencies. Since flutter/packages won't let us publish with a pinned dependency, and since pinning this will likely only cause trouble for our users that migrate to material_ui, let's unpin it now.

Fixes https://github.com/flutter/flutter/issues/185017