### PR TITLE
[cupertino_ui] Bump minor to get to 0.0.2, not patch

### DIFF
--- a/packages/cupertino_ui/pending_changelogs/change_2026_07_20_12251.yaml
+++ b/packages/cupertino_ui/pending_changelogs/change_2026_07_20_12251.yaml
@@ -4,4 +4,4 @@ changelog: |
     flutter_localizations package.
   - Migrates API doc samples and formatting.
   - Updates minimum supported SDK version to Flutter 3.44/Dart 3.12.
-version: patch
+version: minor


### PR DESCRIPTION
See https://github.com/flutter/packages/pull/12257#discussion_r3623894822. This PR shouldn't land unless that one does.