### PR TITLE
[go_router] Document regex constraints for path parameters

### DIFF
--- a/packages/go_router/example/lib/path_parameter_regex.dart
+++ b/packages/go_router/example/lib/path_parameter_regex.dart
@@ -1,0 +1,34 @@
+// Copyright 2013 The Flutter Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+
+/// Router configuration demonstrating regex-constrained path parameters.
+final GoRouter router = GoRouter(
+  routes: <GoRoute>[
+    GoRoute(
+      path: r'/users/:id(\d+)',
+      builder: (BuildContext context, GoRouterState state) {
+        return Scaffold(body: Center(child: Text('User ${state.pathParameters['id']}')));
+      },
+    ),
+  ],
+);
+
+/// Runs the path parameter regular expression example.
+void main() {
+  runApp(const PathParameterRegexApp());
+}
+
+/// A minimal app demonstrating regex-constrained path parameters.
+class PathParameterRegexApp extends StatelessWidget {
+  /// Creates a [PathParameterRegexApp].
+  const PathParameterRegexApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp.router(routerConfig: router);
+  }
+}

--- a/packages/go_router/example/test/path_parameter_regex_test.dart
+++ b/packages/go_router/example/test/path_parameter_regex_test.dart
@@ -1,0 +1,17 @@
+// Copyright 2013 The Flutter Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router_examples/path_parameter_regex.dart' as example;
+
+void main() {
+  testWidgets('matches numeric path parameter', (WidgetTester tester) async {
+    example.router.go('/users/42');
+
+    await tester.pumpWidget(const example.PathParameterRegexApp());
+    await tester.pumpAndSettle();
+
+    expect(find.text('User 42'), findsOneWidget);
+  });
+}

--- a/packages/go_router/lib/src/route.dart
+++ b/packages/go_router/lib/src/route.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// ignore_for_file: doc_directive_unknown
+
 import 'dart:async';
 
 import 'package:collection/collection.dart';
@@ -340,6 +342,19 @@ class GoRoute extends RouteBase {
   /// matches all URIs start with `/family/...`, e.g. `/family/123`,
   /// `/family/456` and etc. The parameter values are stored in [GoRouterState]
   /// that are passed into [pageBuilder] and [builder].
+  ///
+  /// A path parameter may optionally be constrained to a regular expression
+  /// by appending the expression in parentheses after the parameter name:
+  /// `:paramName(regex)`.
+  ///
+  /// {@example /example/lib/path_parameter_regex.dart}
+  ///
+  /// The path matches `/users/42` but not `/users/settings`. If a path segment
+  /// does not satisfy the regular expression, route matching continues with
+  /// other route candidates.
+  ///
+  /// The regular expression is interpreted as a Dart [RegExp] pattern and must
+  /// not contain nested parentheses.
   ///
   /// The query parameter are also capture during the route parsing and stored
   /// in [GoRouterState].

--- a/packages/go_router/pending_changelogs/change_2026_07_24_1784894419364.yaml
+++ b/packages/go_router/pending_changelogs/change_2026_07_24_1784894419364.yaml
@@ -1,0 +1,3 @@
+changelog: |
+  - Documents support for regular expression constraints in GoRoute path parameters.
+version: patch


### PR DESCRIPTION
## Description

Documents the regular expression constraint syntax supported by `GoRoute.path`.

`GoRoute` already supports path parameters in the form `:paramName(regex)`, but this syntax is not currently documented. This change documents the syntax, provides a valid Dart example, and explains how constrained path parameters participate in route matching.

Fixes flutter/flutter#177766

## Testing

- No new tests were added because this is a documentation-only change.
- Ran `dart run script/tool/bin/flutter_plugin_tools.dart test --packages=go_router`.

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under[^1].
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[the version and CHANGELOG instructions]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version-and-changelog-updates
[semantic versioning]: https://dart.dev/tools/pub/versioning#semantic-versions
[repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
