### PR TITLE
[camera_android_camerax] Migrate skills validation test to new dart_skills_lint API

### DIFF
--- a/packages/camera/camera_android_camerax/pubspec.yaml
+++ b/packages/camera/camera_android_camerax/pubspec.yaml
@@ -32,7 +32,7 @@ dev_dependencies:
     git:
       url: https://github.com/flutter/skills.git
       path: tool/dart_skills_lint
-      ref: 8f85e82be6da429980f7cfe84f2f214a06cbfee1
+      ref: 05e5a45fa412ddbdd1d694eee0c71f4bbaea2617
   flutter_test:
     sdk: flutter
   leak_tracker_flutter_testing: any

--- a/packages/camera/camera_android_camerax/test/enforce_tracked_skills_prevent_publishing_rule.dart
+++ b/packages/camera/camera_android_camerax/test/enforce_tracked_skills_prevent_publishing_rule.dart
@@ -71,7 +71,7 @@ class EnforceTrackedSkillsPreventPublishingRule extends SkillRule {
       final String normalizedConfigPath = p.canonicalize(File(skillConfig.path).absolute.path);
       if (normalizedConfigPath == normalizedContextPath) {
         pathFound = true;
-        configuredSeverity = skillConfig.rules['prevent-skills-sh-publishing'];
+        configuredSeverity = skillConfig.ruleConfigs['prevent-skills-sh-publishing']?.severity;
         if (configuredSeverity == AnalysisSeverity.error) {
           ruleEnabled = true;
         }


### PR DESCRIPTION
This update lets us use parameters in dart_skills_lint rules which is needed to be able to add evals that have artifacts that are ignored in git but exist locally. 

Agent authored description below
----
Bumps the pinned `dart_skills_lint` dev_dependency ref to the latest main commit (`05e5a45fa412ddbdd1d694eee0c71f4bbaea2617`) and migrates the skills validation test off the deprecated `LintTargetConfig.rules` getter onto the new `LintTargetConfig.ruleConfigs` API surface.

This is the first candidate migration of the workspace-wide `dart_skills_lint` API updates.

- **Non-test code changed**: None (only `pubspec.yaml` dev_dependencies and `test/` suite).
- **Checks and Tests**: Validated locally that formatting, static analysis, and all package tests pass cleanly.