### PR TITLE
[cupertino_ui] Undo unpublished version info

### DIFF
--- a/packages/cupertino_ui/CHANGELOG.md
+++ b/packages/cupertino_ui/CHANGELOG.md
@@ -1,11 +1,3 @@
-## 0.0.2
-
-* Copied over all Cupertino code from flutter/flutter.
-* Copied over Cupertino localizations from flutter/flutter's
-  flutter_localizations package.
-* Migrated API doc samples and formatting.
-* Updates minimum supported SDK version to Flutter 3.44/Dart 3.12.
-
 ## 0.0.1
 
 * Initial setup of the `cupertino_ui` package, preparing for decoupling Cupertino widgets from the Flutter framework.

--- a/packages/cupertino_ui/pubspec.yaml
+++ b/packages/cupertino_ui/pubspec.yaml
@@ -1,6 +1,6 @@
 name: cupertino_ui
 description: The official Flutter Cupertino Design Library, implementing the iOS design system.
-version: 0.0.2
+version: 0.0.1
 publish_to: none
 repository: https://github.com/flutter/packages/tree/main/packages/cupertino_ui
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A%20cupertino%22


### PR DESCRIPTION
cupertino_ui has had publishing turned off, but we're going to turn on the batch release process soon. This PR adjusts the pubspec version and Changelog to match what's on Pub, so that the batch release process can take over from there.

The version was originally bumped manually in https://github.com/flutter/packages/pull/11649.

PR https://github.com/flutter/packages/pull/12251 will come after this one and will enable the batch release process.