### PR TITLE
[cupertino_ui] Reuse a single `Paint` in `_CupertinoEdgeShadowPainter`

### DIFF
--- a/packages/cupertino_ui/CHANGELOG.md
+++ b/packages/cupertino_ui/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.0.3
+
+- Reuses a single `Paint` object when painting the page transition edge
+  shadow, instead of allocating one per drawn rect per frame.
+
 ## 0.0.2
 
 - Copies over all Cupertino code from flutter/flutter.

--- a/packages/cupertino_ui/lib/src/route.dart
+++ b/packages/cupertino_ui/lib/src/route.dart
@@ -1075,16 +1075,16 @@ class _CupertinoEdgeShadowPainter extends BoxPainter {
     };
 
     var bandColorIndex = 0;
+    final paint = Paint();
     for (var dx = 0; dx < shadowWidth; dx += 1) {
       if (dx ~/ bandWidth != bandColorIndex) {
         bandColorIndex += 1;
       }
-      final paint = Paint()
-        ..color = Color.lerp(
-          colors[bandColorIndex],
-          colors[bandColorIndex + 1],
-          (dx % bandWidth) / bandWidth,
-        )!;
+      paint.color = Color.lerp(
+        colors[bandColorIndex],
+        colors[bandColorIndex + 1],
+        (dx % bandWidth) / bandWidth,
+      )!;
       final double x = start + shadowDirection * dx;
       canvas.drawRect(Rect.fromLTWH(x - 1.0, offset.dy, 1.0, shadowHeight), paint);
     }

--- a/packages/cupertino_ui/pubspec.yaml
+++ b/packages/cupertino_ui/pubspec.yaml
@@ -1,6 +1,6 @@
 name: cupertino_ui
 description: The official Flutter Cupertino Design Library, implementing the iOS design system.
-version: 0.0.2
+version: 0.0.3
 repository: https://github.com/flutter/packages/tree/main/packages/cupertino_ui
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A%20cupertino%22
 


### PR DESCRIPTION
The edge shadow of a Cupertino page transition is drawn as ~20 1px-wide rects per frame, each allocating a fresh `Paint`. This runs on every frame of every `CupertinoPageRoute` push/pop and back-swipe. This PR hoists the `Paint` out of the loop and only updates its color per iteration, matching the pattern already used by `_CupertinoActivityIndicatorPainter`. `Canvas` draw calls snapshot paint state, so mutating and reusing a single `Paint` produces identical output.

Fixes flutter/flutter#190198. (Originally submitted to flutter/flutter as flutter/flutter#190188, redirected here due to the Material/Cupertino decoupling code freeze, flutter/flutter#184093.)

This is a behavior-preserving refactor with no observable output change; existing tests in `packages/cupertino_ui/test/route_test.dart` cover this code path and pass, so I believe this qualifies as test-exempt.

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under[^1].
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [x] All existing and new tests are passing.

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[the version and CHANGELOG instructions]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version-and-changelog-updates
[semantic versioning]: https://dart.dev/tools/pub/versioning#semantic-versions
[repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
