### PR TITLE
[google_maps_flutter_platform_interface] Fix PinConfig code sample

### DIFF
--- a/packages/google_maps_flutter/google_maps_flutter_platform_interface/CHANGELOG.md
+++ b/packages/google_maps_flutter/google_maps_flutter_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.16.1
+
+* Fixes the `PinConfig` code sample in the `BitmapDescriptor` documentation.
+
 ## 2.16.0
 
 * Adds support for `mapTypeControlEnabled`, `fullscreenControlEnabled`, and `streetViewControlEnabled` for web.

--- a/packages/google_maps_flutter/google_maps_flutter_platform_interface/lib/src/types/bitmap.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_platform_interface/lib/src/types/bitmap.dart
@@ -1009,10 +1009,11 @@ class BytesMapBitmap extends MapBitmap {
 /// ```dart
 /// PinConfig(
 ///   glyph: BitmapGlyph(
-///     bitmap: BitmapDescriptor.asset(
+///     bitmap: await BitmapDescriptor.asset(
 ///       ImageConfiguration(size: Size(12, 12)),
-///       'assets/cat.png'
-///    )
+///       'assets/cat.png',
+///     ),
+///   ),
 /// )
 /// ```
 ///

--- a/packages/google_maps_flutter/google_maps_flutter_platform_interface/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter_platform_interface/pubspec.yaml
@@ -4,7 +4,7 @@ repository: https://github.com/flutter/packages/tree/main/packages/google_maps_f
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+maps%22
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 2.16.0
+version: 2.16.1
 
 environment:
   sdk: ^3.10.0


### PR DESCRIPTION
The second `PinConfig` sample in the `BitmapDescriptor` docs (`bitmap.dart:1009`) doesn't compile, for two reasons:

1. **Unbalanced parens** — the block opens `PinConfig(`, `BitmapGlyph(` and `BitmapDescriptor.asset(` but only closes two of them. (The sibling `TextGlyph` sample directly above closes correctly.)
2. **Missing `await`** — `BitmapDescriptor.asset` is declared `static Future<AssetMapBitmap> asset(...)` (line 278), while `BitmapGlyph.bitmap` is `final BitmapDescriptor bitmap;` (line 1106), so a bare `BitmapDescriptor.asset(...)` can't be assigned to it.

The repo's own examples use the awaited form — e.g. `google_maps_flutter_web/example/latest/integration_test/advanced_markers_test.dart:422`:

```dart
bitmap: await BitmapDescriptor.asset(
```

The sample now mirrors that. Paren balance goes from 5 open / 4 close to 5 / 5.

Doc comment only; bumped to 2.16.1 with a CHANGELOG entry per the versioning policy — happy to switch to `## NEXT` if that's preferred for a docs-only change.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter.
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets.
- [ ] I [linked to at least one issue that this PR fixes] in the description above. *(No tracker issue exists for this; it's a two-line doc-sample fix. Happy to file one in flutter/flutter if required.)*
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or I have commented below to indicate which [version change exemption] this PR falls under.
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style], or I have commented below to indicate which [CHANGELOG exemption] this PR falls under.

