### PR TITLE
[material_ui, cupertino_ui] Fix API doc references

### DIFF
--- a/packages/cupertino_ui/lib/cupertino_ui.dart
+++ b/packages/cupertino_ui/lib/cupertino_ui.dart
@@ -11,7 +11,8 @@
 /// example the [Material
 /// Design](https://docs.flutter.dev/ui/widgets/material) set.
 ///
-/// {@youtube 560 315 https://www.youtube.com/watch?v=3PdUaidHc-E}
+// TODO(Piinks): Follow up on youtube support
+// {@youtube 560 315 https://www.youtube.com/watch?v=3PdUaidHc-E}
 ///
 /// See also:
 ///
@@ -19,6 +20,8 @@
 ///    for a catalog of all Cupertino widgets.
 ///  * [flutter.dev/widgets](https://docs.flutter.dev/ui/widgets)
 ///    for a catalog of commonly-used Flutter widgets.
+/// @docImport 'package:flutter_test/flutter_test.dart';
+/// @docImport 'package:intl/intl.dart';
 library cupertino_ui;
 
 export 'package:flutter/widgets.dart';

--- a/packages/cupertino_ui/lib/cupertino_ui.dart
+++ b/packages/cupertino_ui/lib/cupertino_ui.dart
@@ -11,8 +11,7 @@
 /// example the [Material
 /// Design](https://docs.flutter.dev/ui/widgets/material) set.
 ///
-// TODO(Piinks): Follow up on youtube support
-// {@youtube 560 315 https://www.youtube.com/watch?v=3PdUaidHc-E}
+/// Learn more about Cupertino widgets on the [Flutter YouTube channel](https://www.youtube.com/watch?v=3PdUaidHc-E).
 ///
 /// See also:
 ///

--- a/packages/cupertino_ui/lib/src/activity_indicator.dart
+++ b/packages/cupertino_ui/lib/src/activity_indicator.dart
@@ -19,8 +19,7 @@ const Color _kActiveTickColor = CupertinoDynamicColor.withBrightness(
 
 /// An iOS-style activity indicator that spins clockwise.
 ///
-// TODO(Piinks): Follow up on youtube support
-// {@youtube 560 315 https://www.youtube.com/watch?v=AENVH-ZqKDQ}
+/// Learn more about [CupertinoActivityIndicator] on the [Flutter YouTube channel](https://www.youtube.com/watch?v=AENVH-ZqKDQ).
 ///
 /// <callout-box>
 ///

--- a/packages/cupertino_ui/lib/src/activity_indicator.dart
+++ b/packages/cupertino_ui/lib/src/activity_indicator.dart
@@ -19,7 +19,8 @@ const Color _kActiveTickColor = CupertinoDynamicColor.withBrightness(
 
 /// An iOS-style activity indicator that spins clockwise.
 ///
-/// {@youtube 560 315 https://www.youtube.com/watch?v=AENVH-ZqKDQ}
+// TODO(Piinks): Follow up on youtube support
+// {@youtube 560 315 https://www.youtube.com/watch?v=AENVH-ZqKDQ}
 ///
 /// <callout-box>
 ///

--- a/packages/cupertino_ui/lib/src/checkbox.dart
+++ b/packages/cupertino_ui/lib/src/checkbox.dart
@@ -48,8 +48,7 @@ const List<double> _kDisabledDarkGradientOpacities = <double>[0.08, 0.14];
 
 /// A macOS style checkbox.
 ///
-// TODO(Piinks): Follow up on youtube support
-// {@youtube 560 315 https://www.youtube.com/watch?v=ua54JU7k1Us}
+/// Learn more about [CupertinoCheckbox] on the [Flutter YouTube channel](https://www.youtube.com/watch?v=ua54JU7k1Us).
 ///
 /// The checkbox itself does not maintain any state. Instead, when the state of
 /// the checkbox changes, the widget calls the [onChanged] callback. Most

--- a/packages/cupertino_ui/lib/src/checkbox.dart
+++ b/packages/cupertino_ui/lib/src/checkbox.dart
@@ -48,7 +48,8 @@ const List<double> _kDisabledDarkGradientOpacities = <double>[0.08, 0.14];
 
 /// A macOS style checkbox.
 ///
-/// {@youtube 560 315 https://www.youtube.com/watch?v=ua54JU7k1Us}
+// TODO(Piinks): Follow up on youtube support
+// {@youtube 560 315 https://www.youtube.com/watch?v=ua54JU7k1Us}
 ///
 /// The checkbox itself does not maintain any state. Instead, when the state of
 /// the checkbox changes, the widget calls the [onChanged] callback. Most

--- a/packages/cupertino_ui/lib/src/dialog.dart
+++ b/packages/cupertino_ui/lib/src/dialog.dart
@@ -195,8 +195,7 @@ bool _isInAccessibilityMode(BuildContext context) {
 
 /// An iOS-style alert dialog.
 ///
-// TODO(Piinks): Follow up on youtube support
-// {@youtube 560 315 https://www.youtube.com/watch?v=75CsnyRXf5I}
+/// Learn more about [CupertinoAlertDialog] on the [Flutter YouTube channel](https://www.youtube.com/watch?v=75CsnyRXf5I).
 ///
 /// An alert dialog informs the user about situations that require
 /// acknowledgment. An alert dialog has an optional title, optional content,
@@ -1053,8 +1052,7 @@ class _ActionSheetGestureDetector extends StatelessWidget {
 
 /// An iOS-style action sheet.
 ///
-// TODO(Piinks): Follow up on youtube support
-// {@youtube 560 315 https://www.youtube.com/watch?v=U-ao8p4A82k}
+/// Learn more about [CupertinoActionSheet] on the [Flutter YouTube channel](https://www.youtube.com/watch?v=U-ao8p4A82k).
 ///
 /// An action sheet is a specific style of alert that presents the user
 /// with a set of two or more choices related to the current context.

--- a/packages/cupertino_ui/lib/src/dialog.dart
+++ b/packages/cupertino_ui/lib/src/dialog.dart
@@ -195,7 +195,8 @@ bool _isInAccessibilityMode(BuildContext context) {
 
 /// An iOS-style alert dialog.
 ///
-/// {@youtube 560 315 https://www.youtube.com/watch?v=75CsnyRXf5I}
+// TODO(Piinks): Follow up on youtube support
+// {@youtube 560 315 https://www.youtube.com/watch?v=75CsnyRXf5I}
 ///
 /// An alert dialog informs the user about situations that require
 /// acknowledgment. An alert dialog has an optional title, optional content,
@@ -1052,7 +1053,8 @@ class _ActionSheetGestureDetector extends StatelessWidget {
 
 /// An iOS-style action sheet.
 ///
-/// {@youtube 560 315 https://www.youtube.com/watch?v=U-ao8p4A82k}
+// TODO(Piinks): Follow up on youtube support
+// {@youtube 560 315 https://www.youtube.com/watch?v=U-ao8p4A82k}
 ///
 /// An action sheet is a specific style of alert that presents the user
 /// with a set of two or more choices related to the current context.

--- a/packages/cupertino_ui/lib/src/l10n/generated_cupertino_localizations.dart
+++ b/packages/cupertino_ui/lib/src/l10n/generated_cupertino_localizations.dart
@@ -6,6 +6,9 @@
 // To regenerate the file, use:
 // dart script/l10n/bin/gen_localizations.dart --overwrite
 
+/// @docImport 'package:intl/intl.dart';
+library;
+
 import 'dart:collection';
 
 import 'package:flutter/widgets.dart';

--- a/packages/cupertino_ui/lib/src/radio.dart
+++ b/packages/cupertino_ui/lib/src/radio.dart
@@ -59,8 +59,7 @@ const List<double> _kDisabledDarkGradientOpacities = <double>[0.08, 0.14];
 
 /// A widget that builds a [RawRadio] with a macOS-style UI.
 ///
-// TODO(Piinks): Follow up on youtube support
-// {@youtube 560 315 https://www.youtube.com/watch?v=D0xwcz2IqAY}
+/// Learn more about [CupertinoRadio] on the [Flutter YouTube channel](https://www.youtube.com/watch?v=D0xwcz2IqAY).
 ///
 /// Used to select between a number of mutually exclusive values. When one radio
 /// button in a group is selected, the other radio buttons in the group are

--- a/packages/cupertino_ui/lib/src/radio.dart
+++ b/packages/cupertino_ui/lib/src/radio.dart
@@ -59,7 +59,8 @@ const List<double> _kDisabledDarkGradientOpacities = <double>[0.08, 0.14];
 
 /// A widget that builds a [RawRadio] with a macOS-style UI.
 ///
-/// {@youtube 560 315 https://www.youtube.com/watch?v=D0xwcz2IqAY}
+// TODO(Piinks): Follow up on youtube support
+// {@youtube 560 315 https://www.youtube.com/watch?v=D0xwcz2IqAY}
 ///
 /// Used to select between a number of mutually exclusive values. When one radio
 /// button in a group is selected, the other radio buttons in the group are

--- a/packages/cupertino_ui/lib/src/scrollbar.dart
+++ b/packages/cupertino_ui/lib/src/scrollbar.dart
@@ -35,62 +35,9 @@ const double _kScrollbarCrossAxisMargin = 3.0;
 /// To add a scrollbar to a [ScrollView], wrap the scroll view widget in
 /// a [CupertinoScrollbar] widget.
 ///
-/// A scrollbar thumb indicates which portion of a [ScrollView] is actually
-/// visible.
+//// Learn more about [CupertinoScrollbar] on the [Flutter YouTube channel](https://www.youtube.com/watch?v=DbkIQSvwnZc).
 ///
-/// By default, the thumb will fade in and out as the child scroll view
-/// scrolls. When [thumbVisibility] is true, the scrollbar thumb will remain
-/// visible without the fade animation. This requires that the [ScrollController]
-/// associated with the Scrollable widget is provided to [controller], or that
-/// the [PrimaryScrollController] is being used by that Scrollable widget.
-///
-/// If the scrollbar is wrapped around multiple [ScrollView]s, it only responds to
-/// the nearest ScrollView and shows the corresponding scrollbar thumb by default.
-/// The [notificationPredicate] allows the ability to customize which
-/// [ScrollNotification]s the Scrollbar should listen to.
-///
-/// If the child [ScrollView] is infinitely long, the [RawScrollbar] will not be
-/// painted. In this case, the scrollbar cannot accurately represent the
-/// relative location of the visible area, or calculate the accurate delta to
-/// apply when dragging on the thumb or tapping on the track.
-///
-/// ### Interaction
-///
-/// Scrollbars are interactive and can use the [PrimaryScrollController] if
-/// a [controller] is not set. Interactive Scrollbar thumbs can be dragged along
-/// the main axis of the [ScrollView] to change the [ScrollPosition]. Tapping
-/// along the track exclusive of the thumb will trigger a
-/// [ScrollIncrementType.page] based on the relative position to the thumb.
-///
-/// When using the [PrimaryScrollController], it must not be attached to more
-/// than one [ScrollPosition]. [ScrollView]s that have not been provided a
-/// [ScrollController] and have a [ScrollView.scrollDirection] of
-/// [Axis.vertical] will automatically attach their ScrollPosition to the
-/// PrimaryScrollController. Provide a unique ScrollController to each
-/// [Scrollable] in this case to prevent having multiple ScrollPositions
-/// attached to the PrimaryScrollController.
-///
-/// ### Automatic Scrollbars on Desktop Platforms
-///
-/// Scrollbars are added to most [Scrollable] widgets by default on
-/// desktop platforms. This is done through
-/// [ScrollBehavior.buildScrollbar] as part of an app's
-/// [ScrollConfiguration]. Scrollables that do not use the
-/// [PrimaryScrollController] or have a [ScrollController] provided to them
-/// will receive a unique ScrollController for use with the Scrollbar. In this
-/// case, only one Scrollable can be using the PrimaryScrollController, unless
-/// [interactive] is false. To prevent [Axis.vertical] Scrollables from using
-/// the PrimaryScrollController, set [ScrollView.primary] to false. Scrollable
-/// widgets that do not have automatically applied Scrollbars include
-///
-///   * [EditableText]
-///   * [ListWheelScrollView]
-///   * [PageView]
-///   * [NestedScrollView]
-///   * [DropdownButton]
-///
-/// Default Scrollbars can be disabled for the whole app by setting a
-/// [ScrollBehavior] with `scrollbars` set to false.
+/// {@macro flutter.widgets.Scrollbar}
 ///
 /// When dragging a [CupertinoScrollbar] thumb, the thickness and radius will
 /// animate from [thickness] and [radius] to [thicknessWhileDragging] and

--- a/packages/cupertino_ui/lib/src/scrollbar.dart
+++ b/packages/cupertino_ui/lib/src/scrollbar.dart
@@ -35,9 +35,62 @@ const double _kScrollbarCrossAxisMargin = 3.0;
 /// To add a scrollbar to a [ScrollView], wrap the scroll view widget in
 /// a [CupertinoScrollbar] widget.
 ///
-/// {@youtube 560 315 https://www.youtube.com/watch?v=DbkIQSvwnZc}
+/// A scrollbar thumb indicates which portion of a [ScrollView] is actually
+/// visible.
 ///
-/// {@macro flutter.widgets.Scrollbar}
+/// By default, the thumb will fade in and out as the child scroll view
+/// scrolls. When [thumbVisibility] is true, the scrollbar thumb will remain
+/// visible without the fade animation. This requires that the [ScrollController]
+/// associated with the Scrollable widget is provided to [controller], or that
+/// the [PrimaryScrollController] is being used by that Scrollable widget.
+///
+/// If the scrollbar is wrapped around multiple [ScrollView]s, it only responds to
+/// the nearest ScrollView and shows the corresponding scrollbar thumb by default.
+/// The [notificationPredicate] allows the ability to customize which
+/// [ScrollNotification]s the Scrollbar should listen to.
+///
+/// If the child [ScrollView] is infinitely long, the [RawScrollbar] will not be
+/// painted. In this case, the scrollbar cannot accurately represent the
+/// relative location of the visible area, or calculate the accurate delta to
+/// apply when dragging on the thumb or tapping on the track.
+///
+/// ### Interaction
+///
+/// Scrollbars are interactive and can use the [PrimaryScrollController] if
+/// a [controller] is not set. Interactive Scrollbar thumbs can be dragged along
+/// the main axis of the [ScrollView] to change the [ScrollPosition]. Tapping
+/// along the track exclusive of the thumb will trigger a
+/// [ScrollIncrementType.page] based on the relative position to the thumb.
+///
+/// When using the [PrimaryScrollController], it must not be attached to more
+/// than one [ScrollPosition]. [ScrollView]s that have not been provided a
+/// [ScrollController] and have a [ScrollView.scrollDirection] of
+/// [Axis.vertical] will automatically attach their ScrollPosition to the
+/// PrimaryScrollController. Provide a unique ScrollController to each
+/// [Scrollable] in this case to prevent having multiple ScrollPositions
+/// attached to the PrimaryScrollController.
+///
+/// ### Automatic Scrollbars on Desktop Platforms
+///
+/// Scrollbars are added to most [Scrollable] widgets by default on
+/// desktop platforms. This is done through
+/// [ScrollBehavior.buildScrollbar] as part of an app's
+/// [ScrollConfiguration]. Scrollables that do not use the
+/// [PrimaryScrollController] or have a [ScrollController] provided to them
+/// will receive a unique ScrollController for use with the Scrollbar. In this
+/// case, only one Scrollable can be using the PrimaryScrollController, unless
+/// [interactive] is false. To prevent [Axis.vertical] Scrollables from using
+/// the PrimaryScrollController, set [ScrollView.primary] to false. Scrollable
+/// widgets that do not have automatically applied Scrollbars include
+///
+///   * [EditableText]
+///   * [ListWheelScrollView]
+///   * [PageView]
+///   * [NestedScrollView]
+///   * [DropdownButton]
+///
+/// Default Scrollbars can be disabled for the whole app by setting a
+/// [ScrollBehavior] with `scrollbars` set to false.
 ///
 /// When dragging a [CupertinoScrollbar] thumb, the thickness and radius will
 /// animate from [thickness] and [radius] to [thicknessWhileDragging] and

--- a/packages/cupertino_ui/lib/src/scrollbar.dart
+++ b/packages/cupertino_ui/lib/src/scrollbar.dart
@@ -35,7 +35,7 @@ const double _kScrollbarCrossAxisMargin = 3.0;
 /// To add a scrollbar to a [ScrollView], wrap the scroll view widget in
 /// a [CupertinoScrollbar] widget.
 ///
-//// Learn more about [CupertinoScrollbar] on the [Flutter YouTube channel](https://www.youtube.com/watch?v=DbkIQSvwnZc).
+/// Learn more about [CupertinoScrollbar] on the [Flutter YouTube channel](https://www.youtube.com/watch?v=DbkIQSvwnZc).
 ///
 /// {@macro flutter.widgets.Scrollbar}
 ///

--- a/packages/cupertino_ui/lib/src/sheet.dart
+++ b/packages/cupertino_ui/lib/src/sheet.dart
@@ -105,7 +105,7 @@ typedef _GetSheetDragged = bool Function();
 /// Shows a Cupertino-style sheet widget that slides up from the bottom of the
 /// screen and stacks the previous route behind the new sheet.
 ///
-/// Learn more about [CupertinoActionSheet] on the [Flutter YouTube channel](https://www.youtube.com/watch?v=5H-WvH5O29I).
+/// Learn more about [CupertinoSheetRoute] on the [Flutter YouTube channel](https://www.youtube.com/watch?v=5H-WvH5O29I).
 ///
 /// This is a convenience method for displaying [CupertinoSheetRoute] for most
 /// use cases. The Widget returned from `scrollableBuilder` will be used to display

--- a/packages/cupertino_ui/lib/src/sheet.dart
+++ b/packages/cupertino_ui/lib/src/sheet.dart
@@ -105,7 +105,8 @@ typedef _GetSheetDragged = bool Function();
 /// Shows a Cupertino-style sheet widget that slides up from the bottom of the
 /// screen and stacks the previous route behind the new sheet.
 ///
-/// {@youtube 560 315 https://www.youtube.com/watch?v=5H-WvH5O29I}
+// TODO(Piinks): Follow up on youtube support
+// {@youtube 560 315 https://www.youtube.com/watch?v=5H-WvH5O29I}
 ///
 /// This is a convenience method for displaying [CupertinoSheetRoute] for most
 /// use cases. The Widget returned from `scrollableBuilder` will be used to display
@@ -591,7 +592,8 @@ class _StretchDragControllerProvider extends InheritedWidget {
 
 /// Route for displaying an iOS sheet styled page.
 ///
-/// {@youtube 560 315 https://www.youtube.com/watch?v=5H-WvH5O29I}
+// TODO(Piinks): Follow up on youtube support
+// {@youtube 560 315 https://www.youtube.com/watch?v=5H-WvH5O29I}
 ///
 /// The `CupertinoSheetRoute` will slide up from the bottom of the screen and stop
 /// below the top of the screen. If the previous route is a non-sheet route, then

--- a/packages/cupertino_ui/lib/src/sheet.dart
+++ b/packages/cupertino_ui/lib/src/sheet.dart
@@ -105,8 +105,7 @@ typedef _GetSheetDragged = bool Function();
 /// Shows a Cupertino-style sheet widget that slides up from the bottom of the
 /// screen and stacks the previous route behind the new sheet.
 ///
-// TODO(Piinks): Follow up on youtube support
-// {@youtube 560 315 https://www.youtube.com/watch?v=5H-WvH5O29I}
+/// Learn more about [CupertinoActionSheet] on the [Flutter YouTube channel](https://www.youtube.com/watch?v=5H-WvH5O29I).
 ///
 /// This is a convenience method for displaying [CupertinoSheetRoute] for most
 /// use cases. The Widget returned from `scrollableBuilder` will be used to display
@@ -592,8 +591,7 @@ class _StretchDragControllerProvider extends InheritedWidget {
 
 /// Route for displaying an iOS sheet styled page.
 ///
-// TODO(Piinks): Follow up on youtube support
-// {@youtube 560 315 https://www.youtube.com/watch?v=5H-WvH5O29I}
+/// Learn more about [CupertinoSheetRoute] on the [Flutter YouTube channel](https://www.youtube.com/watch?v=5H-WvH5O29I).
 ///
 /// The `CupertinoSheetRoute` will slide up from the bottom of the screen and stop
 /// below the top of the screen. If the previous route is a non-sheet route, then

--- a/packages/cupertino_ui/lib/src/slider.dart
+++ b/packages/cupertino_ui/lib/src/slider.dart
@@ -36,8 +36,7 @@ const double _kVelocityThreshold = 1.0;
 
 /// An iOS-style slider.
 ///
-// TODO(Piinks): Follow up on youtube support
-// {@youtube 560 315 https://www.youtube.com/watch?v=ufb4gIPDmEs}
+/// Learn more about [CupertinoSlider] on the [Flutter YouTube channel](https://www.youtube.com/watch?v=ufb4gIPDmEs).
 ///
 /// Used to select from a range of values.
 ///

--- a/packages/cupertino_ui/lib/src/slider.dart
+++ b/packages/cupertino_ui/lib/src/slider.dart
@@ -36,7 +36,8 @@ const double _kVelocityThreshold = 1.0;
 
 /// An iOS-style slider.
 ///
-/// {@youtube 560 315 https://www.youtube.com/watch?v=ufb4gIPDmEs}
+// TODO(Piinks): Follow up on youtube support
+// {@youtube 560 315 https://www.youtube.com/watch?v=ufb4gIPDmEs}
 ///
 /// Used to select from a range of values.
 ///

--- a/packages/cupertino_ui/lib/src/sliding_segmented_control.dart
+++ b/packages/cupertino_ui/lib/src/sliding_segmented_control.dart
@@ -309,8 +309,7 @@ class _SegmentSeparatorState extends State<_SegmentSeparator>
 
 /// An iOS 13 style segmented control.
 ///
-// TODO(Piinks): Follow up on youtube support
-// {@youtube 560 315 https://www.youtube.com/watch?v=esnBf6V4C34}
+/// Learn more about [CupertinoSlidingSegmentedControl] on the [Flutter YouTube channel](https://www.youtube.com/watch?v=esnBf6V4C34).
 ///
 /// Displays the widgets provided in the [Map] of [children] in a horizontal list.
 /// It allows the user to select between a number of mutually exclusive options,

--- a/packages/cupertino_ui/lib/src/sliding_segmented_control.dart
+++ b/packages/cupertino_ui/lib/src/sliding_segmented_control.dart
@@ -309,7 +309,8 @@ class _SegmentSeparatorState extends State<_SegmentSeparator>
 
 /// An iOS 13 style segmented control.
 ///
-/// {@youtube 560 315 https://www.youtube.com/watch?v=esnBf6V4C34}
+// TODO(Piinks): Follow up on youtube support
+// {@youtube 560 315 https://www.youtube.com/watch?v=esnBf6V4C34}
 ///
 /// Displays the widgets provided in the [Map] of [children] in a horizontal list.
 /// It allows the user to select between a number of mutually exclusive options,

--- a/packages/cupertino_ui/lib/src/switch.dart
+++ b/packages/cupertino_ui/lib/src/switch.dart
@@ -69,7 +69,8 @@ const CupertinoDynamicColor _kOffLabelColor = CupertinoDynamicColor.withBrightne
 ///
 /// Used to toggle the on/off state of a single setting.
 ///
-/// {@youtube 560 315 https://www.youtube.com/watch?v=24tg_N4sdMQ}
+// TODO(Piinks): Follow up on youtube support
+// {@youtube 560 315 https://www.youtube.com/watch?v=24tg_N4sdMQ}
 ///
 /// The switch itself does not maintain its toggle state. Instead, when the
 /// toggle state of the switch changes, the widget calls the [onChanged]

--- a/packages/cupertino_ui/lib/src/switch.dart
+++ b/packages/cupertino_ui/lib/src/switch.dart
@@ -69,8 +69,7 @@ const CupertinoDynamicColor _kOffLabelColor = CupertinoDynamicColor.withBrightne
 ///
 /// Used to toggle the on/off state of a single setting.
 ///
-// TODO(Piinks): Follow up on youtube support
-// {@youtube 560 315 https://www.youtube.com/watch?v=24tg_N4sdMQ}
+/// Learn more about [CupertinoSwitch] on the [Flutter YouTube channel](https://www.youtube.com/watch?v=24tg_N4sdMQ).
 ///
 /// The switch itself does not maintain its toggle state. Instead, when the
 /// toggle state of the switch changes, the widget calls the [onChanged]

--- a/packages/cupertino_ui/pending_changelogs/change_2026_07_28_docRefs.yaml
+++ b/packages/cupertino_ui/pending_changelogs/change_2026_07_28_docRefs.yaml
@@ -1,0 +1,3 @@
+changelog: |
+  - Fix API doc references.
+version: patch

--- a/packages/material_ui/lib/material_ui.dart
+++ b/packages/material_ui/lib/material_ui.dart
@@ -6,8 +6,7 @@
 ///
 /// To use, import `package:material_ui/material_ui.dart`.
 ///
-// TODO(Piinks): Follow up on youtube support
-// {@youtube 560 315 https://www.youtube.com/watch?v=DL0Ix1lnC4w}
+/// Learn more about Material Design widgets on the [Flutter YouTube channel](https://www.youtube.com/watch?v=DL0Ix1lnC4w).
 ///
 /// See also:
 ///

--- a/packages/material_ui/lib/material_ui.dart
+++ b/packages/material_ui/lib/material_ui.dart
@@ -6,7 +6,8 @@
 ///
 /// To use, import `package:material_ui/material_ui.dart`.
 ///
-/// {@youtube 560 315 https://www.youtube.com/watch?v=DL0Ix1lnC4w}
+// TODO(Piinks): Follow up on youtube support
+// {@youtube 560 315 https://www.youtube.com/watch?v=DL0Ix1lnC4w}
 ///
 /// See also:
 ///
@@ -14,6 +15,8 @@
 ///    for a catalog of commonly-used Material component widgets.
 ///  * [m3.material.io](https://m3.material.io/) for the Material 3 specification
 ///  * [m2.material.io](https://m2.material.io/) for the Material 2 specification
+/// @docImport 'package:flutter_test/flutter_test.dart';
+/// @docImport 'package:intl/intl.dart';
 library material_ui;
 
 export 'package:flutter/widgets.dart';

--- a/packages/material_ui/lib/src/about.dart
+++ b/packages/material_ui/lib/src/about.dart
@@ -333,8 +333,7 @@ const double _textVerticalSeparation = 18.0;
 ///
 /// To show an [AboutDialog], use [showAboutDialog].
 ///
-// TODO(Piinks): Follow up on youtube support
-// {@youtube 560 315 https://www.youtube.com/watch?v=YFCSODyFxbE}
+/// Learn more about [AboutDialog] on the [Flutter YouTube channel](https://www.youtube.com/watch?v=YFCSODyFxbE).
 ///
 /// If the application has a [Drawer], the [AboutListTile] widget can make the
 /// process of showing an about dialog simpler.

--- a/packages/material_ui/lib/src/about.dart
+++ b/packages/material_ui/lib/src/about.dart
@@ -333,7 +333,8 @@ const double _textVerticalSeparation = 18.0;
 ///
 /// To show an [AboutDialog], use [showAboutDialog].
 ///
-/// {@youtube 560 315 https://www.youtube.com/watch?v=YFCSODyFxbE}
+// TODO(Piinks): Follow up on youtube support
+// {@youtube 560 315 https://www.youtube.com/watch?v=YFCSODyFxbE}
 ///
 /// If the application has a [Drawer], the [AboutListTile] widget can make the
 /// process of showing an about dialog simpler.

--- a/packages/material_ui/lib/src/animated_icons/animated_icons.dart
+++ b/packages/material_ui/lib/src/animated_icons/animated_icons.dart
@@ -14,7 +14,8 @@ part of material_animated_icons; // ignore: use_string_in_part_of_directives
 ///
 /// The available icons are specified in [AnimatedIcons].
 ///
-/// {@youtube 560 315 https://www.youtube.com/watch?v=pJcbh8pbvJs}
+// TODO(Piinks): Follow up on youtube support
+// {@youtube 560 315 https://www.youtube.com/watch?v=pJcbh8pbvJs}
 ///
 /// <callout-box>
 ///

--- a/packages/material_ui/lib/src/animated_icons/animated_icons.dart
+++ b/packages/material_ui/lib/src/animated_icons/animated_icons.dart
@@ -14,8 +14,7 @@ part of material_animated_icons; // ignore: use_string_in_part_of_directives
 ///
 /// The available icons are specified in [AnimatedIcons].
 ///
-// TODO(Piinks): Follow up on youtube support
-// {@youtube 560 315 https://www.youtube.com/watch?v=pJcbh8pbvJs}
+/// Learn more about [AnimatedIcon] on the [Flutter YouTube channel](https://www.youtube.com/watch?v=pJcbh8pbvJs).
 ///
 /// <callout-box>
 ///

--- a/packages/material_ui/lib/src/app_bar.dart
+++ b/packages/material_ui/lib/src/app_bar.dart
@@ -1520,8 +1520,7 @@ class _SliverAppBarDelegate extends SliverPersistentHeaderDelegate {
 /// common actions with [IconButton]s which are optionally followed by a
 /// [PopupMenuButton] for less common operations.
 ///
-// TODO(Piinks): Follow up on youtube support
-// {@youtube 560 315 https://www.youtube.com/watch?v=R9C5KMJKluE}
+/// Learn more about [SliverAppBar] on the [Flutter YouTube channel](https://www.youtube.com/watch?v=R9C5KMJKluE).
 ///
 /// Sliver app bars are typically used as the first child of a
 /// [CustomScrollView], which lets the app bar integrate with the scroll view so

--- a/packages/material_ui/lib/src/app_bar.dart
+++ b/packages/material_ui/lib/src/app_bar.dart
@@ -1520,7 +1520,8 @@ class _SliverAppBarDelegate extends SliverPersistentHeaderDelegate {
 /// common actions with [IconButton]s which are optionally followed by a
 /// [PopupMenuButton] for less common operations.
 ///
-/// {@youtube 560 315 https://www.youtube.com/watch?v=R9C5KMJKluE}
+// TODO(Piinks): Follow up on youtube support
+// {@youtube 560 315 https://www.youtube.com/watch?v=R9C5KMJKluE}
 ///
 /// Sliver app bars are typically used as the first child of a
 /// [CustomScrollView], which lets the app bar integrate with the scroll view so

--- a/packages/material_ui/lib/src/autocomplete.dart
+++ b/packages/material_ui/lib/src/autocomplete.dart
@@ -12,8 +12,7 @@ import 'theme.dart';
 
 /// {@macro flutter.widgets.RawAutocomplete.RawAutocomplete}
 ///
-// TODO(Piinks): Follow up on youtube support
-// {@youtube 560 315 https://www.youtube.com/watch?v=-Nny8kzW380}
+/// Learn more about [Autocomplete] on the [Flutter YouTube channel](https://www.youtube.com/watch?v=-Nny8kzW380).
 ///
 /// <callout-box>
 ///

--- a/packages/material_ui/lib/src/autocomplete.dart
+++ b/packages/material_ui/lib/src/autocomplete.dart
@@ -12,7 +12,8 @@ import 'theme.dart';
 
 /// {@macro flutter.widgets.RawAutocomplete.RawAutocomplete}
 ///
-/// {@youtube 560 315 https://www.youtube.com/watch?v=-Nny8kzW380}
+// TODO(Piinks): Follow up on youtube support
+// {@youtube 560 315 https://www.youtube.com/watch?v=-Nny8kzW380}
 ///
 /// <callout-box>
 ///

--- a/packages/material_ui/lib/src/checkbox_list_tile.dart
+++ b/packages/material_ui/lib/src/checkbox_list_tile.dart
@@ -34,7 +34,8 @@ enum _CheckboxType { material, adaptive }
 /// The entire list tile is interactive: tapping anywhere in the tile toggles
 /// the checkbox.
 ///
-/// {@youtube 560 315 https://www.youtube.com/watch?v=RkSqPAn9szs}
+// TODO(Piinks): Follow up on youtube support
+// {@youtube 560 315 https://www.youtube.com/watch?v=RkSqPAn9szs}
 ///
 /// The [value], [onChanged], [activeColor] and [checkColor] properties of this widget are
 /// identical to the similarly-named properties on the [Checkbox] widget.

--- a/packages/material_ui/lib/src/checkbox_list_tile.dart
+++ b/packages/material_ui/lib/src/checkbox_list_tile.dart
@@ -34,8 +34,7 @@ enum _CheckboxType { material, adaptive }
 /// The entire list tile is interactive: tapping anywhere in the tile toggles
 /// the checkbox.
 ///
-// TODO(Piinks): Follow up on youtube support
-// {@youtube 560 315 https://www.youtube.com/watch?v=RkSqPAn9szs}
+/// Learn more about [CheckboxListTile] on the [Flutter YouTube channel](https://www.youtube.com/watch?v=RkSqPAn9szs).
 ///
 /// The [value], [onChanged], [activeColor] and [checkColor] properties of this widget are
 /// identical to the similarly-named properties on the [Checkbox] widget.

--- a/packages/material_ui/lib/src/data_table.dart
+++ b/packages/material_ui/lib/src/data_table.dart
@@ -388,7 +388,8 @@ class DataCell {
 /// [Material 2](https://material.io/go/design-data-tables)
 /// design specification.
 ///
-/// {@youtube 560 315 https://www.youtube.com/watch?v=ktTajqbhIcY}
+// TODO(Piinks): Follow up on youtube support
+// {@youtube 560 315 https://www.youtube.com/watch?v=ktTajqbhIcY}
 ///
 /// ## Performance considerations
 ///

--- a/packages/material_ui/lib/src/data_table.dart
+++ b/packages/material_ui/lib/src/data_table.dart
@@ -388,8 +388,7 @@ class DataCell {
 /// [Material 2](https://material.io/go/design-data-tables)
 /// design specification.
 ///
-// TODO(Piinks): Follow up on youtube support
-// {@youtube 560 315 https://www.youtube.com/watch?v=ktTajqbhIcY}
+/// Learn more about [DataTable] on the [Flutter YouTube channel](https://www.youtube.com/watch?v=ktTajqbhIcY).
 ///
 /// ## Performance considerations
 ///

--- a/packages/material_ui/lib/src/dialog.dart
+++ b/packages/material_ui/lib/src/dialog.dart
@@ -327,8 +327,7 @@ class Dialog extends StatelessWidget {
 /// title and an optional list of actions. The title is displayed above the
 /// content and the actions are displayed below the content.
 ///
-// TODO(Piinks): Follow up on youtube support
-// {@youtube 560 315 https://www.youtube.com/watch?v=75CsnyRXf5I}
+/// Learn more about [AlertDialog] on the [Flutter YouTube channel](https://www.youtube.com/watch?v=75CsnyRXf5I).
 ///
 /// For dialogs that offer the user a choice between several options, consider
 /// using a [SimpleDialog].

--- a/packages/material_ui/lib/src/dialog.dart
+++ b/packages/material_ui/lib/src/dialog.dart
@@ -327,7 +327,8 @@ class Dialog extends StatelessWidget {
 /// title and an optional list of actions. The title is displayed above the
 /// content and the actions are displayed below the content.
 ///
-/// {@youtube 560 315 https://www.youtube.com/watch?v=75CsnyRXf5I}
+// TODO(Piinks): Follow up on youtube support
+// {@youtube 560 315 https://www.youtube.com/watch?v=75CsnyRXf5I}
 ///
 /// For dialogs that offer the user a choice between several options, consider
 /// using a [SimpleDialog].

--- a/packages/material_ui/lib/src/divider.dart
+++ b/packages/material_ui/lib/src/divider.dart
@@ -24,8 +24,7 @@ import 'theme.dart';
 /// To create a divider between [ListTile] items, consider using
 /// [ListTile.divideTiles], which is optimized for this case.
 ///
-// TODO(Piinks): Follow up on youtube support
-// {@youtube 560 315 https://www.youtube.com/watch?v=_liUC641Nmk}
+/// Learn more about [Divider] on the [Flutter YouTube channel](https://www.youtube.com/watch?v=_liUC641Nmk).
 ///
 /// The box's total height is controlled by [height]. The appropriate
 /// padding is automatically computed from the height.

--- a/packages/material_ui/lib/src/divider.dart
+++ b/packages/material_ui/lib/src/divider.dart
@@ -24,7 +24,8 @@ import 'theme.dart';
 /// To create a divider between [ListTile] items, consider using
 /// [ListTile.divideTiles], which is optimized for this case.
 ///
-/// {@youtube 560 315 https://www.youtube.com/watch?v=_liUC641Nmk}
+// TODO(Piinks): Follow up on youtube support
+// {@youtube 560 315 https://www.youtube.com/watch?v=_liUC641Nmk}
 ///
 /// The box's total height is controlled by [height]. The appropriate
 /// padding is automatically computed from the height.

--- a/packages/material_ui/lib/src/drawer.dart
+++ b/packages/material_ui/lib/src/drawer.dart
@@ -70,7 +70,8 @@ const Duration _kBaseSettleDuration = Duration(milliseconds: 246);
 /// that's preferred for applications that are configured for Material 3
 /// (see [ThemeData.useMaterial3]).
 ///
-/// {@youtube 560 315 https://www.youtube.com/watch?v=WRj86iHihgY}
+// TODO(Piinks): Follow up on youtube support
+// {@youtube 560 315 https://www.youtube.com/watch?v=WRj86iHihgY}
 ///
 /// Drawers are typically used with the [Scaffold.drawer] property. The child of
 /// the drawer is usually a [ListView] whose first child is a [DrawerHeader]

--- a/packages/material_ui/lib/src/drawer.dart
+++ b/packages/material_ui/lib/src/drawer.dart
@@ -70,8 +70,7 @@ const Duration _kBaseSettleDuration = Duration(milliseconds: 246);
 /// that's preferred for applications that are configured for Material 3
 /// (see [ThemeData.useMaterial3]).
 ///
-// TODO(Piinks): Follow up on youtube support
-// {@youtube 560 315 https://www.youtube.com/watch?v=WRj86iHihgY}
+/// Learn more about [Drawer] on the [Flutter YouTube channel](https://www.youtube.com/watch?v=WRj86iHihgY).
 ///
 /// Drawers are typically used with the [Scaffold.drawer] property. The child of
 /// the drawer is usually a [ListView] whose first child is a [DrawerHeader]

--- a/packages/material_ui/lib/src/dropdown.dart
+++ b/packages/material_ui/lib/src/dropdown.dart
@@ -924,8 +924,7 @@ class DropdownButtonHideUnderline extends InheritedWidget {
 /// from [DropdownButton] to [DropdownMenu].
 ///
 /// ## Using [DropdownButton]
-// TODO(Piinks): Follow up on youtube support
-// {@youtube 560 315 https://www.youtube.com/watch?v=ZzQ_PWrFihg}
+/// Learn more about [DropdownButton] on the [Flutter YouTube channel](https://www.youtube.com/watch?v=ZzQ_PWrFihg).
 ///
 /// One ancestor must be a [Material] widget and typically this is
 /// provided by the app's [Scaffold].

--- a/packages/material_ui/lib/src/dropdown.dart
+++ b/packages/material_ui/lib/src/dropdown.dart
@@ -924,7 +924,8 @@ class DropdownButtonHideUnderline extends InheritedWidget {
 /// from [DropdownButton] to [DropdownMenu].
 ///
 /// ## Using [DropdownButton]
-/// {@youtube 560 315 https://www.youtube.com/watch?v=ZzQ_PWrFihg}
+// TODO(Piinks): Follow up on youtube support
+// {@youtube 560 315 https://www.youtube.com/watch?v=ZzQ_PWrFihg}
 ///
 /// One ancestor must be a [Material] widget and typically this is
 /// provided by the app's [Scaffold].

--- a/packages/material_ui/lib/src/dropdown_menu.dart
+++ b/packages/material_ui/lib/src/dropdown_menu.dart
@@ -150,8 +150,7 @@ enum DropdownMenuCloseBehavior {
 /// A dropdown menu that can be opened from a [TextField]. The selected
 /// menu item is displayed in that field.
 ///
-// TODO(Piinks): Follow up on youtube support
-// {@youtube 560 315 https://www.youtube.com/watch?v=giV9AbM2gd8}
+/// Learn more about [DropdownMenu] on the [Flutter YouTube channel](https://www.youtube.com/watch?v=giV9AbM2gd8).
 ///
 /// This widget is used to help people make a choice from a menu and put the
 /// selected item into the text input field. People can also filter the list based

--- a/packages/material_ui/lib/src/dropdown_menu.dart
+++ b/packages/material_ui/lib/src/dropdown_menu.dart
@@ -150,7 +150,8 @@ enum DropdownMenuCloseBehavior {
 /// A dropdown menu that can be opened from a [TextField]. The selected
 /// menu item is displayed in that field.
 ///
-/// {@youtube 560 315 https://www.youtube.com/watch?v=giV9AbM2gd8}
+// TODO(Piinks): Follow up on youtube support
+// {@youtube 560 315 https://www.youtube.com/watch?v=giV9AbM2gd8}
 ///
 /// This widget is used to help people make a choice from a menu and put the
 /// selected item into the text input field. People can also filter the list based

--- a/packages/material_ui/lib/src/expansion_panel.dart
+++ b/packages/material_ui/lib/src/expansion_panel.dart
@@ -62,8 +62,7 @@ typedef ExpansionPanelHeaderBuilder = Widget Function(BuildContext context, bool
 /// expanded or collapsed. The body of the panel is only visible when it is
 /// expanded.
 ///
-// TODO(Piinks): Follow up on youtube support
-// {@youtube 560 315 https://www.youtube.com/watch?v=2aJZzRMziJc}
+/// Learn more about [ExpansionPanel] on the [Flutter YouTube channel](https://www.youtube.com/watch?v=2aJZzRMziJc).
 ///
 /// Expansion panels are only intended to be used as children for
 /// [ExpansionPanelList].

--- a/packages/material_ui/lib/src/expansion_panel.dart
+++ b/packages/material_ui/lib/src/expansion_panel.dart
@@ -62,7 +62,8 @@ typedef ExpansionPanelHeaderBuilder = Widget Function(BuildContext context, bool
 /// expanded or collapsed. The body of the panel is only visible when it is
 /// expanded.
 ///
-/// {@youtube 560 315 https://www.youtube.com/watch?v=2aJZzRMziJc}
+// TODO(Piinks): Follow up on youtube support
+// {@youtube 560 315 https://www.youtube.com/watch?v=2aJZzRMziJc}
 ///
 /// Expansion panels are only intended to be used as children for
 /// [ExpansionPanelList].

--- a/packages/material_ui/lib/src/flexible_space_bar.dart
+++ b/packages/material_ui/lib/src/flexible_space_bar.dart
@@ -44,7 +44,8 @@ enum StretchMode {
 /// The part of a Material Design [AppBar] that expands, collapses, and
 /// stretches.
 ///
-/// {@youtube 560 315 https://www.youtube.com/watch?v=mSc7qFzxHDw}
+// TODO(Piinks): Follow up on youtube support
+// {@youtube 560 315 https://www.youtube.com/watch?v=mSc7qFzxHDw}
 ///
 /// Most commonly used in the [SliverAppBar.flexibleSpace] field, a flexible
 /// space bar expands and contracts as the app scrolls so that the [AppBar]

--- a/packages/material_ui/lib/src/flexible_space_bar.dart
+++ b/packages/material_ui/lib/src/flexible_space_bar.dart
@@ -44,8 +44,7 @@ enum StretchMode {
 /// The part of a Material Design [AppBar] that expands, collapses, and
 /// stretches.
 ///
-// TODO(Piinks): Follow up on youtube support
-// {@youtube 560 315 https://www.youtube.com/watch?v=mSc7qFzxHDw}
+/// Learn more about [FlexibleSpaceBar] on the [Flutter YouTube channel](https://www.youtube.com/watch?v=mSc7qFzxHDw).
 ///
 /// Most commonly used in the [SliverAppBar.flexibleSpace] field, a flexible
 /// space bar expands and contracts as the app scrolls so that the [AppBar]

--- a/packages/material_ui/lib/src/floating_action_button.dart
+++ b/packages/material_ui/lib/src/floating_action_button.dart
@@ -35,8 +35,7 @@ enum _FloatingActionButtonType { regular, small, large, extended }
 /// to promote a primary action in the application. Floating action buttons are
 /// most commonly used in the [Scaffold.floatingActionButton] field.
 ///
-// TODO(Piinks): Follow up on youtube support
-// {@youtube 560 315 https://www.youtube.com/watch?v=2uaoEDOgk_I}
+/// Learn more about [FloatingActionButton] on the [Flutter YouTube channel](https://www.youtube.com/watch?v=2uaoEDOgk_I).
 ///
 /// Use at most a single floating action button per screen. Floating action
 /// buttons should be used for positive actions such as "create", "share", or

--- a/packages/material_ui/lib/src/floating_action_button.dart
+++ b/packages/material_ui/lib/src/floating_action_button.dart
@@ -35,7 +35,8 @@ enum _FloatingActionButtonType { regular, small, large, extended }
 /// to promote a primary action in the application. Floating action buttons are
 /// most commonly used in the [Scaffold.floatingActionButton] field.
 ///
-/// {@youtube 560 315 https://www.youtube.com/watch?v=2uaoEDOgk_I}
+// TODO(Piinks): Follow up on youtube support
+// {@youtube 560 315 https://www.youtube.com/watch?v=2uaoEDOgk_I}
 ///
 /// Use at most a single floating action button per screen. Floating action
 /// buttons should be used for positive actions such as "create", "share", or

--- a/packages/material_ui/lib/src/l10n/generated_material_localizations.dart
+++ b/packages/material_ui/lib/src/l10n/generated_material_localizations.dart
@@ -6,6 +6,9 @@
 // To regenerate the file, use:
 // dart script/l10n/bin/gen_localizations.dart --overwrite
 
+/// @docImport 'package:intl/intl.dart';
+library;
+
 import 'dart:collection';
 
 import 'package:flutter/widgets.dart';

--- a/packages/material_ui/lib/src/list_tile.dart
+++ b/packages/material_ui/lib/src/list_tile.dart
@@ -168,7 +168,8 @@ enum ListTileTitleAlignment {
 /// A single fixed-height row that typically contains some text as well as
 /// a leading or trailing icon.
 ///
-/// {@youtube 560 315 https://www.youtube.com/watch?v=l8dj0yPBvgQ}
+// TODO(Piinks): Follow up on youtube support
+// {@youtube 560 315 https://www.youtube.com/watch?v=l8dj0yPBvgQ}
 ///
 /// A list tile contains one to three lines of text optionally flanked by icons or
 /// other widgets, such as check boxes. The icons (or other widgets) for the

--- a/packages/material_ui/lib/src/list_tile.dart
+++ b/packages/material_ui/lib/src/list_tile.dart
@@ -168,8 +168,7 @@ enum ListTileTitleAlignment {
 /// A single fixed-height row that typically contains some text as well as
 /// a leading or trailing icon.
 ///
-// TODO(Piinks): Follow up on youtube support
-// {@youtube 560 315 https://www.youtube.com/watch?v=l8dj0yPBvgQ}
+/// Learn more about [ListTile] on the [Flutter YouTube channel](https://www.youtube.com/watch?v=l8dj0yPBvgQ).
 ///
 /// A list tile contains one to three lines of text optionally flanked by icons or
 /// other widgets, such as check boxes. The icons (or other widgets) for the

--- a/packages/material_ui/lib/src/material_state.dart
+++ b/packages/material_ui/lib/src/material_state.dart
@@ -532,8 +532,7 @@ class _WidgetInputBorderMapper extends WidgetStateMapper<InputBorder>
 /// on a widget's interactive "state", which is defined as a set
 /// of [MaterialState]s.
 ///
-// TODO(Piinks): Follow up on youtube support
-// {@youtube 560 315 https://www.youtube.com/watch?v=CylXr3AF3uU}
+/// Learn more about [WidgetStateProperty] on the [Flutter YouTube channel](https://www.youtube.com/watch?v=CylXr3AF3uU).
 ///
 /// Material state properties represent values that depend on a widget's material
 /// "state". The state is encoded as a set of [MaterialState] values, like

--- a/packages/material_ui/lib/src/material_state.dart
+++ b/packages/material_ui/lib/src/material_state.dart
@@ -532,7 +532,8 @@ class _WidgetInputBorderMapper extends WidgetStateMapper<InputBorder>
 /// on a widget's interactive "state", which is defined as a set
 /// of [MaterialState]s.
 ///
-/// {@youtube 560 315 https://www.youtube.com/watch?v=CylXr3AF3uU}
+// TODO(Piinks): Follow up on youtube support
+// {@youtube 560 315 https://www.youtube.com/watch?v=CylXr3AF3uU}
 ///
 /// Material state properties represent values that depend on a widget's material
 /// "state". The state is encoded as a set of [MaterialState] values, like

--- a/packages/material_ui/lib/src/navigation_bar.dart
+++ b/packages/material_ui/lib/src/navigation_bar.dart
@@ -36,7 +36,8 @@ const double _kMaxLabelTextScaleFactor = 1.3;
 
 /// Material 3 Navigation Bar component.
 ///
-/// {@youtube 560 315 https://www.youtube.com/watch?v=DVGYddFaLv0}
+// TODO(Piinks): Follow up on youtube support
+// {@youtube 560 315 https://www.youtube.com/watch?v=DVGYddFaLv0}
 ///
 /// Navigation bars offer a persistent and convenient way to switch between
 /// primary destinations in an app.

--- a/packages/material_ui/lib/src/navigation_bar.dart
+++ b/packages/material_ui/lib/src/navigation_bar.dart
@@ -36,8 +36,7 @@ const double _kMaxLabelTextScaleFactor = 1.3;
 
 /// Material 3 Navigation Bar component.
 ///
-// TODO(Piinks): Follow up on youtube support
-// {@youtube 560 315 https://www.youtube.com/watch?v=DVGYddFaLv0}
+/// Learn more about [NavigationBar] on the [Flutter YouTube channel](https://www.youtube.com/watch?v=DVGYddFaLv0).
 ///
 /// Navigation bars offer a persistent and convenient way to switch between
 /// primary destinations in an app.

--- a/packages/material_ui/lib/src/navigation_bar.dart
+++ b/packages/material_ui/lib/src/navigation_bar.dart
@@ -250,7 +250,7 @@ class NavigationBar extends StatelessWidget {
   /// the [NavigationDestination] is focused, hovered, or pressed.
   final WidgetStateProperty<Color?>? overlayColor;
 
-  //// The text style of the label.
+  /// The text style of the label.
   ///
   /// If null, [NavigationBarThemeData.labelTextStyle] is used. If that
   /// is also null, the default text style is [TextTheme.labelMedium] with

--- a/packages/material_ui/lib/src/navigation_rail.dart
+++ b/packages/material_ui/lib/src/navigation_rail.dart
@@ -28,7 +28,8 @@ const double _kIndicatorHeight = 32;
 /// app to navigate between a small number of views, typically between three and
 /// five.
 ///
-/// {@youtube 560 315 https://www.youtube.com/watch?v=y9xchtVTtqQ}
+// TODO(Piinks): Follow up on youtube support
+// {@youtube 560 315 https://www.youtube.com/watch?v=y9xchtVTtqQ}
 ///
 /// The navigation rail is meant for layouts with wide viewports, such as a
 /// desktop web or tablet landscape layout. For smaller layouts, like mobile

--- a/packages/material_ui/lib/src/navigation_rail.dart
+++ b/packages/material_ui/lib/src/navigation_rail.dart
@@ -28,8 +28,7 @@ const double _kIndicatorHeight = 32;
 /// app to navigate between a small number of views, typically between three and
 /// five.
 ///
-// TODO(Piinks): Follow up on youtube support
-// {@youtube 560 315 https://www.youtube.com/watch?v=y9xchtVTtqQ}
+/// Learn more about [NavigationRail] on the [Flutter YouTube channel](https://www.youtube.com/watch?v=y9xchtVTtqQ).
 ///
 /// The navigation rail is meant for layouts with wide viewports, such as a
 /// desktop web or tablet landscape layout. For smaller layouts, like mobile

--- a/packages/material_ui/lib/src/paginated_data_table.dart
+++ b/packages/material_ui/lib/src/paginated_data_table.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+/// @docImport 'package:flutter_test/flutter_test.dart';
 /// @docImport 'card_theme.dart';
 /// @docImport 'data_table_theme.dart';
 /// @docImport 'text_button.dart';
@@ -327,7 +328,38 @@ class PaginatedDataTable extends StatefulWidget {
   /// {@macro flutter.widgets.scroll_view.controller}
   final ScrollController? controller;
 
-  /// {@macro flutter.widgets.scroll_view.primary}
+  /// {@template material_ui.scroll_view.primary}
+  /// Whether this is the primary scroll view associated with the parent
+  /// [PrimaryScrollController].
+  ///
+  /// When this is true, the scroll view is scrollable even if it does not have
+  /// sufficient content to actually scroll. Otherwise, by default the user can
+  /// only scroll the view if it has sufficient content. See [physics].
+  ///
+  /// Also when true, the scroll view is used for default [ScrollAction]s. If a
+  /// ScrollAction is not handled by an otherwise focused part of the application,
+  /// the ScrollAction will be evaluated using this scroll view, for example,
+  /// when executing [Shortcuts] key events like page up and down.
+  ///
+  /// On iOS, this also identifies the scroll view that will scroll to top in
+  /// response to a tap in the status bar.
+  ///
+  /// Cannot be true while a [ScrollController] is provided to `controller`,
+  /// only one ScrollController can be associated with a ScrollView.
+  ///
+  /// Setting to false will explicitly prevent inheriting any
+  /// [PrimaryScrollController].
+  ///
+  /// Defaults to null. When null, and a controller is not provided,
+  /// [PrimaryScrollController.shouldInherit] is used to decide automatic
+  /// inheritance.
+  ///
+  /// By default, the [PrimaryScrollController] that is injected by each
+  /// [ModalRoute] is configured to automatically be inherited on
+  /// mobile platforms for ScrollViews in the [Axis.vertical]
+  /// scroll direction. Adding another to your app will override the
+  /// PrimaryScrollController above it.
+  /// {@endtemplate}
   final bool? primary;
 
   /// {@macro material_ui.dataTable.headingRowColor}

--- a/packages/material_ui/lib/src/paginated_data_table.dart
+++ b/packages/material_ui/lib/src/paginated_data_table.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// @docImport 'package:flutter_test/flutter_test.dart';
 /// @docImport 'card_theme.dart';
 /// @docImport 'data_table_theme.dart';
 /// @docImport 'text_button.dart';
@@ -328,38 +327,7 @@ class PaginatedDataTable extends StatefulWidget {
   /// {@macro flutter.widgets.scroll_view.controller}
   final ScrollController? controller;
 
-  /// {@template material_ui.scroll_view.primary}
-  /// Whether this is the primary scroll view associated with the parent
-  /// [PrimaryScrollController].
-  ///
-  /// When this is true, the scroll view is scrollable even if it does not have
-  /// sufficient content to actually scroll. Otherwise, by default the user can
-  /// only scroll the view if it has sufficient content. See [physics].
-  ///
-  /// Also when true, the scroll view is used for default [ScrollAction]s. If a
-  /// ScrollAction is not handled by an otherwise focused part of the application,
-  /// the ScrollAction will be evaluated using this scroll view, for example,
-  /// when executing [Shortcuts] key events like page up and down.
-  ///
-  /// On iOS, this also identifies the scroll view that will scroll to top in
-  /// response to a tap in the status bar.
-  ///
-  /// Cannot be true while a [ScrollController] is provided to `controller`,
-  /// only one ScrollController can be associated with a ScrollView.
-  ///
-  /// Setting to false will explicitly prevent inheriting any
-  /// [PrimaryScrollController].
-  ///
-  /// Defaults to null. When null, and a controller is not provided,
-  /// [PrimaryScrollController.shouldInherit] is used to decide automatic
-  /// inheritance.
-  ///
-  /// By default, the [PrimaryScrollController] that is injected by each
-  /// [ModalRoute] is configured to automatically be inherited on
-  /// mobile platforms for ScrollViews in the [Axis.vertical]
-  /// scroll direction. Adding another to your app will override the
-  /// PrimaryScrollController above it.
-  /// {@endtemplate}
+  /// {@macro flutter.widgets.scroll_view.primary}
   final bool? primary;
 
   /// {@macro material_ui.dataTable.headingRowColor}

--- a/packages/material_ui/lib/src/progress_indicator.dart
+++ b/packages/material_ui/lib/src/progress_indicator.dart
@@ -364,8 +364,7 @@ class _LinearProgressIndicatorPainter extends CustomPainter {
 
 /// A Material Design linear progress indicator, also known as a progress bar.
 ///
-// TODO(Piinks): Follow up on youtube support
-// {@youtube 560 315 https://www.youtube.com/watch?v=O-rhXZLtpv0}
+/// Learn more about [LinearProgressIndicator] on the [Flutter YouTube channel](https://www.youtube.com/watch?v=O-rhXZLtpv0).
 ///
 /// A widget that shows progress along a line. There are two kinds of linear
 /// progress indicators:
@@ -799,8 +798,7 @@ class _CircularProgressIndicatorPainter extends CustomPainter {
 /// A Material Design circular progress indicator, which spins to indicate that
 /// the application is busy.
 ///
-// TODO(Piinks): Follow up on youtube support
-// {@youtube 560 315 https://www.youtube.com/watch?v=O-rhXZLtpv0}
+/// Learn more about [CircularProgressIndicator] on the [Flutter YouTube channel](https://www.youtube.com/watch?v=O-rhXZLtpv0).
 ///
 /// A widget that shows progress along a circle. There are two kinds of circular
 /// progress indicators:

--- a/packages/material_ui/lib/src/progress_indicator.dart
+++ b/packages/material_ui/lib/src/progress_indicator.dart
@@ -364,7 +364,8 @@ class _LinearProgressIndicatorPainter extends CustomPainter {
 
 /// A Material Design linear progress indicator, also known as a progress bar.
 ///
-/// {@youtube 560 315 https://www.youtube.com/watch?v=O-rhXZLtpv0}
+// TODO(Piinks): Follow up on youtube support
+// {@youtube 560 315 https://www.youtube.com/watch?v=O-rhXZLtpv0}
 ///
 /// A widget that shows progress along a line. There are two kinds of linear
 /// progress indicators:
@@ -798,7 +799,8 @@ class _CircularProgressIndicatorPainter extends CustomPainter {
 /// A Material Design circular progress indicator, which spins to indicate that
 /// the application is busy.
 ///
-/// {@youtube 560 315 https://www.youtube.com/watch?v=O-rhXZLtpv0}
+// TODO(Piinks): Follow up on youtube support
+// {@youtube 560 315 https://www.youtube.com/watch?v=O-rhXZLtpv0}
 ///
 /// A widget that shows progress along a circle. There are two kinds of circular
 /// progress indicators:

--- a/packages/material_ui/lib/src/range_slider.dart
+++ b/packages/material_ui/lib/src/range_slider.dart
@@ -45,7 +45,8 @@ typedef PaintRangeValueIndicator = void Function(PaintingContext context, Offset
 ///
 /// Used to select a range from a range of values.
 ///
-/// {@youtube 560 315 https://www.youtube.com/watch?v=ufb4gIPDmEs}
+// TODO(Piinks): Follow up on youtube support
+// {@youtube 560 315 https://www.youtube.com/watch?v=ufb4gIPDmEs}
 ///
 /// <callout-box>
 ///

--- a/packages/material_ui/lib/src/range_slider.dart
+++ b/packages/material_ui/lib/src/range_slider.dart
@@ -45,8 +45,7 @@ typedef PaintRangeValueIndicator = void Function(PaintingContext context, Offset
 ///
 /// Used to select a range from a range of values.
 ///
-// TODO(Piinks): Follow up on youtube support
-// {@youtube 560 315 https://www.youtube.com/watch?v=ufb4gIPDmEs}
+/// Learn more about [RangeSlider] on the [Flutter YouTube channel](https://www.youtube.com/watch?v=ufb4gIPDmEs).
 ///
 /// <callout-box>
 ///

--- a/packages/material_ui/lib/src/refresh_indicator.dart
+++ b/packages/material_ui/lib/src/refresh_indicator.dart
@@ -76,7 +76,8 @@ enum _IndicatorType { material, adaptive, noSpinner }
 
 /// A widget that supports the Material "swipe to refresh" idiom.
 ///
-/// {@youtube 560 315 https://www.youtube.com/watch?v=ORApMlzwMdM}
+// TODO(Piinks): Follow up on youtube support
+// {@youtube 560 315 https://www.youtube.com/watch?v=ORApMlzwMdM}
 ///
 /// When the child's [Scrollable] descendant overscrolls, an animated circular
 /// progress indicator is faded into view. When the scroll ends, if the

--- a/packages/material_ui/lib/src/refresh_indicator.dart
+++ b/packages/material_ui/lib/src/refresh_indicator.dart
@@ -76,8 +76,7 @@ enum _IndicatorType { material, adaptive, noSpinner }
 
 /// A widget that supports the Material "swipe to refresh" idiom.
 ///
-// TODO(Piinks): Follow up on youtube support
-// {@youtube 560 315 https://www.youtube.com/watch?v=ORApMlzwMdM}
+/// Learn more about [RefreshIndicator] on the [Flutter YouTube channel](https://www.youtube.com/watch?v=ORApMlzwMdM).
 ///
 /// When the child's [Scrollable] descendant overscrolls, an animated circular
 /// progress indicator is faded into view. When the scroll ends, if the

--- a/packages/material_ui/lib/src/reorderable_list.dart
+++ b/packages/material_ui/lib/src/reorderable_list.dart
@@ -20,7 +20,7 @@ import 'theme.dart';
 
 /// A list whose items the user can interactively reorder by dragging.
 ///
-//// Learn more about [ReorderableListView] on the [Flutter YouTube channel](https://www.youtube.com/watch?v=3fB1mxOsqJE).
+/// Learn more about [ReorderableListView] on the [Flutter YouTube channel](https://www.youtube.com/watch?v=3fB1mxOsqJE).
 ///
 /// This sample shows by dragging the user can reorder the items of the list.
 /// The [onReorderItem] parameter will be called when a child

--- a/packages/material_ui/lib/src/reorderable_list.dart
+++ b/packages/material_ui/lib/src/reorderable_list.dart
@@ -20,7 +20,8 @@ import 'theme.dart';
 
 /// A list whose items the user can interactively reorder by dragging.
 ///
-/// {@youtube 560 315 https://www.youtube.com/watch?v=3fB1mxOsqJE}
+// TODO(Piinks): Follow up on youtube support
+// {@youtube 560 315 https://www.youtube.com/watch?v=3fB1mxOsqJE}
 ///
 /// This sample shows by dragging the user can reorder the items of the list.
 /// The [onReorderItem] parameter will be called when a child
@@ -37,9 +38,9 @@ import 'theme.dart';
 ///
 /// </callout-box>
 ///
-/// By default, on [TargetPlatformVariant.desktop] platforms each item will
+/// By default, on desktop platforms each item will
 /// have a drag handle added on top of it that will allow the user to grab it
-/// to move the item. On [TargetPlatformVariant.mobile], no drag handle will be
+/// to move the item. On mobile platforms, no drag handle will be
 /// added, but when the user long presses anywhere on the item it will start
 /// moving the item. Displaying drag handles can be controlled with
 /// [ReorderableListView.buildDefaultDragHandles].
@@ -321,7 +322,7 @@ class ReorderableListView extends StatefulWidget {
   /// {@macro flutter.widgets.scroll_view.controller}
   final ScrollController? scrollController;
 
-  /// {@macro flutter.widgets.scroll_view.primary}
+  /// {@macro material_ui.scroll_view.primary}
 
   /// Defaults to true when [scrollDirection] is [Axis.vertical] and
   /// [scrollController] is null.

--- a/packages/material_ui/lib/src/reorderable_list.dart
+++ b/packages/material_ui/lib/src/reorderable_list.dart
@@ -20,8 +20,7 @@ import 'theme.dart';
 
 /// A list whose items the user can interactively reorder by dragging.
 ///
-// TODO(Piinks): Follow up on youtube support
-// {@youtube 560 315 https://www.youtube.com/watch?v=3fB1mxOsqJE}
+//// Learn more about [ReorderableListView] on the [Flutter YouTube channel](https://www.youtube.com/watch?v=3fB1mxOsqJE).
 ///
 /// This sample shows by dragging the user can reorder the items of the list.
 /// The [onReorderItem] parameter will be called when a child
@@ -38,9 +37,9 @@ import 'theme.dart';
 ///
 /// </callout-box>
 ///
-/// By default, on desktop platforms each item will
+/// By default, on [TargetPlatformVariant.desktop] platforms each item will
 /// have a drag handle added on top of it that will allow the user to grab it
-/// to move the item. On mobile platforms, no drag handle will be
+/// to move the item. On [TargetPlatformVariant.mobile], no drag handle will be
 /// added, but when the user long presses anywhere on the item it will start
 /// moving the item. Displaying drag handles can be controlled with
 /// [ReorderableListView.buildDefaultDragHandles].
@@ -322,7 +321,7 @@ class ReorderableListView extends StatefulWidget {
   /// {@macro flutter.widgets.scroll_view.controller}
   final ScrollController? scrollController;
 
-  /// {@macro material_ui.scroll_view.primary}
+  /// {@macro flutter.widgets.scroll_view.primary}
 
   /// Defaults to true when [scrollDirection] is [Axis.vertical] and
   /// [scrollController] is null.

--- a/packages/material_ui/lib/src/scaffold.dart
+++ b/packages/material_ui/lib/src/scaffold.dart
@@ -78,7 +78,8 @@ enum _ScaffoldSlot {
 
 /// Manages [SnackBar]s and [MaterialBanner]s for descendant [Scaffold]s.
 ///
-/// {@youtube 560 315 https://www.youtube.com/watch?v=lytQi-slT5Y}
+// TODO(Piinks): Follow up on youtube support
+// {@youtube 560 315 https://www.youtube.com/watch?v=lytQi-slT5Y}
 ///
 /// This class provides APIs for showing snack bars and material banners at the
 /// bottom and top of the screen, respectively.

--- a/packages/material_ui/lib/src/scaffold.dart
+++ b/packages/material_ui/lib/src/scaffold.dart
@@ -78,7 +78,7 @@ enum _ScaffoldSlot {
 
 /// Manages [SnackBar]s and [MaterialBanner]s for descendant [Scaffold]s.
 ///
-/// Learn more about [Scaffold] on the [Flutter YouTube channel](https://www.youtube.com/watch?v=lytQi-slT5Y).
+/// Learn more about [ScaffoldMessenger] on the [Flutter YouTube channel](https://www.youtube.com/watch?v=lytQi-slT5Y).
 ///
 /// This class provides APIs for showing snack bars and material banners at the
 /// bottom and top of the screen, respectively.

--- a/packages/material_ui/lib/src/scaffold.dart
+++ b/packages/material_ui/lib/src/scaffold.dart
@@ -78,8 +78,7 @@ enum _ScaffoldSlot {
 
 /// Manages [SnackBar]s and [MaterialBanner]s for descendant [Scaffold]s.
 ///
-// TODO(Piinks): Follow up on youtube support
-// {@youtube 560 315 https://www.youtube.com/watch?v=lytQi-slT5Y}
+/// Learn more about [Scaffold] on the [Flutter YouTube channel](https://www.youtube.com/watch?v=lytQi-slT5Y).
 ///
 /// This class provides APIs for showing snack bars and material banners at the
 /// bottom and top of the screen, respectively.

--- a/packages/material_ui/lib/src/scrollbar.dart
+++ b/packages/material_ui/lib/src/scrollbar.dart
@@ -2,9 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// @docImport 'package:cupertino_ui/cupertino_ui.dart';
-library;
-
 import 'package:cupertino_ui/cupertino_ui.dart';
 import 'package:flutter/gestures.dart';
 
@@ -25,65 +22,9 @@ const Duration _kScrollbarTimeToFade = Duration(milliseconds: 600);
 /// To add a scrollbar to a [ScrollView], wrap the scroll view
 /// widget in a [Scrollbar] widget.
 ///
-// TODO(Piinks): Follow up on youtube support
-// {@youtube 560 315 https://www.youtube.com/watch?v=DbkIQSvwnZc}
+//// Learn more about [Scrollbar] on the [Flutter YouTube channel](https://www.youtube.com/watch?v=DbkIQSvwnZc).
 ///
-/// A scrollbar thumb indicates which portion of a [ScrollView] is actually
-/// visible.
-///
-/// By default, the thumb will fade in and out as the child scroll view
-/// scrolls. When [thumbVisibility] is true, the scrollbar thumb will remain
-/// visible without the fade animation. This requires that the [ScrollController]
-/// associated with the Scrollable widget is provided to [controller], or that
-/// the [PrimaryScrollController] is being used by that Scrollable widget.
-///
-/// If the scrollbar is wrapped around multiple [ScrollView]s, it only responds to
-/// the nearest ScrollView and shows the corresponding scrollbar thumb by default.
-/// The [notificationPredicate] allows the ability to customize which
-/// [ScrollNotification]s the Scrollbar should listen to.
-///
-/// If the child [ScrollView] is infinitely long, the [RawScrollbar] will not be
-/// painted. In this case, the scrollbar cannot accurately represent the
-/// relative location of the visible area, or calculate the accurate delta to
-/// apply when dragging on the thumb or tapping on the track.
-///
-/// ### Interaction
-///
-/// Scrollbars are interactive and can use the [PrimaryScrollController] if
-/// a [controller] is not set. Interactive Scrollbar thumbs can be dragged along
-/// the main axis of the [ScrollView] to change the [ScrollPosition]. Tapping
-/// along the track exclusive of the thumb will trigger a
-/// [ScrollIncrementType.page] based on the relative position to the thumb.
-///
-/// When using the [PrimaryScrollController], it must not be attached to more
-/// than one [ScrollPosition]. [ScrollView]s that have not been provided a
-/// [ScrollController] and have a [ScrollView.scrollDirection] of
-/// [Axis.vertical] will automatically attach their ScrollPosition to the
-/// PrimaryScrollController. Provide a unique ScrollController to each
-/// [Scrollable] in this case to prevent having multiple ScrollPositions
-/// attached to the PrimaryScrollController.
-///
-/// ### Automatic Scrollbars on Desktop Platforms
-///
-/// Scrollbars are added to most [Scrollable] widgets by default on
-/// desktop platforms. This is done through
-/// [ScrollBehavior.buildScrollbar] as part of an app's
-/// [ScrollConfiguration]. Scrollables that do not use the
-/// [PrimaryScrollController] or have a [ScrollController] provided to them
-/// will receive a unique ScrollController for use with the Scrollbar. In this
-/// case, only one Scrollable can be using the PrimaryScrollController, unless
-/// [interactive] is false. To prevent [Axis.vertical] Scrollables from using
-/// the PrimaryScrollController, set [ScrollView.primary] to false. Scrollable
-/// widgets that do not have automatically applied Scrollbars include
-///
-///   * [EditableText]
-///   * [ListWheelScrollView]
-///   * [PageView]
-///   * [NestedScrollView]
-///   * [DropdownButton]
-///
-/// Default Scrollbars can be disabled for the whole app by setting a
-/// [ScrollBehavior] with `scrollbars` set to false.
+/// {@macro flutter.widgets.Scrollbar}
 ///
 /// Dynamically changes to a [CupertinoScrollbar], an iOS style scrollbar, by
 /// default on the iOS platform.

--- a/packages/material_ui/lib/src/scrollbar.dart
+++ b/packages/material_ui/lib/src/scrollbar.dart
@@ -22,7 +22,7 @@ const Duration _kScrollbarTimeToFade = Duration(milliseconds: 600);
 /// To add a scrollbar to a [ScrollView], wrap the scroll view
 /// widget in a [Scrollbar] widget.
 ///
-//// Learn more about [Scrollbar] on the [Flutter YouTube channel](https://www.youtube.com/watch?v=DbkIQSvwnZc).
+/// Learn more about [Scrollbar] on the [Flutter YouTube channel](https://www.youtube.com/watch?v=DbkIQSvwnZc).
 ///
 /// {@macro flutter.widgets.Scrollbar}
 ///

--- a/packages/material_ui/lib/src/scrollbar.dart
+++ b/packages/material_ui/lib/src/scrollbar.dart
@@ -2,6 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+/// @docImport 'package:cupertino_ui/cupertino_ui.dart';
+library;
+
 import 'package:cupertino_ui/cupertino_ui.dart';
 import 'package:flutter/gestures.dart';
 
@@ -22,9 +25,65 @@ const Duration _kScrollbarTimeToFade = Duration(milliseconds: 600);
 /// To add a scrollbar to a [ScrollView], wrap the scroll view
 /// widget in a [Scrollbar] widget.
 ///
-/// {@youtube 560 315 https://www.youtube.com/watch?v=DbkIQSvwnZc}
+// TODO(Piinks): Follow up on youtube support
+// {@youtube 560 315 https://www.youtube.com/watch?v=DbkIQSvwnZc}
 ///
-/// {@macro flutter.widgets.Scrollbar}
+/// A scrollbar thumb indicates which portion of a [ScrollView] is actually
+/// visible.
+///
+/// By default, the thumb will fade in and out as the child scroll view
+/// scrolls. When [thumbVisibility] is true, the scrollbar thumb will remain
+/// visible without the fade animation. This requires that the [ScrollController]
+/// associated with the Scrollable widget is provided to [controller], or that
+/// the [PrimaryScrollController] is being used by that Scrollable widget.
+///
+/// If the scrollbar is wrapped around multiple [ScrollView]s, it only responds to
+/// the nearest ScrollView and shows the corresponding scrollbar thumb by default.
+/// The [notificationPredicate] allows the ability to customize which
+/// [ScrollNotification]s the Scrollbar should listen to.
+///
+/// If the child [ScrollView] is infinitely long, the [RawScrollbar] will not be
+/// painted. In this case, the scrollbar cannot accurately represent the
+/// relative location of the visible area, or calculate the accurate delta to
+/// apply when dragging on the thumb or tapping on the track.
+///
+/// ### Interaction
+///
+/// Scrollbars are interactive and can use the [PrimaryScrollController] if
+/// a [controller] is not set. Interactive Scrollbar thumbs can be dragged along
+/// the main axis of the [ScrollView] to change the [ScrollPosition]. Tapping
+/// along the track exclusive of the thumb will trigger a
+/// [ScrollIncrementType.page] based on the relative position to the thumb.
+///
+/// When using the [PrimaryScrollController], it must not be attached to more
+/// than one [ScrollPosition]. [ScrollView]s that have not been provided a
+/// [ScrollController] and have a [ScrollView.scrollDirection] of
+/// [Axis.vertical] will automatically attach their ScrollPosition to the
+/// PrimaryScrollController. Provide a unique ScrollController to each
+/// [Scrollable] in this case to prevent having multiple ScrollPositions
+/// attached to the PrimaryScrollController.
+///
+/// ### Automatic Scrollbars on Desktop Platforms
+///
+/// Scrollbars are added to most [Scrollable] widgets by default on
+/// desktop platforms. This is done through
+/// [ScrollBehavior.buildScrollbar] as part of an app's
+/// [ScrollConfiguration]. Scrollables that do not use the
+/// [PrimaryScrollController] or have a [ScrollController] provided to them
+/// will receive a unique ScrollController for use with the Scrollbar. In this
+/// case, only one Scrollable can be using the PrimaryScrollController, unless
+/// [interactive] is false. To prevent [Axis.vertical] Scrollables from using
+/// the PrimaryScrollController, set [ScrollView.primary] to false. Scrollable
+/// widgets that do not have automatically applied Scrollbars include
+///
+///   * [EditableText]
+///   * [ListWheelScrollView]
+///   * [PageView]
+///   * [NestedScrollView]
+///   * [DropdownButton]
+///
+/// Default Scrollbars can be disabled for the whole app by setting a
+/// [ScrollBehavior] with `scrollbars` set to false.
 ///
 /// Dynamically changes to a [CupertinoScrollbar], an iOS style scrollbar, by
 /// default on the iOS platform.

--- a/packages/material_ui/lib/src/selectable_text.dart
+++ b/packages/material_ui/lib/src/selectable_text.dart
@@ -84,8 +84,7 @@ class _SelectableTextSelectionGestureDetectorBuilder extends TextSelectionGestur
 /// The string might break across multiple lines or might all be displayed on
 /// the same line depending on the layout constraints.
 ///
-// TODO(Piinks): Follow up on youtube support
-// {@youtube 560 315 https://www.youtube.com/watch?v=ZSU3ZXOs6hc}
+/// Learn more about [SelectableText] on the [Flutter YouTube channel](https://www.youtube.com/watch?v=ZSU3ZXOs6hc).
 ///
 /// The [style] argument is optional. When omitted, the text will use the style
 /// from the closest enclosing [DefaultTextStyle]. If the given style's

--- a/packages/material_ui/lib/src/selectable_text.dart
+++ b/packages/material_ui/lib/src/selectable_text.dart
@@ -84,7 +84,8 @@ class _SelectableTextSelectionGestureDetectorBuilder extends TextSelectionGestur
 /// The string might break across multiple lines or might all be displayed on
 /// the same line depending on the layout constraints.
 ///
-/// {@youtube 560 315 https://www.youtube.com/watch?v=ZSU3ZXOs6hc}
+// TODO(Piinks): Follow up on youtube support
+// {@youtube 560 315 https://www.youtube.com/watch?v=ZSU3ZXOs6hc}
 ///
 /// The [style] argument is optional. When omitted, the text will use the style
 /// from the closest enclosing [DefaultTextStyle]. If the given style's

--- a/packages/material_ui/lib/src/slider.dart
+++ b/packages/material_ui/lib/src/slider.dart
@@ -76,7 +76,8 @@ enum SliderInteraction {
 ///
 /// Used to select from a range of values.
 ///
-/// {@youtube 560 315 https://www.youtube.com/watch?v=ufb4gIPDmEs}
+// TODO(Piinks): Follow up on youtube support
+// {@youtube 560 315 https://www.youtube.com/watch?v=ufb4gIPDmEs}
 ///
 /// <callout-box>
 ///

--- a/packages/material_ui/lib/src/slider.dart
+++ b/packages/material_ui/lib/src/slider.dart
@@ -76,8 +76,7 @@ enum SliderInteraction {
 ///
 /// Used to select from a range of values.
 ///
-// TODO(Piinks): Follow up on youtube support
-// {@youtube 560 315 https://www.youtube.com/watch?v=ufb4gIPDmEs}
+/// Learn more about [Slider] on the [Flutter YouTube channel](https://www.youtube.com/watch?v=ufb4gIPDmEs).
 ///
 /// <callout-box>
 ///

--- a/packages/material_ui/lib/src/snack_bar.dart
+++ b/packages/material_ui/lib/src/snack_bar.dart
@@ -217,8 +217,7 @@ class _SnackBarActionState extends State<SnackBarAction> {
 /// A lightweight message with an optional action which briefly displays at the
 /// bottom of the screen.
 ///
-// TODO(Piinks): Follow up on youtube support
-// {@youtube 560 315 https://www.youtube.com/watch?v=zpO6n_oZWw0}
+/// Learn more about [SnackBar] on the [Flutter YouTube channel](https://www.youtube.com/watch?v=zpO6n_oZWw0).
 ///
 /// To display a snack bar, call `ScaffoldMessenger.of(context).showSnackBar()`,
 /// passing an instance of [SnackBar] that describes the message.

--- a/packages/material_ui/lib/src/snack_bar.dart
+++ b/packages/material_ui/lib/src/snack_bar.dart
@@ -217,7 +217,8 @@ class _SnackBarActionState extends State<SnackBarAction> {
 /// A lightweight message with an optional action which briefly displays at the
 /// bottom of the screen.
 ///
-/// {@youtube 560 315 https://www.youtube.com/watch?v=zpO6n_oZWw0}
+// TODO(Piinks): Follow up on youtube support
+// {@youtube 560 315 https://www.youtube.com/watch?v=zpO6n_oZWw0}
 ///
 /// To display a snack bar, call `ScaffoldMessenger.of(context).showSnackBar()`,
 /// passing an instance of [SnackBar] that describes the message.

--- a/packages/material_ui/lib/src/switch_list_tile.dart
+++ b/packages/material_ui/lib/src/switch_list_tile.dart
@@ -31,7 +31,8 @@ enum _SwitchListTileType { material, adaptive }
 
 /// A [ListTile] with a [Switch]. In other words, a switch with a label.
 ///
-/// {@youtube 560 315 https://www.youtube.com/watch?v=0igIjvtEWNU}
+// TODO(Piinks): Follow up on youtube support
+// {@youtube 560 315 https://www.youtube.com/watch?v=0igIjvtEWNU}
 ///
 /// The entire list tile is interactive: tapping anywhere in the tile toggles
 /// the switch. Tapping and dragging the [Switch] also triggers the [onChanged]

--- a/packages/material_ui/lib/src/switch_list_tile.dart
+++ b/packages/material_ui/lib/src/switch_list_tile.dart
@@ -31,8 +31,7 @@ enum _SwitchListTileType { material, adaptive }
 
 /// A [ListTile] with a [Switch]. In other words, a switch with a label.
 ///
-// TODO(Piinks): Follow up on youtube support
-// {@youtube 560 315 https://www.youtube.com/watch?v=0igIjvtEWNU}
+/// Learn more about [SwitchListTile] on the [Flutter YouTube channel](https://www.youtube.com/watch?v=0igIjvtEWNU).
 ///
 /// The entire list tile is interactive: tapping anywhere in the tile toggles
 /// the switch. Tapping and dragging the [Switch] also triggers the [onChanged]

--- a/packages/material_ui/lib/src/tab_controller.dart
+++ b/packages/material_ui/lib/src/tab_controller.dart
@@ -318,7 +318,8 @@ class _TabControllerScope extends InheritedWidget {
 /// The [TabController] for descendant widgets that don't specify one
 /// explicitly.
 ///
-/// {@youtube 560 315 https://www.youtube.com/watch?v=POtoEH-5l40}
+// TODO(Piinks): Follow up on youtube support
+// {@youtube 560 315 https://www.youtube.com/watch?v=POtoEH-5l40}
 ///
 /// [DefaultTabController] is an inherited widget that is used to share a
 /// [TabController] with a [TabBar] or a [TabBarView]. It's used when sharing an

--- a/packages/material_ui/lib/src/tab_controller.dart
+++ b/packages/material_ui/lib/src/tab_controller.dart
@@ -318,8 +318,7 @@ class _TabControllerScope extends InheritedWidget {
 /// The [TabController] for descendant widgets that don't specify one
 /// explicitly.
 ///
-// TODO(Piinks): Follow up on youtube support
-// {@youtube 560 315 https://www.youtube.com/watch?v=POtoEH-5l40}
+/// Learn more about [DefaultTabController] on the [Flutter YouTube channel](https://www.youtube.com/watch?v=POtoEH-5l40).
 ///
 /// [DefaultTabController] is an inherited widget that is used to share a
 /// [TabController] with a [TabBar] or a [TabBarView]. It's used when sharing an

--- a/packages/material_ui/lib/src/tabs.dart
+++ b/packages/material_ui/lib/src/tabs.dart
@@ -939,8 +939,7 @@ typedef TabValueChanged<T> = void Function(T value, int index);
 /// Typically created as the [AppBar.bottom] part of an [AppBar] and in
 /// conjunction with a [TabBarView].
 ///
-// TODO(Piinks): Follow up on youtube support
-// {@youtube 560 315 https://www.youtube.com/watch?v=POtoEH-5l40}
+/// Learn more about [TabBar] on the [Flutter YouTube channel](https://www.youtube.com/watch?v=POtoEH-5l40).
 ///
 /// If a [TabController] is not provided, then a [DefaultTabController] ancestor
 /// must be provided instead. The tab controller's [TabController.length] must
@@ -2254,8 +2253,7 @@ class _TabBarState extends State<TabBar> {
 ///
 /// This widget is typically used in conjunction with a [TabBar].
 ///
-// TODO(Piinks): Follow up on youtube support
-// {@youtube 560 315 https://www.youtube.com/watch?v=POtoEH-5l40}
+/// Learn more about [TabBarView] on the [Flutter YouTube channel](https://www.youtube.com/watch?v=POtoEH-5l40).
 ///
 /// If a [TabController] is not provided, then there must be a [DefaultTabController]
 /// ancestor.
@@ -2634,8 +2632,7 @@ class TabPageSelectorIndicator extends StatelessWidget {
 /// Uses [TabPageSelectorIndicator] to display a row of small circular
 /// indicators, one per tab.
 ///
-// TODO(Piinks): Follow up on youtube support
-// {@youtube 560 315 https://www.youtube.com/watch?v=Q628ue9Cq7U}
+/// Learn more about [TabPageSelector] on the [Flutter YouTube channel](https://www.youtube.com/watch?v=Q628ue9Cq7U).
 ///
 /// The selected tab's indicator is highlighted. Often used in conjunction with
 /// a [TabBarView].

--- a/packages/material_ui/lib/src/tabs.dart
+++ b/packages/material_ui/lib/src/tabs.dart
@@ -939,7 +939,8 @@ typedef TabValueChanged<T> = void Function(T value, int index);
 /// Typically created as the [AppBar.bottom] part of an [AppBar] and in
 /// conjunction with a [TabBarView].
 ///
-/// {@youtube 560 315 https://www.youtube.com/watch?v=POtoEH-5l40}
+// TODO(Piinks): Follow up on youtube support
+// {@youtube 560 315 https://www.youtube.com/watch?v=POtoEH-5l40}
 ///
 /// If a [TabController] is not provided, then a [DefaultTabController] ancestor
 /// must be provided instead. The tab controller's [TabController.length] must
@@ -2253,7 +2254,8 @@ class _TabBarState extends State<TabBar> {
 ///
 /// This widget is typically used in conjunction with a [TabBar].
 ///
-/// {@youtube 560 315 https://www.youtube.com/watch?v=POtoEH-5l40}
+// TODO(Piinks): Follow up on youtube support
+// {@youtube 560 315 https://www.youtube.com/watch?v=POtoEH-5l40}
 ///
 /// If a [TabController] is not provided, then there must be a [DefaultTabController]
 /// ancestor.
@@ -2632,7 +2634,8 @@ class TabPageSelectorIndicator extends StatelessWidget {
 /// Uses [TabPageSelectorIndicator] to display a row of small circular
 /// indicators, one per tab.
 ///
-/// {@youtube 560 315 https://www.youtube.com/watch?v=Q628ue9Cq7U}
+// TODO(Piinks): Follow up on youtube support
+// {@youtube 560 315 https://www.youtube.com/watch?v=Q628ue9Cq7U}
 ///
 /// The selected tab's indicator is highlighted. Often used in conjunction with
 /// a [TabBarView].

--- a/packages/material_ui/lib/src/theme.dart
+++ b/packages/material_ui/lib/src/theme.dart
@@ -23,7 +23,8 @@ const Duration kThemeAnimationDuration = Duration(milliseconds: 200);
 ///
 /// A theme describes the colors and typographic choices of an application.
 ///
-/// {@youtube 560 315 https://www.youtube.com/watch?v=oTvQDJOBXmM}
+// TODO(Piinks): Follow up on youtube support
+// {@youtube 560 315 https://www.youtube.com/watch?v=oTvQDJOBXmM}
 ///
 /// Descendant widgets obtain the current theme's [ThemeData] object using
 /// [Theme.of]. When a widget uses [Theme.of], it is automatically rebuilt if

--- a/packages/material_ui/lib/src/theme.dart
+++ b/packages/material_ui/lib/src/theme.dart
@@ -23,8 +23,7 @@ const Duration kThemeAnimationDuration = Duration(milliseconds: 200);
 ///
 /// A theme describes the colors and typographic choices of an application.
 ///
-// TODO(Piinks): Follow up on youtube support
-// {@youtube 560 315 https://www.youtube.com/watch?v=oTvQDJOBXmM}
+/// Learn more about [Theme] on the [Flutter YouTube channel](https://www.youtube.com/watch?v=oTvQDJOBXmM).
 ///
 /// Descendant widgets obtain the current theme's [ThemeData] object using
 /// [Theme.of]. When a widget uses [Theme.of], it is automatically rebuilt if

--- a/packages/material_ui/lib/src/theme_data.dart
+++ b/packages/material_ui/lib/src/theme_data.dart
@@ -121,8 +121,7 @@ class Adaptation<T> {
 
 /// An interface that defines custom additions to a [ThemeData] object.
 ///
-// TODO(Piinks): Follow up on youtube support
-// {@youtube 560 315 https://www.youtube.com/watch?v=8-szcYzFVao}
+/// Learn more about [ThemeExtension] on the [Flutter YouTube channel](https://www.youtube.com/watch?v=8-szcYzFVao).
 ///
 /// Typically used for custom colors. To use, subclass [ThemeExtension],
 /// define a number of fields (e.g. [Color]s), and implement the [copyWith] and

--- a/packages/material_ui/lib/src/theme_data.dart
+++ b/packages/material_ui/lib/src/theme_data.dart
@@ -121,7 +121,8 @@ class Adaptation<T> {
 
 /// An interface that defines custom additions to a [ThemeData] object.
 ///
-/// {@youtube 560 315 https://www.youtube.com/watch?v=8-szcYzFVao}
+// TODO(Piinks): Follow up on youtube support
+// {@youtube 560 315 https://www.youtube.com/watch?v=8-szcYzFVao}
 ///
 /// Typically used for custom colors. To use, subclass [ThemeExtension],
 /// define a number of fields (e.g. [Color]s), and implement the [copyWith] and

--- a/packages/material_ui/lib/src/toggle_buttons.dart
+++ b/packages/material_ui/lib/src/toggle_buttons.dart
@@ -39,8 +39,7 @@ import 'toggle_buttons_theme.dart';
 /// that's preferred for applications that are configured for Material 3
 /// (see [ThemeData.useMaterial3]).
 ///
-// TODO(Piinks): Follow up on youtube support
-// {@youtube 560 315 https://www.youtube.com/watch?v=kVEguaQWGAY}
+/// Learn more about [ToggleButtons] on the [Flutter YouTube channel](https://www.youtube.com/watch?v=kVEguaQWGAY).
 ///
 /// ## Updating to [SegmentedButton]
 ///

--- a/packages/material_ui/lib/src/toggle_buttons.dart
+++ b/packages/material_ui/lib/src/toggle_buttons.dart
@@ -39,7 +39,8 @@ import 'toggle_buttons_theme.dart';
 /// that's preferred for applications that are configured for Material 3
 /// (see [ThemeData.useMaterial3]).
 ///
-/// {@youtube 560 315 https://www.youtube.com/watch?v=kVEguaQWGAY}
+// TODO(Piinks): Follow up on youtube support
+// {@youtube 560 315 https://www.youtube.com/watch?v=kVEguaQWGAY}
 ///
 /// ## Updating to [SegmentedButton]
 ///

--- a/packages/material_ui/lib/src/tooltip.dart
+++ b/packages/material_ui/lib/src/tooltip.dart
@@ -35,8 +35,7 @@ import 'tooltip_visibility.dart';
 /// representation of the widget, which, for example, can be vocalized by a
 /// screen reader.
 ///
-// TODO(Piinks): Follow up on youtube support
-// {@youtube 560 315 https://www.youtube.com/watch?v=EeEfD5fI-5Q}
+/// Learn more about [Tooltip] on the [Flutter YouTube channel](https://www.youtube.com/watch?v=EeEfD5fI-5Q).
 ///
 /// <callout-box>
 ///

--- a/packages/material_ui/lib/src/tooltip.dart
+++ b/packages/material_ui/lib/src/tooltip.dart
@@ -35,7 +35,8 @@ import 'tooltip_visibility.dart';
 /// representation of the widget, which, for example, can be vocalized by a
 /// screen reader.
 ///
-/// {@youtube 560 315 https://www.youtube.com/watch?v=EeEfD5fI-5Q}
+// TODO(Piinks): Follow up on youtube support
+// {@youtube 560 315 https://www.youtube.com/watch?v=EeEfD5fI-5Q}
 ///
 /// <callout-box>
 ///

--- a/packages/material_ui/pending_changelogs/change_2026_07_28_docRefs.yaml
+++ b/packages/material_ui/pending_changelogs/change_2026_07_28_docRefs.yaml
@@ -1,0 +1,3 @@
+changelog: |
+  - Fix API doc references.
+version: patch

--- a/script/l10n/bin/gen_localizations.dart
+++ b/script/l10n/bin/gen_localizations.dart
@@ -84,9 +84,7 @@ String generateArbBasedLocalizationSubclasses({
   assert(supportedLanguagesDocMacro.isNotEmpty);
   generateConstructorForCountrySubClass ??= generateConstructor;
   final output = StringBuffer();
-  output.writeln(
-    generateHeader('dart script/l10n/bin/gen_localizations.dart --overwrite'),
-  );
+  output.writeln(generateHeader('dart script/l10n/bin/gen_localizations.dart --overwrite'));
 
   final supportedLocales = StringBuffer();
 

--- a/script/l10n/lib/gen_cupertino_localizations.dart
+++ b/script/l10n/lib/gen_cupertino_localizations.dart
@@ -14,6 +14,9 @@ String generateCupertinoHeader(String regenerateInstructions) {
 // To regenerate the file, use:
 // $regenerateInstructions
 
+/// @docImport 'package:intl/intl.dart';
+library;
+
 import 'dart:collection';
 
 import 'package:flutter/widgets.dart';

--- a/script/l10n/lib/gen_material_localizations.dart
+++ b/script/l10n/lib/gen_material_localizations.dart
@@ -14,6 +14,9 @@ String generateMaterialHeader(String regenerateInstructions) {
 // To regenerate the file, use:
 // $regenerateInstructions
 
+/// @docImport 'package:intl/intl.dart';
+library;
+
 import 'dart:collection';
 
 import 'package:flutter/widgets.dart';


### PR DESCRIPTION
Fix doc references in material_ui and cupertino_ui
Towards https://github.com/flutter/flutter/issues/189629

I also commented out youtube directives since they do not work outside of the SDK.

There are some references we cannot fix in the design packages themselves, largely due tot he fact that material_ui and cupertino_ui export the widgets library. That pulls in doc references from the widgets library that cannot be resolved outside of the scope of the SDK.

We can change the doc upstream in the SDK, but that feel like a poor choice to make the docs less helpful in the SDK in order to resolve a reference issue in a downstream package.
Something we are planning for after the initial 1.0 is to remove the export of widgets from both packages, which will resolve the remaining issues.

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under[^1].
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[the version and CHANGELOG instructions]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version-and-changelog-updates
[semantic versioning]: https://dart.dev/tools/pub/versioning#semantic-versions
[repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
