### PR TITLE
[webview_flutter] Convert from XCTest to Swift Testing

### DIFF
--- a/packages/webview_flutter/webview_flutter_wkwebview/darwin/Tests/AuthenticationChallengeResponseProxyAPITests.swift
+++ b/packages/webview_flutter/webview_flutter_wkwebview/darwin/Tests/AuthenticationChallengeResponseProxyAPITests.swift
@@ -2,22 +2,23 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import XCTest
+import Foundation
+import Testing
 
 @testable import webview_flutter_wkwebview
 
-class AuthenticationChallengeResponseProxyAPITests: XCTestCase {
-  func testPigeonDefaultConstructor() {
+@Suite struct AuthenticationChallengeResponseProxyAPITests {
+  @Test func pigeonDefaultConstructor() throws {
     let registrar = TestProxyApiRegistrar()
     let api = registrar.apiDelegate.pigeonApiAuthenticationChallengeResponse(registrar)
 
     let instance = try? api.pigeonDelegate.pigeonDefaultConstructor(
       pigeonApi: api, disposition: UrlSessionAuthChallengeDisposition.useCredential,
       credential: URLCredential())
-    XCTAssertNotNil(instance)
+    #expect(instance != nil)
   }
 
-  func testDisposition() {
+  @Test func disposition() throws {
     let registrar = TestProxyApiRegistrar()
     let api = registrar.apiDelegate.pigeonApiAuthenticationChallengeResponse(registrar)
 
@@ -25,10 +26,10 @@ class AuthenticationChallengeResponseProxyAPITests: XCTestCase {
       disposition: .useCredential, credential: URLCredential())
     let value = try? api.pigeonDelegate.disposition(pigeonApi: api, pigeonInstance: instance)
 
-    XCTAssertEqual(value, UrlSessionAuthChallengeDisposition.useCredential)
+    #expect(value == UrlSessionAuthChallengeDisposition.useCredential)
   }
 
-  func testCredential() {
+  @Test func credential() throws {
     let registrar = TestProxyApiRegistrar()
     let api = registrar.apiDelegate.pigeonApiAuthenticationChallengeResponse(registrar)
 
@@ -36,6 +37,6 @@ class AuthenticationChallengeResponseProxyAPITests: XCTestCase {
       disposition: .useCredential, credential: URLCredential())
     let value = try? api.pigeonDelegate.credential(pigeonApi: api, pigeonInstance: instance)
 
-    XCTAssertEqual(value, instance.credential)
+    #expect(value == instance.credential)
   }
 }

--- a/packages/webview_flutter/webview_flutter_wkwebview/darwin/Tests/AuthenticationChallengeResponseProxyAPITests.swift
+++ b/packages/webview_flutter/webview_flutter_wkwebview/darwin/Tests/AuthenticationChallengeResponseProxyAPITests.swift
@@ -8,7 +8,7 @@ import Testing
 @testable import webview_flutter_wkwebview
 
 @Suite struct AuthenticationChallengeResponseProxyAPITests {
-  @Test func pigeonDefaultConstructor() throws {
+  @Test func pigeonDefaultConstructor() {
     let registrar = TestProxyApiRegistrar()
     let api = registrar.apiDelegate.pigeonApiAuthenticationChallengeResponse(registrar)
 
@@ -24,7 +24,7 @@ import Testing
 
     let instance = AuthenticationChallengeResponse(
       disposition: .useCredential, credential: URLCredential())
-    let value = try? api.pigeonDelegate.disposition(pigeonApi: api, pigeonInstance: instance)
+    let value = try api.pigeonDelegate.disposition(pigeonApi: api, pigeonInstance: instance)
 
     #expect(value == UrlSessionAuthChallengeDisposition.useCredential)
   }
@@ -35,7 +35,7 @@ import Testing
 
     let instance = AuthenticationChallengeResponse(
       disposition: .useCredential, credential: URLCredential())
-    let value = try? api.pigeonDelegate.credential(pigeonApi: api, pigeonInstance: instance)
+    let value = try api.pigeonDelegate.credential(pigeonApi: api, pigeonInstance: instance)
 
     #expect(value == instance.credential)
   }

--- a/packages/webview_flutter/webview_flutter_wkwebview/darwin/Tests/ColorProxyAPITests.swift
+++ b/packages/webview_flutter/webview_flutter_wkwebview/darwin/Tests/ColorProxyAPITests.swift
@@ -2,7 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import XCTest
+import Foundation
+import Testing
 
 @testable import webview_flutter_wkwebview
 
@@ -10,15 +11,15 @@ import XCTest
   import UIKit
 #endif
 
-class ColorProxyAPITests: XCTestCase {
+@Suite struct ColorProxyAPITests {
   #if os(iOS)
-    func testPigeonDefaultConstructor() {
+    @Test func pigeonDefaultConstructor() throws {
       let registrar = TestProxyApiRegistrar()
       let api = registrar.apiDelegate.pigeonApiUIColor(registrar)
 
       let instance = try? api.pigeonDelegate.pigeonDefaultConstructor(
         pigeonApi: api, red: 1.0, green: 1.0, blue: 1.0, alpha: 1.0)
-      XCTAssertNotNil(instance)
+      #expect(instance != nil)
     }
   #endif
 }

--- a/packages/webview_flutter/webview_flutter_wkwebview/darwin/Tests/ColorProxyAPITests.swift
+++ b/packages/webview_flutter/webview_flutter_wkwebview/darwin/Tests/ColorProxyAPITests.swift
@@ -13,7 +13,7 @@ import Testing
 
 @Suite struct ColorProxyAPITests {
   #if os(iOS)
-    @Test func pigeonDefaultConstructor() throws {
+    @Test func pigeonDefaultConstructor() {
       let registrar = TestProxyApiRegistrar()
       let api = registrar.apiDelegate.pigeonApiUIColor(registrar)
 

--- a/packages/webview_flutter/webview_flutter_wkwebview/darwin/Tests/ErrorProxyAPITests.swift
+++ b/packages/webview_flutter/webview_flutter_wkwebview/darwin/Tests/ErrorProxyAPITests.swift
@@ -14,7 +14,7 @@ import Testing
 
     let code = 0
     let instance = NSError(domain: "", code: code)
-    let value = try? api.pigeonDelegate.code(pigeonApi: api, pigeonInstance: instance)
+    let value = try api.pigeonDelegate.code(pigeonApi: api, pigeonInstance: instance)
 
     #expect(value == Int64(code))
   }
@@ -25,7 +25,7 @@ import Testing
 
     let domain = "domain"
     let instance = NSError(domain: domain, code: 0)
-    let value = try? api.pigeonDelegate.domain(pigeonApi: api, pigeonInstance: instance)
+    let value = try api.pigeonDelegate.domain(pigeonApi: api, pigeonInstance: instance)
 
     #expect(value == domain)
   }
@@ -36,7 +36,7 @@ import Testing
 
     let userInfo: [String: String?] = ["some": "info"]
     let instance = NSError(domain: "", code: 0, userInfo: userInfo as [String: Any])
-    let value = try? api.pigeonDelegate.userInfo(pigeonApi: api, pigeonInstance: instance)
+    let value = try api.pigeonDelegate.userInfo(pigeonApi: api, pigeonInstance: instance)
 
     #expect(value as! [String: String?] == userInfo)
   }

--- a/packages/webview_flutter/webview_flutter_wkwebview/darwin/Tests/ErrorProxyAPITests.swift
+++ b/packages/webview_flutter/webview_flutter_wkwebview/darwin/Tests/ErrorProxyAPITests.swift
@@ -2,12 +2,13 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import XCTest
+import Foundation
+import Testing
 
 @testable import webview_flutter_wkwebview
 
-class ErrorProxyAPITests: XCTestCase {
-  func testCode() {
+@Suite struct ErrorProxyAPITests {
+  @Test func code() throws {
     let registrar = TestProxyApiRegistrar()
     let api = registrar.apiDelegate.pigeonApiNSError(registrar)
 
@@ -15,10 +16,10 @@ class ErrorProxyAPITests: XCTestCase {
     let instance = NSError(domain: "", code: code)
     let value = try? api.pigeonDelegate.code(pigeonApi: api, pigeonInstance: instance)
 
-    XCTAssertEqual(value, Int64(code))
+    #expect(value == Int64(code))
   }
 
-  func testDomain() {
+  @Test func domain() throws {
     let registrar = TestProxyApiRegistrar()
     let api = registrar.apiDelegate.pigeonApiNSError(registrar)
 
@@ -26,10 +27,10 @@ class ErrorProxyAPITests: XCTestCase {
     let instance = NSError(domain: domain, code: 0)
     let value = try? api.pigeonDelegate.domain(pigeonApi: api, pigeonInstance: instance)
 
-    XCTAssertEqual(value, domain)
+    #expect(value == domain)
   }
 
-  func testUserInfo() {
+  @Test func userInfo() throws {
     let registrar = TestProxyApiRegistrar()
     let api = registrar.apiDelegate.pigeonApiNSError(registrar)
 
@@ -37,6 +38,6 @@ class ErrorProxyAPITests: XCTestCase {
     let instance = NSError(domain: "", code: 0, userInfo: userInfo as [String: Any])
     let value = try? api.pigeonDelegate.userInfo(pigeonApi: api, pigeonInstance: instance)
 
-    XCTAssertEqual(value as! [String: String?], userInfo)
+    #expect(value as! [String: String?] == userInfo)
   }
 }

--- a/packages/webview_flutter/webview_flutter_wkwebview/darwin/Tests/FWFWebViewFlutterWKWebViewExternalAPITests.swift
+++ b/packages/webview_flutter/webview_flutter_wkwebview/darwin/Tests/FWFWebViewFlutterWKWebViewExternalAPITests.swift
@@ -2,8 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import Foundation
+import Testing
 import WebKit
-import XCTest
 
 @testable import webview_flutter_wkwebview
 
@@ -15,8 +16,8 @@ import XCTest
   #error("Unsupported platform.")
 #endif
 
-class FWFWebViewFlutterWKWebViewExternalAPITests: XCTestCase {
-  @MainActor func testWebViewForIdentifier() {
+@Suite struct FWFWebViewFlutterWKWebViewExternalAPITests {
+  @MainActor @Test func webViewForIdentifier() throws {
     let registry = TestRegistry()
 
     #if os(iOS)
@@ -36,23 +37,23 @@ class FWFWebViewFlutterWKWebViewExternalAPITests: XCTestCase {
 
     let result = FWFWebViewFlutterWKWebViewExternalAPI.webView(
       forIdentifier: Int64(webViewIdentifier), withPluginRegistry: registry)
-    XCTAssertEqual(result, webView)
+    #expect(result == webView)
   }
 
-  @MainActor func testWebViewForIdentifierHandlesIncorrectRegistry() {
+  @MainActor @Test func webViewForIdentifierHandlesIncorrectRegistry() throws {
     let registry = TestRegistry()
     // Ensure that passing an empty registry, such as the FlutterAppDelegate
     // in an app that has adopted UIScene, gracefully returns nil.
     let result = FWFWebViewFlutterWKWebViewExternalAPI.webView(
       forIdentifier: 0, withPluginRegistry: registry)
-    XCTAssertEqual(result, nil)
+    #expect(result == nil)
   }
 
   // FlutterPluginRegistrar.valuePublished(byPlugin:) is not available on macOS. This
   // can be removed once this method becomes available.
   // See https://github.com/flutter/flutter/issues/186911.
   #if os(iOS)
-    @MainActor func testWebViewForIdentifierFromRegistrar() {
+    @MainActor @Test func webViewForIdentifierFromRegistrar() throws {
       let registry = TestRegistry()
 
       #if os(iOS)
@@ -72,16 +73,16 @@ class FWFWebViewFlutterWKWebViewExternalAPITests: XCTestCase {
 
       let result = FWFWebViewFlutterWKWebViewExternalAPI.webView(
         forIdentifier: Int64(webViewIdentifier), withPluginRegistrar: registrar)
-      XCTAssertEqual(result, webView)
+      #expect(result == webView)
     }
 
-    @MainActor func testWebViewForIdentifierHandlesIncorrectRegistrar() {
+    @MainActor @Test func webViewForIdentifierHandlesIncorrectRegistrar() throws {
       let registrar = TestFlutterPluginRegistrar()
       // Ensure that passing an empty registry, such as the FlutterAppDelegate
       // in an app that has adopted UIScene, gracefully returns nil.
       let result = FWFWebViewFlutterWKWebViewExternalAPI.webView(
         forIdentifier: 0, withPluginRegistrar: registrar)
-      XCTAssertEqual(result, nil)
+      #expect(result == nil)
     }
   #endif
 }

--- a/packages/webview_flutter/webview_flutter_wkwebview/darwin/Tests/FrameInfoProxyAPITests.swift
+++ b/packages/webview_flutter/webview_flutter_wkwebview/darwin/Tests/FrameInfoProxyAPITests.swift
@@ -15,7 +15,7 @@ import WebKit
     let api = registrar.apiDelegate.pigeonApiWKFrameInfo(registrar)
 
     let instance = TestFrameInfo.instance
-    let value = try? api.pigeonDelegate.isMainFrame(pigeonApi: api, pigeonInstance: instance)
+    let value = try api.pigeonDelegate.isMainFrame(pigeonApi: api, pigeonInstance: instance)
 
     #expect(value == instance.isMainFrame)
   }
@@ -25,7 +25,7 @@ import WebKit
     let api = registrar.apiDelegate.pigeonApiWKFrameInfo(registrar)
 
     let instance = TestFrameInfo.instance
-    let value = try? api.pigeonDelegate.request(pigeonApi: api, pigeonInstance: instance)
+    let value = try api.pigeonDelegate.request(pigeonApi: api, pigeonInstance: instance)
 
     #expect(value?.value == instance.request)
   }
@@ -35,7 +35,7 @@ import WebKit
     let api = registrar.apiDelegate.pigeonApiWKFrameInfo(registrar)
 
     let instance = TestFrameInfoWithNilRequest.instance
-    let value = try? api.pigeonDelegate.request(pigeonApi: api, pigeonInstance: instance)
+    let value = try api.pigeonDelegate.request(pigeonApi: api, pigeonInstance: instance)
     // On macOS 15.5+, `WKFrameInfo.request` returns with an empty URLRequest.
     // Previously it would return nil so accept either.
     if value != nil {

--- a/packages/webview_flutter/webview_flutter_wkwebview/darwin/Tests/FrameInfoProxyAPITests.swift
+++ b/packages/webview_flutter/webview_flutter_wkwebview/darwin/Tests/FrameInfoProxyAPITests.swift
@@ -2,34 +2,35 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import Foundation
+import Testing
 import WebKit
-import XCTest
 
 @testable import webview_flutter_wkwebview
 
 @MainActor
-class FrameInfoProxyAPITests: XCTestCase {
-  @MainActor func testIsMainFrame() {
+@Suite struct FrameInfoProxyAPITests {
+  @MainActor @Test func isMainFrame() throws {
     let registrar = TestProxyApiRegistrar()
     let api = registrar.apiDelegate.pigeonApiWKFrameInfo(registrar)
 
     let instance = TestFrameInfo.instance
     let value = try? api.pigeonDelegate.isMainFrame(pigeonApi: api, pigeonInstance: instance)
 
-    XCTAssertEqual(value, instance.isMainFrame)
+    #expect(value == instance.isMainFrame)
   }
 
-  @MainActor func testRequest() {
+  @MainActor @Test func request() throws {
     let registrar = TestProxyApiRegistrar()
     let api = registrar.apiDelegate.pigeonApiWKFrameInfo(registrar)
 
     let instance = TestFrameInfo.instance
     let value = try? api.pigeonDelegate.request(pigeonApi: api, pigeonInstance: instance)
 
-    XCTAssertEqual(value?.value, instance.request)
+    #expect(value?.value == instance.request)
   }
 
-  @MainActor func testNilRequest() {
+  @MainActor @Test func nilRequest() throws {
     let registrar = TestProxyApiRegistrar()
     let api = registrar.apiDelegate.pigeonApiWKFrameInfo(registrar)
 
@@ -38,9 +39,9 @@ class FrameInfoProxyAPITests: XCTestCase {
     // On macOS 15.5+, `WKFrameInfo.request` returns with an empty URLRequest.
     // Previously it would return nil so accept either.
     if value != nil {
-      XCTAssertEqual(value?.value.url?.absoluteString, "")
+      #expect(value?.value.url?.absoluteString == "")
     } else {
-      XCTAssertNil(value)
+      #expect(value == nil)
     }
   }
 }

--- a/packages/webview_flutter/webview_flutter_wkwebview/darwin/Tests/GetTrustResultResponseProxyAPITests.swift
+++ b/packages/webview_flutter/webview_flutter_wkwebview/darwin/Tests/GetTrustResultResponseProxyAPITests.swift
@@ -13,7 +13,7 @@ import Testing
     let api = registrar.apiDelegate.pigeonApiGetTrustResultResponse(registrar)
 
     let instance = GetTrustResultResponse(result: SecTrustResultType.invalid, resultCode: -1)
-    let value = try? api.pigeonDelegate.result(pigeonApi: api, pigeonInstance: instance)
+    let value = try api.pigeonDelegate.result(pigeonApi: api, pigeonInstance: instance)
 
     #expect(value == DartSecTrustResultType.invalid)
   }
@@ -23,7 +23,7 @@ import Testing
     let api = registrar.apiDelegate.pigeonApiGetTrustResultResponse(registrar)
 
     let instance = GetTrustResultResponse(result: SecTrustResultType.invalid, resultCode: -1)
-    let value = try? api.pigeonDelegate.resultCode(pigeonApi: api, pigeonInstance: instance)
+    let value = try api.pigeonDelegate.resultCode(pigeonApi: api, pigeonInstance: instance)
 
     #expect(value == -1)
   }

--- a/packages/webview_flutter/webview_flutter_wkwebview/darwin/Tests/GetTrustResultResponseProxyAPITests.swift
+++ b/packages/webview_flutter/webview_flutter_wkwebview/darwin/Tests/GetTrustResultResponseProxyAPITests.swift
@@ -2,28 +2,29 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import XCTest
+import Foundation
+import Testing
 
 @testable import webview_flutter_wkwebview
 
-class GetTrustResultResponseProxyAPITests: XCTestCase {
-  func testResult() {
+@Suite struct GetTrustResultResponseProxyAPITests {
+  @Test func result() throws {
     let registrar = TestProxyApiRegistrar()
     let api = registrar.apiDelegate.pigeonApiGetTrustResultResponse(registrar)
 
     let instance = GetTrustResultResponse(result: SecTrustResultType.invalid, resultCode: -1)
     let value = try? api.pigeonDelegate.result(pigeonApi: api, pigeonInstance: instance)
 
-    XCTAssertEqual(value, DartSecTrustResultType.invalid)
+    #expect(value == DartSecTrustResultType.invalid)
   }
 
-  func testResultCode() {
+  @Test func resultCode() throws {
     let registrar = TestProxyApiRegistrar()
     let api = registrar.apiDelegate.pigeonApiGetTrustResultResponse(registrar)
 
     let instance = GetTrustResultResponse(result: SecTrustResultType.invalid, resultCode: -1)
     let value = try? api.pigeonDelegate.resultCode(pigeonApi: api, pigeonInstance: instance)
 
-    XCTAssertEqual(value, -1)
+    #expect(value == -1)
   }
 }

--- a/packages/webview_flutter/webview_flutter_wkwebview/darwin/Tests/HTTPCookieProxyAPITests.swift
+++ b/packages/webview_flutter/webview_flutter_wkwebview/darwin/Tests/HTTPCookieProxyAPITests.swift
@@ -8,7 +8,7 @@ import Testing
 @testable import webview_flutter_wkwebview
 
 @Suite struct HTTPCookieProxyAPITests {
-  @Test func pigeonDefaultConstructor() throws {
+  @Test func pigeonDefaultConstructor() {
     let registrar = TestProxyApiRegistrar()
     let api = registrar.apiDelegate.pigeonApiHTTPCookie(registrar)
 
@@ -25,7 +25,7 @@ import Testing
     let instance = HTTPCookie(properties: [
       .name: "foo", .value: "bar", .domain: "http://google.com", .path: "/anything",
     ])!
-    let value = try? api.pigeonDelegate.getProperties(pigeonApi: api, pigeonInstance: instance)
+    let value = try api.pigeonDelegate.getProperties(pigeonApi: api, pigeonInstance: instance)
 
     #expect(value?[.name] as? String == "foo")
     #expect(value?[.value] as? String == "bar")

--- a/packages/webview_flutter/webview_flutter_wkwebview/darwin/Tests/HTTPCookieProxyAPITests.swift
+++ b/packages/webview_flutter/webview_flutter_wkwebview/darwin/Tests/HTTPCookieProxyAPITests.swift
@@ -2,22 +2,23 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import XCTest
+import Foundation
+import Testing
 
 @testable import webview_flutter_wkwebview
 
-class HTTPCookieProxyAPITests: XCTestCase {
-  func testPigeonDefaultConstructor() {
+@Suite struct HTTPCookieProxyAPITests {
+  @Test func pigeonDefaultConstructor() throws {
     let registrar = TestProxyApiRegistrar()
     let api = registrar.apiDelegate.pigeonApiHTTPCookie(registrar)
 
     let instance = try? api.pigeonDelegate.pigeonDefaultConstructor(
       pigeonApi: api,
       properties: [.name: "foo", .value: "bar", .domain: "http://google.com", .path: "/anything"])
-    XCTAssertNotNil(instance)
+    #expect(instance != nil)
   }
 
-  func testGetProperties() {
+  @Test func getProperties() throws {
     let registrar = TestProxyApiRegistrar()
     let api = registrar.apiDelegate.pigeonApiHTTPCookie(registrar)
 
@@ -26,9 +27,9 @@ class HTTPCookieProxyAPITests: XCTestCase {
     ])!
     let value = try? api.pigeonDelegate.getProperties(pigeonApi: api, pigeonInstance: instance)
 
-    XCTAssertEqual(value?[.name] as? String, "foo")
-    XCTAssertEqual(value?[.value] as? String, "bar")
-    XCTAssertEqual(value?[.domain] as? String, "http://google.com")
-    XCTAssertEqual(value?[.path] as? String, "/anything")
+    #expect(value?[.name] as? String == "foo")
+    #expect(value?[.value] as? String == "bar")
+    #expect(value?[.domain] as? String == "http://google.com")
+    #expect(value?[.path] as? String == "/anything")
   }
 }

--- a/packages/webview_flutter/webview_flutter_wkwebview/darwin/Tests/HTTPCookieStoreProxyAPITests.swift
+++ b/packages/webview_flutter/webview_flutter_wkwebview/darwin/Tests/HTTPCookieStoreProxyAPITests.swift
@@ -65,9 +65,7 @@ import WebKit
         }
       }
     }
-    #expect(cookies.count == 2)
-    #expect(cookies.contains(cookie1))
-    #expect(cookies.contains(cookie2))
+    #expect(cookies == [cookie1, cookie2])
   }
 }
 

--- a/packages/webview_flutter/webview_flutter_wkwebview/darwin/Tests/HTTPCookieStoreProxyAPITests.swift
+++ b/packages/webview_flutter/webview_flutter_wkwebview/darwin/Tests/HTTPCookieStoreProxyAPITests.swift
@@ -19,7 +19,7 @@ import WebKit
       .path: "/anything",
     ])!
 
-    try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+    try await withCheckedThrowingContinuation { continuation in
       api.pigeonDelegate.setCookie(
         pigeonApi: api,
         pigeonInstance: instance!,
@@ -51,8 +51,7 @@ import WebKit
     instance!.allCookies = [cookie1, cookie2]
 
     // Test fetching all cookies
-    let cookies = try await withCheckedThrowingContinuation {
-      (continuation: CheckedContinuation<[HTTPCookie], Error>) in
+    let cookies = try await withCheckedThrowingContinuation { continuation in
       api.pigeonDelegate.getAllCookies(
         pigeonApi: api,
         pigeonInstance: instance!

--- a/packages/webview_flutter/webview_flutter_wkwebview/darwin/Tests/HTTPCookieStoreProxyAPITests.swift
+++ b/packages/webview_flutter/webview_flutter_wkwebview/darwin/Tests/HTTPCookieStoreProxyAPITests.swift
@@ -2,13 +2,14 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import Foundation
+import Testing
 import WebKit
-import XCTest
 
 @testable import webview_flutter_wkwebview
 
-class HTTPCookieStoreProxyAPITests: XCTestCase {
-  @MainActor func testSetCookie() {
+@Suite struct HTTPCookieStoreProxyAPITests {
+  @MainActor @Test func setCookie() async throws {
     let registrar = TestProxyApiRegistrar()
     let api = registrar.apiDelegate.pigeonApiWKHTTPCookieStore(registrar)
 
@@ -18,26 +19,24 @@ class HTTPCookieStoreProxyAPITests: XCTestCase {
       .path: "/anything",
     ])!
 
-    let expect = expectation(description: "Wait for setCookie.")
-    api.pigeonDelegate.setCookie(
-      pigeonApi: api,
-      pigeonInstance: instance!,
-      cookie: cookie
-    ) {
-      result in
-      switch result {
-      case .success(_):
-        XCTAssertEqual(instance!.setCookieArg, cookie)
-      case .failure(let error):
-        XCTFail("\(error)")
+    try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+      api.pigeonDelegate.setCookie(
+        pigeonApi: api,
+        pigeonInstance: instance!,
+        cookie: cookie
+      ) { result in
+        switch result {
+        case .success(_):
+          continuation.resume()
+        case .failure(let error):
+          continuation.resume(throwing: error)
+        }
       }
-      expect.fulfill()
     }
-
-    wait(for: [expect], timeout: 1.0)
+    #expect(instance!.setCookieArg == cookie)
   }
 
-  @MainActor func testGetCookies() {
+  @MainActor @Test func getCookies() async throws {
     let registrar = TestProxyApiRegistrar()
     let api = registrar.apiDelegate.pigeonApiWKHTTPCookieStore(registrar)
 
@@ -52,23 +51,23 @@ class HTTPCookieStoreProxyAPITests: XCTestCase {
     instance!.allCookies = [cookie1, cookie2]
 
     // Test fetching all cookies
-    let expectAll = expectation(description: "Wait for getAllCookies.")
-    api.pigeonDelegate.getAllCookies(
-      pigeonApi: api,
-      pigeonInstance: instance!
-    ) { result in
-      switch result {
-      case .success(let cookies):
-        XCTAssertEqual(cookies.count, 2)
-        XCTAssertTrue(cookies.contains(cookie1))
-        XCTAssertTrue(cookies.contains(cookie2))
-      case .failure(let error):
-        XCTFail("\(error)")
+    let cookies = try await withCheckedThrowingContinuation {
+      (continuation: CheckedContinuation<[HTTPCookie], Error>) in
+      api.pigeonDelegate.getAllCookies(
+        pigeonApi: api,
+        pigeonInstance: instance!
+      ) { result in
+        switch result {
+        case .success(let cookies):
+          continuation.resume(returning: cookies)
+        case .failure(let error):
+          continuation.resume(throwing: error)
+        }
       }
-      expectAll.fulfill()
     }
-
-    wait(for: [expectAll], timeout: 1.0)
+    #expect(cookies.count == 2)
+    #expect(cookies.contains(cookie1))
+    #expect(cookies.contains(cookie2))
   }
 }
 

--- a/packages/webview_flutter/webview_flutter_wkwebview/darwin/Tests/HTTPURLResponseProxyAPITests.swift
+++ b/packages/webview_flutter/webview_flutter_wkwebview/darwin/Tests/HTTPURLResponseProxyAPITests.swift
@@ -14,7 +14,7 @@ import Testing
 
     let instance = HTTPURLResponse(
       url: URL(string: "http://google.com")!, statusCode: 400, httpVersion: nil, headerFields: nil)!
-    let value = try? api.pigeonDelegate.statusCode(pigeonApi: api, pigeonInstance: instance)
+    let value = try api.pigeonDelegate.statusCode(pigeonApi: api, pigeonInstance: instance)
 
     #expect(value == Int64(instance.statusCode))
   }

--- a/packages/webview_flutter/webview_flutter_wkwebview/darwin/Tests/HTTPURLResponseProxyAPITests.swift
+++ b/packages/webview_flutter/webview_flutter_wkwebview/darwin/Tests/HTTPURLResponseProxyAPITests.swift
@@ -2,12 +2,13 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import XCTest
+import Foundation
+import Testing
 
 @testable import webview_flutter_wkwebview
 
-class HTTPURLResponseProxyAPITests: XCTestCase {
-  func testStatusCode() {
+@Suite struct HTTPURLResponseProxyAPITests {
+  @Test func statusCode() throws {
     let registrar = TestProxyApiRegistrar()
     let api = registrar.apiDelegate.pigeonApiHTTPURLResponse(registrar)
 
@@ -15,6 +16,6 @@ class HTTPURLResponseProxyAPITests: XCTestCase {
       url: URL(string: "http://google.com")!, statusCode: 400, httpVersion: nil, headerFields: nil)!
     let value = try? api.pigeonDelegate.statusCode(pigeonApi: api, pigeonInstance: instance)
 
-    XCTAssertEqual(value, Int64(instance.statusCode))
+    #expect(value == Int64(instance.statusCode))
   }
 }

--- a/packages/webview_flutter/webview_flutter_wkwebview/darwin/Tests/NSObjectProxyAPITests.swift
+++ b/packages/webview_flutter/webview_flutter_wkwebview/darwin/Tests/NSObjectProxyAPITests.swift
@@ -2,20 +2,21 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import XCTest
+import Foundation
+import Testing
 
 @testable import webview_flutter_wkwebview
 
-class ObjectProxyAPITests: XCTestCase {
-  func testPigeonDefaultConstructor() {
+@Suite struct ObjectProxyAPITests {
+  @Test func pigeonDefaultConstructor() throws {
     let registrar = TestProxyApiRegistrar()
     let api = registrar.apiDelegate.pigeonApiNSObject(registrar)
 
     let instance = try? api.pigeonDelegate.pigeonDefaultConstructor(pigeonApi: api)
-    XCTAssertNotNil(instance)
+    #expect(instance != nil)
   }
 
-  func testAddObserver() {
+  @Test func addObserver() throws {
     let registrar = TestProxyApiRegistrar()
     let api = registrar.apiDelegate.pigeonApiNSObject(registrar)
 
@@ -30,10 +31,10 @@ class ObjectProxyAPITests: XCTestCase {
     var nativeOptions: NSKeyValueObservingOptions = []
     nativeOptions.insert(.new)
 
-    XCTAssertEqual(instance.addObserverArgs, [observer, keyPath, nativeOptions.rawValue])
+    #expect(instance.addObserverArgs == [observer, keyPath, nativeOptions.rawValue])
   }
 
-  func testRemoveObserver() {
+  @Test func removeObserver() throws {
     let registrar = TestProxyApiRegistrar()
     let api = registrar.apiDelegate.pigeonApiNSObject(registrar)
 
@@ -43,10 +44,10 @@ class ObjectProxyAPITests: XCTestCase {
     try? api.pigeonDelegate.removeObserver(
       pigeonApi: api, pigeonInstance: instance, observer: object, keyPath: keyPath)
 
-    XCTAssertEqual(instance.removeObserverArgs, [object, keyPath])
+    #expect(instance.removeObserverArgs == [object, keyPath])
   }
 
-  func testObserveValue() {
+  @Test func observeValue() throws {
     let api = TestObjectApi()
 
     let registrar = TestProxyApiRegistrar()
@@ -56,7 +57,7 @@ class ObjectProxyAPITests: XCTestCase {
     let change = [NSKeyValueChangeKey.indexesKey: -1]
     instance.observeValue(forKeyPath: keyPath, of: object, change: change, context: nil)
 
-    XCTAssertEqual(api.observeValueArgs, [keyPath, object, [KeyValueChangeKey.indexes: -1]])
+    #expect(api.observeValueArgs == [keyPath, object, [KeyValueChangeKey.indexes: -1]])
   }
 }
 

--- a/packages/webview_flutter/webview_flutter_wkwebview/darwin/Tests/NSObjectProxyAPITests.swift
+++ b/packages/webview_flutter/webview_flutter_wkwebview/darwin/Tests/NSObjectProxyAPITests.swift
@@ -8,7 +8,7 @@ import Testing
 @testable import webview_flutter_wkwebview
 
 @Suite struct ObjectProxyAPITests {
-  @Test func pigeonDefaultConstructor() throws {
+  @Test func pigeonDefaultConstructor() {
     let registrar = TestProxyApiRegistrar()
     let api = registrar.apiDelegate.pigeonApiNSObject(registrar)
 
@@ -24,7 +24,7 @@ import Testing
     let observer = NSObject()
     let keyPath = "myString"
     let options: [KeyValueObservingOptions] = [.newValue]
-    try? api.pigeonDelegate.addObserver(
+    try api.pigeonDelegate.addObserver(
       pigeonApi: api, pigeonInstance: instance, observer: observer, keyPath: keyPath,
       options: options)
 
@@ -41,7 +41,7 @@ import Testing
     let instance = TestObject()
     let object = NSObject()
     let keyPath = "myString"
-    try? api.pigeonDelegate.removeObserver(
+    try api.pigeonDelegate.removeObserver(
       pigeonApi: api, pigeonInstance: instance, observer: object, keyPath: keyPath)
 
     #expect(instance.removeObserverArgs == [object, keyPath])

--- a/packages/webview_flutter/webview_flutter_wkwebview/darwin/Tests/NavigationActionProxyAPITests.swift
+++ b/packages/webview_flutter/webview_flutter_wkwebview/darwin/Tests/NavigationActionProxyAPITests.swift
@@ -2,40 +2,41 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import Foundation
+import Testing
 import WebKit
-import XCTest
 
 @testable import webview_flutter_wkwebview
 
-class NavigationActionProxyAPITests: XCTestCase {
-  @MainActor func testRequest() {
+@Suite struct NavigationActionProxyAPITests {
+  @MainActor @Test func request() throws {
     let registrar = TestProxyApiRegistrar()
     let api = registrar.apiDelegate.pigeonApiWKNavigationAction(registrar)
 
     let instance: TestNavigationAction? = TestNavigationAction()
     let value = try? api.pigeonDelegate.request(pigeonApi: api, pigeonInstance: instance!)
 
-    XCTAssertEqual(value?.value, instance!.request)
+    #expect(value?.value == instance!.request)
   }
 
-  @MainActor func testTargetFrame() {
+  @MainActor @Test func targetFrame() throws {
     let registrar = TestProxyApiRegistrar()
     let api = registrar.apiDelegate.pigeonApiWKNavigationAction(registrar)
 
     let instance: TestNavigationAction? = TestNavigationAction()
     let value = try? api.pigeonDelegate.targetFrame(pigeonApi: api, pigeonInstance: instance!)
 
-    XCTAssertEqual(value, instance!.targetFrame)
+    #expect(value == instance!.targetFrame)
   }
 
-  @MainActor func testNavigationType() {
+  @MainActor @Test func navigationType() throws {
     let registrar = TestProxyApiRegistrar()
     let api = registrar.apiDelegate.pigeonApiWKNavigationAction(registrar)
 
     let instance: TestNavigationAction? = TestNavigationAction()
     let value = try? api.pigeonDelegate.navigationType(pigeonApi: api, pigeonInstance: instance!)
 
-    XCTAssertEqual(value, .formSubmitted)
+    #expect(value == .formSubmitted)
   }
 }
 

--- a/packages/webview_flutter/webview_flutter_wkwebview/darwin/Tests/NavigationActionProxyAPITests.swift
+++ b/packages/webview_flutter/webview_flutter_wkwebview/darwin/Tests/NavigationActionProxyAPITests.swift
@@ -14,9 +14,9 @@ import WebKit
     let api = registrar.apiDelegate.pigeonApiWKNavigationAction(registrar)
 
     let instance: TestNavigationAction? = TestNavigationAction()
-    let value = try? api.pigeonDelegate.request(pigeonApi: api, pigeonInstance: instance!)
+    let value = try api.pigeonDelegate.request(pigeonApi: api, pigeonInstance: instance!)
 
-    #expect(value?.value == instance!.request)
+    #expect(value.value == instance!.request)
   }
 
   @MainActor @Test func targetFrame() throws {
@@ -24,7 +24,7 @@ import WebKit
     let api = registrar.apiDelegate.pigeonApiWKNavigationAction(registrar)
 
     let instance: TestNavigationAction? = TestNavigationAction()
-    let value = try? api.pigeonDelegate.targetFrame(pigeonApi: api, pigeonInstance: instance!)
+    let value = try api.pigeonDelegate.targetFrame(pigeonApi: api, pigeonInstance: instance!)
 
     #expect(value == instance!.targetFrame)
   }
@@ -34,7 +34,7 @@ import WebKit
     let api = registrar.apiDelegate.pigeonApiWKNavigationAction(registrar)
 
     let instance: TestNavigationAction? = TestNavigationAction()
-    let value = try? api.pigeonDelegate.navigationType(pigeonApi: api, pigeonInstance: instance!)
+    let value = try api.pigeonDelegate.navigationType(pigeonApi: api, pigeonInstance: instance!)
 
     #expect(value == .formSubmitted)
   }

--- a/packages/webview_flutter/webview_flutter_wkwebview/darwin/Tests/NavigationDelegateProxyAPITests.swift
+++ b/packages/webview_flutter/webview_flutter_wkwebview/darwin/Tests/NavigationDelegateProxyAPITests.swift
@@ -9,7 +9,7 @@ import WebKit
 @testable import webview_flutter_wkwebview
 
 @Suite struct NavigationDelegateProxyAPITests {
-  @Test func pigeonDefaultConstructor() throws {
+  @Test func pigeonDefaultConstructor() {
     let registrar = TestProxyApiRegistrar()
     let api = registrar.apiDelegate.pigeonApiWKNavigationDelegate(registrar)
 

--- a/packages/webview_flutter/webview_flutter_wkwebview/darwin/Tests/NavigationDelegateProxyAPITests.swift
+++ b/packages/webview_flutter/webview_flutter_wkwebview/darwin/Tests/NavigationDelegateProxyAPITests.swift
@@ -2,21 +2,22 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import Foundation
+import Testing
 import WebKit
-import XCTest
 
 @testable import webview_flutter_wkwebview
 
-class NavigationDelegateProxyAPITests: XCTestCase {
-  func testPigeonDefaultConstructor() {
+@Suite struct NavigationDelegateProxyAPITests {
+  @Test func pigeonDefaultConstructor() throws {
     let registrar = TestProxyApiRegistrar()
     let api = registrar.apiDelegate.pigeonApiWKNavigationDelegate(registrar)
 
     let instance = try? api.pigeonDelegate.pigeonDefaultConstructor(pigeonApi: api)
-    XCTAssertNotNil(instance)
+    #expect(instance != nil)
   }
 
-  @MainActor func testDidFinishNavigation() {
+  @MainActor @Test func didFinishNavigation() throws {
     let api = TestNavigationDelegateApi()
     let registrar = TestProxyApiRegistrar()
     let instance = NavigationDelegateImpl(api: api, registrar: registrar)
@@ -24,60 +25,54 @@ class NavigationDelegateProxyAPITests: XCTestCase {
 
     instance.webView(webView, didFinish: nil)
 
-    XCTAssertEqual(api.didFinishNavigationArgs, [webView, webView.url?.absoluteString])
+    #expect(api.didFinishNavigationArgs == [webView, webView.url?.absoluteString])
   }
 
-  @MainActor func testDidStartProvisionalNavigation() {
+  @MainActor @Test func didStartProvisionalNavigation() throws {
     let api = TestNavigationDelegateApi()
     let registrar = TestProxyApiRegistrar()
     let instance = NavigationDelegateImpl(api: api, registrar: registrar)
     let webView = TestWebView(frame: .zero)
     instance.webView(webView, didStartProvisionalNavigation: nil)
 
-    XCTAssertEqual(api.didStartProvisionalNavigationArgs, [webView, webView.url?.absoluteString])
+    #expect(api.didStartProvisionalNavigationArgs == [webView, webView.url?.absoluteString])
   }
 
-  @MainActor func testDecidePolicyForNavigationAction() {
+  @MainActor @Test func decidePolicyForNavigationAction() async throws {
     let api = TestNavigationDelegateApi()
     let registrar = TestProxyApiRegistrar()
     let instance = NavigationDelegateImpl(api: api, registrar: registrar)
     let webView = WKWebView(frame: .zero)
     let navigationAction = TestNavigationAction()
 
-    let callbackExpectation = expectation(description: "Wait for callback.")
-    var result: WKNavigationActionPolicy?
-    instance.webView(webView, decidePolicyFor: navigationAction) { policy in
-      result = policy
-      callbackExpectation.fulfill()
+    let result = await withCheckedContinuation { continuation in
+      instance.webView(webView, decidePolicyFor: navigationAction) { policy in
+        continuation.resume(returning: policy)
+      }
     }
 
-    wait(for: [callbackExpectation], timeout: 1.0)
-
-    XCTAssertEqual(api.decidePolicyForNavigationActionArgs, [webView, navigationAction])
-    XCTAssertEqual(result, .allow)
+    #expect(api.decidePolicyForNavigationActionArgs == [webView, navigationAction])
+    #expect(result == .allow)
   }
 
-  @MainActor func testDecidePolicyForNavigationResponse() {
+  @MainActor @Test func decidePolicyForNavigationResponse() async throws {
     let api = TestNavigationDelegateApi()
     let registrar = TestProxyApiRegistrar()
     let instance = NavigationDelegateImpl(api: api, registrar: registrar)
     let webView = WKWebView(frame: .zero)
     let navigationResponse = TestNavigationResponse.instance
 
-    var result: WKNavigationResponsePolicy?
-    let callbackExpectation = expectation(description: "Wait for callback.")
-    instance.webView(webView, decidePolicyFor: navigationResponse) { policy in
-      result = policy
-      callbackExpectation.fulfill()
+    let result = await withCheckedContinuation { continuation in
+      instance.webView(webView, decidePolicyFor: navigationResponse) { policy in
+        continuation.resume(returning: policy)
+      }
     }
 
-    wait(for: [callbackExpectation], timeout: 1.0)
-
-    XCTAssertEqual(api.decidePolicyForNavigationResponseArgs, [webView, navigationResponse])
-    XCTAssertEqual(result, .cancel)
+    #expect(api.decidePolicyForNavigationResponseArgs == [webView, navigationResponse])
+    #expect(result == .cancel)
   }
 
-  @MainActor func testDidFailNavigation() {
+  @MainActor @Test func didFailNavigation() throws {
     let api = TestNavigationDelegateApi()
     let registrar = TestProxyApiRegistrar()
     let instance = NavigationDelegateImpl(api: api, registrar: registrar)
@@ -85,10 +80,10 @@ class NavigationDelegateProxyAPITests: XCTestCase {
     let error = NSError(domain: "", code: 12)
     instance.webView(webView, didFail: nil, withError: error)
 
-    XCTAssertEqual(api.didFailNavigationArgs, [webView, error])
+    #expect(api.didFailNavigationArgs == [webView, error])
   }
 
-  @MainActor func testDidFailProvisionalNavigation() {
+  @MainActor @Test func didFailProvisionalNavigation() throws {
     let api = TestNavigationDelegateApi()
     let registrar = TestProxyApiRegistrar()
     let instance = NavigationDelegateImpl(api: api, registrar: registrar)
@@ -96,20 +91,20 @@ class NavigationDelegateProxyAPITests: XCTestCase {
     let error = NSError(domain: "", code: 12)
     instance.webView(webView, didFailProvisionalNavigation: nil, withError: error)
 
-    XCTAssertEqual(api.didFailProvisionalNavigationArgs, [webView, error])
+    #expect(api.didFailProvisionalNavigationArgs == [webView, error])
   }
 
-  @MainActor func testWebViewWebContentProcessDidTerminate() {
+  @MainActor @Test func webViewWebContentProcessDidTerminate() throws {
     let api = TestNavigationDelegateApi()
     let registrar = TestProxyApiRegistrar()
     let instance = NavigationDelegateImpl(api: api, registrar: registrar)
     let webView = WKWebView(frame: .zero)
     instance.webViewWebContentProcessDidTerminate(webView)
 
-    XCTAssertEqual(api.webViewWebContentProcessDidTerminateArgs, [webView])
+    #expect(api.webViewWebContentProcessDidTerminateArgs == [webView])
   }
 
-  @MainActor func testDidReceiveAuthenticationChallenge() {
+  @MainActor @Test func didReceiveAuthenticationChallenge() async throws {
     let api = TestNavigationDelegateApi()
     let registrar = TestProxyApiRegistrar()
     let instance = NavigationDelegateImpl(api: api, registrar: registrar)
@@ -118,22 +113,17 @@ class NavigationDelegateProxyAPITests: XCTestCase {
       protectionSpace: URLProtectionSpace(), proposedCredential: nil, previousFailureCount: 3,
       failureResponse: nil, error: nil, sender: TestURLAuthenticationChallengeSender())
 
-    var dispositionResult: URLSession.AuthChallengeDisposition?
-    var credentialResult: URLCredential?
-    let callbackExpectation = expectation(description: "Wait for callback.")
-    instance.webView(webView, didReceive: challenge) { disposition, credential in
-      dispositionResult = disposition
-      credentialResult = credential
-      callbackExpectation.fulfill()
+    let (dispositionResult, credentialResult) = await withCheckedContinuation { continuation in
+      instance.webView(webView, didReceive: challenge) { disposition, credential in
+        continuation.resume(returning: (disposition, credential))
+      }
     }
 
-    wait(for: [callbackExpectation], timeout: 1.0)
-
-    XCTAssertEqual(api.didReceiveAuthenticationChallengeArgs, [webView, challenge])
-    XCTAssertEqual(dispositionResult, .useCredential)
-    XCTAssertEqual(credentialResult?.user, "user1")
-    XCTAssertEqual(credentialResult?.password, "password1")
-    XCTAssertEqual(credentialResult?.persistence, URLCredential.Persistence.none)
+    #expect(api.didReceiveAuthenticationChallengeArgs == [webView, challenge])
+    #expect(dispositionResult == .useCredential)
+    #expect(credentialResult?.user == "user1")
+    #expect(credentialResult?.password == "password1")
+    #expect(credentialResult?.persistence == URLCredential.Persistence.none)
   }
 }
 

--- a/packages/webview_flutter/webview_flutter_wkwebview/darwin/Tests/NavigationResponseProxyAPITests.swift
+++ b/packages/webview_flutter/webview_flutter_wkwebview/darwin/Tests/NavigationResponseProxyAPITests.swift
@@ -9,7 +9,7 @@ import WebKit
 @testable import webview_flutter_wkwebview
 
 @Suite struct NavigationResponseProxyAPITests {
-  @MainActor @Test func response() throws {
+  @MainActor @Test func response() {
     let registrar = TestProxyApiRegistrar()
     let api = registrar.apiDelegate.pigeonApiWKNavigationResponse(registrar)
 
@@ -24,7 +24,7 @@ import WebKit
     let api = registrar.apiDelegate.pigeonApiWKNavigationResponse(registrar)
 
     let instance = TestNavigationResponse.instance
-    let value = try? api.pigeonDelegate.isForMainFrame(pigeonApi: api, pigeonInstance: instance)
+    let value = try api.pigeonDelegate.isForMainFrame(pigeonApi: api, pigeonInstance: instance)
 
     #expect(value == instance.isForMainFrame)
   }

--- a/packages/webview_flutter/webview_flutter_wkwebview/darwin/Tests/NavigationResponseProxyAPITests.swift
+++ b/packages/webview_flutter/webview_flutter_wkwebview/darwin/Tests/NavigationResponseProxyAPITests.swift
@@ -2,30 +2,31 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import Foundation
+import Testing
 import WebKit
-import XCTest
 
 @testable import webview_flutter_wkwebview
 
-class NavigationResponseProxyAPITests: XCTestCase {
-  @MainActor func testResponse() {
+@Suite struct NavigationResponseProxyAPITests {
+  @MainActor @Test func response() throws {
     let registrar = TestProxyApiRegistrar()
     let api = registrar.apiDelegate.pigeonApiWKNavigationResponse(registrar)
 
     let instance = TestNavigationResponse.instance
     let value = try? api.pigeonDelegate.response(pigeonApi: api, pigeonInstance: instance)
 
-    XCTAssertEqual(value, instance.response)
+    #expect(value == instance.response)
   }
 
-  @MainActor func testIsForMainFrame() {
+  @MainActor @Test func isForMainFrame() throws {
     let registrar = TestProxyApiRegistrar()
     let api = registrar.apiDelegate.pigeonApiWKNavigationResponse(registrar)
 
     let instance = TestNavigationResponse.instance
     let value = try? api.pigeonDelegate.isForMainFrame(pigeonApi: api, pigeonInstance: instance)
 
-    XCTAssertEqual(value, instance.isForMainFrame)
+    #expect(value == instance.isForMainFrame)
   }
 }
 

--- a/packages/webview_flutter/webview_flutter_wkwebview/darwin/Tests/PlatformViewImplTests.swift
+++ b/packages/webview_flutter/webview_flutter_wkwebview/darwin/Tests/PlatformViewImplTests.swift
@@ -11,7 +11,7 @@ import Testing
   import UIKit
 #endif
 
-@Suite struct PlatformViewImplTests {
+@Suite @MainActor struct PlatformViewImplTests {
   #if os(iOS)
     @Test func platformViewImplStoresViewWithAWeakReference() throws {
       var view: UIView? = UIView()

--- a/packages/webview_flutter/webview_flutter_wkwebview/darwin/Tests/PlatformViewImplTests.swift
+++ b/packages/webview_flutter/webview_flutter_wkwebview/darwin/Tests/PlatformViewImplTests.swift
@@ -2,7 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import XCTest
+import Foundation
+import Testing
 
 @testable import webview_flutter_wkwebview
 
@@ -10,16 +11,16 @@ import XCTest
   import UIKit
 #endif
 
-class PlatformViewImplTests: XCTestCase {
+@Suite struct PlatformViewImplTests {
   #if os(iOS)
-    func testPlatformViewImplStoresViewWithAWeakReference() {
+    @Test func platformViewImplStoresViewWithAWeakReference() throws {
       var view: UIView? = UIView()
       let platformView = PlatformViewImpl(uiView: view!)
 
-      XCTAssertNotNil(platformView.uiView)
+      #expect(platformView.uiView != nil)
 
       view = nil
-      XCTAssertNil(platformView.uiView)
+      #expect(platformView.uiView == nil)
     }
   #endif
 }

--- a/packages/webview_flutter/webview_flutter_wkwebview/darwin/Tests/PreferencesProxyAPITests.swift
+++ b/packages/webview_flutter/webview_flutter_wkwebview/darwin/Tests/PreferencesProxyAPITests.swift
@@ -19,7 +19,7 @@ import WebKit
 
       let instance = WKPreferences()
       let enabled = true
-      try? api.pigeonDelegate.setJavaScriptEnabled(
+      try api.pigeonDelegate.setJavaScriptEnabled(
         pigeonApi: api, pigeonInstance: instance, enabled: enabled)
 
       #expect(instance.javaScriptEnabled == enabled)

--- a/packages/webview_flutter/webview_flutter_wkwebview/darwin/Tests/PreferencesProxyAPITests.swift
+++ b/packages/webview_flutter/webview_flutter_wkwebview/darwin/Tests/PreferencesProxyAPITests.swift
@@ -2,15 +2,16 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import Foundation
+import Testing
 import WebKit
-import XCTest
 
 @testable import webview_flutter_wkwebview
 
-class PreferencesProxyAPITests: XCTestCase {
-  @MainActor func testSetJavaScriptEnabled() throws {
+@Suite struct PreferencesProxyAPITests {
+  @MainActor @Test func setJavaScriptEnabled() throws {
     if #available(iOS 14.0, macOS 11.0, *) {
-      throw XCTSkip("Required API is not available for this test.")
+      return
 
     } else {
       let registrar = TestProxyApiRegistrar()
@@ -21,11 +22,11 @@ class PreferencesProxyAPITests: XCTestCase {
       try? api.pigeonDelegate.setJavaScriptEnabled(
         pigeonApi: api, pigeonInstance: instance, enabled: enabled)
 
-      XCTAssertEqual(instance.javaScriptEnabled, enabled)
+      #expect(instance.javaScriptEnabled == enabled)
     }
   }
 
-  @MainActor func testSetJavaScriptCanOpenWindowsAutomatically() throws {
+  @MainActor @Test func setJavaScriptCanOpenWindowsAutomatically() throws {
     let registrar = TestProxyApiRegistrar()
     let api = registrar.apiDelegate.pigeonApiWKPreferences(registrar)
 
@@ -34,6 +35,6 @@ class PreferencesProxyAPITests: XCTestCase {
     try api.pigeonDelegate.setJavaScriptCanOpenWindowsAutomatically(
       pigeonApi: api, pigeonInstance: instance, enabled: enabled)
 
-    XCTAssertEqual(instance.javaScriptCanOpenWindowsAutomatically, enabled)
+    #expect(instance.javaScriptCanOpenWindowsAutomatically == enabled)
   }
 }

--- a/packages/webview_flutter/webview_flutter_wkwebview/darwin/Tests/ProxyAPIRegistrarTests.swift
+++ b/packages/webview_flutter/webview_flutter_wkwebview/darwin/Tests/ProxyAPIRegistrarTests.swift
@@ -8,13 +8,12 @@ import Testing
 @testable import webview_flutter_wkwebview
 
 @Suite struct ProxyAPIRegistrarTests {
-  @Test func logFlutterMethodFailureDoesNotThrowAnError() throws {
+  // Method should log a message and not throw an error. DO NOT add 'throws' to this
+  // test, as it is here to enforce that the method doesn't throw.
+  @Test func logFlutterMethodFailureDoesNotThrowAnError() {
     let registrar = TestProxyApiRegistrar()
 
-    // Method should log a message and not throw an error.
-    #expect(throws: Never.self) {
-      try registrar.logFlutterMethodFailure(
-        PigeonError(code: "code", message: "message", details: nil), methodName: "aMethod")
-    }
+    registrar.logFlutterMethodFailure(
+      PigeonError(code: "code", message: "message", details: nil), methodName: "aMethod")
   }
 }

--- a/packages/webview_flutter/webview_flutter_wkwebview/darwin/Tests/ProxyAPIRegistrarTests.swift
+++ b/packages/webview_flutter/webview_flutter_wkwebview/darwin/Tests/ProxyAPIRegistrarTests.swift
@@ -2,18 +2,20 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import XCTest
+import Foundation
+import Testing
 
 @testable import webview_flutter_wkwebview
 
-class ProxyAPIRegistrarTests: XCTestCase {
-  func testLogFlutterMethodFailureDoesNotThrowAnError() {
+@Suite struct ProxyAPIRegistrarTests {
+  @Test func logFlutterMethodFailureDoesNotThrowAnError() throws {
     let registrar = TestProxyApiRegistrar()
 
-    XCTExpectFailure("Method should log a message and not throw an error.") {
-      XCTAssertThrowsError(
-        registrar.logFlutterMethodFailure(
-          PigeonError(code: "code", message: "message", details: nil), methodName: "aMethod"))
+    withKnownIssue("Method should log a message and not throw an error.") {
+      #expect(throws: (any Error).self) {
+        try registrar.logFlutterMethodFailure(
+          PigeonError(code: "code", message: "message", details: nil), methodName: "aMethod")
+      }
     }
   }
 }

--- a/packages/webview_flutter/webview_flutter_wkwebview/darwin/Tests/ProxyAPIRegistrarTests.swift
+++ b/packages/webview_flutter/webview_flutter_wkwebview/darwin/Tests/ProxyAPIRegistrarTests.swift
@@ -11,11 +11,10 @@ import Testing
   @Test func logFlutterMethodFailureDoesNotThrowAnError() throws {
     let registrar = TestProxyApiRegistrar()
 
-    withKnownIssue("Method should log a message and not throw an error.") {
-      #expect(throws: (any Error).self) {
-        try registrar.logFlutterMethodFailure(
-          PigeonError(code: "code", message: "message", details: nil), methodName: "aMethod")
-      }
+    // Method should log a message and not throw an error.
+    #expect(throws: Never.self) {
+      try registrar.logFlutterMethodFailure(
+        PigeonError(code: "code", message: "message", details: nil), methodName: "aMethod")
     }
   }
 }

--- a/packages/webview_flutter/webview_flutter_wkwebview/darwin/Tests/ScriptMessageHandlerProxyAPITests.swift
+++ b/packages/webview_flutter/webview_flutter_wkwebview/darwin/Tests/ScriptMessageHandlerProxyAPITests.swift
@@ -2,21 +2,22 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import Foundation
+import Testing
 import WebKit
-import XCTest
 
 @testable import webview_flutter_wkwebview
 
-class ScriptMessageHandlerProxyAPITests: XCTestCase {
-  func testPigeonDefaultConstructor() {
+@Suite struct ScriptMessageHandlerProxyAPITests {
+  @Test func pigeonDefaultConstructor() throws {
     let registrar = TestProxyApiRegistrar()
     let api = registrar.apiDelegate.pigeonApiWKScriptMessageHandler(registrar)
 
     let instance = try? api.pigeonDelegate.pigeonDefaultConstructor(pigeonApi: api)
-    XCTAssertNotNil(instance)
+    #expect(instance != nil)
   }
 
-  @MainActor func testDidReceiveScriptMessage() {
+  @MainActor @Test func didReceiveScriptMessage() throws {
     let api = TestScriptMessageHandlerApi()
     let registrar = TestProxyApiRegistrar()
     let instance = ScriptMessageHandlerImpl(api: api, registrar: registrar)
@@ -25,7 +26,7 @@ class ScriptMessageHandlerProxyAPITests: XCTestCase {
 
     instance.userContentController(controller, didReceive: message)
 
-    XCTAssertEqual(api.didReceiveScriptMessageArgs, [controller, message])
+    #expect(api.didReceiveScriptMessageArgs == [controller, message])
   }
 }
 

--- a/packages/webview_flutter/webview_flutter_wkwebview/darwin/Tests/ScriptMessageHandlerProxyAPITests.swift
+++ b/packages/webview_flutter/webview_flutter_wkwebview/darwin/Tests/ScriptMessageHandlerProxyAPITests.swift
@@ -9,7 +9,7 @@ import WebKit
 @testable import webview_flutter_wkwebview
 
 @Suite struct ScriptMessageHandlerProxyAPITests {
-  @Test func pigeonDefaultConstructor() throws {
+  @Test func pigeonDefaultConstructor() {
     let registrar = TestProxyApiRegistrar()
     let api = registrar.apiDelegate.pigeonApiWKScriptMessageHandler(registrar)
 

--- a/packages/webview_flutter/webview_flutter_wkwebview/darwin/Tests/ScriptMessageProxyAPITests.swift
+++ b/packages/webview_flutter/webview_flutter_wkwebview/darwin/Tests/ScriptMessageProxyAPITests.swift
@@ -9,7 +9,7 @@ import WebKit
 @testable import webview_flutter_wkwebview
 
 @Suite struct ScriptMessageProxyAPITests {
-  @MainActor @Test func name() throws {
+  @MainActor @Test func name() {
     let registrar = TestProxyApiRegistrar()
     let api = registrar.apiDelegate.pigeonApiWKScriptMessage(registrar)
 
@@ -24,7 +24,7 @@ import WebKit
     let api = registrar.apiDelegate.pigeonApiWKScriptMessage(registrar)
 
     let instance = TestScriptMessage()
-    let value = try? api.pigeonDelegate.body(pigeonApi: api, pigeonInstance: instance)
+    let value = try api.pigeonDelegate.body(pigeonApi: api, pigeonInstance: instance)
 
     #expect(value as! Int == 23)
   }

--- a/packages/webview_flutter/webview_flutter_wkwebview/darwin/Tests/ScriptMessageProxyAPITests.swift
+++ b/packages/webview_flutter/webview_flutter_wkwebview/darwin/Tests/ScriptMessageProxyAPITests.swift
@@ -2,30 +2,31 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import Foundation
+import Testing
 import WebKit
-import XCTest
 
 @testable import webview_flutter_wkwebview
 
-class ScriptMessageProxyAPITests: XCTestCase {
-  @MainActor func testName() {
+@Suite struct ScriptMessageProxyAPITests {
+  @MainActor @Test func name() throws {
     let registrar = TestProxyApiRegistrar()
     let api = registrar.apiDelegate.pigeonApiWKScriptMessage(registrar)
 
     let instance = TestScriptMessage()
     let value = try? api.pigeonDelegate.name(pigeonApi: api, pigeonInstance: instance)
 
-    XCTAssertEqual(value, instance.name)
+    #expect(value == instance.name)
   }
 
-  @MainActor func testBody() {
+  @MainActor @Test func body() throws {
     let registrar = TestProxyApiRegistrar()
     let api = registrar.apiDelegate.pigeonApiWKScriptMessage(registrar)
 
     let instance = TestScriptMessage()
     let value = try? api.pigeonDelegate.body(pigeonApi: api, pigeonInstance: instance)
 
-    XCTAssertEqual(value as! Int, 23)
+    #expect(value as! Int == 23)
   }
 }
 

--- a/packages/webview_flutter/webview_flutter_wkwebview/darwin/Tests/ScrollViewDelegateProxyAPITests.swift
+++ b/packages/webview_flutter/webview_flutter_wkwebview/darwin/Tests/ScrollViewDelegateProxyAPITests.swift
@@ -13,7 +13,7 @@ import Testing
 
 @Suite struct ScrollViewDelegateProxyAPITests {
   #if os(iOS)
-    @Test func pigeonDefaultConstructor() throws {
+    @Test func pigeonDefaultConstructor() {
       let registrar = TestProxyApiRegistrar()
       let api = registrar.apiDelegate.pigeonApiUIScrollViewDelegate(registrar)
 

--- a/packages/webview_flutter/webview_flutter_wkwebview/darwin/Tests/ScrollViewDelegateProxyAPITests.swift
+++ b/packages/webview_flutter/webview_flutter_wkwebview/darwin/Tests/ScrollViewDelegateProxyAPITests.swift
@@ -2,7 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import XCTest
+import Foundation
+import Testing
 
 @testable import webview_flutter_wkwebview
 
@@ -10,17 +11,17 @@ import XCTest
   import UIKit
 #endif
 
-class ScrollViewDelegateProxyAPITests: XCTestCase {
+@Suite struct ScrollViewDelegateProxyAPITests {
   #if os(iOS)
-    func testPigeonDefaultConstructor() {
+    @Test func pigeonDefaultConstructor() throws {
       let registrar = TestProxyApiRegistrar()
       let api = registrar.apiDelegate.pigeonApiUIScrollViewDelegate(registrar)
 
       let instance = try? api.pigeonDelegate.pigeonDefaultConstructor(pigeonApi: api)
-      XCTAssertNotNil(instance)
+      #expect(instance != nil)
     }
 
-    @MainActor func testScrollViewDidScroll() {
+    @MainActor @Test func scrollViewDidScroll() throws {
       let api = TestScrollViewDelegateApi()
       let registrar = TestProxyApiRegistrar()
       let instance = ScrollViewDelegateImpl(api: api, registrar: registrar)
@@ -30,7 +31,7 @@ class ScrollViewDelegateProxyAPITests: XCTestCase {
       scrollView.contentOffset = CGPoint(x: x, y: y)
       instance.scrollViewDidScroll(scrollView)
 
-      XCTAssertEqual(api.scrollViewDidScrollArgs, [scrollView, x, y])
+      #expect(api.scrollViewDidScrollArgs == [scrollView, x, y])
     }
   #endif
 }

--- a/packages/webview_flutter/webview_flutter_wkwebview/darwin/Tests/ScrollViewProxyAPITests.swift
+++ b/packages/webview_flutter/webview_flutter_wkwebview/darwin/Tests/ScrollViewProxyAPITests.swift
@@ -2,7 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import XCTest
+import Foundation
+import Testing
 
 @testable import webview_flutter_wkwebview
 
@@ -10,19 +11,19 @@ import XCTest
   import UIKit
 #endif
 
-class ScrollViewProxyAPITests: XCTestCase {
+@Suite struct ScrollViewProxyAPITests {
   #if os(iOS)
-    @MainActor func testGetContentOffset() {
+    @MainActor @Test func getContentOffset() throws {
       let registrar = TestProxyApiRegistrar()
       let api = registrar.apiDelegate.pigeonApiUIScrollView(registrar)
 
       let instance = TestScrollView(frame: .zero)
       let value = try? api.pigeonDelegate.getContentOffset(pigeonApi: api, pigeonInstance: instance)
 
-      XCTAssertEqual(value, [instance.contentOffset.x, instance.contentOffset.y])
+      #expect(value == [instance.contentOffset.x, instance.contentOffset.y])
     }
 
-    @MainActor func testScrollBy() {
+    @MainActor @Test func scrollBy() throws {
       let registrar = TestProxyApiRegistrar()
       let api = registrar.apiDelegate.pigeonApiUIScrollView(registrar)
 
@@ -30,10 +31,10 @@ class ScrollViewProxyAPITests: XCTestCase {
       instance.contentOffset = CGPoint(x: 1.0, y: 1.0)
       try? api.pigeonDelegate.scrollBy(pigeonApi: api, pigeonInstance: instance, x: 1.0, y: 1.0)
 
-      XCTAssertEqual(instance.setContentOffsetArgs as? [Double], [2.0, 2.0])
+      #expect(instance.setContentOffsetArgs as? [Double] == [2.0, 2.0])
     }
 
-    @MainActor func testSetContentOffset() {
+    @MainActor @Test func setContentOffset() throws {
       let registrar = TestProxyApiRegistrar()
       let api = registrar.apiDelegate.pigeonApiUIScrollView(registrar)
 
@@ -42,10 +43,10 @@ class ScrollViewProxyAPITests: XCTestCase {
       let y = 1.0
       try? api.pigeonDelegate.setContentOffset(pigeonApi: api, pigeonInstance: instance, x: x, y: y)
 
-      XCTAssertEqual(instance.setContentOffsetArgs as? [Double], [x, y])
+      #expect(instance.setContentOffsetArgs as? [Double] == [x, y])
     }
 
-    @MainActor func testSetDelegate() {
+    @MainActor @Test func setDelegate() throws {
       let registrar = TestProxyApiRegistrar()
       let api = registrar.apiDelegate.pigeonApiUIScrollView(registrar)
 
@@ -55,11 +56,11 @@ class ScrollViewProxyAPITests: XCTestCase {
       try? api.pigeonDelegate.setDelegate(
         pigeonApi: api, pigeonInstance: instance, delegate: delegate)
 
-      XCTAssertEqual(instance.setDelegateArgs, [delegate])
+      #expect(instance.setDelegateArgs == [delegate])
     }
 
     @MainActor
-    func testSetBounces() {
+    @Test func setBounces() throws {
       let registrar = TestProxyApiRegistrar()
       let api = registrar.apiDelegate.pigeonApiUIScrollView(registrar)
 
@@ -67,13 +68,13 @@ class ScrollViewProxyAPITests: XCTestCase {
       let value = true
       try? api.pigeonDelegate.setBounces(pigeonApi: api, pigeonInstance: instance, value: value)
 
-      XCTAssertEqual(instance.bounces, value)
+      #expect(instance.bounces == value)
     }
 
     #if compiler(>=6.0)
       @available(iOS 17.4, *)
       @MainActor
-      func testSetBouncesHorizontally() {
+      @Test func setBouncesHorizontally() throws {
         let registrar = TestProxyApiRegistrar()
         let api = registrar.apiDelegate.pigeonApiUIScrollView(registrar)
 
@@ -82,12 +83,12 @@ class ScrollViewProxyAPITests: XCTestCase {
         try? api.pigeonDelegate.setBouncesHorizontally(
           pigeonApi: api, pigeonInstance: instance, value: value)
 
-        XCTAssertEqual(instance.bouncesHorizontally, value)
+        #expect(instance.bouncesHorizontally == value)
       }
 
       @available(iOS 17.4, *)
       @MainActor
-      func testSetBouncesVertically() {
+      @Test func setBouncesVertically() throws {
         let registrar = TestProxyApiRegistrar()
         let api = registrar.apiDelegate.pigeonApiUIScrollView(registrar)
 
@@ -96,12 +97,12 @@ class ScrollViewProxyAPITests: XCTestCase {
         try? api.pigeonDelegate.setBouncesVertically(
           pigeonApi: api, pigeonInstance: instance, value: value)
 
-        XCTAssertEqual(instance.bouncesVertically, value)
+        #expect(instance.bouncesVertically == value)
       }
     #endif
 
     @MainActor
-    func testSetAlwaysBounceVertical() {
+    @Test func setAlwaysBounceVertical() throws {
       let registrar = TestProxyApiRegistrar()
       let api = registrar.apiDelegate.pigeonApiUIScrollView(registrar)
 
@@ -110,11 +111,11 @@ class ScrollViewProxyAPITests: XCTestCase {
       try? api.pigeonDelegate.setAlwaysBounceVertical(
         pigeonApi: api, pigeonInstance: instance, value: value)
 
-      XCTAssertEqual(instance.alwaysBounceVertical, value)
+      #expect(instance.alwaysBounceVertical == value)
     }
 
     @MainActor
-    func testSetAlwaysBounceHorizontal() {
+    @Test func setAlwaysBounceHorizontal() throws {
       let registrar = TestProxyApiRegistrar()
       let api = registrar.apiDelegate.pigeonApiUIScrollView(registrar)
 
@@ -123,10 +124,10 @@ class ScrollViewProxyAPITests: XCTestCase {
       try? api.pigeonDelegate.setAlwaysBounceHorizontal(
         pigeonApi: api, pigeonInstance: instance, value: value)
 
-      XCTAssertEqual(instance.alwaysBounceHorizontal, value)
+      #expect(instance.alwaysBounceHorizontal == value)
     }
 
-    @MainActor func testSetShowsVerticalScrollIndicator() {
+    @MainActor @Test func setShowsVerticalScrollIndicator() throws {
       let registrar = TestProxyApiRegistrar()
       let api = registrar.apiDelegate.pigeonApiUIScrollView(registrar)
 
@@ -135,10 +136,10 @@ class ScrollViewProxyAPITests: XCTestCase {
       try? api.pigeonDelegate.setShowsVerticalScrollIndicator(
         pigeonApi: api, pigeonInstance: instance, value: value)
 
-      XCTAssertEqual(instance.showsVerticalScrollIndicator, value)
+      #expect(instance.showsVerticalScrollIndicator == value)
     }
 
-    @MainActor func testSetShowsHorizontalScrollIndicator() {
+    @MainActor @Test func setShowsHorizontalScrollIndicator() throws {
       let registrar = TestProxyApiRegistrar()
       let api = registrar.apiDelegate.pigeonApiUIScrollView(registrar)
 
@@ -147,7 +148,7 @@ class ScrollViewProxyAPITests: XCTestCase {
       try? api.pigeonDelegate.setShowsHorizontalScrollIndicator(
         pigeonApi: api, pigeonInstance: instance, value: value)
 
-      XCTAssertEqual(instance.showsHorizontalScrollIndicator, value)
+      #expect(instance.showsHorizontalScrollIndicator == value)
     }
   #endif
 }

--- a/packages/webview_flutter/webview_flutter_wkwebview/darwin/Tests/ScrollViewProxyAPITests.swift
+++ b/packages/webview_flutter/webview_flutter_wkwebview/darwin/Tests/ScrollViewProxyAPITests.swift
@@ -29,7 +29,7 @@ import Testing
 
       let instance = TestScrollView(frame: .zero)
       instance.contentOffset = CGPoint(x: 1.0, y: 1.0)
-      try? api.pigeonDelegate.scrollBy(pigeonApi: api, pigeonInstance: instance, x: 1.0, y: 1.0)
+      try api.pigeonDelegate.scrollBy(pigeonApi: api, pigeonInstance: instance, x: 1.0, y: 1.0)
 
       #expect(instance.setContentOffsetArgs as? [Double] == [2.0, 2.0])
     }
@@ -41,7 +41,7 @@ import Testing
       let instance = TestScrollView(frame: .zero)
       let x = 1.0
       let y = 1.0
-      try? api.pigeonDelegate.setContentOffset(pigeonApi: api, pigeonInstance: instance, x: x, y: y)
+      try api.pigeonDelegate.setContentOffset(pigeonApi: api, pigeonInstance: instance, x: x, y: y)
 
       #expect(instance.setContentOffsetArgs as? [Double] == [x, y])
     }
@@ -53,7 +53,7 @@ import Testing
       let instance = TestScrollView(frame: .zero)
       let delegate = ScrollViewDelegateImpl(
         api: registrar.apiDelegate.pigeonApiUIScrollViewDelegate(registrar), registrar: registrar)
-      try? api.pigeonDelegate.setDelegate(
+      try api.pigeonDelegate.setDelegate(
         pigeonApi: api, pigeonInstance: instance, delegate: delegate)
 
       #expect(instance.setDelegateArgs == [delegate])
@@ -66,7 +66,7 @@ import Testing
 
       let instance = TestScrollView()
       let value = true
-      try? api.pigeonDelegate.setBounces(pigeonApi: api, pigeonInstance: instance, value: value)
+      try api.pigeonDelegate.setBounces(pigeonApi: api, pigeonInstance: instance, value: value)
 
       #expect(instance.bounces == value)
     }
@@ -80,7 +80,7 @@ import Testing
 
         let instance = TestScrollView()
         let value = true
-        try? api.pigeonDelegate.setBouncesHorizontally(
+        try api.pigeonDelegate.setBouncesHorizontally(
           pigeonApi: api, pigeonInstance: instance, value: value)
 
         #expect(instance.bouncesHorizontally == value)
@@ -94,7 +94,7 @@ import Testing
 
         let instance = TestScrollView()
         let value = true
-        try? api.pigeonDelegate.setBouncesVertically(
+        try api.pigeonDelegate.setBouncesVertically(
           pigeonApi: api, pigeonInstance: instance, value: value)
 
         #expect(instance.bouncesVertically == value)
@@ -108,7 +108,7 @@ import Testing
 
       let instance = TestScrollView()
       let value = true
-      try? api.pigeonDelegate.setAlwaysBounceVertical(
+      try api.pigeonDelegate.setAlwaysBounceVertical(
         pigeonApi: api, pigeonInstance: instance, value: value)
 
       #expect(instance.alwaysBounceVertical == value)
@@ -121,7 +121,7 @@ import Testing
 
       let instance = TestScrollView()
       let value = true
-      try? api.pigeonDelegate.setAlwaysBounceHorizontal(
+      try api.pigeonDelegate.setAlwaysBounceHorizontal(
         pigeonApi: api, pigeonInstance: instance, value: value)
 
       #expect(instance.alwaysBounceHorizontal == value)
@@ -133,7 +133,7 @@ import Testing
 
       let instance = TestScrollView()
       let value = true
-      try? api.pigeonDelegate.setShowsVerticalScrollIndicator(
+      try api.pigeonDelegate.setShowsVerticalScrollIndicator(
         pigeonApi: api, pigeonInstance: instance, value: value)
 
       #expect(instance.showsVerticalScrollIndicator == value)
@@ -145,7 +145,7 @@ import Testing
 
       let instance = TestScrollView()
       let value = true
-      try? api.pigeonDelegate.setShowsHorizontalScrollIndicator(
+      try api.pigeonDelegate.setShowsHorizontalScrollIndicator(
         pigeonApi: api, pigeonInstance: instance, value: value)
 
       #expect(instance.showsHorizontalScrollIndicator == value)

--- a/packages/webview_flutter/webview_flutter_wkwebview/darwin/Tests/ScrollViewProxyAPITests.swift
+++ b/packages/webview_flutter/webview_flutter_wkwebview/darwin/Tests/ScrollViewProxyAPITests.swift
@@ -18,9 +18,9 @@ import Testing
       let api = registrar.apiDelegate.pigeonApiUIScrollView(registrar)
 
       let instance = TestScrollView(frame: .zero)
-      let value = try? api.pigeonDelegate.getContentOffset(pigeonApi: api, pigeonInstance: instance)
+      let value = try api.pigeonDelegate.getContentOffset(pigeonApi: api, pigeonInstance: instance)
 
-      #expect(value == [instance.contentOffset.x, instance.contentOffset.y])
+      #expect(value == [instance.contentOffset.x, instance.contentOffset.y] as [Double])
     }
 
     @MainActor @Test func scrollBy() throws {

--- a/packages/webview_flutter/webview_flutter_wkwebview/darwin/Tests/SecCertificateProxyAPITests.swift
+++ b/packages/webview_flutter/webview_flutter_wkwebview/darwin/Tests/SecCertificateProxyAPITests.swift
@@ -2,7 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import XCTest
+import Foundation
+import Testing
 
 @testable import webview_flutter_wkwebview
 
@@ -14,7 +15,7 @@ import XCTest
   #error("Unsupported platform.")
 #endif
 
-class SecCertificateProxyAPITests: XCTestCase {
+@Suite struct SecCertificateProxyAPITests {
   func createDummyCertificate() -> SecCertificate {
     let url = FlutterAssetManager().urlForAsset("assets/test_cert.der")!
     let certificateData = NSData(contentsOf: url)
@@ -22,7 +23,7 @@ class SecCertificateProxyAPITests: XCTestCase {
     return SecCertificateCreateWithData(nil, certificateData!)!
   }
 
-  func testCopyData() {
+  @Test func copyData() throws {
     let registrar = TestProxyApiRegistrar()
     let delegate = TestSecCertificateProxyAPIDelegate()
     let api = PigeonApiSecCertificate(pigeonRegistrar: registrar, delegate: delegate)
@@ -30,7 +31,7 @@ class SecCertificateProxyAPITests: XCTestCase {
     let value = try? api.pigeonDelegate.copyData(
       pigeonApi: api, certificate: SecCertificateWrapper(value: createDummyCertificate()))
 
-    XCTAssertEqual(value?.data, delegate.data)
+    #expect(value?.data == delegate.data)
   }
 }
 

--- a/packages/webview_flutter/webview_flutter_wkwebview/darwin/Tests/SecCertificateProxyAPITests.swift
+++ b/packages/webview_flutter/webview_flutter_wkwebview/darwin/Tests/SecCertificateProxyAPITests.swift
@@ -28,10 +28,10 @@ import Testing
     let delegate = TestSecCertificateProxyAPIDelegate()
     let api = PigeonApiSecCertificate(pigeonRegistrar: registrar, delegate: delegate)
 
-    let value = try? api.pigeonDelegate.copyData(
+    let value = try api.pigeonDelegate.copyData(
       pigeonApi: api, certificate: SecCertificateWrapper(value: createDummyCertificate()))
 
-    #expect(value?.data == delegate.data)
+    #expect(value.data == delegate.data)
   }
 }
 

--- a/packages/webview_flutter/webview_flutter_wkwebview/darwin/Tests/SecTrustProxyAPITests.swift
+++ b/packages/webview_flutter/webview_flutter_wkwebview/darwin/Tests/SecTrustProxyAPITests.swift
@@ -49,7 +49,7 @@ import Testing
     let api = PigeonApiSecTrust(pigeonRegistrar: registrar, delegate: delegate)
 
     let trust = createTrust(delegate: delegate)
-    let value = try? api.pigeonDelegate.copyExceptions(pigeonApi: api, trust: trust)
+    let value = try api.pigeonDelegate.copyExceptions(pigeonApi: api, trust: trust)
 
     #expect(value?.data == Data())
   }
@@ -60,7 +60,7 @@ import Testing
     let api = PigeonApiSecTrust(pigeonRegistrar: registrar, delegate: delegate)
 
     let trust = createTrust(delegate: delegate)
-    let value = try? api.pigeonDelegate.setExceptions(
+    let value = try api.pigeonDelegate.setExceptions(
       pigeonApi: api, trust: trust, exceptions: FlutterStandardTypedData(bytes: Data()))
 
     #expect(value == false)
@@ -72,10 +72,10 @@ import Testing
     let api = PigeonApiSecTrust(pigeonRegistrar: registrar, delegate: delegate)
 
     let trust = createTrust(delegate: delegate)
-    let value = try? api.pigeonDelegate.getTrustResult(pigeonApi: api, trust: trust)
+    let value = try api.pigeonDelegate.getTrustResult(pigeonApi: api, trust: trust)
 
-    #expect(value?.result == SecTrustResultType.invalid)
-    #expect(value?.resultCode == -1)
+    #expect(value.result == SecTrustResultType.invalid)
+    #expect(value.resultCode == -1)
   }
 
   @Test func copyCertificateChain() throws {
@@ -84,7 +84,7 @@ import Testing
     let api = PigeonApiSecTrust(pigeonRegistrar: registrar, delegate: delegate)
 
     let trust = createTrust(delegate: delegate)
-    let value = try? api.pigeonDelegate.copyCertificateChain(pigeonApi: api, trust: trust)
+    let value = try api.pigeonDelegate.copyCertificateChain(pigeonApi: api, trust: trust)
 
     #expect(value?.count == 1)
     #expect(value?.first?.value != nil)

--- a/packages/webview_flutter/webview_flutter_wkwebview/darwin/Tests/SecTrustProxyAPITests.swift
+++ b/packages/webview_flutter/webview_flutter_wkwebview/darwin/Tests/SecTrustProxyAPITests.swift
@@ -2,7 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import XCTest
+import Foundation
+import Testing
 
 @testable import webview_flutter_wkwebview
 
@@ -14,7 +15,7 @@ import XCTest
   #error("Unsupported platform.")
 #endif
 
-class SecTrustProxyAPITests: XCTestCase {
+@Suite struct SecTrustProxyAPITests {
   func createTrust(delegate: TestSecTrustProxyAPIDelegate) -> SecTrustWrapper {
     var trust: SecTrust?
     SecTrustCreateWithCertificates(
@@ -23,30 +24,26 @@ class SecTrustProxyAPITests: XCTestCase {
     return SecTrustWrapper(value: trust!)
   }
 
-  func testEvaluateWithError() {
+  @Test func evaluateWithError() async throws {
     let registrar = TestProxyApiRegistrar()
     let delegate = TestSecTrustProxyAPIDelegate()
     let api = PigeonApiSecTrust(pigeonRegistrar: registrar, delegate: delegate)
 
-    let expect = expectation(description: "Wait for setCookie.")
-    let trust = createTrust(delegate: delegate)
-    var resultValue: Bool?
-
-    api.pigeonDelegate.evaluateWithError(pigeonApi: api, trust: trust) { result in
-      switch result {
-      case .success(let value):
-        resultValue = value
-      case .failure(_):
-        break
+    let resultValue: Bool = try await withCheckedThrowingContinuation { continuation in
+      let trust = createTrust(delegate: delegate)
+      api.pigeonDelegate.evaluateWithError(pigeonApi: api, trust: trust) { result in
+        switch result {
+        case .success(let value):
+          continuation.resume(returning: value)
+        case .failure(let error):
+          continuation.resume(throwing: error)
+        }
       }
-      expect.fulfill()
     }
-
-    wait(for: [expect], timeout: 5.0)
-    XCTAssertEqual(resultValue, true)
+    #expect(resultValue == true)
   }
 
-  func testCopyExceptions() {
+  @Test func copyExceptions() throws {
     let registrar = TestProxyApiRegistrar()
     let delegate = TestSecTrustProxyAPIDelegate()
     let api = PigeonApiSecTrust(pigeonRegistrar: registrar, delegate: delegate)
@@ -54,10 +51,10 @@ class SecTrustProxyAPITests: XCTestCase {
     let trust = createTrust(delegate: delegate)
     let value = try? api.pigeonDelegate.copyExceptions(pigeonApi: api, trust: trust)
 
-    XCTAssertEqual(value?.data, Data())
+    #expect(value?.data == Data())
   }
 
-  func testSetExceptions() {
+  @Test func setExceptions() throws {
     let registrar = TestProxyApiRegistrar()
     let delegate = TestSecTrustProxyAPIDelegate()
     let api = PigeonApiSecTrust(pigeonRegistrar: registrar, delegate: delegate)
@@ -66,10 +63,10 @@ class SecTrustProxyAPITests: XCTestCase {
     let value = try? api.pigeonDelegate.setExceptions(
       pigeonApi: api, trust: trust, exceptions: FlutterStandardTypedData(bytes: Data()))
 
-    XCTAssertEqual(value, false)
+    #expect(value == false)
   }
 
-  func testGetTrustResult() {
+  @Test func getTrustResult() throws {
     let registrar = TestProxyApiRegistrar()
     let delegate = TestSecTrustProxyAPIDelegate()
     let api = PigeonApiSecTrust(pigeonRegistrar: registrar, delegate: delegate)
@@ -77,11 +74,11 @@ class SecTrustProxyAPITests: XCTestCase {
     let trust = createTrust(delegate: delegate)
     let value = try? api.pigeonDelegate.getTrustResult(pigeonApi: api, trust: trust)
 
-    XCTAssertEqual(value?.result, SecTrustResultType.invalid)
-    XCTAssertEqual(value?.resultCode, -1)
+    #expect(value?.result == SecTrustResultType.invalid)
+    #expect(value?.resultCode == -1)
   }
 
-  func testCopyCertificateChain() {
+  @Test func copyCertificateChain() throws {
     let registrar = TestProxyApiRegistrar()
     let delegate = TestSecTrustProxyAPIDelegate()
     let api = PigeonApiSecTrust(pigeonRegistrar: registrar, delegate: delegate)
@@ -89,8 +86,8 @@ class SecTrustProxyAPITests: XCTestCase {
     let trust = createTrust(delegate: delegate)
     let value = try? api.pigeonDelegate.copyCertificateChain(pigeonApi: api, trust: trust)
 
-    XCTAssertEqual(value?.count, 1)
-    XCTAssertNotNil(value?.first?.value)
+    #expect(value?.count == 1)
+    #expect(value?.first?.value != nil)
   }
 }
 

--- a/packages/webview_flutter/webview_flutter_wkwebview/darwin/Tests/SecurityOriginProxyAPITests.swift
+++ b/packages/webview_flutter/webview_flutter_wkwebview/darwin/Tests/SecurityOriginProxyAPITests.swift
@@ -2,43 +2,44 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import Foundation
+import Testing
 import WebKit
-import XCTest
 
 @testable import webview_flutter_wkwebview
 
 @MainActor
-class SecurityOriginProxyAPITests: XCTestCase {
+@Suite struct SecurityOriginProxyAPITests {
   static let testSecurityOrigin = TestSecurityOrigin.customInit()
 
-  @MainActor func testHost() {
+  @MainActor @Test func host() throws {
     let registrar = TestProxyApiRegistrar()
     let api = registrar.apiDelegate.pigeonApiWKSecurityOrigin(registrar)
 
     let instance = SecurityOriginProxyAPITests.testSecurityOrigin
     let value = try? api.pigeonDelegate.host(pigeonApi: api, pigeonInstance: instance)
 
-    XCTAssertEqual(value, instance.host)
+    #expect(value == instance.host)
   }
 
-  @MainActor func testPort() {
+  @MainActor @Test func port() throws {
     let registrar = TestProxyApiRegistrar()
     let api = registrar.apiDelegate.pigeonApiWKSecurityOrigin(registrar)
 
     let instance = SecurityOriginProxyAPITests.testSecurityOrigin
     let value = try? api.pigeonDelegate.port(pigeonApi: api, pigeonInstance: instance)
 
-    XCTAssertEqual(value, Int64(instance.port))
+    #expect(value == Int64(instance.port))
   }
 
-  @MainActor func testSecurityProtocol() {
+  @MainActor @Test func securityProtocol() throws {
     let registrar = TestProxyApiRegistrar()
     let api = registrar.apiDelegate.pigeonApiWKSecurityOrigin(registrar)
 
     let instance = SecurityOriginProxyAPITests.testSecurityOrigin
     let value = try? api.pigeonDelegate.securityProtocol(pigeonApi: api, pigeonInstance: instance)
 
-    XCTAssertEqual(value, instance.`protocol`)
+    #expect(value == instance.`protocol`)
   }
 }
 

--- a/packages/webview_flutter/webview_flutter_wkwebview/darwin/Tests/SecurityOriginProxyAPITests.swift
+++ b/packages/webview_flutter/webview_flutter_wkwebview/darwin/Tests/SecurityOriginProxyAPITests.swift
@@ -12,7 +12,7 @@ import WebKit
 @Suite struct SecurityOriginProxyAPITests {
   static let testSecurityOrigin = TestSecurityOrigin.customInit()
 
-  @MainActor @Test func host() throws {
+  @MainActor @Test func host() {
     let registrar = TestProxyApiRegistrar()
     let api = registrar.apiDelegate.pigeonApiWKSecurityOrigin(registrar)
 
@@ -27,7 +27,7 @@ import WebKit
     let api = registrar.apiDelegate.pigeonApiWKSecurityOrigin(registrar)
 
     let instance = SecurityOriginProxyAPITests.testSecurityOrigin
-    let value = try? api.pigeonDelegate.port(pigeonApi: api, pigeonInstance: instance)
+    let value = try api.pigeonDelegate.port(pigeonApi: api, pigeonInstance: instance)
 
     #expect(value == Int64(instance.port))
   }
@@ -37,7 +37,7 @@ import WebKit
     let api = registrar.apiDelegate.pigeonApiWKSecurityOrigin(registrar)
 
     let instance = SecurityOriginProxyAPITests.testSecurityOrigin
-    let value = try? api.pigeonDelegate.securityProtocol(pigeonApi: api, pigeonInstance: instance)
+    let value = try api.pigeonDelegate.securityProtocol(pigeonApi: api, pigeonInstance: instance)
 
     #expect(value == instance.`protocol`)
   }

--- a/packages/webview_flutter/webview_flutter_wkwebview/darwin/Tests/UIDelegateProxyAPITests.swift
+++ b/packages/webview_flutter/webview_flutter_wkwebview/darwin/Tests/UIDelegateProxyAPITests.swift
@@ -9,7 +9,7 @@ import WebKit
 @testable import webview_flutter_wkwebview
 
 @Suite struct UIDelegateProxyAPITests {
-  @Test func pigeonDefaultConstructor() throws {
+  @Test func pigeonDefaultConstructor() {
     let registrar = TestProxyApiRegistrar()
     let api = registrar.apiDelegate.pigeonApiWKUIDelegate(registrar)
 

--- a/packages/webview_flutter/webview_flutter_wkwebview/darwin/Tests/UIDelegateProxyAPITests.swift
+++ b/packages/webview_flutter/webview_flutter_wkwebview/darwin/Tests/UIDelegateProxyAPITests.swift
@@ -2,21 +2,22 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import Foundation
+import Testing
 import WebKit
-import XCTest
 
 @testable import webview_flutter_wkwebview
 
-class UIDelegateProxyAPITests: XCTestCase {
-  func testPigeonDefaultConstructor() {
+@Suite struct UIDelegateProxyAPITests {
+  @Test func pigeonDefaultConstructor() throws {
     let registrar = TestProxyApiRegistrar()
     let api = registrar.apiDelegate.pigeonApiWKUIDelegate(registrar)
 
     let instance = try? api.pigeonDelegate.pigeonDefaultConstructor(pigeonApi: api)
-    XCTAssertNotNil(instance)
+    #expect(instance != nil)
   }
 
-  @MainActor func testOnCreateWebView() {
+  @MainActor @Test func onCreateWebView() throws {
     let api = TestDelegateApi()
     let registrar = TestProxyApiRegistrar()
     let instance = UIDelegateImpl(api: api, registrar: registrar)
@@ -28,12 +29,12 @@ class UIDelegateProxyAPITests: XCTestCase {
       webView, createWebViewWith: configuration, for: navigationAction,
       windowFeatures: WKWindowFeatures())
 
-    XCTAssertEqual(api.onCreateWebViewArgs, [webView, configuration, navigationAction])
-    XCTAssertNil(result)
+    #expect(api.onCreateWebViewArgs == [webView, configuration, navigationAction])
+    #expect(result == nil)
   }
 
   @available(iOS 15.0, macOS 12.0, *)
-  @MainActor func testRequestMediaCapturePermission() {
+  @MainActor @Test func requestMediaCapturePermission() async throws {
     let api = TestDelegateApi()
     let registrar = TestProxyApiRegistrar()
     let instance = UIDelegateImpl(api: api, registrar: registrar)
@@ -42,23 +43,20 @@ class UIDelegateProxyAPITests: XCTestCase {
     let frame = TestFrameInfo.instance
     let type: WKMediaCaptureType = .camera
 
-    var resultDecision: WKPermissionDecision?
-    let callbackExpectation = expectation(description: "Wait for callback.")
-    instance.webView(
-      webView, requestMediaCapturePermissionFor: origin, initiatedByFrame: frame, type: type
-    ) { decision in
-      resultDecision = decision
-      callbackExpectation.fulfill()
+    let resultDecision = await withCheckedContinuation { continuation in
+      instance.webView(
+        webView, requestMediaCapturePermissionFor: origin, initiatedByFrame: frame, type: type
+      ) { decision in
+        continuation.resume(returning: decision)
+      }
     }
 
-    wait(for: [callbackExpectation], timeout: 1.0)
-
-    XCTAssertEqual(
-      api.requestMediaCapturePermissionArgs, [webView, origin, frame, MediaCaptureType.camera])
-    XCTAssertEqual(resultDecision, .prompt)
+    #expect(
+      api.requestMediaCapturePermissionArgs == [webView, origin, frame, MediaCaptureType.camera])
+    #expect(resultDecision == .prompt)
   }
 
-  @MainActor func testRunJavaScriptAlertPanel() {
+  @MainActor @Test func runJavaScriptAlertPanel() throws {
     let api = TestDelegateApi()
     let registrar = TestProxyApiRegistrar()
     let instance = UIDelegateImpl(api: api, registrar: registrar)
@@ -70,10 +68,10 @@ class UIDelegateProxyAPITests: XCTestCase {
     {
     }
 
-    XCTAssertEqual(api.runJavaScriptAlertPanelArgs, [webView, message, frame])
+    #expect(api.runJavaScriptAlertPanelArgs == [webView, message, frame])
   }
 
-  @MainActor func testRunJavaScriptConfirmPanel() {
+  @MainActor @Test func runJavaScriptConfirmPanel() async throws {
     let api = TestDelegateApi()
     let registrar = TestProxyApiRegistrar()
     let instance = UIDelegateImpl(api: api, registrar: registrar)
@@ -81,22 +79,19 @@ class UIDelegateProxyAPITests: XCTestCase {
     let message = "myString"
     let frame = TestFrameInfo.instance
 
-    var confirmedResult: Bool?
-    let callbackExpectation = expectation(description: "Wait for callback.")
-    instance.webView(
-      webView, runJavaScriptConfirmPanelWithMessage: message, initiatedByFrame: frame
-    ) { confirmed in
-      confirmedResult = confirmed
-      callbackExpectation.fulfill()
+    let confirmedResult = await withCheckedContinuation { continuation in
+      instance.webView(
+        webView, runJavaScriptConfirmPanelWithMessage: message, initiatedByFrame: frame
+      ) { confirmed in
+        continuation.resume(returning: confirmed)
+      }
     }
 
-    wait(for: [callbackExpectation], timeout: 1.0)
-
-    XCTAssertEqual(api.runJavaScriptConfirmPanelArgs, [webView, message, frame])
-    XCTAssertEqual(confirmedResult, true)
+    #expect(api.runJavaScriptConfirmPanelArgs == [webView, message, frame])
+    #expect(confirmedResult == true)
   }
 
-  @MainActor func testRunJavaScriptTextInputPanel() {
+  @MainActor @Test func runJavaScriptTextInputPanel() async throws {
     let api = TestDelegateApi()
     let registrar = TestProxyApiRegistrar()
     let instance = UIDelegateImpl(api: api, registrar: registrar)
@@ -105,20 +100,17 @@ class UIDelegateProxyAPITests: XCTestCase {
     let defaultText = "myString3"
     let frame = TestFrameInfo.instance
 
-    var inputResult: String?
-    let callbackExpectation = expectation(description: "Wait for callback.")
-    instance.webView(
-      webView, runJavaScriptTextInputPanelWithPrompt: prompt, defaultText: defaultText,
-      initiatedByFrame: frame
-    ) { input in
-      inputResult = input
-      callbackExpectation.fulfill()
+    let inputResult = await withCheckedContinuation { continuation in
+      instance.webView(
+        webView, runJavaScriptTextInputPanelWithPrompt: prompt, defaultText: defaultText,
+        initiatedByFrame: frame
+      ) { input in
+        continuation.resume(returning: input)
+      }
     }
 
-    wait(for: [callbackExpectation], timeout: 1.0)
-
-    XCTAssertEqual(api.runJavaScriptTextInputPanelArgs, [webView, prompt, defaultText, frame])
-    XCTAssertEqual(inputResult, "myString2")
+    #expect(api.runJavaScriptTextInputPanelArgs == [webView, prompt, defaultText, frame])
+    #expect(inputResult == "myString2")
   }
 }
 

--- a/packages/webview_flutter/webview_flutter_wkwebview/darwin/Tests/UIViewProxyAPITests.swift
+++ b/packages/webview_flutter/webview_flutter_wkwebview/darwin/Tests/UIViewProxyAPITests.swift
@@ -2,7 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import XCTest
+import Foundation
+import Testing
 
 @testable import webview_flutter_wkwebview
 
@@ -10,9 +11,9 @@ import XCTest
   import UIKit
 #endif
 
-class UIViewProxyAPITests: XCTestCase {
+@Suite struct UIViewProxyAPITests {
   #if os(iOS)
-    @MainActor func testSetBackgroundColor() {
+    @MainActor @Test func setBackgroundColor() throws {
       let registrar = TestProxyApiRegistrar()
       let api = registrar.apiDelegate.pigeonApiUIView(registrar)
 
@@ -25,11 +26,10 @@ class UIViewProxyAPITests: XCTestCase {
         pigeonApi: api, pigeonInstance: instance,
         value: UIColor(red: red, green: green, blue: blue, alpha: alpha))
 
-      XCTAssertEqual(
-        instance.backgroundColor, UIColor(red: red, green: green, blue: blue, alpha: alpha))
+      #expect(instance.backgroundColor == UIColor(red: red, green: green, blue: blue, alpha: alpha))
     }
 
-    @MainActor func testSetOpaque() {
+    @MainActor @Test func setOpaque() throws {
       let registrar = TestProxyApiRegistrar()
       let api = registrar.apiDelegate.pigeonApiUIView(registrar)
 
@@ -37,7 +37,7 @@ class UIViewProxyAPITests: XCTestCase {
       let opaque = true
       try? api.pigeonDelegate.setOpaque(pigeonApi: api, pigeonInstance: instance, opaque: opaque)
 
-      XCTAssertEqual(instance.isOpaque, opaque)
+      #expect(instance.isOpaque == opaque)
     }
   #endif
 }

--- a/packages/webview_flutter/webview_flutter_wkwebview/darwin/Tests/UIViewProxyAPITests.swift
+++ b/packages/webview_flutter/webview_flutter_wkwebview/darwin/Tests/UIViewProxyAPITests.swift
@@ -22,7 +22,7 @@ import Testing
       let green = 0.2
       let blue = 0.3
       let alpha = 0.4
-      try? api.pigeonDelegate.setBackgroundColor(
+      try api.pigeonDelegate.setBackgroundColor(
         pigeonApi: api, pigeonInstance: instance,
         value: UIColor(red: red, green: green, blue: blue, alpha: alpha))
 
@@ -35,7 +35,7 @@ import Testing
 
       let instance = UIView(frame: .zero)
       let opaque = true
-      try? api.pigeonDelegate.setOpaque(pigeonApi: api, pigeonInstance: instance, opaque: opaque)
+      try api.pigeonDelegate.setOpaque(pigeonApi: api, pigeonInstance: instance, opaque: opaque)
 
       #expect(instance.isOpaque == opaque)
     }

--- a/packages/webview_flutter/webview_flutter_wkwebview/darwin/Tests/URLAuthenticationChallengeProxyAPITests.swift
+++ b/packages/webview_flutter/webview_flutter_wkwebview/darwin/Tests/URLAuthenticationChallengeProxyAPITests.swift
@@ -2,20 +2,25 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import XCTest
+import Foundation
+import Testing
 
 @testable import webview_flutter_wkwebview
 
-class URLAuthenticationChallengeProxyAPITests: XCTestCase {
-  func testGetProtectionSpace() {
+@Suite struct URLAuthenticationChallengeProxyAPITests {
+  @Test func getProtectionSpace() throws {
     let registrar = TestProxyApiRegistrar()
     let api = registrar.apiDelegate.pigeonApiURLAuthenticationChallenge(registrar)
 
     let instance = URLAuthenticationChallenge(
       protectionSpace: URLProtectionSpace(), proposedCredential: nil, previousFailureCount: 3,
       failureResponse: nil, error: nil, sender: TestURLAuthenticationChallengeSender())
-    let value = try? api.pigeonDelegate.getProtectionSpace(pigeonApi: api, pigeonInstance: instance)
+    let value = try api.pigeonDelegate.getProtectionSpace(pigeonApi: api, pigeonInstance: instance)
 
-    XCTAssertEqual(value, instance.protectionSpace)
+    #expect(value.host == instance.protectionSpace.host)
+    #expect(value.port == instance.protectionSpace.port)
+    #expect(value.protocol == instance.protectionSpace.protocol)
+    #expect(value.realm == instance.protectionSpace.realm)
+    #expect(value.authenticationMethod == instance.protectionSpace.authenticationMethod)
   }
 }

--- a/packages/webview_flutter/webview_flutter_wkwebview/darwin/Tests/URLAuthenticationChallengeProxyAPITests.swift
+++ b/packages/webview_flutter/webview_flutter_wkwebview/darwin/Tests/URLAuthenticationChallengeProxyAPITests.swift
@@ -17,7 +17,6 @@ import Testing
       failureResponse: nil, error: nil, sender: TestURLAuthenticationChallengeSender())
     let value = try api.pigeonDelegate.getProtectionSpace(pigeonApi: api, pigeonInstance: instance)
 
-    #expect(value.host == instance.protectionSpace.host)
     #expect(value.port == instance.protectionSpace.port)
     #expect(value.protocol == instance.protectionSpace.protocol)
     #expect(value.realm == instance.protectionSpace.realm)

--- a/packages/webview_flutter/webview_flutter_wkwebview/darwin/Tests/URLCredentialProxyAPITests.swift
+++ b/packages/webview_flutter/webview_flutter_wkwebview/darwin/Tests/URLCredentialProxyAPITests.swift
@@ -8,7 +8,7 @@ import Testing
 @testable import webview_flutter_wkwebview
 
 @Suite struct URLCredentialProxyAPITests {
-  @Test func withUser() throws {
+  @Test func withUser() {
     let registrar = TestProxyApiRegistrar()
     let api = registrar.apiDelegate.pigeonApiURLCredential(registrar)
 

--- a/packages/webview_flutter/webview_flutter_wkwebview/darwin/Tests/URLCredentialProxyAPITests.swift
+++ b/packages/webview_flutter/webview_flutter_wkwebview/darwin/Tests/URLCredentialProxyAPITests.swift
@@ -2,17 +2,18 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import XCTest
+import Foundation
+import Testing
 
 @testable import webview_flutter_wkwebview
 
-class URLCredentialProxyAPITests: XCTestCase {
-  func testWithUser() {
+@Suite struct URLCredentialProxyAPITests {
+  @Test func withUser() throws {
     let registrar = TestProxyApiRegistrar()
     let api = registrar.apiDelegate.pigeonApiURLCredential(registrar)
 
     let instance = try? api.pigeonDelegate.withUser(
       pigeonApi: api, user: "myString", password: "myString", persistence: .none)
-    XCTAssertNotNil(instance)
+    #expect(instance != nil)
   }
 }

--- a/packages/webview_flutter/webview_flutter_wkwebview/darwin/Tests/URLProtectionSpaceProxyAPITests.swift
+++ b/packages/webview_flutter/webview_flutter_wkwebview/darwin/Tests/URLProtectionSpaceProxyAPITests.swift
@@ -8,7 +8,7 @@ import Testing
 @testable import webview_flutter_wkwebview
 
 @Suite struct ProtectionSpaceProxyAPITests {
-  @Test func host() throws {
+  @Test func host() {
     let registrar = TestProxyApiRegistrar()
     let api = registrar.apiDelegate.pigeonApiURLProtectionSpace(registrar)
 
@@ -27,7 +27,7 @@ import Testing
     let instance = URLProtectionSpace(
       host: "host", port: 23, protocol: "protocol", realm: "realm", authenticationMethod: "myMethod"
     )
-    let value = try? api.pigeonDelegate.port(pigeonApi: api, pigeonInstance: instance)
+    let value = try api.pigeonDelegate.port(pigeonApi: api, pigeonInstance: instance)
 
     #expect(value == Int64(instance.port))
   }
@@ -39,7 +39,7 @@ import Testing
     let instance = URLProtectionSpace(
       host: "host", port: 23, protocol: "protocol", realm: "realm", authenticationMethod: "myMethod"
     )
-    let value = try? api.pigeonDelegate.realm(pigeonApi: api, pigeonInstance: instance)
+    let value = try api.pigeonDelegate.realm(pigeonApi: api, pigeonInstance: instance)
 
     #expect(value == instance.realm)
   }
@@ -51,7 +51,7 @@ import Testing
     let instance = URLProtectionSpace(
       host: "host", port: 23, protocol: "protocol", realm: "realm", authenticationMethod: "myMethod"
     )
-    let value = try? api.pigeonDelegate.authenticationMethod(
+    let value = try api.pigeonDelegate.authenticationMethod(
       pigeonApi: api, pigeonInstance: instance)
 
     #expect(value == instance.authenticationMethod)
@@ -64,7 +64,7 @@ import Testing
     let instance = TestProtectionSpace(
       host: "host", port: 23, protocol: "protocol", realm: "realm", authenticationMethod: "myMethod"
     )
-    let value = try? api.pigeonDelegate.getServerTrust(pigeonApi: api, pigeonInstance: instance)
+    let value = try api.pigeonDelegate.getServerTrust(pigeonApi: api, pigeonInstance: instance)
 
     #expect(value!.value == instance.serverTrust)
   }

--- a/packages/webview_flutter/webview_flutter_wkwebview/darwin/Tests/URLProtectionSpaceProxyAPITests.swift
+++ b/packages/webview_flutter/webview_flutter_wkwebview/darwin/Tests/URLProtectionSpaceProxyAPITests.swift
@@ -2,12 +2,13 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import XCTest
+import Foundation
+import Testing
 
 @testable import webview_flutter_wkwebview
 
-class ProtectionSpaceProxyAPITests: XCTestCase {
-  func testHost() {
+@Suite struct ProtectionSpaceProxyAPITests {
+  @Test func host() throws {
     let registrar = TestProxyApiRegistrar()
     let api = registrar.apiDelegate.pigeonApiURLProtectionSpace(registrar)
 
@@ -16,10 +17,10 @@ class ProtectionSpaceProxyAPITests: XCTestCase {
     )
     let value = try? api.pigeonDelegate.host(pigeonApi: api, pigeonInstance: instance)
 
-    XCTAssertEqual(value, instance.host)
+    #expect(value == instance.host)
   }
 
-  func testPort() {
+  @Test func port() throws {
     let registrar = TestProxyApiRegistrar()
     let api = registrar.apiDelegate.pigeonApiURLProtectionSpace(registrar)
 
@@ -28,10 +29,10 @@ class ProtectionSpaceProxyAPITests: XCTestCase {
     )
     let value = try? api.pigeonDelegate.port(pigeonApi: api, pigeonInstance: instance)
 
-    XCTAssertEqual(value, Int64(instance.port))
+    #expect(value == Int64(instance.port))
   }
 
-  func testRealm() {
+  @Test func realm() throws {
     let registrar = TestProxyApiRegistrar()
     let api = registrar.apiDelegate.pigeonApiURLProtectionSpace(registrar)
 
@@ -40,10 +41,10 @@ class ProtectionSpaceProxyAPITests: XCTestCase {
     )
     let value = try? api.pigeonDelegate.realm(pigeonApi: api, pigeonInstance: instance)
 
-    XCTAssertEqual(value, instance.realm)
+    #expect(value == instance.realm)
   }
 
-  func testAuthenticationMethod() {
+  @Test func authenticationMethod() throws {
     let registrar = TestProxyApiRegistrar()
     let api = registrar.apiDelegate.pigeonApiURLProtectionSpace(registrar)
 
@@ -53,10 +54,10 @@ class ProtectionSpaceProxyAPITests: XCTestCase {
     let value = try? api.pigeonDelegate.authenticationMethod(
       pigeonApi: api, pigeonInstance: instance)
 
-    XCTAssertEqual(value, instance.authenticationMethod)
+    #expect(value == instance.authenticationMethod)
   }
 
-  func testGetServerTrust() {
+  @Test func getServerTrust() throws {
     let registrar = TestProxyApiRegistrar()
     let api = registrar.apiDelegate.pigeonApiURLProtectionSpace(registrar)
 
@@ -65,7 +66,7 @@ class ProtectionSpaceProxyAPITests: XCTestCase {
     )
     let value = try? api.pigeonDelegate.getServerTrust(pigeonApi: api, pigeonInstance: instance)
 
-    XCTAssertEqual(value!.value, instance.serverTrust)
+    #expect(value!.value == instance.serverTrust)
   }
 }
 

--- a/packages/webview_flutter/webview_flutter_wkwebview/darwin/Tests/URLRequestProxyAPITests.swift
+++ b/packages/webview_flutter/webview_flutter_wkwebview/darwin/Tests/URLRequestProxyAPITests.swift
@@ -16,7 +16,7 @@ import Testing
 #endif
 
 @Suite struct RequestProxyAPITests {
-  @Test func pigeonDefaultConstructor() throws {
+  @Test func pigeonDefaultConstructor() {
     let registrar = TestProxyApiRegistrar()
     let api = registrar.apiDelegate.pigeonApiURLRequest(registrar)
 
@@ -29,7 +29,7 @@ import Testing
     let api = registrar.apiDelegate.pigeonApiURLRequest(registrar)
 
     let instance = URLRequestWrapper(URLRequest(url: URL(string: "http://google.com")!))
-    let value = try? api.pigeonDelegate.getUrl(pigeonApi: api, pigeonInstance: instance)
+    let value = try api.pigeonDelegate.getUrl(pigeonApi: api, pigeonInstance: instance)
 
     #expect(value == instance.value.url?.absoluteString)
   }
@@ -40,7 +40,7 @@ import Testing
 
     let instance = URLRequestWrapper(URLRequest(url: URL(string: "http://google.com")!))
     let method = "GET"
-    try? api.pigeonDelegate.setHttpMethod(pigeonApi: api, pigeonInstance: instance, method: method)
+    try api.pigeonDelegate.setHttpMethod(pigeonApi: api, pigeonInstance: instance, method: method)
 
     #expect(instance.value.httpMethod == method)
   }
@@ -53,7 +53,7 @@ import Testing
 
     let method = "POST"
     instance.value.httpMethod = method
-    let value = try? api.pigeonDelegate.getHttpMethod(pigeonApi: api, pigeonInstance: instance)
+    let value = try api.pigeonDelegate.getHttpMethod(pigeonApi: api, pigeonInstance: instance)
 
     #expect(value == method)
   }
@@ -64,7 +64,7 @@ import Testing
 
     let instance = URLRequestWrapper(URLRequest(url: URL(string: "http://google.com")!))
     let body = FlutterStandardTypedData(bytes: Data())
-    try? api.pigeonDelegate.setHttpBody(pigeonApi: api, pigeonInstance: instance, body: body)
+    try api.pigeonDelegate.setHttpBody(pigeonApi: api, pigeonInstance: instance, body: body)
 
     #expect(instance.value.httpBody == body.data)
   }
@@ -76,7 +76,7 @@ import Testing
     let instance = URLRequestWrapper(URLRequest(url: URL(string: "http://google.com")!))
     let body = FlutterStandardTypedData(bytes: Data())
     instance.value.httpBody = body.data
-    let value = try? api.pigeonDelegate.getHttpBody(pigeonApi: api, pigeonInstance: instance)
+    let value = try api.pigeonDelegate.getHttpBody(pigeonApi: api, pigeonInstance: instance)
 
     #expect(value?.data == body.data)
   }
@@ -87,7 +87,7 @@ import Testing
 
     let instance = URLRequestWrapper(URLRequest(url: URL(string: "http://google.com")!))
     let fields = ["key": "value"]
-    try? api.pigeonDelegate.setAllHttpHeaderFields(
+    try api.pigeonDelegate.setAllHttpHeaderFields(
       pigeonApi: api, pigeonInstance: instance, fields: fields)
 
     #expect(instance.value.allHTTPHeaderFields == fields)
@@ -101,7 +101,7 @@ import Testing
     let fields = ["key": "value"]
     instance.value.allHTTPHeaderFields = fields
 
-    let value = try? api.pigeonDelegate.getAllHttpHeaderFields(
+    let value = try api.pigeonDelegate.getAllHttpHeaderFields(
       pigeonApi: api, pigeonInstance: instance)
 
     #expect(value == fields)

--- a/packages/webview_flutter/webview_flutter_wkwebview/darwin/Tests/URLRequestProxyAPITests.swift
+++ b/packages/webview_flutter/webview_flutter_wkwebview/darwin/Tests/URLRequestProxyAPITests.swift
@@ -2,7 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import XCTest
+import Foundation
+import Testing
 
 @testable import webview_flutter_wkwebview
 
@@ -14,26 +15,26 @@ import XCTest
   #error("Unsupported platform.")
 #endif
 
-class RequestProxyAPITests: XCTestCase {
-  func testPigeonDefaultConstructor() {
+@Suite struct RequestProxyAPITests {
+  @Test func pigeonDefaultConstructor() throws {
     let registrar = TestProxyApiRegistrar()
     let api = registrar.apiDelegate.pigeonApiURLRequest(registrar)
 
     let instance = try? api.pigeonDelegate.pigeonDefaultConstructor(pigeonApi: api, url: "myString")
-    XCTAssertNotNil(instance)
+    #expect(instance != nil)
   }
 
-  func testGetUrl() {
+  @Test func getUrl() throws {
     let registrar = TestProxyApiRegistrar()
     let api = registrar.apiDelegate.pigeonApiURLRequest(registrar)
 
     let instance = URLRequestWrapper(URLRequest(url: URL(string: "http://google.com")!))
     let value = try? api.pigeonDelegate.getUrl(pigeonApi: api, pigeonInstance: instance)
 
-    XCTAssertEqual(value, instance.value.url?.absoluteString)
+    #expect(value == instance.value.url?.absoluteString)
   }
 
-  func testSetHttpMethod() {
+  @Test func setHttpMethod() throws {
     let registrar = TestProxyApiRegistrar()
     let api = registrar.apiDelegate.pigeonApiURLRequest(registrar)
 
@@ -41,10 +42,10 @@ class RequestProxyAPITests: XCTestCase {
     let method = "GET"
     try? api.pigeonDelegate.setHttpMethod(pigeonApi: api, pigeonInstance: instance, method: method)
 
-    XCTAssertEqual(instance.value.httpMethod, method)
+    #expect(instance.value.httpMethod == method)
   }
 
-  func testGetHttpMethod() {
+  @Test func getHttpMethod() throws {
     let registrar = TestProxyApiRegistrar()
     let api = registrar.apiDelegate.pigeonApiURLRequest(registrar)
 
@@ -54,10 +55,10 @@ class RequestProxyAPITests: XCTestCase {
     instance.value.httpMethod = method
     let value = try? api.pigeonDelegate.getHttpMethod(pigeonApi: api, pigeonInstance: instance)
 
-    XCTAssertEqual(value, method)
+    #expect(value == method)
   }
 
-  func testSetHttpBody() {
+  @Test func setHttpBody() throws {
     let registrar = TestProxyApiRegistrar()
     let api = registrar.apiDelegate.pigeonApiURLRequest(registrar)
 
@@ -65,10 +66,10 @@ class RequestProxyAPITests: XCTestCase {
     let body = FlutterStandardTypedData(bytes: Data())
     try? api.pigeonDelegate.setHttpBody(pigeonApi: api, pigeonInstance: instance, body: body)
 
-    XCTAssertEqual(instance.value.httpBody, body.data)
+    #expect(instance.value.httpBody == body.data)
   }
 
-  func testGetHttpBody() {
+  @Test func getHttpBody() throws {
     let registrar = TestProxyApiRegistrar()
     let api = registrar.apiDelegate.pigeonApiURLRequest(registrar)
 
@@ -77,10 +78,10 @@ class RequestProxyAPITests: XCTestCase {
     instance.value.httpBody = body.data
     let value = try? api.pigeonDelegate.getHttpBody(pigeonApi: api, pigeonInstance: instance)
 
-    XCTAssertEqual(value?.data, body.data)
+    #expect(value?.data == body.data)
   }
 
-  func testSetAllHttpHeaderFields() {
+  @Test func setAllHttpHeaderFields() throws {
     let registrar = TestProxyApiRegistrar()
     let api = registrar.apiDelegate.pigeonApiURLRequest(registrar)
 
@@ -89,10 +90,10 @@ class RequestProxyAPITests: XCTestCase {
     try? api.pigeonDelegate.setAllHttpHeaderFields(
       pigeonApi: api, pigeonInstance: instance, fields: fields)
 
-    XCTAssertEqual(instance.value.allHTTPHeaderFields, fields)
+    #expect(instance.value.allHTTPHeaderFields == fields)
   }
 
-  func testGetAllHttpHeaderFields() {
+  @Test func getAllHttpHeaderFields() throws {
     let registrar = TestProxyApiRegistrar()
     let api = registrar.apiDelegate.pigeonApiURLRequest(registrar)
 
@@ -103,6 +104,6 @@ class RequestProxyAPITests: XCTestCase {
     let value = try? api.pigeonDelegate.getAllHttpHeaderFields(
       pigeonApi: api, pigeonInstance: instance)
 
-    XCTAssertEqual(value, fields)
+    #expect(value == fields)
   }
 }

--- a/packages/webview_flutter/webview_flutter_wkwebview/darwin/Tests/UserContentControllerProxyAPITests.swift
+++ b/packages/webview_flutter/webview_flutter_wkwebview/darwin/Tests/UserContentControllerProxyAPITests.swift
@@ -17,7 +17,7 @@ import WebKit
     let handler = ScriptMessageHandlerImpl(
       api: registrar.apiDelegate.pigeonApiWKScriptMessageHandler(registrar), registrar: registrar)
     let name = "myString"
-    try? api.pigeonDelegate.addScriptMessageHandler(
+    try api.pigeonDelegate.addScriptMessageHandler(
       pigeonApi: api, pigeonInstance: instance, handler: handler, name: name)
 
     #expect(instance.addScriptMessageHandlerArgs == [handler, name])
@@ -29,7 +29,7 @@ import WebKit
 
     let instance = TestUserContentController()
     let name = "myString"
-    try? api.pigeonDelegate.removeScriptMessageHandler(
+    try api.pigeonDelegate.removeScriptMessageHandler(
       pigeonApi: api, pigeonInstance: instance, name: name)
 
     #expect(instance.removeScriptMessageHandlerArgs == [name])
@@ -40,7 +40,7 @@ import WebKit
     let api = registrar.apiDelegate.pigeonApiWKUserContentController(registrar)
 
     let instance = TestUserContentController()
-    try? api.pigeonDelegate.removeAllScriptMessageHandlers(pigeonApi: api, pigeonInstance: instance)
+    try api.pigeonDelegate.removeAllScriptMessageHandlers(pigeonApi: api, pigeonInstance: instance)
 
     #expect(instance.removeAllScriptMessageHandlersCalled)
   }
@@ -51,7 +51,7 @@ import WebKit
 
     let instance = TestUserContentController()
     let userScript = WKUserScript(source: "", injectionTime: .atDocumentEnd, forMainFrameOnly: true)
-    try? api.pigeonDelegate.addUserScript(
+    try api.pigeonDelegate.addUserScript(
       pigeonApi: api, pigeonInstance: instance, userScript: userScript)
 
     #expect(instance.addUserScriptArgs == [userScript])
@@ -62,7 +62,7 @@ import WebKit
     let api = registrar.apiDelegate.pigeonApiWKUserContentController(registrar)
 
     let instance = TestUserContentController()
-    try? api.pigeonDelegate.removeAllUserScripts(pigeonApi: api, pigeonInstance: instance)
+    try api.pigeonDelegate.removeAllUserScripts(pigeonApi: api, pigeonInstance: instance)
 
     #expect(instance.removeAllUserScriptsCalled)
   }

--- a/packages/webview_flutter/webview_flutter_wkwebview/darwin/Tests/UserContentControllerProxyAPITests.swift
+++ b/packages/webview_flutter/webview_flutter_wkwebview/darwin/Tests/UserContentControllerProxyAPITests.swift
@@ -2,13 +2,14 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import Foundation
+import Testing
 import WebKit
-import XCTest
 
 @testable import webview_flutter_wkwebview
 
-class UserContentControllerProxyAPITests: XCTestCase {
-  @MainActor func testAddScriptMessageHandler() {
+@Suite struct UserContentControllerProxyAPITests {
+  @MainActor @Test func addScriptMessageHandler() throws {
     let registrar = TestProxyApiRegistrar()
     let api = registrar.apiDelegate.pigeonApiWKUserContentController(registrar)
 
@@ -19,10 +20,10 @@ class UserContentControllerProxyAPITests: XCTestCase {
     try? api.pigeonDelegate.addScriptMessageHandler(
       pigeonApi: api, pigeonInstance: instance, handler: handler, name: name)
 
-    XCTAssertEqual(instance.addScriptMessageHandlerArgs, [handler, name])
+    #expect(instance.addScriptMessageHandlerArgs == [handler, name])
   }
 
-  @MainActor func testRemoveScriptMessageHandler() {
+  @MainActor @Test func removeScriptMessageHandler() throws {
     let registrar = TestProxyApiRegistrar()
     let api = registrar.apiDelegate.pigeonApiWKUserContentController(registrar)
 
@@ -31,20 +32,20 @@ class UserContentControllerProxyAPITests: XCTestCase {
     try? api.pigeonDelegate.removeScriptMessageHandler(
       pigeonApi: api, pigeonInstance: instance, name: name)
 
-    XCTAssertEqual(instance.removeScriptMessageHandlerArgs, [name])
+    #expect(instance.removeScriptMessageHandlerArgs == [name])
   }
 
-  @MainActor func testRemoveAllScriptMessageHandlers() {
+  @MainActor @Test func removeAllScriptMessageHandlers() throws {
     let registrar = TestProxyApiRegistrar()
     let api = registrar.apiDelegate.pigeonApiWKUserContentController(registrar)
 
     let instance = TestUserContentController()
     try? api.pigeonDelegate.removeAllScriptMessageHandlers(pigeonApi: api, pigeonInstance: instance)
 
-    XCTAssertTrue(instance.removeAllScriptMessageHandlersCalled)
+    #expect(instance.removeAllScriptMessageHandlersCalled)
   }
 
-  @MainActor func testAddUserScript() {
+  @MainActor @Test func addUserScript() throws {
     let registrar = TestProxyApiRegistrar()
     let api = registrar.apiDelegate.pigeonApiWKUserContentController(registrar)
 
@@ -53,17 +54,17 @@ class UserContentControllerProxyAPITests: XCTestCase {
     try? api.pigeonDelegate.addUserScript(
       pigeonApi: api, pigeonInstance: instance, userScript: userScript)
 
-    XCTAssertEqual(instance.addUserScriptArgs, [userScript])
+    #expect(instance.addUserScriptArgs == [userScript])
   }
 
-  @MainActor func testRemoveAllUserScripts() {
+  @MainActor @Test func removeAllUserScripts() throws {
     let registrar = TestProxyApiRegistrar()
     let api = registrar.apiDelegate.pigeonApiWKUserContentController(registrar)
 
     let instance = TestUserContentController()
     try? api.pigeonDelegate.removeAllUserScripts(pigeonApi: api, pigeonInstance: instance)
 
-    XCTAssertTrue(instance.removeAllUserScriptsCalled)
+    #expect(instance.removeAllUserScriptsCalled)
   }
 
 }

--- a/packages/webview_flutter/webview_flutter_wkwebview/darwin/Tests/UserScriptProxyAPITests.swift
+++ b/packages/webview_flutter/webview_flutter_wkwebview/darwin/Tests/UserScriptProxyAPITests.swift
@@ -2,22 +2,23 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import Foundation
+import Testing
 import WebKit
-import XCTest
 
 @testable import webview_flutter_wkwebview
 
-class UserScriptProxyAPITests: XCTestCase {
-  func testPigeonDefaultConstructor() {
+@Suite struct UserScriptProxyAPITests {
+  @Test func pigeonDefaultConstructor() throws {
     let registrar = TestProxyApiRegistrar()
     let api = registrar.apiDelegate.pigeonApiWKUserScript(registrar)
 
     let instance = try? api.pigeonDelegate.pigeonDefaultConstructor(
       pigeonApi: api, source: "myString", injectionTime: .atDocumentStart, isForMainFrameOnly: true)
-    XCTAssertNotNil(instance)
+    #expect(instance != nil)
   }
 
-  @MainActor func testSource() {
+  @MainActor @Test func source() throws {
     let registrar = TestProxyApiRegistrar()
     let api = registrar.apiDelegate.pigeonApiWKUserScript(registrar)
 
@@ -25,10 +26,10 @@ class UserScriptProxyAPITests: XCTestCase {
       source: "source", injectionTime: .atDocumentEnd, forMainFrameOnly: false)
     let value = try? api.pigeonDelegate.source(pigeonApi: api, pigeonInstance: instance)
 
-    XCTAssertEqual(value, instance.source)
+    #expect(value == instance.source)
   }
 
-  @MainActor func testInjectionTime() {
+  @MainActor @Test func injectionTime() throws {
     let registrar = TestProxyApiRegistrar()
     let api = registrar.apiDelegate.pigeonApiWKUserScript(registrar)
 
@@ -36,10 +37,10 @@ class UserScriptProxyAPITests: XCTestCase {
       source: "source", injectionTime: .atDocumentEnd, forMainFrameOnly: false)
     let value = try? api.pigeonDelegate.injectionTime(pigeonApi: api, pigeonInstance: instance)
 
-    XCTAssertEqual(value, .atDocumentEnd)
+    #expect(value == .atDocumentEnd)
   }
 
-  @MainActor func testIsMainFrameOnly() {
+  @MainActor @Test func isMainFrameOnly() throws {
     let registrar = TestProxyApiRegistrar()
     let api = registrar.apiDelegate.pigeonApiWKUserScript(registrar)
 
@@ -47,6 +48,6 @@ class UserScriptProxyAPITests: XCTestCase {
       source: "source", injectionTime: .atDocumentEnd, forMainFrameOnly: false)
     let value = try? api.pigeonDelegate.isForMainFrameOnly(pigeonApi: api, pigeonInstance: instance)
 
-    XCTAssertEqual(value, instance.isForMainFrameOnly)
+    #expect(value == instance.isForMainFrameOnly)
   }
 }

--- a/packages/webview_flutter/webview_flutter_wkwebview/darwin/Tests/UserScriptProxyAPITests.swift
+++ b/packages/webview_flutter/webview_flutter_wkwebview/darwin/Tests/UserScriptProxyAPITests.swift
@@ -9,7 +9,7 @@ import WebKit
 @testable import webview_flutter_wkwebview
 
 @Suite struct UserScriptProxyAPITests {
-  @MainActor @Test func pigeonDefaultConstructor() throws {
+  @MainActor @Test func pigeonDefaultConstructor() {
     let registrar = TestProxyApiRegistrar()
     let api = registrar.apiDelegate.pigeonApiWKUserScript(registrar)
 
@@ -24,7 +24,7 @@ import WebKit
 
     let instance = WKUserScript(
       source: "source", injectionTime: .atDocumentEnd, forMainFrameOnly: false)
-    let value = try? api.pigeonDelegate.source(pigeonApi: api, pigeonInstance: instance)
+    let value = try api.pigeonDelegate.source(pigeonApi: api, pigeonInstance: instance)
 
     #expect(value == instance.source)
   }
@@ -35,7 +35,7 @@ import WebKit
 
     let instance = WKUserScript(
       source: "source", injectionTime: .atDocumentEnd, forMainFrameOnly: false)
-    let value = try? api.pigeonDelegate.injectionTime(pigeonApi: api, pigeonInstance: instance)
+    let value = try api.pigeonDelegate.injectionTime(pigeonApi: api, pigeonInstance: instance)
 
     #expect(value == .atDocumentEnd)
   }
@@ -46,7 +46,7 @@ import WebKit
 
     let instance = WKUserScript(
       source: "source", injectionTime: .atDocumentEnd, forMainFrameOnly: false)
-    let value = try? api.pigeonDelegate.isForMainFrameOnly(pigeonApi: api, pigeonInstance: instance)
+    let value = try api.pigeonDelegate.isForMainFrameOnly(pigeonApi: api, pigeonInstance: instance)
 
     #expect(value == instance.isForMainFrameOnly)
   }

--- a/packages/webview_flutter/webview_flutter_wkwebview/darwin/Tests/UserScriptProxyAPITests.swift
+++ b/packages/webview_flutter/webview_flutter_wkwebview/darwin/Tests/UserScriptProxyAPITests.swift
@@ -9,7 +9,7 @@ import WebKit
 @testable import webview_flutter_wkwebview
 
 @Suite struct UserScriptProxyAPITests {
-  @Test func pigeonDefaultConstructor() throws {
+  @MainActor @Test func pigeonDefaultConstructor() throws {
     let registrar = TestProxyApiRegistrar()
     let api = registrar.apiDelegate.pigeonApiWKUserScript(registrar)
 

--- a/packages/webview_flutter/webview_flutter_wkwebview/darwin/Tests/WebViewConfigurationProxyAPITests.swift
+++ b/packages/webview_flutter/webview_flutter_wkwebview/darwin/Tests/WebViewConfigurationProxyAPITests.swift
@@ -9,7 +9,7 @@ import WebKit
 @testable import webview_flutter_wkwebview
 
 @Suite struct WebViewConfigurationProxyAPITests {
-  @Test func pigeonDefaultConstructor() throws {
+  @Test func pigeonDefaultConstructor() {
     let registrar = TestProxyApiRegistrar()
     let api = registrar.apiDelegate.pigeonApiWKWebViewConfiguration(registrar)
 
@@ -23,7 +23,7 @@ import WebKit
 
     let instance = WKWebViewConfiguration()
     let controller = WKUserContentController()
-    try? api.pigeonDelegate.setUserContentController(
+    try api.pigeonDelegate.setUserContentController(
       pigeonApi: api, pigeonInstance: instance, controller: controller)
 
     #expect(instance.userContentController == controller)
@@ -34,7 +34,7 @@ import WebKit
     let api = registrar.apiDelegate.pigeonApiWKWebViewConfiguration(registrar)
 
     let instance = WKWebViewConfiguration()
-    let value = try? api.pigeonDelegate.getUserContentController(
+    let value = try api.pigeonDelegate.getUserContentController(
       pigeonApi: api, pigeonInstance: instance)
 
     #expect(value == instance.userContentController)
@@ -46,7 +46,7 @@ import WebKit
 
     let instance = WKWebViewConfiguration()
     let dataStore = WKWebsiteDataStore.default()
-    try? api.pigeonDelegate.setWebsiteDataStore(
+    try api.pigeonDelegate.setWebsiteDataStore(
       pigeonApi: api, pigeonInstance: instance, dataStore: dataStore)
 
     #expect(instance.websiteDataStore == dataStore)
@@ -57,7 +57,7 @@ import WebKit
     let api = registrar.apiDelegate.pigeonApiWKWebViewConfiguration(registrar)
 
     let instance = WKWebViewConfiguration()
-    let value = try? api.pigeonDelegate.getWebsiteDataStore(
+    let value = try api.pigeonDelegate.getWebsiteDataStore(
       pigeonApi: api, pigeonInstance: instance)
 
     #expect(value == instance.websiteDataStore)
@@ -69,7 +69,7 @@ import WebKit
 
     let instance = WKWebViewConfiguration()
     let preferences = WKPreferences()
-    try? api.pigeonDelegate.setPreferences(
+    try api.pigeonDelegate.setPreferences(
       pigeonApi: api, pigeonInstance: instance, preferences: preferences)
 
     #expect(instance.preferences == preferences)
@@ -80,7 +80,7 @@ import WebKit
     let api = registrar.apiDelegate.pigeonApiWKWebViewConfiguration(registrar)
 
     let instance = WKWebViewConfiguration()
-    let value = try? api.pigeonDelegate.getPreferences(pigeonApi: api, pigeonInstance: instance)
+    let value = try api.pigeonDelegate.getPreferences(pigeonApi: api, pigeonInstance: instance)
 
     #expect(value == instance.preferences)
   }
@@ -91,7 +91,7 @@ import WebKit
 
     let instance = WKWebViewConfiguration()
     let allow = true
-    try? api.pigeonDelegate.setAllowsInlineMediaPlayback(
+    try api.pigeonDelegate.setAllowsInlineMediaPlayback(
       pigeonApi: api, pigeonInstance: instance, allow: allow)
 
     // setAllowsInlineMediaPlayback does not existing on macOS; the call above should no-op for macOS.
@@ -107,7 +107,7 @@ import WebKit
 
     let instance = WKWebViewConfiguration()
     let limit = true
-    try? api.pigeonDelegate.setLimitsNavigationsToAppBoundDomains(
+    try api.pigeonDelegate.setLimitsNavigationsToAppBoundDomains(
       pigeonApi: api, pigeonInstance: instance, limit: limit)
 
     #expect(instance.limitsNavigationsToAppBoundDomains == limit)
@@ -119,7 +119,7 @@ import WebKit
 
     let instance = WKWebViewConfiguration()
     let type: AudiovisualMediaType = .none
-    try? api.pigeonDelegate.setMediaTypesRequiringUserActionForPlayback(
+    try api.pigeonDelegate.setMediaTypesRequiringUserActionForPlayback(
       pigeonApi: api, pigeonInstance: instance, type: type)
 
     #expect(instance.mediaTypesRequiringUserActionForPlayback == [])
@@ -130,7 +130,7 @@ import WebKit
     let api = registrar.apiDelegate.pigeonApiWKWebViewConfiguration(registrar)
 
     let instance = WKWebViewConfiguration()
-    let value = try? api.pigeonDelegate.getDefaultWebpagePreferences(
+    let value = try api.pigeonDelegate.getDefaultWebpagePreferences(
       pigeonApi: api, pigeonInstance: instance)
 
     #expect(value == instance.defaultWebpagePreferences)

--- a/packages/webview_flutter/webview_flutter_wkwebview/darwin/Tests/WebViewConfigurationProxyAPITests.swift
+++ b/packages/webview_flutter/webview_flutter_wkwebview/darwin/Tests/WebViewConfigurationProxyAPITests.swift
@@ -2,21 +2,22 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import Foundation
+import Testing
 import WebKit
-import XCTest
 
 @testable import webview_flutter_wkwebview
 
-class WebViewConfigurationProxyAPITests: XCTestCase {
-  func testPigeonDefaultConstructor() {
+@Suite struct WebViewConfigurationProxyAPITests {
+  @Test func pigeonDefaultConstructor() throws {
     let registrar = TestProxyApiRegistrar()
     let api = registrar.apiDelegate.pigeonApiWKWebViewConfiguration(registrar)
 
     let instance = try? api.pigeonDelegate.pigeonDefaultConstructor(pigeonApi: api)
-    XCTAssertNotNil(instance)
+    #expect(instance != nil)
   }
 
-  @MainActor func testSetUserContentController() {
+  @MainActor @Test func setUserContentController() throws {
     let registrar = TestProxyApiRegistrar()
     let api = registrar.apiDelegate.pigeonApiWKWebViewConfiguration(registrar)
 
@@ -25,10 +26,10 @@ class WebViewConfigurationProxyAPITests: XCTestCase {
     try? api.pigeonDelegate.setUserContentController(
       pigeonApi: api, pigeonInstance: instance, controller: controller)
 
-    XCTAssertEqual(instance.userContentController, controller)
+    #expect(instance.userContentController == controller)
   }
 
-  @MainActor func testGetUserContentController() {
+  @MainActor @Test func getUserContentController() throws {
     let registrar = TestProxyApiRegistrar()
     let api = registrar.apiDelegate.pigeonApiWKWebViewConfiguration(registrar)
 
@@ -36,10 +37,10 @@ class WebViewConfigurationProxyAPITests: XCTestCase {
     let value = try? api.pigeonDelegate.getUserContentController(
       pigeonApi: api, pigeonInstance: instance)
 
-    XCTAssertEqual(value, instance.userContentController)
+    #expect(value == instance.userContentController)
   }
 
-  @MainActor func testSetWebsiteDataStore() {
+  @MainActor @Test func setWebsiteDataStore() throws {
     let registrar = TestProxyApiRegistrar()
     let api = registrar.apiDelegate.pigeonApiWKWebViewConfiguration(registrar)
 
@@ -48,10 +49,10 @@ class WebViewConfigurationProxyAPITests: XCTestCase {
     try? api.pigeonDelegate.setWebsiteDataStore(
       pigeonApi: api, pigeonInstance: instance, dataStore: dataStore)
 
-    XCTAssertEqual(instance.websiteDataStore, dataStore)
+    #expect(instance.websiteDataStore == dataStore)
   }
 
-  @MainActor func testGetWebsiteDataStore() {
+  @MainActor @Test func getWebsiteDataStore() throws {
     let registrar = TestProxyApiRegistrar()
     let api = registrar.apiDelegate.pigeonApiWKWebViewConfiguration(registrar)
 
@@ -59,10 +60,10 @@ class WebViewConfigurationProxyAPITests: XCTestCase {
     let value = try? api.pigeonDelegate.getWebsiteDataStore(
       pigeonApi: api, pigeonInstance: instance)
 
-    XCTAssertEqual(value, instance.websiteDataStore)
+    #expect(value == instance.websiteDataStore)
   }
 
-  @MainActor func testSetPreferences() {
+  @MainActor @Test func setPreferences() throws {
     let registrar = TestProxyApiRegistrar()
     let api = registrar.apiDelegate.pigeonApiWKWebViewConfiguration(registrar)
 
@@ -71,20 +72,20 @@ class WebViewConfigurationProxyAPITests: XCTestCase {
     try? api.pigeonDelegate.setPreferences(
       pigeonApi: api, pigeonInstance: instance, preferences: preferences)
 
-    XCTAssertEqual(instance.preferences, preferences)
+    #expect(instance.preferences == preferences)
   }
 
-  @MainActor func testGetPreferences() {
+  @MainActor @Test func getPreferences() throws {
     let registrar = TestProxyApiRegistrar()
     let api = registrar.apiDelegate.pigeonApiWKWebViewConfiguration(registrar)
 
     let instance = WKWebViewConfiguration()
     let value = try? api.pigeonDelegate.getPreferences(pigeonApi: api, pigeonInstance: instance)
 
-    XCTAssertEqual(value, instance.preferences)
+    #expect(value == instance.preferences)
   }
 
-  @MainActor func testSetAllowsInlineMediaPlayback() {
+  @MainActor @Test func setAllowsInlineMediaPlayback() throws {
     let registrar = TestProxyApiRegistrar()
     let api = registrar.apiDelegate.pigeonApiWKWebViewConfiguration(registrar)
 
@@ -95,12 +96,12 @@ class WebViewConfigurationProxyAPITests: XCTestCase {
 
     // setAllowsInlineMediaPlayback does not existing on macOS; the call above should no-op for macOS.
     #if !os(macOS)
-      XCTAssertEqual(instance.allowsInlineMediaPlayback, allow)
+      #expect(instance.allowsInlineMediaPlayback == allow)
     #endif
   }
 
   @available(iOS 14.0, macOS 11.0, *)
-  @MainActor func testSetLimitsNavigationsToAppBoundDomains() {
+  @MainActor @Test func setLimitsNavigationsToAppBoundDomains() throws {
     let registrar = TestProxyApiRegistrar()
     let api = registrar.apiDelegate.pigeonApiWKWebViewConfiguration(registrar)
 
@@ -109,10 +110,10 @@ class WebViewConfigurationProxyAPITests: XCTestCase {
     try? api.pigeonDelegate.setLimitsNavigationsToAppBoundDomains(
       pigeonApi: api, pigeonInstance: instance, limit: limit)
 
-    XCTAssertEqual(instance.limitsNavigationsToAppBoundDomains, limit)
+    #expect(instance.limitsNavigationsToAppBoundDomains == limit)
   }
 
-  @MainActor func testSetMediaTypesRequiringUserActionForPlayback() {
+  @MainActor @Test func setMediaTypesRequiringUserActionForPlayback() throws {
     let registrar = TestProxyApiRegistrar()
     let api = registrar.apiDelegate.pigeonApiWKWebViewConfiguration(registrar)
 
@@ -121,10 +122,10 @@ class WebViewConfigurationProxyAPITests: XCTestCase {
     try? api.pigeonDelegate.setMediaTypesRequiringUserActionForPlayback(
       pigeonApi: api, pigeonInstance: instance, type: type)
 
-    XCTAssertEqual(instance.mediaTypesRequiringUserActionForPlayback, [])
+    #expect(instance.mediaTypesRequiringUserActionForPlayback == [])
   }
 
-  @MainActor func testGetDefaultWebpagePreferences() {
+  @MainActor @Test func getDefaultWebpagePreferences() throws {
     let registrar = TestProxyApiRegistrar()
     let api = registrar.apiDelegate.pigeonApiWKWebViewConfiguration(registrar)
 
@@ -132,6 +133,6 @@ class WebViewConfigurationProxyAPITests: XCTestCase {
     let value = try? api.pigeonDelegate.getDefaultWebpagePreferences(
       pigeonApi: api, pigeonInstance: instance)
 
-    XCTAssertEqual(value, instance.defaultWebpagePreferences)
+    #expect(value == instance.defaultWebpagePreferences)
   }
 }

--- a/packages/webview_flutter/webview_flutter_wkwebview/darwin/Tests/WebViewFlutterPluginTests.swift
+++ b/packages/webview_flutter/webview_flutter_wkwebview/darwin/Tests/WebViewFlutterPluginTests.swift
@@ -14,7 +14,7 @@ import Testing
 
 @Suite struct WebViewFlutterPluginTests {
   #if os(iOS)
-    @Test func instanceManagerIsDeallocatedInApplicationWillTerminate() async throws {
+    @MainActor @Test func instanceManagerIsDeallocatedInApplicationWillTerminate() async throws {
       let plugin = WebViewFlutterPlugin(binaryMessenger: TestBinaryMessenger())
       plugin.proxyApiRegistrar!.setUp()
 
@@ -45,7 +45,7 @@ import Testing
       }
     }
 
-    @Test func instanceManagerIsDeallocatedInSceneDidDisconnect() async throws {
+    @MainActor @Test func instanceManagerIsDeallocatedInSceneDidDisconnect() async throws {
       let plugin = WebViewFlutterPlugin(binaryMessenger: TestBinaryMessenger())
       plugin.proxyApiRegistrar!.setUp()
 

--- a/packages/webview_flutter/webview_flutter_wkwebview/darwin/Tests/WebViewFlutterPluginTests.swift
+++ b/packages/webview_flutter/webview_flutter_wkwebview/darwin/Tests/WebViewFlutterPluginTests.swift
@@ -2,7 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import XCTest
+import Foundation
+import Testing
 
 @testable import webview_flutter_wkwebview
 
@@ -11,9 +12,9 @@ import XCTest
   import UIKit
 #endif
 
-class WebViewFlutterPluginTests: XCTestCase {
+@Suite struct WebViewFlutterPluginTests {
   #if os(iOS)
-    func testInstanceManagerIsDeallocatedInApplicationWillTerminate() {
+    @Test func instanceManagerIsDeallocatedInApplicationWillTerminate() async throws {
       let plugin = WebViewFlutterPlugin(binaryMessenger: TestBinaryMessenger())
       plugin.proxyApiRegistrar!.setUp()
 
@@ -29,21 +30,22 @@ class WebViewFlutterPluginTests: XCTestCase {
       }
       objc_setAssociatedObject(
         plugin.proxyApiRegistrar!.instanceManager, key, finalizer, .OBJC_ASSOCIATION_RETAIN)
-      let expectation = self.expectation(description: "Wait for InstanceManager to be deallocated.")
-      TestFinalizer.onDeinit = {
-        expectation.fulfill()
+
+      await confirmation("Wait for InstanceManager to be deallocated.") { confirm in
+        TestFinalizer.onDeinit = {
+          confirm()
+        }
+
+        // Ensure method is from `FlutterApplicationLifeCycleDelegate`.
+        (plugin as FlutterApplicationLifeCycleDelegate).applicationWillTerminate!(
+          UIApplication.shared)
+        #expect(plugin.proxyApiRegistrar == nil)
+
+        finalizer = nil
       }
-
-      // Ensure method is from `FlutterApplicationLifeCycleDelegate`.
-      (plugin as FlutterApplicationLifeCycleDelegate).applicationWillTerminate!(
-        UIApplication.shared)
-      XCTAssertNil(plugin.proxyApiRegistrar)
-
-      finalizer = nil
-      waitForExpectations(timeout: 5.0)
     }
 
-    func testInstanceManagerIsDeallocatedInSceneDidDisconnect() {
+    @Test func instanceManagerIsDeallocatedInSceneDidDisconnect() async throws {
       let plugin = WebViewFlutterPlugin(binaryMessenger: TestBinaryMessenger())
       plugin.proxyApiRegistrar!.setUp()
 
@@ -59,19 +61,20 @@ class WebViewFlutterPluginTests: XCTestCase {
       }
       objc_setAssociatedObject(
         plugin.proxyApiRegistrar!.instanceManager, key, finalizer, .OBJC_ASSOCIATION_RETAIN)
-      let expectation = self.expectation(description: "Wait for InstanceManager to be deallocated.")
-      TestFinalizer.onDeinit = {
-        expectation.fulfill()
+
+      await confirmation("Wait for InstanceManager to be deallocated.") { confirm in
+        TestFinalizer.onDeinit = {
+          confirm()
+        }
+
+        let scene = UIApplication.shared.connectedScenes.first!
+
+        // Ensure method is from `FlutterSceneLifeCycleDelegate`.
+        (plugin as FlutterSceneLifeCycleDelegate).sceneDidDisconnect?(scene)
+        #expect(plugin.proxyApiRegistrar == nil)
+
+        finalizer = nil
       }
-
-      let scene = UIApplication.shared.connectedScenes.first!
-
-      // Ensure method is from `FlutterSceneLifeCycleDelegate`.
-      (plugin as FlutterSceneLifeCycleDelegate).sceneDidDisconnect?(scene)
-      XCTAssertNil(plugin.proxyApiRegistrar)
-
-      finalizer = nil
-      waitForExpectations(timeout: 5.0)
     }
   #endif
 }

--- a/packages/webview_flutter/webview_flutter_wkwebview/darwin/Tests/WebViewProxyAPITests.swift
+++ b/packages/webview_flutter/webview_flutter_wkwebview/darwin/Tests/WebViewProxyAPITests.swift
@@ -23,7 +23,7 @@ import WebKit
     }
   #endif
 
-  @MainActor @Test func pigeonDefaultConstructor() throws {
+  @MainActor @Test func pigeonDefaultConstructor() {
     let registrar = TestProxyApiRegistrar()
     let api = webViewProxyAPI(forRegistrar: registrar)
 
@@ -37,7 +37,7 @@ import WebKit
     let api = webViewProxyAPI(forRegistrar: registrar)
 
     let instance = TestViewWKWebView()
-    let value = try? api.pigeonDelegate.configuration(pigeonApi: api, pigeonInstance: instance)
+    let value = try api.pigeonDelegate.configuration(pigeonApi: api, pigeonInstance: instance)
 
     #expect(value == instance.configuration)
   }
@@ -48,7 +48,7 @@ import WebKit
       let api = webViewProxyAPI(forRegistrar: registrar)
 
       let instance = TestViewWKWebView()
-      let value = try? api.pigeonDelegate.scrollView(pigeonApi: api, pigeonInstance: instance)
+      let value = try api.pigeonDelegate.scrollView(pigeonApi: api, pigeonInstance: instance)
 
       #expect(value == instance.scrollView)
     }
@@ -61,7 +61,7 @@ import WebKit
     let instance = TestViewWKWebView()
     let delegate = UIDelegateImpl(
       api: registrar.apiDelegate.pigeonApiWKUIDelegate(registrar), registrar: registrar)
-    try? api.pigeonDelegate.setUIDelegate(
+    try api.pigeonDelegate.setUIDelegate(
       pigeonApi: api, pigeonInstance: instance, delegate: delegate)
 
     #expect(instance.uiDelegate as! UIDelegateImpl == delegate)
@@ -74,7 +74,7 @@ import WebKit
     let instance = TestViewWKWebView()
     let delegate = NavigationDelegateImpl(
       api: registrar.apiDelegate.pigeonApiWKNavigationDelegate(registrar), registrar: registrar)
-    try? api.pigeonDelegate.setNavigationDelegate(
+    try api.pigeonDelegate.setNavigationDelegate(
       pigeonApi: api, pigeonInstance: instance, delegate: delegate)
 
     #expect(instance.navigationDelegate as! NavigationDelegateImpl == delegate)
@@ -85,7 +85,7 @@ import WebKit
     let api = webViewProxyAPI(forRegistrar: registrar)
 
     let instance = TestViewWKWebView()
-    let value = try? api.pigeonDelegate.getUrl(pigeonApi: api, pigeonInstance: instance)
+    let value = try api.pigeonDelegate.getUrl(pigeonApi: api, pigeonInstance: instance)
 
     #expect(value == instance.url?.absoluteString)
   }
@@ -95,7 +95,7 @@ import WebKit
     let api = webViewProxyAPI(forRegistrar: registrar)
 
     let instance = TestViewWKWebView()
-    let value = try? api.pigeonDelegate.getEstimatedProgress(
+    let value = try api.pigeonDelegate.getEstimatedProgress(
       pigeonApi: api, pigeonInstance: instance)
 
     #expect(value == instance.estimatedProgress)
@@ -107,7 +107,7 @@ import WebKit
 
     let instance = TestViewWKWebView()
     let request = URLRequestWrapper(URLRequest(url: URL(string: "http://google.com")!))
-    try? api.pigeonDelegate.load(pigeonApi: api, pigeonInstance: instance, request: request)
+    try api.pigeonDelegate.load(pigeonApi: api, pigeonInstance: instance, request: request)
 
     #expect(instance.loadArgs == [request.value])
   }
@@ -119,7 +119,7 @@ import WebKit
     let instance = TestViewWKWebView()
     let string = "myString"
     let baseUrl = "http://google.com"
-    try? api.pigeonDelegate.loadHtmlString(
+    try api.pigeonDelegate.loadHtmlString(
       pigeonApi: api, pigeonInstance: instance, string: string, baseUrl: baseUrl)
 
     #expect(instance.loadHtmlStringArgs == [string, URL(string: baseUrl)])
@@ -132,7 +132,7 @@ import WebKit
     let instance = TestViewWKWebView()
     let url = "myDirectory/myFile.txt"
     let readAccessUrl = "myDirectory/"
-    try? api.pigeonDelegate.loadFileUrl(
+    try api.pigeonDelegate.loadFileUrl(
       pigeonApi: api, pigeonInstance: instance, url: url, readAccessUrl: readAccessUrl)
 
     #expect(
@@ -148,11 +148,11 @@ import WebKit
 
     let instance = TestViewWKWebView()
     let key = "assets/www/index.html"
-    try? api.pigeonDelegate.loadFlutterAsset(pigeonApi: api, pigeonInstance: instance, key: key)
+    try api.pigeonDelegate.loadFlutterAsset(pigeonApi: api, pigeonInstance: instance, key: key)
 
     #expect(instance.loadFileUrlArgs?.count == 2)
-    let url = try #require(instance.loadFileUrlArgs![0])
-    let readAccessURL = try #require(instance.loadFileUrlArgs![1])
+    let url = instance.loadFileUrlArgs![0]
+    let readAccessURL = instance.loadFileUrlArgs![1]
 
     #expect(url.absoluteString.contains("index.html"))
     #expect(readAccessURL.absoluteString.contains("assets/www/"))
@@ -163,7 +163,7 @@ import WebKit
     let api = webViewProxyAPI(forRegistrar: registrar)
 
     let instance = TestViewWKWebView()
-    let value = try? api.pigeonDelegate.canGoBack(pigeonApi: api, pigeonInstance: instance)
+    let value = try api.pigeonDelegate.canGoBack(pigeonApi: api, pigeonInstance: instance)
 
     #expect(value == instance.canGoBack)
   }
@@ -173,7 +173,7 @@ import WebKit
     let api = webViewProxyAPI(forRegistrar: registrar)
 
     let instance = TestViewWKWebView()
-    let value = try? api.pigeonDelegate.canGoForward(pigeonApi: api, pigeonInstance: instance)
+    let value = try api.pigeonDelegate.canGoForward(pigeonApi: api, pigeonInstance: instance)
 
     #expect(value == instance.canGoForward)
   }
@@ -183,7 +183,7 @@ import WebKit
     let api = webViewProxyAPI(forRegistrar: registrar)
 
     let instance = TestViewWKWebView()
-    try? api.pigeonDelegate.goBack(pigeonApi: api, pigeonInstance: instance)
+    try api.pigeonDelegate.goBack(pigeonApi: api, pigeonInstance: instance)
 
     #expect(instance.goBackCalled)
   }
@@ -193,7 +193,7 @@ import WebKit
     let api = webViewProxyAPI(forRegistrar: registrar)
 
     let instance = TestViewWKWebView()
-    try? api.pigeonDelegate.goForward(pigeonApi: api, pigeonInstance: instance)
+    try api.pigeonDelegate.goForward(pigeonApi: api, pigeonInstance: instance)
 
     #expect(instance.goForwardCalled)
   }
@@ -203,7 +203,7 @@ import WebKit
     let api = webViewProxyAPI(forRegistrar: registrar)
 
     let instance = TestViewWKWebView()
-    try? api.pigeonDelegate.reload(pigeonApi: api, pigeonInstance: instance)
+    try api.pigeonDelegate.reload(pigeonApi: api, pigeonInstance: instance)
 
     #expect(instance.reloadCalled)
   }
@@ -213,7 +213,7 @@ import WebKit
     let api = webViewProxyAPI(forRegistrar: registrar)
 
     let instance = TestViewWKWebView()
-    let value = try? api.pigeonDelegate.getTitle(pigeonApi: api, pigeonInstance: instance)
+    let value = try api.pigeonDelegate.getTitle(pigeonApi: api, pigeonInstance: instance)
 
     #expect(value == instance.title)
   }
@@ -224,7 +224,7 @@ import WebKit
 
     let instance = TestViewWKWebView()
     let allow = true
-    try? api.pigeonDelegate.setAllowsBackForwardNavigationGestures(
+    try api.pigeonDelegate.setAllowsBackForwardNavigationGestures(
       pigeonApi: api, pigeonInstance: instance, allow: allow)
 
     #expect(instance.setAllowsBackForwardNavigationGesturesArgs == [allow])
@@ -236,7 +236,7 @@ import WebKit
 
     let instance = TestViewWKWebView()
     let userAgent = "myString"
-    try? api.pigeonDelegate.setCustomUserAgent(
+    try api.pigeonDelegate.setCustomUserAgent(
       pigeonApi: api, pigeonInstance: instance, userAgent: userAgent)
 
     #expect(instance.setCustomUserAgentArgs == [userAgent])
@@ -271,7 +271,7 @@ import WebKit
 
     let instance = TestViewWKWebView()
     let inspectable = true
-    try? api.pigeonDelegate.setInspectable(
+    try api.pigeonDelegate.setInspectable(
       pigeonApi: api, pigeonInstance: instance, inspectable: inspectable)
 
     #expect(instance.setInspectableArgs == [inspectable])
@@ -284,7 +284,7 @@ import WebKit
 
     let instance = TestViewWKWebView()
     let allow: Bool = true
-    try? api.pigeonDelegate.setAllowsLinkPreview(
+    try api.pigeonDelegate.setAllowsLinkPreview(
       pigeonApi: api, pigeonInstance: instance, allow: allow)
 
     #expect(instance.allowsLinkPreview == allow)
@@ -295,7 +295,7 @@ import WebKit
     let api = webViewProxyAPI(forRegistrar: registrar)
 
     let instance = TestViewWKWebView()
-    let value = try? api.pigeonDelegate.getCustomUserAgent(pigeonApi: api, pigeonInstance: instance)
+    let value = try api.pigeonDelegate.getCustomUserAgent(pigeonApi: api, pigeonInstance: instance)
 
     #expect(value == instance.customUserAgent)
   }

--- a/packages/webview_flutter/webview_flutter_wkwebview/darwin/Tests/WebViewProxyAPITests.swift
+++ b/packages/webview_flutter/webview_flutter_wkwebview/darwin/Tests/WebViewProxyAPITests.swift
@@ -2,8 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import Foundation
+import Testing
 import WebKit
-import XCTest
 
 @testable import webview_flutter_wkwebview
 
@@ -11,7 +12,7 @@ import XCTest
   import UIKit
 #endif
 
-class WebViewProxyAPITests: XCTestCase {
+@Suite struct WebViewProxyAPITests {
   #if os(iOS)
     func webViewProxyAPI(forRegistrar registrar: ProxyAPIRegistrar) -> PigeonApiUIViewWKWebView {
       return registrar.apiDelegate.pigeonApiUIViewWKWebView(registrar)
@@ -22,38 +23,38 @@ class WebViewProxyAPITests: XCTestCase {
     }
   #endif
 
-  @MainActor func testPigeonDefaultConstructor() {
+  @MainActor @Test func pigeonDefaultConstructor() throws {
     let registrar = TestProxyApiRegistrar()
     let api = webViewProxyAPI(forRegistrar: registrar)
 
     let instance = try? api.pigeonDelegate.pigeonDefaultConstructor(
       pigeonApi: api, initialConfiguration: WKWebViewConfiguration())
-    XCTAssertNotNil(instance)
+    #expect(instance != nil)
   }
 
-  @MainActor func testConfiguration() {
+  @MainActor @Test func configuration() throws {
     let registrar = TestProxyApiRegistrar()
     let api = webViewProxyAPI(forRegistrar: registrar)
 
     let instance = TestViewWKWebView()
     let value = try? api.pigeonDelegate.configuration(pigeonApi: api, pigeonInstance: instance)
 
-    XCTAssertEqual(value, instance.configuration)
+    #expect(value == instance.configuration)
   }
 
   #if os(iOS)
-    @MainActor func testScrollView() {
+    @MainActor @Test func scrollView() throws {
       let registrar = TestProxyApiRegistrar()
       let api = webViewProxyAPI(forRegistrar: registrar)
 
       let instance = TestViewWKWebView()
       let value = try? api.pigeonDelegate.scrollView(pigeonApi: api, pigeonInstance: instance)
 
-      XCTAssertEqual(value, instance.scrollView)
+      #expect(value == instance.scrollView)
     }
   #endif
 
-  @MainActor func testSetUIDelegate() {
+  @MainActor @Test func setUIDelegate() throws {
     let registrar = TestProxyApiRegistrar()
     let api = webViewProxyAPI(forRegistrar: registrar)
 
@@ -63,10 +64,10 @@ class WebViewProxyAPITests: XCTestCase {
     try? api.pigeonDelegate.setUIDelegate(
       pigeonApi: api, pigeonInstance: instance, delegate: delegate)
 
-    XCTAssertEqual(instance.uiDelegate as! UIDelegateImpl, delegate)
+    #expect(instance.uiDelegate as! UIDelegateImpl == delegate)
   }
 
-  @MainActor func testSetNavigationDelegate() {
+  @MainActor @Test func setNavigationDelegate() throws {
     let registrar = TestProxyApiRegistrar()
     let api = webViewProxyAPI(forRegistrar: registrar)
 
@@ -76,20 +77,20 @@ class WebViewProxyAPITests: XCTestCase {
     try? api.pigeonDelegate.setNavigationDelegate(
       pigeonApi: api, pigeonInstance: instance, delegate: delegate)
 
-    XCTAssertEqual(instance.navigationDelegate as! NavigationDelegateImpl, delegate)
+    #expect(instance.navigationDelegate as! NavigationDelegateImpl == delegate)
   }
 
-  @MainActor func testGetUrl() {
+  @MainActor @Test func getUrl() throws {
     let registrar = TestProxyApiRegistrar()
     let api = webViewProxyAPI(forRegistrar: registrar)
 
     let instance = TestViewWKWebView()
     let value = try? api.pigeonDelegate.getUrl(pigeonApi: api, pigeonInstance: instance)
 
-    XCTAssertEqual(value, instance.url?.absoluteString)
+    #expect(value == instance.url?.absoluteString)
   }
 
-  @MainActor func testGetEstimatedProgress() {
+  @MainActor @Test func getEstimatedProgress() throws {
     let registrar = TestProxyApiRegistrar()
     let api = webViewProxyAPI(forRegistrar: registrar)
 
@@ -97,10 +98,10 @@ class WebViewProxyAPITests: XCTestCase {
     let value = try? api.pigeonDelegate.getEstimatedProgress(
       pigeonApi: api, pigeonInstance: instance)
 
-    XCTAssertEqual(value, instance.estimatedProgress)
+    #expect(value == instance.estimatedProgress)
   }
 
-  @MainActor func testLoad() {
+  @MainActor @Test func load() throws {
     let registrar = TestProxyApiRegistrar()
     let api = webViewProxyAPI(forRegistrar: registrar)
 
@@ -108,10 +109,10 @@ class WebViewProxyAPITests: XCTestCase {
     let request = URLRequestWrapper(URLRequest(url: URL(string: "http://google.com")!))
     try? api.pigeonDelegate.load(pigeonApi: api, pigeonInstance: instance, request: request)
 
-    XCTAssertEqual(instance.loadArgs, [request.value])
+    #expect(instance.loadArgs == [request.value])
   }
 
-  @MainActor func testLoadHtmlString() {
+  @MainActor @Test func loadHtmlString() throws {
     let registrar = TestProxyApiRegistrar()
     let api = webViewProxyAPI(forRegistrar: registrar)
 
@@ -121,10 +122,10 @@ class WebViewProxyAPITests: XCTestCase {
     try? api.pigeonDelegate.loadHtmlString(
       pigeonApi: api, pigeonInstance: instance, string: string, baseUrl: baseUrl)
 
-    XCTAssertEqual(instance.loadHtmlStringArgs, [string, URL(string: baseUrl)])
+    #expect(instance.loadHtmlStringArgs == [string, URL(string: baseUrl)])
   }
 
-  @MainActor func testLoadFileUrl() {
+  @MainActor @Test func loadFileUrl() throws {
     let registrar = TestProxyApiRegistrar()
     let api = webViewProxyAPI(forRegistrar: registrar)
 
@@ -134,15 +135,14 @@ class WebViewProxyAPITests: XCTestCase {
     try? api.pigeonDelegate.loadFileUrl(
       pigeonApi: api, pigeonInstance: instance, url: url, readAccessUrl: readAccessUrl)
 
-    XCTAssertEqual(
-      instance.loadFileUrlArgs,
-      [
+    #expect(
+      instance.loadFileUrlArgs == [
         URL(fileURLWithPath: url, isDirectory: false),
         URL(fileURLWithPath: readAccessUrl, isDirectory: true),
       ])
   }
 
-  @MainActor func testLoadFlutterAsset() {
+  @MainActor @Test func loadFlutterAsset() throws {
     let registrar = TestProxyApiRegistrar()
     let api = webViewProxyAPI(forRegistrar: registrar)
 
@@ -150,75 +150,75 @@ class WebViewProxyAPITests: XCTestCase {
     let key = "assets/www/index.html"
     try? api.pigeonDelegate.loadFlutterAsset(pigeonApi: api, pigeonInstance: instance, key: key)
 
-    XCTAssertEqual(instance.loadFileUrlArgs?.count, 2)
-    let url = try! XCTUnwrap(instance.loadFileUrlArgs![0])
-    let readAccessURL = try! XCTUnwrap(instance.loadFileUrlArgs![1])
+    #expect(instance.loadFileUrlArgs?.count == 2)
+    let url = try #require(instance.loadFileUrlArgs![0])
+    let readAccessURL = try #require(instance.loadFileUrlArgs![1])
 
-    XCTAssertTrue(url.absoluteString.contains("index.html"))
-    XCTAssertTrue(readAccessURL.absoluteString.contains("assets/www/"))
+    #expect(url.absoluteString.contains("index.html"))
+    #expect(readAccessURL.absoluteString.contains("assets/www/"))
   }
 
-  @MainActor func testCanGoBack() {
+  @MainActor @Test func canGoBack() throws {
     let registrar = TestProxyApiRegistrar()
     let api = webViewProxyAPI(forRegistrar: registrar)
 
     let instance = TestViewWKWebView()
     let value = try? api.pigeonDelegate.canGoBack(pigeonApi: api, pigeonInstance: instance)
 
-    XCTAssertEqual(value, instance.canGoBack)
+    #expect(value == instance.canGoBack)
   }
 
-  @MainActor func testCanGoForward() {
+  @MainActor @Test func canGoForward() throws {
     let registrar = TestProxyApiRegistrar()
     let api = webViewProxyAPI(forRegistrar: registrar)
 
     let instance = TestViewWKWebView()
     let value = try? api.pigeonDelegate.canGoForward(pigeonApi: api, pigeonInstance: instance)
 
-    XCTAssertEqual(value, instance.canGoForward)
+    #expect(value == instance.canGoForward)
   }
 
-  @MainActor func testGoBack() {
+  @MainActor @Test func goBack() throws {
     let registrar = TestProxyApiRegistrar()
     let api = webViewProxyAPI(forRegistrar: registrar)
 
     let instance = TestViewWKWebView()
     try? api.pigeonDelegate.goBack(pigeonApi: api, pigeonInstance: instance)
 
-    XCTAssertTrue(instance.goBackCalled)
+    #expect(instance.goBackCalled)
   }
 
-  @MainActor func testGoForward() {
+  @MainActor @Test func goForward() throws {
     let registrar = TestProxyApiRegistrar()
     let api = webViewProxyAPI(forRegistrar: registrar)
 
     let instance = TestViewWKWebView()
     try? api.pigeonDelegate.goForward(pigeonApi: api, pigeonInstance: instance)
 
-    XCTAssertTrue(instance.goForwardCalled)
+    #expect(instance.goForwardCalled)
   }
 
-  @MainActor func testReload() {
+  @MainActor @Test func reload() throws {
     let registrar = TestProxyApiRegistrar()
     let api = webViewProxyAPI(forRegistrar: registrar)
 
     let instance = TestViewWKWebView()
     try? api.pigeonDelegate.reload(pigeonApi: api, pigeonInstance: instance)
 
-    XCTAssertTrue(instance.reloadCalled)
+    #expect(instance.reloadCalled)
   }
 
-  @MainActor func testGetTitle() {
+  @MainActor @Test func getTitle() throws {
     let registrar = TestProxyApiRegistrar()
     let api = webViewProxyAPI(forRegistrar: registrar)
 
     let instance = TestViewWKWebView()
     let value = try? api.pigeonDelegate.getTitle(pigeonApi: api, pigeonInstance: instance)
 
-    XCTAssertEqual(value, instance.title)
+    #expect(value == instance.title)
   }
 
-  @MainActor func testSetAllowsBackForwardNavigationGestures() {
+  @MainActor @Test func setAllowsBackForwardNavigationGestures() throws {
     let registrar = TestProxyApiRegistrar()
     let api = webViewProxyAPI(forRegistrar: registrar)
 
@@ -227,10 +227,10 @@ class WebViewProxyAPITests: XCTestCase {
     try? api.pigeonDelegate.setAllowsBackForwardNavigationGestures(
       pigeonApi: api, pigeonInstance: instance, allow: allow)
 
-    XCTAssertEqual(instance.setAllowsBackForwardNavigationGesturesArgs, [allow])
+    #expect(instance.setAllowsBackForwardNavigationGesturesArgs == [allow])
   }
 
-  @MainActor func testSetCustomUserAgent() {
+  @MainActor @Test func setCustomUserAgent() throws {
     let registrar = TestProxyApiRegistrar()
     let api = webViewProxyAPI(forRegistrar: registrar)
 
@@ -239,10 +239,10 @@ class WebViewProxyAPITests: XCTestCase {
     try? api.pigeonDelegate.setCustomUserAgent(
       pigeonApi: api, pigeonInstance: instance, userAgent: userAgent)
 
-    XCTAssertEqual(instance.setCustomUserAgentArgs, [userAgent])
+    #expect(instance.setCustomUserAgentArgs == [userAgent])
   }
 
-  @MainActor func testEvaluateJavaScript() {
+  @MainActor @Test func evaluateJavaScript() throws {
     let registrar = TestProxyApiRegistrar()
     let api = webViewProxyAPI(forRegistrar: registrar)
 
@@ -261,11 +261,11 @@ class WebViewProxyAPITests: XCTestCase {
         }
       })
 
-    XCTAssertEqual(instance.evaluateJavaScriptArgs, [javaScriptString])
-    XCTAssertEqual(resultValue as! String, "returnValue")
+    #expect(instance.evaluateJavaScriptArgs == [javaScriptString])
+    #expect(resultValue as! String == "returnValue")
   }
 
-  @MainActor func testSetInspectable() {
+  @MainActor @Test func setInspectable() throws {
     let registrar = TestProxyApiRegistrar()
     let api = webViewProxyAPI(forRegistrar: registrar)
 
@@ -274,11 +274,11 @@ class WebViewProxyAPITests: XCTestCase {
     try? api.pigeonDelegate.setInspectable(
       pigeonApi: api, pigeonInstance: instance, inspectable: inspectable)
 
-    XCTAssertEqual(instance.setInspectableArgs, [inspectable])
-    XCTAssertFalse(instance.isInspectable)
+    #expect(instance.setInspectableArgs == [inspectable])
+    #expect(!(instance.isInspectable))
   }
 
-  @MainActor func testSetAllowsLinkPreview() {
+  @MainActor @Test func setAllowsLinkPreview() throws {
     let registrar = TestProxyApiRegistrar()
     let api = webViewProxyAPI(forRegistrar: registrar)
 
@@ -287,42 +287,42 @@ class WebViewProxyAPITests: XCTestCase {
     try? api.pigeonDelegate.setAllowsLinkPreview(
       pigeonApi: api, pigeonInstance: instance, allow: allow)
 
-    XCTAssertEqual(instance.allowsLinkPreview, allow)
+    #expect(instance.allowsLinkPreview == allow)
   }
 
-  @MainActor func testGetCustomUserAgent() {
+  @MainActor @Test func getCustomUserAgent() throws {
     let registrar = TestProxyApiRegistrar()
     let api = webViewProxyAPI(forRegistrar: registrar)
 
     let instance = TestViewWKWebView()
     let value = try? api.pigeonDelegate.getCustomUserAgent(pigeonApi: api, pigeonInstance: instance)
 
-    XCTAssertEqual(value, instance.customUserAgent)
+    #expect(value == instance.customUserAgent)
   }
 
   #if os(iOS)
-    @MainActor func testWebViewContentInsetBehaviorShouldBeNever() {
+    @MainActor @Test func webViewContentInsetBehaviorShouldBeNever() throws {
       let registrar = TestProxyApiRegistrar()
       let api = PigeonApiWKWebView(pigeonRegistrar: registrar, delegate: WebViewProxyAPIDelegate())
 
       let webView = WebViewImpl(
         api: api, registrar: registrar, frame: .zero, configuration: WKWebViewConfiguration())
 
-      XCTAssertEqual(webView.scrollView.contentInsetAdjustmentBehavior, .never)
+      #expect(webView.scrollView.contentInsetAdjustmentBehavior == .never)
     }
 
     @MainActor
-    func testScrollViewsAutomaticallyAdjustsScrollIndicatorInsetsShouldbeFalse() {
+    @Test func scrollViewsAutomaticallyAdjustsScrollIndicatorInsetsShouldbeFalse() throws {
       let registrar = TestProxyApiRegistrar()
       let api = PigeonApiWKWebView(pigeonRegistrar: registrar, delegate: WebViewProxyAPIDelegate())
 
       let webView = WebViewImpl(
         api: api, registrar: registrar, frame: .zero, configuration: WKWebViewConfiguration())
 
-      XCTAssertFalse(webView.scrollView.automaticallyAdjustsScrollIndicatorInsets)
+      #expect(!(webView.scrollView.automaticallyAdjustsScrollIndicatorInsets))
     }
 
-    @MainActor func testContentInsetsSumAlwaysZeroAfterSetFrame() {
+    @MainActor @Test func contentInsetsSumAlwaysZeroAfterSetFrame() throws {
       let registrar = TestProxyApiRegistrar()
       let api = PigeonApiWKWebView(pigeonRegistrar: registrar, delegate: WebViewProxyAPIDelegate())
 
@@ -332,10 +332,10 @@ class WebViewProxyAPITests: XCTestCase {
       webView.scrollView.contentInset = UIEdgeInsets(top: 0, left: 0, bottom: 300, right: 300)
 
       webView.frame = .zero
-      XCTAssertEqual(webView.scrollView.contentInset, .zero)
+      #expect(webView.scrollView.contentInset == .zero)
     }
 
-    @MainActor func testContentInsetsIsOppositeOfScrollViewAdjustedInset() {
+    @MainActor @Test func contentInsetsIsOppositeOfScrollViewAdjustedInset() throws {
       let registrar = TestProxyApiRegistrar()
       let api = PigeonApiWKWebView(pigeonRegistrar: registrar, delegate: WebViewProxyAPIDelegate())
 
@@ -346,10 +346,10 @@ class WebViewProxyAPITests: XCTestCase {
 
       webView.frame = .zero
       let contentInset: UIEdgeInsets = webView.scrollView.contentInset
-      XCTAssertEqual(contentInset.left, -webView.scrollView.adjustedContentInset.left)
-      XCTAssertEqual(contentInset.top, -webView.scrollView.adjustedContentInset.top)
-      XCTAssertEqual(contentInset.right, -webView.scrollView.adjustedContentInset.right)
-      XCTAssertEqual(contentInset.bottom, -webView.scrollView.adjustedContentInset.bottom)
+      #expect(contentInset.left == -webView.scrollView.adjustedContentInset.left)
+      #expect(contentInset.top == -webView.scrollView.adjustedContentInset.top)
+      #expect(contentInset.right == -webView.scrollView.adjustedContentInset.right)
+      #expect(contentInset.bottom == -webView.scrollView.adjustedContentInset.bottom)
     }
   #endif
 }

--- a/packages/webview_flutter/webview_flutter_wkwebview/darwin/Tests/WebpagePreferencesProxyAPITests.swift
+++ b/packages/webview_flutter/webview_flutter_wkwebview/darwin/Tests/WebpagePreferencesProxyAPITests.swift
@@ -16,7 +16,7 @@ import WebKit
 
     let instance = WKWebpagePreferences()
     let allow = true
-    try? api.pigeonDelegate.setAllowsContentJavaScript(
+    try api.pigeonDelegate.setAllowsContentJavaScript(
       pigeonApi: api, pigeonInstance: instance, allow: allow)
 
     #expect(instance.allowsContentJavaScript == allow)

--- a/packages/webview_flutter/webview_flutter_wkwebview/darwin/Tests/WebpagePreferencesProxyAPITests.swift
+++ b/packages/webview_flutter/webview_flutter_wkwebview/darwin/Tests/WebpagePreferencesProxyAPITests.swift
@@ -2,14 +2,15 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import Foundation
+import Testing
 import WebKit
-import XCTest
 
 @testable import webview_flutter_wkwebview
 
-class WebpagePreferencesProxyAPITests: XCTestCase {
+@Suite struct WebpagePreferencesProxyAPITests {
   @available(iOS 14.0, macOS 11.0, *)
-  @MainActor func testSetAllowsContentJavaScript() {
+  @MainActor @Test func setAllowsContentJavaScript() throws {
     let registrar = TestProxyApiRegistrar()
     let api = registrar.apiDelegate.pigeonApiWKWebpagePreferences(registrar)
 
@@ -18,6 +19,6 @@ class WebpagePreferencesProxyAPITests: XCTestCase {
     try? api.pigeonDelegate.setAllowsContentJavaScript(
       pigeonApi: api, pigeonInstance: instance, allow: allow)
 
-    XCTAssertEqual(instance.allowsContentJavaScript, allow)
+    #expect(instance.allowsContentJavaScript == allow)
   }
 }

--- a/packages/webview_flutter/webview_flutter_wkwebview/darwin/Tests/WebsiteDataStoreProxyAPITests.swift
+++ b/packages/webview_flutter/webview_flutter_wkwebview/darwin/Tests/WebsiteDataStoreProxyAPITests.swift
@@ -29,7 +29,7 @@ import WebKit
     let dataTypes: [WebsiteDataType] = [.localStorage]
     let modificationTimeInSecondsSinceEpoch = 0.0
 
-    let removeDataOfTypesResult = try await withCheckedThrowingContinuation {
+    let _ = try await withCheckedThrowingContinuation {
       (continuation: CheckedContinuation<Bool, Error>) in
       api.pigeonDelegate.removeDataOfTypes(
         pigeonApi: api, pigeonInstance: instance, dataTypes: dataTypes,
@@ -43,6 +43,6 @@ import WebKit
           }
         })
     }
-    #expect(removeDataOfTypesResult == removeDataOfTypesResult)
+    // If the test doesn't throw, it has succeeded.
   }
 }

--- a/packages/webview_flutter/webview_flutter_wkwebview/darwin/Tests/WebsiteDataStoreProxyAPITests.swift
+++ b/packages/webview_flutter/webview_flutter_wkwebview/darwin/Tests/WebsiteDataStoreProxyAPITests.swift
@@ -2,25 +2,26 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import Foundation
+import Testing
 import WebKit
-import XCTest
 
 @testable import webview_flutter_wkwebview
 
-class WebsiteDataStoreProxyAPITests: XCTestCase {
+@Suite struct WebsiteDataStoreProxyAPITests {
   @available(iOS 17.0, *)
-  @MainActor func testHttpCookieStore() {
+  @MainActor @Test func httpCookieStore() throws {
     let registrar = TestProxyApiRegistrar()
     let api = registrar.apiDelegate.pigeonApiWKWebsiteDataStore(registrar)
 
     let instance = WKWebsiteDataStore.default()
     let value = try? api.pigeonDelegate.httpCookieStore(pigeonApi: api, pigeonInstance: instance)
 
-    XCTAssertEqual(value, instance.httpCookieStore)
+    #expect(value == instance.httpCookieStore)
   }
 
   @available(iOS 17.0, *)
-  @MainActor func testRemoveDataOfTypes() {
+  @MainActor @Test func removeDataOfTypes() async throws {
     let registrar = TestProxyApiRegistrar()
     let api = registrar.apiDelegate.pigeonApiWKWebsiteDataStore(registrar)
 
@@ -28,24 +29,20 @@ class WebsiteDataStoreProxyAPITests: XCTestCase {
     let dataTypes: [WebsiteDataType] = [.localStorage]
     let modificationTimeInSecondsSinceEpoch = 0.0
 
-    let removeDataOfTypesExpectation = expectation(
-      description: "Wait for result of removeDataOfTypes.")
-
-    var removeDataOfTypesResult: Bool?
-    api.pigeonDelegate.removeDataOfTypes(
-      pigeonApi: api, pigeonInstance: instance, dataTypes: dataTypes,
-      modificationTimeInSecondsSinceEpoch: modificationTimeInSecondsSinceEpoch,
-      completion: { result in
-        switch result {
-        case .success(let hasRecords):
-          removeDataOfTypesResult = hasRecords
-        case .failure(_): break
-        }
-
-        removeDataOfTypesExpectation.fulfill()
-      })
-
-    wait(for: [removeDataOfTypesExpectation], timeout: 10.0)
-    XCTAssertNotNil(removeDataOfTypesResult)
+    let removeDataOfTypesResult = try await withCheckedThrowingContinuation {
+      (continuation: CheckedContinuation<Bool, Error>) in
+      api.pigeonDelegate.removeDataOfTypes(
+        pigeonApi: api, pigeonInstance: instance, dataTypes: dataTypes,
+        modificationTimeInSecondsSinceEpoch: modificationTimeInSecondsSinceEpoch,
+        completion: { result in
+          switch result {
+          case .success(let hasRecords):
+            continuation.resume(returning: hasRecords)
+          case .failure(let error):
+            continuation.resume(throwing: error)
+          }
+        })
+    }
+    #expect(removeDataOfTypesResult == removeDataOfTypesResult)
   }
 }

--- a/packages/webview_flutter/webview_flutter_wkwebview/darwin/Tests/WebsiteDataStoreProxyAPITests.swift
+++ b/packages/webview_flutter/webview_flutter_wkwebview/darwin/Tests/WebsiteDataStoreProxyAPITests.swift
@@ -15,7 +15,7 @@ import WebKit
     let api = registrar.apiDelegate.pigeonApiWKWebsiteDataStore(registrar)
 
     let instance = WKWebsiteDataStore.default()
-    let value = try? api.pigeonDelegate.httpCookieStore(pigeonApi: api, pigeonInstance: instance)
+    let value = try api.pigeonDelegate.httpCookieStore(pigeonApi: api, pigeonInstance: instance)
 
     #expect(value == instance.httpCookieStore)
   }
@@ -29,15 +29,14 @@ import WebKit
     let dataTypes: [WebsiteDataType] = [.localStorage]
     let modificationTimeInSecondsSinceEpoch = 0.0
 
-    let _ = try await withCheckedThrowingContinuation {
-      (continuation: CheckedContinuation<Bool, Error>) in
+    try await withCheckedThrowingContinuation { continuation in
       api.pigeonDelegate.removeDataOfTypes(
         pigeonApi: api, pigeonInstance: instance, dataTypes: dataTypes,
         modificationTimeInSecondsSinceEpoch: modificationTimeInSecondsSinceEpoch,
         completion: { result in
           switch result {
-          case .success(let hasRecords):
-            continuation.resume(returning: hasRecords)
+          case .success:
+            continuation.resume()
           case .failure(let error):
             continuation.resume(throwing: error)
           }


### PR DESCRIPTION
Converts all of the webview_flutter unit tests from XCTest to Swift testing. This was mostly done by Gemini (mostly purely mechanical conversion), with some minor cleanup after I reviewed it. As with other conversions, this is focused on converting more or less directly, without adopting new features like parameterization.

Part of https://github.com/flutter/flutter/issues/180787 

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under[^1].
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [x] All existing and new tests are passing.

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[the version and CHANGELOG instructions]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version-and-changelog-updates
[semantic versioning]: https://dart.dev/tools/pub/versioning#semantic-versions
[repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
