### PR TITLE
Exempt evals directories from version checks

### DIFF
--- a/script/tool/lib/src/common/package_state_utils.dart
+++ b/script/tool/lib/src/common/package_state_utils.dart
@@ -193,6 +193,8 @@ Future<bool> _isDevChange(
   return _isTestChange(pathComponents) ||
       // Agent directories (.agents/) are for developer-only utility tools (skills, scripts).
       pathComponents.first == '.agents' ||
+      // Eval directories (evals/) are for evaluation utility code.
+      pathComponents.first == 'evals' ||
       // The top-level "tool" directory is for non-client-facing utility
       // code, such as test scripts.
       pathComponents.first == 'tool' ||

--- a/script/tool/test/common/package_state_utils_test.dart
+++ b/script/tool/test/common/package_state_utils_test.dart
@@ -117,6 +117,22 @@ void main() {
       expect(state.needsChangelogChange, false);
     });
 
+    test('does not require version or changelog change for evals changes', () async {
+      final RepositoryPackage package = createFakePlugin('a_plugin', packagesDir);
+
+      const changedFiles = <String>['packages/a_plugin/evals/foo.dart'];
+
+      final PackageChangeState state = await checkPackageChangeState(
+        package,
+        changedPaths: changedFiles,
+        relativePackagePath: 'packages/a_plugin/',
+      );
+
+      expect(state.hasChanges, true);
+      expect(state.needsVersionChange, false);
+      expect(state.needsChangelogChange, false);
+    });
+
     test('only considers a root "tool" folder to be special', () async {
       final RepositoryPackage package = createFakePlugin('a_plugin', packagesDir);
 


### PR DESCRIPTION
This pr is blocked by https://github.com/flutter/packages/pull/12298. 

This came up in https://github.com/flutter/packages/pull/12297. I decided landing the tool focused pr was much easier to review than stacking this work on https://github.com/flutter/packages/pull/12285 - @reidbaker 

---
Agent authored pr description
This PR exempts .agents and evals directories from triggering missing changelog and version update errors.

TAG=agy
CONV=24c0c9b5-7e8d-407c-ae84-a577061bd6ff