### PR TITLE
[tool] Support pre-1.0 versions in batch releases

### DIFF
--- a/script/tool/CHANGELOG.md
+++ b/script/tool/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Adds support for batch release of pre-1.0 packgaes.
+
 ## 0.14.4
 
 * Adds `--run-on-staged-packages` argument to support running commands only

--- a/script/tool/CHANGELOG.md
+++ b/script/tool/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## NEXT
 
-* Adds support for batch release of pre-1.0 packgaes.
+* Adds support for batch release of pre-1.0 packages.
 
 ## 0.14.4
 

--- a/script/tool/lib/src/branches_for_batch_release_command.dart
+++ b/script/tool/lib/src/branches_for_batch_release_command.dart
@@ -78,10 +78,8 @@ class BranchesForBatchReleaseCommand extends PackageCommand {
     }
 
     final pubspec = Pubspec.parse(package.pubspecFile.readAsStringSync());
-    if (pubspec.version == null || pubspec.version!.major < 1) {
-      printError(
-        'This script only supports packages with version >= 1.0.0. Current version: ${pubspec.version}.',
-      );
+    if (pubspec.version == null) {
+      printError('The package has no version specified.');
       throw ToolExit(_kExitPackageMalformed);
     }
     final _ReleaseInfo releaseInfo = _getReleaseInfo(pendingChangelogs, pubspec.version!);
@@ -131,13 +129,32 @@ class BranchesForBatchReleaseCommand extends PackageCommand {
     }
     final VersionChange effectiveVersionChange = VersionChange.values[versionIndex];
 
-    final Version? newVersion = switch (effectiveVersionChange) {
-      VersionChange.skip => null,
-      VersionChange.major => Version(oldVersion.major + 1, 0, 0),
-      VersionChange.minor => Version(oldVersion.major, oldVersion.minor + 1, 0),
-      VersionChange.patch => Version(oldVersion.major, oldVersion.minor, oldVersion.patch + 1),
-    };
+    final Version? newVersion = _newVersionFollowingDartSemVer(oldVersion, effectiveVersionChange);
     return _ReleaseInfo(newVersion, changelogs);
+  }
+
+  Version? _newVersionFollowingDartSemVer(Version oldVersion, VersionChange change) {
+    if (oldVersion.major == 0) {
+      final oldBuildNumber = oldVersion.build.isEmpty ? 0 : oldVersion.build.first as int;
+      return switch (change) {
+        VersionChange.skip => null,
+        VersionChange.major => Version(0, oldVersion.minor + 1, 0),
+        VersionChange.minor => Version(0, oldVersion.minor, oldVersion.patch + 1),
+        VersionChange.patch => Version(
+          0,
+          oldVersion.minor,
+          oldVersion.patch,
+          build: '${oldBuildNumber + 1}',
+        ),
+      };
+    } else {
+      return switch (change) {
+        VersionChange.skip => null,
+        VersionChange.major => Version(oldVersion.major + 1, 0, 0),
+        VersionChange.minor => Version(oldVersion.major, oldVersion.minor + 1, 0),
+        VersionChange.patch => Version(oldVersion.major, oldVersion.minor, oldVersion.patch + 1),
+      };
+    }
   }
 
   /// Creates a branch with a commit contains the changes for the release.

--- a/script/tool/test/branches_for_batch_release_command_test.dart
+++ b/script/tool/test/branches_for_batch_release_command_test.dart
@@ -35,17 +35,13 @@ void main() {
         '--remote=origin',
       ], errorHandler: errorHandler);
 
-  RepositoryPackage createTestPackage() {
-    final RepositoryPackage package = createFakePackage('a_package', packagesDir);
+  RepositoryPackage createTestPackage({String version = '1.0.0'}) {
+    final RepositoryPackage package = createFakePackage('a_package', packagesDir, version: version);
 
     package.changelogFile.writeAsStringSync('''
-## 1.0.0
+## $version
 
 - Old changes
-''');
-    package.pubspecFile.writeAsStringSync('''
-name: a_package
-version: 1.0.0
 ''');
     package.directory.childDirectory('pending_changelogs').createSync();
     return package;
@@ -183,6 +179,89 @@ version: patch
       expect(changelogContent, startsWith('## 1.0.1'));
       expect(changelogContent, contains('A new feature'));
       expect(gitProcessRunner.recordedCalls, orderedEquals(getExpectedGitCalls('1.0.1')));
+    });
+    test('bumps "patch" version for minor pre-1.0', () async {
+      final RepositoryPackage package = createTestPackage(version: '0.1.0');
+      addTearDown(() {
+        package.directory.deleteSync(recursive: true);
+      });
+      createPendingChangelogFile(package, 'a.yaml', '''
+changelog: A new feature
+version: minor
+''');
+
+      final List<String> output = await runBatchCommand();
+
+      expect(
+        output,
+        containsAllInOrder(<String>[
+          'Parsing package "a_package"...',
+          '  Creating new branch "release-branch"...',
+          '  Pushing branch release-branch to remote origin...',
+        ]),
+      );
+
+      expect(package.pubspecFile.readAsStringSync(), contains('version: 0.1.1'));
+      final String changelogContent = package.changelogFile.readAsStringSync();
+      expect(changelogContent, startsWith('## 0.1.1'));
+      expect(changelogContent, contains('A new feature'));
+      expect(gitProcessRunner.recordedCalls, orderedEquals(getExpectedGitCalls('0.1.1')));
+    });
+
+    test('bumps "minor" version for major in pre-1.0', () async {
+      final RepositoryPackage package = createTestPackage(version: '0.1.0');
+      addTearDown(() {
+        package.directory.deleteSync(recursive: true);
+      });
+      createPendingChangelogFile(package, 'a.yaml', '''
+changelog: A new feature
+version: major
+''');
+
+      final List<String> output = await runBatchCommand();
+
+      expect(
+        output,
+        containsAllInOrder(<String>[
+          'Parsing package "a_package"...',
+          '  Creating new branch "release-branch"...',
+          '  Pushing branch release-branch to remote origin...',
+        ]),
+      );
+
+      expect(package.pubspecFile.readAsStringSync(), contains('version: 0.2.0'));
+      final String changelogContent = package.changelogFile.readAsStringSync();
+      expect(changelogContent, startsWith('## 0.2.0'));
+      expect(changelogContent, contains('A new feature'));
+      expect(gitProcessRunner.recordedCalls, orderedEquals(getExpectedGitCalls('0.2.0')));
+    });
+
+    test('bumps build number for patch in pre-1.0', () async {
+      final RepositoryPackage package = createTestPackage(version: '0.1.0');
+      addTearDown(() {
+        package.directory.deleteSync(recursive: true);
+      });
+      createPendingChangelogFile(package, 'a.yaml', '''
+changelog: A new feature
+version: patch
+''');
+
+      final List<String> output = await runBatchCommand();
+
+      expect(
+        output,
+        containsAllInOrder(<String>[
+          'Parsing package "a_package"...',
+          '  Creating new branch "release-branch"...',
+          '  Pushing branch release-branch to remote origin...',
+        ]),
+      );
+
+      expect(package.pubspecFile.readAsStringSync(), contains('version: 0.1.0+1'));
+      final String changelogContent = package.changelogFile.readAsStringSync();
+      expect(changelogContent, startsWith('## 0.1.0+1'));
+      expect(changelogContent, contains('A new feature'));
+      expect(gitProcessRunner.recordedCalls, orderedEquals(getExpectedGitCalls('0.1.0+1')));
     });
 
     test('merges multiple changelogs, minor and major', () async {
@@ -598,44 +677,6 @@ version: major
       );
 
       expect(output.last, contains('Failed to push to release-a_package-2.0.0: error'));
-    });
-
-    test('throws for pre-1.0.0 packages', () async {
-      final RepositoryPackage package = createFakePackage('a_package', packagesDir);
-
-      addTearDown(() {
-        package.directory.deleteSync(recursive: true);
-      });
-
-      // Set a pre-1.0.0 version.
-      package.changelogFile.writeAsStringSync('''
-## 0.5.0
-
-- Old changes
-''');
-      package.pubspecFile.writeAsStringSync('''
-name: a_package
-version: 0.5.0
-''');
-      package.directory.childDirectory('pending_changelogs').createSync();
-      createPendingChangelogFile(package, 'a.yaml', '''
-changelog: A new feature
-version: minor
-''');
-
-      final List<String> output = await runBatchCommand(
-        errorHandler: (Error e) {
-          expect(e, isA<ToolExit>());
-          expect((e as ToolExit).exitCode, 3);
-        },
-      );
-
-      expect(
-        output.last,
-        contains(
-          'This script only supports packages with version >= 1.0.0. Current version: 0.5.0.',
-        ),
-      );
     });
   });
 }


### PR DESCRIPTION
Adds support for Dart's semver convention of shifting the conceptual meaning of versions by one place for pre-1.0 package when determining batch release versions.

For example, a batch release with a "major" changelog entry would go from 0.x.y to 0.x+1.0.