### PR TITLE
[material_ui, cupertino_ui] Update changelogs for the prerelease

### DIFF
--- a/packages/cupertino_ui/CHANGELOG.md
+++ b/packages/cupertino_ui/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Copied over all Cupertino code from flutter/flutter.
 * Copied over Cupertino localizations from flutter/flutter's
   flutter_localizations package.
+* Migrated API doc samples and formatting.
 * Updates minimum supported SDK version to Flutter 3.44/Dart 3.12.
 
 ## 0.0.1

--- a/packages/cupertino_ui/CHANGELOG.md
+++ b/packages/cupertino_ui/CHANGELOG.md
@@ -1,6 +1,8 @@
-## NEXT
+## 0.0.2
 
-* Updates minimum supported SDK version to Flutter 3.38/Dart 3.10.
+* Copied over all Cupertino code from flutter/flutter.
+* Copied over Cupertino localizations from flutter/flutter's
+  flutter_localizations package.
 
 ## 0.0.1
 

--- a/packages/cupertino_ui/CHANGELOG.md
+++ b/packages/cupertino_ui/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Copied over all Cupertino code from flutter/flutter.
 * Copied over Cupertino localizations from flutter/flutter's
   flutter_localizations package.
+* Updates minimum supported SDK version to Flutter 3.44/Dart 3.12.
 
 ## 0.0.1
 

--- a/packages/material_ui/CHANGELOG.md
+++ b/packages/material_ui/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Copied over Material localizations from flutter/flutter's
   flutter_localizations package.
 * Unpin material_color_utilities.
+* Migrated API doc samples and formatting.
 * Updates minimum supported SDK version to Flutter 3.44/Dart 3.12.
 
 ## 0.0.1

--- a/packages/material_ui/CHANGELOG.md
+++ b/packages/material_ui/CHANGELOG.md
@@ -1,6 +1,9 @@
-## NEXT
+## 0.0.2
 
-* Updates minimum supported SDK version to Flutter 3.38/Dart 3.10.
+* Copied over all Material code from flutter/flutter.
+* Copied over Material localizations from flutter/flutter's
+  flutter_localizations package.
+* Unpin material_color_utilities.
 
 ## 0.0.1
 

--- a/packages/material_ui/CHANGELOG.md
+++ b/packages/material_ui/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Copied over Material localizations from flutter/flutter's
   flutter_localizations package.
 * Unpin material_color_utilities.
+* Updates minimum supported SDK version to Flutter 3.44/Dart 3.12.
 
 ## 0.0.1
 


### PR DESCRIPTION
Update changelogs for 0.0.2, which will be the first prerelease with the real code.