### PR TITLE
[tool] Rename batch change override label

### DIFF
--- a/.github/workflows/batch_release_pr.yml
+++ b/.github/workflows/batch_release_pr.yml
@@ -70,7 +70,7 @@ jobs:
             --head "${HEAD_BRANCH_NAME}" \
             --title "[${GITHUB_EVENT_CLIENT_PAYLOAD_PACKAGE}] Batch release" \
             --body "This PR was created automatically to batch release the \`${GITHUB_EVENT_CLIENT_PAYLOAD_PACKAGE}\`." \
-            --label "override: skip-batch-release-repo-check-${GITHUB_EVENT_CLIENT_PAYLOAD_PACKAGE}"
+            --label "override: batch-${GITHUB_EVENT_CLIENT_PAYLOAD_PACKAGE}"
         env:
           NEEDS_CREATE_BATCH_RELEASE_BRANCH_OUTPUTS_RELEASE_BRANCH: ${{ needs.create_batch_release_branch.outputs.release_branch }}
           GITHUB_EVENT_CLIENT_PAYLOAD_PACKAGE: ${{ github.event.client_payload.package }}

--- a/.github/workflows/sync_release_pr.yml
+++ b/.github/workflows/sync_release_pr.yml
@@ -49,4 +49,4 @@ jobs:
             --head "${GITHUB_REF_NAME}" \
             --title "Sync ${GITHUB_REF_NAME} to main" \
             --body "This automated PR syncs the changes from the release branch ${GITHUB_REF_NAME} back to the main branch." \
-            --label "override: skip-batch-release-repo-check-${PACKAGE_NAME}"
+            --label "override: batch-${PACKAGE_NAME}"

--- a/script/tool/lib/src/validators/version_and_changelog_validator.dart
+++ b/script/tool/lib/src/validators/version_and_changelog_validator.dart
@@ -164,11 +164,11 @@ class VersionAndChangelogValidator {
       pubspec: pubspec,
       ignorePlatformInterfaceBreaks: ignorePlatformInterfaceBreaks,
     );
-    // PR with override: skip-batch-release-repo-check-<package> label is going to sync
-    // changelog.md and pubspec.yaml changes back to main branch.
-    // Proceed with regular version check.
+    // PR with override: batch-<package> label is batching the pending
+    // changelogs into CHANGELOG.md, so do the standard checks instead of batch
+    // checks.
     final bool shouldSkipBatchReleaseRepoCheck = _prLabels.contains(
-      'override: skip-batch-release-repo-check-${pubspec.name}',
+      'override: batch-${pubspec.name}',
     );
     bool versionChanged;
 

--- a/script/tool/test/validate_command_version_test.dart
+++ b/script/tool/test/validate_command_version_test.dart
@@ -1584,7 +1584,7 @@ release:
         );
       });
       test(
-        'ignores changelog and pubspec yaml version modifications check with override: skip-batch-release-repo-check label',
+        'ignores changelog and pubspec yaml version modifications check with override: batch-<package> label',
         () async {
           final RepositoryPackage package = createFakePackage(
             'package',
@@ -1615,7 +1615,7 @@ packages/package/pubspec.yaml
           final List<String> output = await runCapturingPrint(runner, <String>[
             'validate',
             '--base-sha=main',
-            '--pr-labels=override: skip-batch-release-repo-check-package',
+            '--pr-labels=override: batch-package',
           ]);
 
           expect(


### PR DESCRIPTION
(again)

This was given a more descriptive lbale in
https://github.com/flutter/packages/pull/11835, but it appears based on failures when attempting to generate the PR that there is an undocumented length limit of 50 characters for label names, and `override: skip-batch-release-repo-check-` uses 40 of them, which causes problems when adding the package name.

This renames to `override: batch-`, which is less descriptive, but should work around the length limit.

Longer term, we may need to revisit having the package name in the label to avoid edge case issues with long package names.