### PR TITLE
[camera_android_camerax] Update `AGENTS.md` to improve video recording integration tests

### DIFF
--- a/packages/camera/camera_android_camerax/AGENTS.md
+++ b/packages/camera/camera_android_camerax/AGENTS.md
@@ -23,5 +23,5 @@
 - Maintain high test coverage using [dart-add-unit-test](.agents/skills/dart-add-unit-test/SKILL.md)
   and [dart-collect-coverage](.agents/skills/dart-collect-coverage/SKILL.md).
 - Avoid duplicating constant strings; reuse existing ones from adjacent code.
-- **Video Recording Integration Tests**: You MUST insert a delay (e.g., `await Future<void>.delayed(const Duration(seconds: 4));`) after starting a video recording and before stopping it. Without this delay, the test will flake or fail because the Android device/emulator needs time to initialize the encoder and capture frames before finalizing.
+- **Testing Guidelines**: You MUST read and follow all rules in [TESTING.md](TESTING.md) BEFORE writing or modifying any tests. This is CRITICAL for preventing CI flakiness.
 - **CRITICAL**: When spawning subagents, NEVER provide absolute file paths in prompts. ALWAYS use relative paths. Passing absolute paths breaks `Workspace: branch` isolation and causes state bleed into the active workspace.

--- a/packages/camera/camera_android_camerax/AGENTS.md
+++ b/packages/camera/camera_android_camerax/AGENTS.md
@@ -23,4 +23,5 @@
 - Maintain high test coverage using [dart-add-unit-test](.agents/skills/dart-add-unit-test/SKILL.md)
   and [dart-collect-coverage](.agents/skills/dart-collect-coverage/SKILL.md).
 - Avoid duplicating constant strings; reuse existing ones from adjacent code.
+- **Video Recording Integration Tests**: You MUST insert a delay (e.g., `await Future<void>.delayed(const Duration(seconds: 4));`) after starting a video recording and before stopping it. Without this delay, the test will flake or fail because the Android device/emulator needs time to initialize the encoder and capture frames before finalizing.
 - **CRITICAL**: When spawning subagents, NEVER provide absolute file paths in prompts. ALWAYS use relative paths. Passing absolute paths breaks `Workspace: branch` isolation and causes state bleed into the active workspace.

--- a/packages/camera/camera_android_camerax/TESTING.md
+++ b/packages/camera/camera_android_camerax/TESTING.md
@@ -1,0 +1,9 @@
+# Testing Best Practices
+
+This document outlines testing rules and best practices for the `camera_android_camerax` package. All contributors MUST follow these guidelines to prevent CI flakiness and maintain code quality.
+
+## Integration Tests
+
+- **Video Recording Delay**: You MUST add a delay of at least 4 seconds (e.g., `await Future<void>.delayed(const Duration(seconds: 4));`) before stopping a video recording. 
+  - *Why*: Both physical Android devices and emulators require time for the CameraX encoder to initialize and capture actual video frames. Stopping immediately will result in an empty or corrupted file, causing CI flakes.
+  - *Example*: See the `video recording state is cleared after camera is disposed` test in [`example/integration_test/integration_test.dart`](example/integration_test/integration_test.dart).


### PR DESCRIPTION
Adds note to `AGENTS.md` to hint to agents that if they add integration tests for video recording, they should add a delay between starting/stopping recordings to ensure the camera has enough time to initialized and get a valid recording.

Inspired by an agent running into this while creating https://github.com/flutter/packages/pull/12145 (see https://github.com/flutter/packages/pull/12145#issuecomment-5107663485)

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I [linked to at least one issue that this PR fixes] in the description above.
- [ ] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under[^1].
- [ ] I updated/added any relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[the version and CHANGELOG instructions]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version-and-changelog-updates
[semantic versioning]: https://dart.dev/tools/pub/versioning#semantic-versions
[repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
