### PR TITLE
[packages] Add changelog style references to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ This document provides guidance for AI agents to effectively contribute to the `
 
 - **Format All Code**: Every code change must be formatted using the repository's tools.
 - **Pass All Tests**: All changes must pass linting, analysis, and relevant tests.
-- **Update CHANGELOGs**: Any user-facing change or bug fix in a package requires an update to its `CHANGELOG.md` and `pubspec.yaml` version.
+- **Update CHANGELOGs**: Any user-facing change or bug fix in a package requires an update to its `CHANGELOG.md` and `pubspec.yaml` version. Ensure you follow the [CHANGELOG style guide](https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style).
 - **Follow Conventions**: Adhere to the repository's specific conventions, such as federated plugin structure and code generation steps.
 
 ## Agent Environment Setup
@@ -154,4 +154,4 @@ dart run $REPO_ROOT/script/tool/bin/flutter_plugin_tools.dart update-release-inf
   - When making public API changes, use `--version=minor` instead.
 - `--base-branch=origin/main`: Diffs against the `main` branch to find changed packages.
 
-If you update manually, follow semantic versioning and the repository's CHANGELOG format.
+If you update manually, follow semantic versioning and the [repository's CHANGELOG style](https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style).


### PR DESCRIPTION
*Adds links to the official Flutter CHANGELOG style guidelines to the AGENTS.md document to clarify formatting rules for agents and contributors.*

Tests for AGENTS.md on the roadmap but do not exist for this repo yet. If we had evals then this pr would also contain a new expectation that an expected code reference in a changelog does contain `codeReference`. 
This pr and https://github.com/flutter/flutter/pull/189922 are both to fix https://github.com/flutter/packages/pull/12145/changes#r3625889893

## Pre-Review Checklist

- [x] I read the Contributor Guide and followed the process outlined there for submitting PRs.
- [x] I read the AI contribution guidelines and understand my responsibilities, or I am not using AI tools.
- [x] I read the Tree Hygiene page, which explains my responsibilities.
- [x] I read and followed the relevant style guides and ran the auto-formatter.
- [x] I signed the CLA.
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I linked to at least one issue that this PR fixes in the description above.
- [x] I followed the version and CHANGELOG instructions, using semantic versioning and the repository CHANGELOG style, or I have commented below to indicate which documented exception this PR falls under.
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or I have commented below to indicate which test exemption this PR falls under.
- [x] All existing and new tests are passing.
