### PR TITLE
[google_fonts] Remove failed loads from pendingFonts

### DIFF
--- a/packages/google_fonts/CHANGELOG.md
+++ b/packages/google_fonts/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 8.2.1
+
+- Fixes `pendingFonts()` retaining failed font loads.
+
 ## 8.2.0
 
 - Extract the class `Config` to its own file and rename it `GoogleFontsConfig`. The `Config` class is now deprecated.

--- a/packages/google_fonts/lib/src/google_fonts_base.dart
+++ b/packages/google_fonts/lib/src/google_fonts_base.dart
@@ -28,8 +28,8 @@ void clearCache() => _loadedFonts.clear();
 
 /// Set of [Future]s corresponding to fonts that are loading.
 ///
-/// When a font is loading, a future is added to this set. When it is loaded in
-/// the [FontLoader], that future is removed from this set.
+/// When a font is loading, a future is added to this set. When the load
+/// completes, whether successfully or with an error, that future is removed.
 final Set<Future<void>> pendingFontFutures = <Future<void>>{};
 
 /// Default client used to fetch fonts when one is not supplied.
@@ -106,7 +106,7 @@ TextStyle googleFontsTextStyle({
 
   final Future<void> loadingFuture = loadFontIfNecessary(descriptor);
   pendingFontFutures.add(loadingFuture);
-  loadingFuture.then((_) => pendingFontFutures.remove(loadingFuture));
+  loadingFuture.whenComplete(() => pendingFontFutures.remove(loadingFuture)).ignore();
 
   return textStyle.copyWith(
     fontFamily: familyWithVariant.toString(),

--- a/packages/google_fonts/pubspec.yaml
+++ b/packages/google_fonts/pubspec.yaml
@@ -2,7 +2,7 @@ name: google_fonts
 description: A Flutter package to use fonts from fonts.google.com. Supports HTTP fetching, caching, and asset bundling.
 repository: https://github.com/flutter/packages/tree/main/packages/google_fonts
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+google_fonts%22
-version: 8.2.0
+version: 8.2.1
 
 environment:
   sdk: ^3.10.0

--- a/packages/google_fonts/test/load_font_if_necessary_test.dart
+++ b/packages/google_fonts/test/load_font_if_necessary_test.dart
@@ -88,6 +88,10 @@ final GoogleFontsDescriptor fakeDescriptor = GoogleFontsDescriptor(
   file: _fakeResponseFile,
 );
 
+final Map<GoogleFontsVariant, GoogleFontsFile> _fakeFonts = <GoogleFontsVariant, GoogleFontsFile>{
+  fakeDescriptor.familyWithVariant.googleFontsVariant: fakeDescriptor.file,
+};
+
 // Same family & variant, different file.
 final GoogleFontsDescriptor fakeDescriptorDifferentFile = GoogleFontsDescriptor(
   familyWithVariant: fakeDescriptor.familyWithVariant,
@@ -360,5 +364,16 @@ void main() {
       ),
       returnsNormally,
     );
+  });
+
+  test('pendingFonts removes failed font loads', () async {
+    when(mockHttpClient.gets(any)).thenAnswer((_) async {
+      return http.Response('', 404);
+    });
+
+    googleFontsTextStyle(fontFamily: fakeDescriptor.familyWithVariant.family, fonts: _fakeFonts);
+
+    await expectLater(GoogleFonts.pendingFonts(), throwsException);
+    expect(await GoogleFonts.pendingFonts(), isEmpty);
   });
 }


### PR DESCRIPTION
Failed font loads remain in `pendingFontFutures` because the current cleanup
callback runs only after successful completion. As a result, every later
`GoogleFonts.pendingFonts()` call rethrows the same completed error.

This change removes a tracked load on either completion path while preserving
the original error for the caller currently awaiting `pendingFonts()`. It adds
regression coverage showing that the first call reports the load failure and a
later call is no longer poisoned by it.

Fixes flutter/flutter#182430.

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under[^1].
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[the version and CHANGELOG instructions]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version-and-changelog-updates
[semantic versioning]: https://dart.dev/tools/pub/versioning#semantic-versions
[repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
