### PR TITLE
[material_ui] Remove manual version changes

### DIFF
--- a/packages/material_ui/CHANGELOG.md
+++ b/packages/material_ui/CHANGELOG.md
@@ -1,12 +1,3 @@
-## 0.0.2
-
-* Copied over all Material code from flutter/flutter.
-* Copied over Material localizations from flutter/flutter's
-  flutter_localizations package.
-* Unpin material_color_utilities.
-* Migrated API doc samples and formatting.
-* Updates minimum supported SDK version to Flutter 3.44/Dart 3.12.
-
 ## 0.0.1
 
 * Initial setup of the `material_ui` package, preparing for decoupling Material widgets from the Flutter framework.

--- a/packages/material_ui/pubspec.yaml
+++ b/packages/material_ui/pubspec.yaml
@@ -1,6 +1,6 @@
 name: material_ui
 description: The official Flutter Material UI Library, implementing Google's Material Design design system.
-version: 0.0.2
+version: 0.0.1
 publish_to: none
 repository: https://github.com/flutter/packages/tree/main/packages/material_ui
 issue_tracker:  https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A%20material%20design%22


### PR DESCRIPTION
material_ui has had publishing turned off, but we're going to turn on the batch release process soon. This PR adjusts the pubspec version and Changelog to match what's on Pub, so that the batch release process can take over from there.

The version was originally bumped manually in https://github.com/flutter/packages/pull/11649.

This is the material_ui version of https://github.com/flutter/packages/pull/12252.

A future PR will come after this one and will enable the batch release process.

In follow up PR https://github.com/flutter/packages/pull/12258, I will make a pending changelog like this:

```yaml
changelog: |
  - Copies over all Material code from flutter/flutter.
  - Copies over Material localizations from flutter/flutter's flutter_localizations package.
  - Unpins material_color_utilities.
  - Migrates API doc samples and formatting.
  - Updates minimum supported SDK version to Flutter 3.44/Dart 3.12.

version: patch
```