### PR TITLE
ci: Fix Zizmor github-env failure in install_flutter action

### DIFF
--- a/.github/workflows/internals/install_flutter/action.yml
+++ b/.github/workflows/internals/install_flutter/action.yml
@@ -16,7 +16,6 @@ runs:
       run: |
         cd $HOME
         git clone https://github.com/flutter/flutter.git --depth 1 -b 3.44.0 _flutter
-        echo "$HOME/_flutter/bin" >> $GITHUB_PATH
         cd $GITHUB_WORKSPACE
 
     # GITHUB_PATH write is safe here as it only appends a hardcoded, trusted path ($HOME/_flutter/bin) with no user-controlled input.


### PR DESCRIPTION
Zizmor was flagging this failure in another review. 
Agent suggested deleting this line since the following line does the same thing and I agree. 
Secondary validation will be this pr passing presubmit. 

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [ ] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I [linked to at least one issue that this PR fixes] in the description above.
- [] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under[^1].
- [ ] I updated/added any relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [x] All existing and new tests are passing.
