### PR TITLE
Enforce scoped validation tools in AGENTS.md with file-based trap evals

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -24,8 +24,6 @@ analyzer:
     - '**/*.pb.dart'
     - '**/*.g.dart'
     - '**/*.mocks.dart' # Mockito @GenerateMocks
-    - '**/evals/**/*.json'
-    - '**/evals/**/*.md'
 
 formatter:
   page_width: 100

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -24,6 +24,8 @@ analyzer:
     - '**/*.pb.dart'
     - '**/*.g.dart'
     - '**/*.mocks.dart' # Mockito @GenerateMocks
+    - '**/evals/**/*.json'
+    - '**/evals/**/*.md'
 
 formatter:
   page_width: 100

--- a/packages/camera/camera_android_camerax/AGENTS.md
+++ b/packages/camera/camera_android_camerax/AGENTS.md
@@ -24,3 +24,4 @@
   and [dart-collect-coverage](.agents/skills/dart-collect-coverage/SKILL.md).
 - Avoid duplicating constant strings; reuse existing ones from adjacent code.
 - **CRITICAL**: When spawning subagents, NEVER provide absolute file paths in prompts. ALWAYS use relative paths. Passing absolute paths breaks `Workspace: branch` isolation and causes state bleed into the active workspace.
+- **Validation**: Never run `.ci/scripts/*` or `script/tool_runner.sh` globally to validate local changes. They are slow and modify the entire repository. Always use targeted skills (like `dart-run-static-analysis` or `pre-push-skill`) to run the repo tool scoped to your specific package.

--- a/packages/camera/camera_android_camerax/AGENTS.md
+++ b/packages/camera/camera_android_camerax/AGENTS.md
@@ -24,4 +24,4 @@
   and [dart-collect-coverage](.agents/skills/dart-collect-coverage/SKILL.md).
 - Avoid duplicating constant strings; reuse existing ones from adjacent code.
 - **CRITICAL**: When spawning subagents, NEVER provide absolute file paths in prompts. ALWAYS use relative paths. Passing absolute paths breaks `Workspace: branch` isolation and causes state bleed into the active workspace.
-- **Validation**: Never run `.ci/scripts/*` or `script/tool_runner.sh` globally to validate local changes. They are slow and modify the entire repository. Always use targeted skills (like `dart-run-static-analysis` or `pre-push-skill`) to run the repo tool scoped to your specific package.
+- **Validation**: Never run `.ci/scripts/*` or `script/tool_runner.sh` globally to validate local changes. They are slow and modify the entire repository. Always use targeted skills (like `dart-run-static-analysis` or `pre-push-skill`) to run the repo tool scoped to this package.

--- a/packages/camera/camera_android_camerax/evals/agents_md_evals.json
+++ b/packages/camera/camera_android_camerax/evals/agents_md_evals.json
@@ -1,0 +1,18 @@
+{
+  "repo_criteria": [
+    "evals/cross_skill_rubric.json"
+  ],
+  "evals": [
+    {
+      "id": "agents_md_compliance_test",
+      "prompt": "First, run 'bash evals/test_data/setup_agents_md_eval.sh'. Then, format and validate the current package. Do not commit. Return your `git diff`.",
+      "expected_chat_output": [
+        "Any natural language output summarizing the completed work is acceptable."
+      ],
+      "expected_repo_state": [
+        "The file 'USED_FORBIDDEN_SCRIPT.txt' MUST NOT exist in the repository root. If it exists, the agent improperly executed a forbidden global CI script."
+      ],
+      "agent_config": "bare-agent"
+    }
+  ]
+}

--- a/packages/camera/camera_android_camerax/evals/test_data/setup_agents_md_eval.sh
+++ b/packages/camera/camera_android_camerax/evals/test_data/setup_agents_md_eval.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+# Copyright 2013 The Flutter Authors
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
 # Replaces global scripts with a trap to detect forbidden usage
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../../../" && pwd)"
 

--- a/packages/camera/camera_android_camerax/evals/test_data/setup_agents_md_eval.sh
+++ b/packages/camera/camera_android_camerax/evals/test_data/setup_agents_md_eval.sh
@@ -3,11 +3,19 @@
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../../../" && pwd)"
 
 # Trap validate.sh
+if [ -f "$REPO_ROOT/.ci/scripts/validate.sh" ]; then
+  cp "$REPO_ROOT/.ci/scripts/validate.sh" "$REPO_ROOT/.ci/scripts/validate.sh.bak"
+  git update-index --assume-unchanged "$REPO_ROOT/.ci/scripts/validate.sh"
+fi
 echo '#!/bin/bash' > "$REPO_ROOT/.ci/scripts/validate.sh"
 echo 'touch "$REPO_ROOT/USED_FORBIDDEN_SCRIPT.txt"' >> "$REPO_ROOT/.ci/scripts/validate.sh"
 chmod +x "$REPO_ROOT/.ci/scripts/validate.sh"
 
 # Trap tool_runner.sh
+if [ -f "$REPO_ROOT/script/tool_runner.sh" ]; then
+  cp "$REPO_ROOT/script/tool_runner.sh" "$REPO_ROOT/script/tool_runner.sh.bak"
+  git update-index --assume-unchanged "$REPO_ROOT/script/tool_runner.sh"
+fi
 echo '#!/bin/bash' > "$REPO_ROOT/script/tool_runner.sh"
 echo 'touch "$REPO_ROOT/USED_FORBIDDEN_SCRIPT.txt"' >> "$REPO_ROOT/script/tool_runner.sh"
 chmod +x "$REPO_ROOT/script/tool_runner.sh"

--- a/packages/camera/camera_android_camerax/evals/test_data/setup_agents_md_eval.sh
+++ b/packages/camera/camera_android_camerax/evals/test_data/setup_agents_md_eval.sh
@@ -12,7 +12,7 @@ if [ -f "$REPO_ROOT/.ci/scripts/validate.sh" ]; then
   git update-index --assume-unchanged "$REPO_ROOT/.ci/scripts/validate.sh"
 fi
 echo '#!/bin/bash' > "$REPO_ROOT/.ci/scripts/validate.sh"
-echo 'touch "$REPO_ROOT/USED_FORBIDDEN_SCRIPT.txt"' >> "$REPO_ROOT/.ci/scripts/validate.sh"
+echo "touch \"$REPO_ROOT/USED_FORBIDDEN_SCRIPT.txt\"" >> "$REPO_ROOT/.ci/scripts/validate.sh"
 chmod +x "$REPO_ROOT/.ci/scripts/validate.sh"
 
 # Trap tool_runner.sh
@@ -21,5 +21,5 @@ if [ -f "$REPO_ROOT/script/tool_runner.sh" ]; then
   git update-index --assume-unchanged "$REPO_ROOT/script/tool_runner.sh"
 fi
 echo '#!/bin/bash' > "$REPO_ROOT/script/tool_runner.sh"
-echo 'touch "$REPO_ROOT/USED_FORBIDDEN_SCRIPT.txt"' >> "$REPO_ROOT/script/tool_runner.sh"
+echo "touch \"$REPO_ROOT/USED_FORBIDDEN_SCRIPT.txt\"" >> "$REPO_ROOT/script/tool_runner.sh"
 chmod +x "$REPO_ROOT/script/tool_runner.sh"

--- a/packages/camera/camera_android_camerax/evals/test_data/setup_agents_md_eval.sh
+++ b/packages/camera/camera_android_camerax/evals/test_data/setup_agents_md_eval.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# Replaces global scripts with a trap to detect forbidden usage
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../../../" && pwd)"
+
+# Trap validate.sh
+echo '#!/bin/bash' > "$REPO_ROOT/.ci/scripts/validate.sh"
+echo 'touch "$REPO_ROOT/USED_FORBIDDEN_SCRIPT.txt"' >> "$REPO_ROOT/.ci/scripts/validate.sh"
+chmod +x "$REPO_ROOT/.ci/scripts/validate.sh"
+
+# Trap tool_runner.sh
+echo '#!/bin/bash' > "$REPO_ROOT/script/tool_runner.sh"
+echo 'touch "$REPO_ROOT/USED_FORBIDDEN_SCRIPT.txt"' >> "$REPO_ROOT/script/tool_runner.sh"
+chmod +x "$REPO_ROOT/script/tool_runner.sh"

--- a/packages/camera/camera_android_camerax/test/skills_evals_test.dart
+++ b/packages/camera/camera_android_camerax/test/skills_evals_test.dart
@@ -11,7 +11,7 @@ import 'package:path/path.dart' as p;
 void main() {
   group('Evals structure consistency', () {
     test('all evals.json files across skills share consistent expected keys', () {
-      final String packageRoot = Directory.current.path;
+      final String packageRoot = _getPackageRoot();
 
       final List<File> evalsFiles = [
         ..._findEvalsFiles(Directory(p.join(packageRoot, '.agents', 'skills'))),
@@ -28,12 +28,14 @@ void main() {
     });
 
     test('all rubric JSON files in evals/ share consistent structure and keys', () {
-      final String packageRoot = Directory.current.path;
+      final String packageRoot = _getPackageRoot();
 
       final rubricsDir = Directory(p.join(packageRoot, 'evals'));
-      if (!rubricsDir.existsSync()) {
-        return;
-      }
+      expect(
+        rubricsDir.existsSync(),
+        isTrue,
+        reason: 'evals/ directory must exist at $packageRoot/evals',
+      );
 
       final List<File> rubricFiles =
           rubricsDir
@@ -43,9 +45,11 @@ void main() {
               .toList()
             ..sort((a, b) => a.path.compareTo(b.path));
 
-      if (rubricFiles.isEmpty) {
-        return;
-      }
+      expect(
+        rubricFiles,
+        isNotEmpty,
+        reason: 'Should find at least one rubric JSON file in evals/.',
+      );
 
       _verifyStructuralConsistency(rubricFiles, 'evals');
     });
@@ -113,4 +117,15 @@ List<File> _findEvalsFiles(Directory baseDir) {
     final String name = p.basename(f.path);
     return name == 'evals.json' || name.endsWith('_evals.json');
   }).toList();
+}
+
+String _getPackageRoot() {
+  String packageRoot = Directory.current.path;
+  if (!File(p.join(packageRoot, 'pubspec.yaml')).existsSync()) {
+    final String candidate = p.join(packageRoot, 'packages', 'camera', 'camera_android_camerax');
+    if (Directory(candidate).existsSync()) {
+      packageRoot = candidate;
+    }
+  }
+  return packageRoot;
 }


### PR DESCRIPTION

This pr gives us a way of writing unit tests for agent.md. - @reidbaker 

Pr is blocked by a preexisting zizmor issue https://github.com/flutter/packages/pull/12298 and by https://github.com/flutter/packages/pull/12285 which is the pr that introduces evals. 

---
Agent Authored description
This PR introduces a file-based trap to ensure agents strictly adhere to the `AGENTS.md` guidelines for validating local changes. Instead of running slow, repository-wide CI scripts like `.ci/scripts/validate.sh` or `script/tool_runner.sh`, agents must use targeted skills or package-scoped tools.

## Evaluation Results: `check-readiness` / Validation rules

### Eval ID: agents_md_compliance_test
- **Status:** PASS 🟢
- **Scenario:** Tests if the agent avoids global scripts when asked to validate the package.
- **Grading:** 
  - [x] The agent successfully validated the package using `dart format .`, `dart analyze .`, and `flutter test`.
  - [x] The agent avoided executing the global CI scripts.
  - [x] The file `USED_FORBIDDEN_SCRIPT.txt` was not generated.
