### PR TITLE
[webview_flutter] Adds NavigationDelegate.onCreateWindow for target=_blank / window.open

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -86,3 +86,4 @@ LeanCode <contribution@leancode.pl>
 Piotr Denert <pdenert09@gmail.com>
 Marcin Chudy <marcinchudy94@gmail.com>
 Paweł Jakubowski <pawel.jakubowski@leancode.pl>
+Mateusz Jabłoński <mateusz.jablonski@ramp.network>

--- a/packages/webview_flutter/webview_flutter/CHANGELOG.md
+++ b/packages/webview_flutter/webview_flutter/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.15.0
+
+* Adds NavigationDelegate.onCreateWindow for target=_blank / window.open.
+
 ## 4.14.1
 
 * Adds documentation for `NavigationDelegate` callback parameters.

--- a/packages/webview_flutter/webview_flutter/example/pubspec.yaml
+++ b/packages/webview_flutter/webview_flutter/example/pubspec.yaml
@@ -35,3 +35,9 @@ flutter:
     - assets/sample_video.mp4
     - assets/www/index.html
     - assets/www/styles/style.css
+# FOR TESTING AND INITIAL REVIEW ONLY. DO NOT MERGE.
+# See https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changing-federated-plugins
+dependency_overrides:
+  webview_flutter_android: {path: ../../../../packages/webview_flutter/webview_flutter_android}
+  webview_flutter_platform_interface: {path: ../../../../packages/webview_flutter/webview_flutter_platform_interface}
+  webview_flutter_wkwebview: {path: ../../../../packages/webview_flutter/webview_flutter_wkwebview}

--- a/packages/webview_flutter/webview_flutter/lib/src/navigation_delegate.dart
+++ b/packages/webview_flutter/webview_flutter/lib/src/navigation_delegate.dart
@@ -39,6 +39,9 @@ class NavigationDelegate {
   ///
   /// {@template webview_fluttter.NavigationDelegate.constructor}
   /// **`onNavigationRequest`:** invoked when a navigation request is pending.
+  /// **`onCreateWindow`:** invoked when the page opens a new window
+  ///   (`target=_blank` / `window.open`). The host should handle the URL; the
+  ///   WebView will not load it when this callback is set.
   /// **`onPageStarted`:** invoked when a page starts loading.
   /// **`onPageFinished`:** invoked when a page finishes loading.
   /// **`onProgress`:** invoked when page loading progress changes.
@@ -52,6 +55,7 @@ class NavigationDelegate {
   /// {@endtemplate}
   NavigationDelegate({
     FutureOr<NavigationDecision> Function(NavigationRequest request)? onNavigationRequest,
+    void Function(String url)? onCreateWindow,
     void Function(String url)? onPageStarted,
     void Function(String url)? onPageFinished,
     void Function(int progress)? onProgress,
@@ -63,6 +67,7 @@ class NavigationDelegate {
   }) : this.fromPlatformCreationParams(
          const PlatformNavigationDelegateCreationParams(),
          onNavigationRequest: onNavigationRequest,
+         onCreateWindow: onCreateWindow,
          onPageStarted: onPageStarted,
          onPageFinished: onPageFinished,
          onProgress: onProgress,
@@ -107,6 +112,7 @@ class NavigationDelegate {
   NavigationDelegate.fromPlatformCreationParams(
     PlatformNavigationDelegateCreationParams params, {
     FutureOr<NavigationDecision> Function(NavigationRequest request)? onNavigationRequest,
+    void Function(String url)? onCreateWindow,
     void Function(String url)? onPageStarted,
     void Function(String url)? onPageFinished,
     void Function(int progress)? onProgress,
@@ -118,6 +124,7 @@ class NavigationDelegate {
   }) : this.fromPlatform(
          PlatformNavigationDelegate(params),
          onNavigationRequest: onNavigationRequest,
+         onCreateWindow: onCreateWindow,
          onPageStarted: onPageStarted,
          onPageFinished: onPageFinished,
          onProgress: onProgress,
@@ -134,6 +141,7 @@ class NavigationDelegate {
   NavigationDelegate.fromPlatform(
     this.platform, {
     this.onNavigationRequest,
+    this.onCreateWindow,
     this.onPageStarted,
     this.onPageFinished,
     this.onProgress,
@@ -145,6 +153,9 @@ class NavigationDelegate {
   }) {
     if (onNavigationRequest != null) {
       platform.setOnNavigationRequest(onNavigationRequest!);
+    }
+    if (onCreateWindow != null) {
+      platform.setOnCreateWindow(onCreateWindow!);
     }
     if (onPageStarted != null) {
       platform.setOnPageStarted(onPageStarted!);
@@ -188,6 +199,12 @@ class NavigationDelegate {
   ///
   /// See [NavigationDecision].
   final NavigationRequestCallback? onNavigationRequest;
+
+  /// Invoked when the page requests a new window (`target=_blank` / `window.open`).
+  ///
+  /// When set, the URL is not loaded in the WebView; the host should handle it
+  /// (e.g. open the system browser).
+  final CreateWindowCallback? onCreateWindow;
 
   /// Invoked when a page has started loading.
   final PageEventCallback? onPageStarted;

--- a/packages/webview_flutter/webview_flutter/lib/webview_flutter.dart
+++ b/packages/webview_flutter/webview_flutter/lib/webview_flutter.dart
@@ -18,6 +18,7 @@ export 'package:webview_flutter_platform_interface/webview_flutter_platform_inte
         NavigationDecision,
         NavigationRequest,
         NavigationRequestCallback,
+        CreateWindowCallback,
         PageEventCallback,
         PlatformNavigationDelegateCreationParams,
         PlatformWebViewControllerCreationParams,

--- a/packages/webview_flutter/webview_flutter/lib/webview_flutter.dart
+++ b/packages/webview_flutter/webview_flutter/lib/webview_flutter.dart
@@ -4,6 +4,7 @@
 
 export 'package:webview_flutter_platform_interface/webview_flutter_platform_interface.dart'
     show
+        CreateWindowCallback,
         HttpAuthRequest,
         HttpResponseError,
         HttpResponseErrorCallback,
@@ -18,7 +19,6 @@ export 'package:webview_flutter_platform_interface/webview_flutter_platform_inte
         NavigationDecision,
         NavigationRequest,
         NavigationRequestCallback,
-        CreateWindowCallback,
         PageEventCallback,
         PlatformNavigationDelegateCreationParams,
         PlatformWebViewControllerCreationParams,

--- a/packages/webview_flutter/webview_flutter/pubspec.yaml
+++ b/packages/webview_flutter/webview_flutter/pubspec.yaml
@@ -21,12 +21,9 @@ flutter:
 dependencies:
   flutter:
     sdk: flutter
-  webview_flutter_android:
-    path: ../webview_flutter_android
-  webview_flutter_platform_interface:
-    path: ../webview_flutter_platform_interface
-  webview_flutter_wkwebview:
-    path: ../webview_flutter_wkwebview
+  webview_flutter_android: ^4.14.0
+  webview_flutter_platform_interface: ^2.16.0
+  webview_flutter_wkwebview: ^3.27.0
 
 dev_dependencies:
   build_runner: ^2.1.5
@@ -39,3 +36,9 @@ topics:
   - html
   - webview
   - webview-flutter
+# FOR TESTING AND INITIAL REVIEW ONLY. DO NOT MERGE.
+# See https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changing-federated-plugins
+dependency_overrides:
+  webview_flutter_android: {path: ../../../packages/webview_flutter/webview_flutter_android}
+  webview_flutter_platform_interface: {path: ../../../packages/webview_flutter/webview_flutter_platform_interface}
+  webview_flutter_wkwebview: {path: ../../../packages/webview_flutter/webview_flutter_wkwebview}

--- a/packages/webview_flutter/webview_flutter/pubspec.yaml
+++ b/packages/webview_flutter/webview_flutter/pubspec.yaml
@@ -2,7 +2,7 @@ name: webview_flutter
 description: A Flutter plugin that provides a WebView widget backed by the system webview.
 repository: https://github.com/flutter/packages/tree/main/packages/webview_flutter/webview_flutter
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+webview%22
-version: 4.14.1
+version: 4.15.0
 
 environment:
   sdk: ^3.10.0

--- a/packages/webview_flutter/webview_flutter/pubspec.yaml
+++ b/packages/webview_flutter/webview_flutter/pubspec.yaml
@@ -21,9 +21,12 @@ flutter:
 dependencies:
   flutter:
     sdk: flutter
-  webview_flutter_android: ^4.12.0
-  webview_flutter_platform_interface: ^2.15.1
-  webview_flutter_wkwebview: ^3.25.1
+  webview_flutter_android:
+    path: ../webview_flutter_android
+  webview_flutter_platform_interface:
+    path: ../webview_flutter_platform_interface
+  webview_flutter_wkwebview:
+    path: ../webview_flutter_wkwebview
 
 dev_dependencies:
   build_runner: ^2.1.5

--- a/packages/webview_flutter/webview_flutter/test/navigation_delegate_test.dart
+++ b/packages/webview_flutter/webview_flutter/test/navigation_delegate_test.dart
@@ -26,6 +26,16 @@ void main() {
       verify(delegate.platform.setOnNavigationRequest(onNavigationRequest));
     });
 
+    test('onCreateWindow', () async {
+      WebViewPlatform.instance = TestWebViewPlatform();
+
+      void onCreateWindow(String url) {}
+
+      final delegate = NavigationDelegate(onCreateWindow: onCreateWindow);
+
+      verify(delegate.platform.setOnCreateWindow(onCreateWindow));
+    });
+
     test('onPageStarted', () async {
       WebViewPlatform.instance = TestWebViewPlatform();
 

--- a/packages/webview_flutter/webview_flutter/test/navigation_delegate_test.mocks.dart
+++ b/packages/webview_flutter/webview_flutter/test/navigation_delegate_test.mocks.dart
@@ -149,6 +149,15 @@ class MockPlatformNavigationDelegate extends _i1.Mock implements _i3.PlatformNav
           as _i8.Future<void>);
 
   @override
+  _i8.Future<void> setOnCreateWindow(_i3.CreateWindowCallback? onCreateWindow) =>
+      (super.noSuchMethod(
+            Invocation.method(#setOnCreateWindow, [onCreateWindow]),
+            returnValue: _i8.Future<void>.value(),
+            returnValueForMissingStub: _i8.Future<void>.value(),
+          )
+          as _i8.Future<void>);
+
+  @override
   _i8.Future<void> setOnPageStarted(_i3.PageEventCallback? onPageStarted) =>
       (super.noSuchMethod(
             Invocation.method(#setOnPageStarted, [onPageStarted]),

--- a/packages/webview_flutter/webview_flutter_android/CHANGELOG.md
+++ b/packages/webview_flutter/webview_flutter_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.14.0
+
+* Adds NavigationDelegate.onCreateWindow for target=_blank / window.open.
+
 ## 4.13.0
 
 * Adds new method for accessing a native `WebView` from a `FlutterPluginBinding`.

--- a/packages/webview_flutter/webview_flutter_android/android/src/main/java/io/flutter/plugins/webviewflutter/AndroidWebkitLibrary.g.kt
+++ b/packages/webview_flutter/webview_flutter_android/android/src/main/java/io/flutter/plugins/webviewflutter/AndroidWebkitLibrary.g.kt
@@ -3524,6 +3524,48 @@ abstract class PigeonApiWebViewClient(
   }
 
   /**
+   * Notifies Dart that the page requested a new window (`target=_blank` /
+   * `window.open`).
+   */
+  fun onCreateWindow(
+      pigeon_instanceArg: android.webkit.WebViewClient,
+      urlArg: String,
+      callback: (Result<Unit>) -> Unit
+  ) {
+    if (pigeonRegistrar.ignoreCallsToDart) {
+      callback(
+          Result.failure(
+              AndroidWebKitError("ignore-calls-error", "Calls to Dart are being ignored.", "")))
+      return
+    } else if (!pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
+      callback(
+          Result.failure(
+              AndroidWebKitError(
+                  "missing-instance-error",
+                  "Callback to `WebViewClient.onCreateWindow` failed because native instance was not in the instance manager.",
+                  "")))
+      return
+    }
+    val binaryMessenger = pigeonRegistrar.binaryMessenger
+    val codec = pigeonRegistrar.codec
+    val channelName = "dev.flutter.pigeon.webview_flutter_android.WebViewClient.onCreateWindow"
+    val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
+    channel.send(listOf(pigeon_instanceArg, urlArg)) {
+      if (it is List<*>) {
+        if (it.size > 1) {
+          callback(
+              Result.failure(
+                  AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
+        } else {
+          callback(Result.success(Unit))
+        }
+      } else {
+        callback(Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
+      }
+    }
+  }
+
+  /**
    * Give the host application a chance to take control when a URL is about to be loaded in the
    * current WebView.
    */

--- a/packages/webview_flutter/webview_flutter_android/android/src/main/java/io/flutter/plugins/webviewflutter/AndroidWebkitLibrary.g.kt
+++ b/packages/webview_flutter/webview_flutter_android/android/src/main/java/io/flutter/plugins/webviewflutter/AndroidWebkitLibrary.g.kt
@@ -10,17 +10,16 @@ package io.flutter.plugins.webviewflutter
 import android.util.Log
 import io.flutter.plugin.common.BasicMessageChannel
 import io.flutter.plugin.common.BinaryMessenger
+import io.flutter.plugin.common.EventChannel
 import io.flutter.plugin.common.MessageCodec
+import io.flutter.plugin.common.StandardMethodCodec
 import io.flutter.plugin.common.StandardMessageCodec
 import java.io.ByteArrayOutputStream
 import java.nio.ByteBuffer
-
 private object AndroidWebkitLibraryPigeonUtils {
 
   fun createConnectionError(channelName: String): AndroidWebKitError {
-    return AndroidWebKitError(
-        "channel-error", "Unable to establish connection on channel: '$channelName'.", "")
-  }
+    return AndroidWebKitError("channel-error",  "Unable to establish connection on channel: '$channelName'.", "")  }
 
   fun wrapResult(result: Any?): List<Any?> {
     return listOf(result)
@@ -28,48 +27,50 @@ private object AndroidWebkitLibraryPigeonUtils {
 
   fun wrapError(exception: Throwable): List<Any?> {
     return if (exception is AndroidWebKitError) {
-      listOf(exception.code, exception.message, exception.details)
+      listOf(
+        exception.code,
+        exception.message,
+        exception.details
+      )
     } else {
       listOf(
-          exception.javaClass.simpleName,
-          exception.toString(),
-          "Cause: " + exception.cause + ", Stacktrace: " + Log.getStackTraceString(exception))
+        exception.javaClass.simpleName,
+        exception.toString(),
+        "Cause: " + exception.cause + ", Stacktrace: " + Log.getStackTraceString(exception)
+      )
     }
   }
 }
 
 /**
  * Error class for passing custom error details to Flutter via a thrown PlatformException.
- *
  * @property code The error code.
  * @property message The error message.
  * @property details The error details. Must be a datatype supported by the api codec.
  */
-class AndroidWebKitError(
-    val code: String,
-    override val message: String? = null,
-    val details: Any? = null
+class AndroidWebKitError (
+  val code: String,
+  override val message: String? = null,
+  val details: Any? = null
 ) : RuntimeException()
 /**
  * Maintains instances used to communicate with the corresponding objects in Dart.
  *
- * Objects stored in this container are represented by an object in Dart that is also stored in an
- * InstanceManager with the same identifier.
+ * Objects stored in this container are represented by an object in Dart that is also stored in
+ * an InstanceManager with the same identifier.
  *
  * When an instance is added with an identifier, either can be used to retrieve the other.
  *
- * Added instances are added as a weak reference and a strong reference. When the strong reference
- * is removed with [remove] and the weak reference is deallocated, the
- * `finalizationListener.onFinalize` is called with the instance's identifier. However, if the
- * strong reference is removed and then the identifier is retrieved with the intention to pass the
- * identifier to Dart (e.g. calling [getIdentifierForStrongReference]), the strong reference to the
- * instance is recreated. The strong reference will then need to be removed manually again.
+ * Added instances are added as a weak reference and a strong reference. When the strong
+ * reference is removed with [remove] and the weak reference is deallocated, the
+ * `finalizationListener.onFinalize` is called with the instance's identifier. However, if the strong
+ * reference is removed and then the identifier is retrieved with the intention to pass the identifier
+ * to Dart (e.g. calling [getIdentifierForStrongReference]), the strong reference to the instance
+ * is recreated. The strong reference will then need to be removed manually again.
  */
 @Suppress("UNCHECKED_CAST", "MemberVisibilityCanBePrivate")
-class AndroidWebkitLibraryPigeonInstanceManager(
-    private val finalizationListener: PigeonFinalizationListener
-) {
-  /** Interface for listening when a weak reference of an instance is removed from the manager. */
+class AndroidWebkitLibraryPigeonInstanceManager(private val finalizationListener: PigeonFinalizationListener) {
+  /** Interface for listening when a weak reference of an instance is removed from the manager.  */
   interface PigeonFinalizationListener {
     fun onFinalize(identifier: Long)
   }
@@ -138,20 +139,19 @@ class AndroidWebkitLibraryPigeonInstanceManager(
     private const val tag = "PigeonInstanceManager"
 
     /**
-     * Instantiate a new manager with a listener for garbage collected weak references.
+     * Instantiate a new manager with a listener for garbage collected weak
+     * references.
      *
      * When the manager is no longer needed, [stopFinalizationListener] must be called.
      */
-    fun create(
-        finalizationListener: PigeonFinalizationListener
-    ): AndroidWebkitLibraryPigeonInstanceManager {
+    fun create(finalizationListener: PigeonFinalizationListener): AndroidWebkitLibraryPigeonInstanceManager {
       return AndroidWebkitLibraryPigeonInstanceManager(finalizationListener)
     }
   }
 
   /**
-   * Removes `identifier` and return its associated strongly referenced instance, if present, from
-   * the manager.
+   * Removes `identifier` and return its associated strongly referenced instance, if present,
+   * from the manager.
    */
   fun <T> remove(identifier: Long): T? {
     logWarningIfFinalizationListenerHasStopped()
@@ -165,13 +165,15 @@ class AndroidWebkitLibraryPigeonInstanceManager(
   /**
    * Retrieves the identifier paired with an instance, if present, otherwise `null`.
    *
+   *
    * If the manager contains a strong reference to `instance`, it will return the identifier
    * associated with `instance`. If the manager contains only a weak reference to `instance`, a new
    * strong reference to `instance` will be added and will need to be removed again with [remove].
    *
+   *
    * If this method returns a nonnull identifier, this method also expects the Dart
-   * `AndroidWebkitLibraryPigeonInstanceManager` to have, or recreate, a weak reference to the Dart
-   * instance the identifier is associated with.
+   * `AndroidWebkitLibraryPigeonInstanceManager` to have, or recreate, a weak reference to the Dart instance the
+   * identifier is associated with.
    */
   fun getIdentifierForStrongReference(instance: Any?): Long? {
     logWarningIfFinalizationListenerHasStopped()
@@ -188,9 +190,9 @@ class AndroidWebkitLibraryPigeonInstanceManager(
   /**
    * Adds a new instance that was instantiated from Dart.
    *
-   * The same instance can be added multiple times, but each identifier must be unique. This allows
-   * two objects that are equivalent (e.g. the `equals` method returns true and their hashcodes are
-   * equal) to both be added.
+   * The same instance can be added multiple times, but each identifier must be unique. This
+   * allows two objects that are equivalent (e.g. the `equals` method returns true and their
+   * hashcodes are equal) to both be added.
    *
    * [identifier] must be >= 0 and unique.
    */
@@ -202,15 +204,13 @@ class AndroidWebkitLibraryPigeonInstanceManager(
   /**
    * Adds a new unique instance that was instantiated from the host platform.
    *
-   * If the manager contains [instance], this returns the corresponding identifier. If the manager
-   * does not contain [instance], this adds the instance and returns a unique identifier for that
-   * [instance].
+   * If the manager contains [instance], this returns the corresponding identifier. If the
+   * manager does not contain [instance], this adds the instance and returns a unique
+   * identifier for that [instance].
    */
   fun addHostCreatedInstance(instance: Any): Long {
     logWarningIfFinalizationListenerHasStopped()
-    require(!containsInstance(instance)) {
-      "Instance of ${instance.javaClass} has already been added."
-    }
+    require(!containsInstance(instance)) { "Instance of ${instance.javaClass} has already been added." }
     val identifier = nextIdentifier++
     addInstance(instance, identifier)
     return identifier
@@ -294,43 +294,39 @@ class AndroidWebkitLibraryPigeonInstanceManager(
   private fun logWarningIfFinalizationListenerHasStopped() {
     if (hasFinalizationListenerStopped()) {
       Log.w(
-          tag,
-          "The manager was used after calls to the PigeonFinalizationListener has been stopped.")
+        tag,
+        "The manager was used after calls to the PigeonFinalizationListener has been stopped."
+      )
     }
   }
 }
+
 
 /** Generated API for managing the Dart and native `InstanceManager`s. */
 private class AndroidWebkitLibraryPigeonInstanceManagerApi(val binaryMessenger: BinaryMessenger) {
   companion object {
     /** The codec used by AndroidWebkitLibraryPigeonInstanceManagerApi. */
-    val codec: MessageCodec<Any?> by lazy { AndroidWebkitLibraryPigeonCodec() }
+    val codec: MessageCodec<Any?> by lazy {
+      AndroidWebkitLibraryPigeonCodec()
+    }
 
     /**
-     * Sets up an instance of `AndroidWebkitLibraryPigeonInstanceManagerApi` to handle messages from
-     * the `binaryMessenger`.
+     * Sets up an instance of `AndroidWebkitLibraryPigeonInstanceManagerApi` to handle messages from the
+     * `binaryMessenger`.
      */
-    fun setUpMessageHandlers(
-        binaryMessenger: BinaryMessenger,
-        instanceManager: AndroidWebkitLibraryPigeonInstanceManager?
-    ) {
+    fun setUpMessageHandlers(binaryMessenger: BinaryMessenger, instanceManager: AndroidWebkitLibraryPigeonInstanceManager?) {
       run {
-        val channel =
-            BasicMessageChannel<Any?>(
-                binaryMessenger,
-                "dev.flutter.pigeon.webview_flutter_android.PigeonInternalInstanceManager.removeStrongReference",
-                codec)
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.PigeonInternalInstanceManager.removeStrongReference", codec)
         if (instanceManager != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val identifierArg = args[0] as Long
-            val wrapped: List<Any?> =
-                try {
-                  instanceManager.remove<Any?>(identifierArg)
-                  listOf(null)
-                } catch (exception: Throwable) {
-                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-                }
+            val wrapped: List<Any?> = try {
+              instanceManager.remove<Any?>(identifierArg)
+              listOf(null)
+            } catch (exception: Throwable) {
+              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+            }
             reply.reply(wrapped)
           }
         } else {
@@ -338,20 +334,15 @@ private class AndroidWebkitLibraryPigeonInstanceManagerApi(val binaryMessenger: 
         }
       }
       run {
-        val channel =
-            BasicMessageChannel<Any?>(
-                binaryMessenger,
-                "dev.flutter.pigeon.webview_flutter_android.PigeonInternalInstanceManager.clear",
-                codec)
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.PigeonInternalInstanceManager.clear", codec)
         if (instanceManager != null) {
           channel.setMessageHandler { _, reply ->
-            val wrapped: List<Any?> =
-                try {
-                  instanceManager.clear()
-                  listOf(null)
-                } catch (exception: Throwable) {
-                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-                }
+            val wrapped: List<Any?> = try {
+              instanceManager.clear()
+              listOf(null)
+            } catch (exception: Throwable) {
+              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+            }
             reply.reply(wrapped)
           }
         } else {
@@ -361,28 +352,26 @@ private class AndroidWebkitLibraryPigeonInstanceManagerApi(val binaryMessenger: 
     }
   }
 
-  fun removeStrongReference(identifierArg: Long, callback: (Result<Unit>) -> Unit) {
-    val channelName =
-        "dev.flutter.pigeon.webview_flutter_android.PigeonInternalInstanceManager.removeStrongReference"
+  fun removeStrongReference(identifierArg: Long, callback: (Result<Unit>) -> Unit)
+{
+    val channelName = "dev.flutter.pigeon.webview_flutter_android.PigeonInternalInstanceManager.removeStrongReference"
     val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
     channel.send(listOf(identifierArg)) {
       if (it is List<*>) {
         if (it.size > 1) {
-          callback(
-              Result.failure(
-                  AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
+          callback(Result.failure(AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
         } else {
           callback(Result.success(Unit))
         }
       } else {
         callback(Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
-      }
+      } 
     }
   }
 }
 /**
- * Provides implementations for each ProxyApi implementation and provides access to resources needed
- * by any implementation.
+ * Provides implementations for each ProxyApi implementation and provides access to resources
+ * needed by any implementation.
  */
 abstract class AndroidWebkitLibraryPigeonProxyApiRegistrar(val binaryMessenger: BinaryMessenger) {
   /** Whether APIs should ignore calling to Dart. */
@@ -399,19 +388,20 @@ abstract class AndroidWebkitLibraryPigeonProxyApiRegistrar(val binaryMessenger: 
 
   init {
     val api = AndroidWebkitLibraryPigeonInstanceManagerApi(binaryMessenger)
-    instanceManager =
-        AndroidWebkitLibraryPigeonInstanceManager.create(
-            object : AndroidWebkitLibraryPigeonInstanceManager.PigeonFinalizationListener {
-              override fun onFinalize(identifier: Long) {
-                api.removeStrongReference(identifier) {
-                  if (it.isFailure) {
-                    Log.e(
-                        "PigeonProxyApiRegistrar",
-                        "Failed to remove Dart strong reference with identifier: $identifier")
-                  }
-                }
-              }
-            })
+    instanceManager = AndroidWebkitLibraryPigeonInstanceManager.create(
+      object : AndroidWebkitLibraryPigeonInstanceManager.PigeonFinalizationListener {
+        override fun onFinalize(identifier: Long) {
+          api.removeStrongReference(identifier) {
+            if (it.isFailure) {
+              Log.e(
+                "PigeonProxyApiRegistrar",
+                "Failed to remove Dart strong reference with identifier: $identifier"
+              )
+            }
+          }
+        }
+      }
+    )
   }
   /**
    * An implementation of [PigeonApiWebResourceRequest] used to add a new Dart instance of
@@ -438,8 +428,8 @@ abstract class AndroidWebkitLibraryPigeonProxyApiRegistrar(val binaryMessenger: 
   abstract fun getPigeonApiWebResourceErrorCompat(): PigeonApiWebResourceErrorCompat
 
   /**
-   * An implementation of [PigeonApiWebViewPoint] used to add a new Dart instance of `WebViewPoint`
-   * to the Dart `InstanceManager`.
+   * An implementation of [PigeonApiWebViewPoint] used to add a new Dart instance of
+   * `WebViewPoint` to the Dart `InstanceManager`.
    */
   abstract fun getPigeonApiWebViewPoint(): PigeonApiWebViewPoint
 
@@ -456,14 +446,14 @@ abstract class AndroidWebkitLibraryPigeonProxyApiRegistrar(val binaryMessenger: 
   abstract fun getPigeonApiCookieManager(): PigeonApiCookieManager
 
   /**
-   * An implementation of [PigeonApiWebView] used to add a new Dart instance of `WebView` to the
-   * Dart `InstanceManager`.
+   * An implementation of [PigeonApiWebView] used to add a new Dart instance of
+   * `WebView` to the Dart `InstanceManager`.
    */
   abstract fun getPigeonApiWebView(): PigeonApiWebView
 
   /**
-   * An implementation of [PigeonApiWebSettings] used to add a new Dart instance of `WebSettings` to
-   * the Dart `InstanceManager`.
+   * An implementation of [PigeonApiWebSettings] used to add a new Dart instance of
+   * `WebSettings` to the Dart `InstanceManager`.
    */
   abstract fun getPigeonApiWebSettings(): PigeonApiWebSettings
 
@@ -498,8 +488,8 @@ abstract class AndroidWebkitLibraryPigeonProxyApiRegistrar(val binaryMessenger: 
   abstract fun getPigeonApiFlutterAssetManager(): PigeonApiFlutterAssetManager
 
   /**
-   * An implementation of [PigeonApiWebStorage] used to add a new Dart instance of `WebStorage` to
-   * the Dart `InstanceManager`.
+   * An implementation of [PigeonApiWebStorage] used to add a new Dart instance of
+   * `WebStorage` to the Dart `InstanceManager`.
    */
   abstract fun getPigeonApiWebStorage(): PigeonApiWebStorage
 
@@ -522,14 +512,14 @@ abstract class AndroidWebkitLibraryPigeonProxyApiRegistrar(val binaryMessenger: 
   abstract fun getPigeonApiCustomViewCallback(): PigeonApiCustomViewCallback
 
   /**
-   * An implementation of [PigeonApiView] used to add a new Dart instance of `View` to the Dart
-   * `InstanceManager`.
+   * An implementation of [PigeonApiView] used to add a new Dart instance of
+   * `View` to the Dart `InstanceManager`.
    */
   abstract fun getPigeonApiView(): PigeonApiView
 
   /**
-   * An implementation of [PigeonApiGeolocationPermissionsCallback] used to add a new Dart instance
-   * of `GeolocationPermissionsCallback` to the Dart `InstanceManager`.
+   * An implementation of [PigeonApiGeolocationPermissionsCallback] used to add a new Dart instance of
+   * `GeolocationPermissionsCallback` to the Dart `InstanceManager`.
    */
   abstract fun getPigeonApiGeolocationPermissionsCallback(): PigeonApiGeolocationPermissionsCallback
 
@@ -552,10 +542,11 @@ abstract class AndroidWebkitLibraryPigeonProxyApiRegistrar(val binaryMessenger: 
   abstract fun getPigeonApiClientCertRequest(): PigeonApiClientCertRequest
 
   /**
-   * An implementation of [PigeonApiPrivateKey] used to add a new Dart instance of `PrivateKey` to
-   * the Dart `InstanceManager`.
+   * An implementation of [PigeonApiPrivateKey] used to add a new Dart instance of
+   * `PrivateKey` to the Dart `InstanceManager`.
    */
-  open fun getPigeonApiPrivateKey(): PigeonApiPrivateKey {
+  open fun getPigeonApiPrivateKey(): PigeonApiPrivateKey
+  {
     return PigeonApiPrivateKey(this)
   }
 
@@ -563,7 +554,8 @@ abstract class AndroidWebkitLibraryPigeonProxyApiRegistrar(val binaryMessenger: 
    * An implementation of [PigeonApiX509Certificate] used to add a new Dart instance of
    * `X509Certificate` to the Dart `InstanceManager`.
    */
-  open fun getPigeonApiX509Certificate(): PigeonApiX509Certificate {
+  open fun getPigeonApiX509Certificate(): PigeonApiX509Certificate
+  {
     return PigeonApiX509Certificate(this)
   }
 
@@ -574,8 +566,8 @@ abstract class AndroidWebkitLibraryPigeonProxyApiRegistrar(val binaryMessenger: 
   abstract fun getPigeonApiSslErrorHandler(): PigeonApiSslErrorHandler
 
   /**
-   * An implementation of [PigeonApiSslError] used to add a new Dart instance of `SslError` to the
-   * Dart `InstanceManager`.
+   * An implementation of [PigeonApiSslError] used to add a new Dart instance of
+   * `SslError` to the Dart `InstanceManager`.
    */
   abstract fun getPigeonApiSslError(): PigeonApiSslError
 
@@ -592,8 +584,8 @@ abstract class AndroidWebkitLibraryPigeonProxyApiRegistrar(val binaryMessenger: 
   abstract fun getPigeonApiSslCertificate(): PigeonApiSslCertificate
 
   /**
-   * An implementation of [PigeonApiCertificate] used to add a new Dart instance of `Certificate` to
-   * the Dart `InstanceManager`.
+   * An implementation of [PigeonApiCertificate] used to add a new Dart instance of
+   * `Certificate` to the Dart `InstanceManager`.
    */
   abstract fun getPigeonApiCertificate(): PigeonApiCertificate
 
@@ -610,41 +602,31 @@ abstract class AndroidWebkitLibraryPigeonProxyApiRegistrar(val binaryMessenger: 
   abstract fun getPigeonApiWebViewFeature(): PigeonApiWebViewFeature
 
   fun setUp() {
-    AndroidWebkitLibraryPigeonInstanceManagerApi.setUpMessageHandlers(
-        binaryMessenger, instanceManager)
+    AndroidWebkitLibraryPigeonInstanceManagerApi.setUpMessageHandlers(binaryMessenger, instanceManager)
     PigeonApiCookieManager.setUpMessageHandlers(binaryMessenger, getPigeonApiCookieManager())
     PigeonApiWebView.setUpMessageHandlers(binaryMessenger, getPigeonApiWebView())
     PigeonApiWebSettings.setUpMessageHandlers(binaryMessenger, getPigeonApiWebSettings())
-    PigeonApiJavaScriptChannel.setUpMessageHandlers(
-        binaryMessenger, getPigeonApiJavaScriptChannel())
+    PigeonApiJavaScriptChannel.setUpMessageHandlers(binaryMessenger, getPigeonApiJavaScriptChannel())
     PigeonApiWebViewClient.setUpMessageHandlers(binaryMessenger, getPigeonApiWebViewClient())
     PigeonApiDownloadListener.setUpMessageHandlers(binaryMessenger, getPigeonApiDownloadListener())
     PigeonApiWebChromeClient.setUpMessageHandlers(binaryMessenger, getPigeonApiWebChromeClient())
-    PigeonApiFlutterAssetManager.setUpMessageHandlers(
-        binaryMessenger, getPigeonApiFlutterAssetManager())
+    PigeonApiFlutterAssetManager.setUpMessageHandlers(binaryMessenger, getPigeonApiFlutterAssetManager())
     PigeonApiWebStorage.setUpMessageHandlers(binaryMessenger, getPigeonApiWebStorage())
-    PigeonApiPermissionRequest.setUpMessageHandlers(
-        binaryMessenger, getPigeonApiPermissionRequest())
-    PigeonApiCustomViewCallback.setUpMessageHandlers(
-        binaryMessenger, getPigeonApiCustomViewCallback())
+    PigeonApiPermissionRequest.setUpMessageHandlers(binaryMessenger, getPigeonApiPermissionRequest())
+    PigeonApiCustomViewCallback.setUpMessageHandlers(binaryMessenger, getPigeonApiCustomViewCallback())
     PigeonApiView.setUpMessageHandlers(binaryMessenger, getPigeonApiView())
-    PigeonApiGeolocationPermissionsCallback.setUpMessageHandlers(
-        binaryMessenger, getPigeonApiGeolocationPermissionsCallback())
+    PigeonApiGeolocationPermissionsCallback.setUpMessageHandlers(binaryMessenger, getPigeonApiGeolocationPermissionsCallback())
     PigeonApiHttpAuthHandler.setUpMessageHandlers(binaryMessenger, getPigeonApiHttpAuthHandler())
     PigeonApiAndroidMessage.setUpMessageHandlers(binaryMessenger, getPigeonApiAndroidMessage())
-    PigeonApiClientCertRequest.setUpMessageHandlers(
-        binaryMessenger, getPigeonApiClientCertRequest())
+    PigeonApiClientCertRequest.setUpMessageHandlers(binaryMessenger, getPigeonApiClientCertRequest())
     PigeonApiSslErrorHandler.setUpMessageHandlers(binaryMessenger, getPigeonApiSslErrorHandler())
     PigeonApiSslError.setUpMessageHandlers(binaryMessenger, getPigeonApiSslError())
-    PigeonApiSslCertificateDName.setUpMessageHandlers(
-        binaryMessenger, getPigeonApiSslCertificateDName())
+    PigeonApiSslCertificateDName.setUpMessageHandlers(binaryMessenger, getPigeonApiSslCertificateDName())
     PigeonApiSslCertificate.setUpMessageHandlers(binaryMessenger, getPigeonApiSslCertificate())
     PigeonApiCertificate.setUpMessageHandlers(binaryMessenger, getPigeonApiCertificate())
-    PigeonApiWebSettingsCompat.setUpMessageHandlers(
-        binaryMessenger, getPigeonApiWebSettingsCompat())
+    PigeonApiWebSettingsCompat.setUpMessageHandlers(binaryMessenger, getPigeonApiWebSettingsCompat())
     PigeonApiWebViewFeature.setUpMessageHandlers(binaryMessenger, getPigeonApiWebViewFeature())
   }
-
   fun tearDown() {
     AndroidWebkitLibraryPigeonInstanceManagerApi.setUpMessageHandlers(binaryMessenger, null)
     PigeonApiCookieManager.setUpMessageHandlers(binaryMessenger, null)
@@ -672,17 +654,17 @@ abstract class AndroidWebkitLibraryPigeonProxyApiRegistrar(val binaryMessenger: 
     PigeonApiWebViewFeature.setUpMessageHandlers(binaryMessenger, null)
   }
 }
-
-private class AndroidWebkitLibraryPigeonProxyApiBaseCodec(
-    val registrar: AndroidWebkitLibraryPigeonProxyApiRegistrar
-) : AndroidWebkitLibraryPigeonCodec() {
+private class AndroidWebkitLibraryPigeonProxyApiBaseCodec(val registrar: AndroidWebkitLibraryPigeonProxyApiRegistrar) : AndroidWebkitLibraryPigeonCodec() {
   override fun readValueOfType(type: Byte, buffer: ByteBuffer): Any? {
     return when (type) {
       128.toByte() -> {
         val identifier: Long = readValue(buffer) as Long
         val instance: Any? = registrar.instanceManager.getInstance(identifier)
         if (instance == null) {
-          Log.e("PigeonProxyApiBaseCodec", "Failed to find instance with identifier: $identifier")
+          Log.e(
+            "PigeonProxyApiBaseCodec",
+            "Failed to find instance with identifier: $identifier"
+          )
         }
         return instance
       }
@@ -691,33 +673,16 @@ private class AndroidWebkitLibraryPigeonProxyApiBaseCodec(
   }
 
   override fun writeValue(stream: ByteArrayOutputStream, value: Any?) {
-    if (value is Boolean ||
-        value is ByteArray ||
-        value is Double ||
-        value is DoubleArray ||
-        value is FloatArray ||
-        value is Int ||
-        value is IntArray ||
-        value is List<*> ||
-        value is Long ||
-        value is LongArray ||
-        value is Map<*, *> ||
-        value is String ||
-        value is FileChooserMode ||
-        value is ConsoleMessageLevel ||
-        value is OverScrollMode ||
-        value is SslErrorType ||
-        value is MixedContentMode ||
-        value is WindowInsetsType ||
-        value == null) {
+    if (value is Boolean || value is ByteArray || value is Double || value is DoubleArray || value is FloatArray || value is Int || value is IntArray || value is List<*> || value is Long || value is LongArray || value is Map<*, *> || value is String || value is FileChooserMode || value is ConsoleMessageLevel || value is OverScrollMode || value is SslErrorType || value is MixedContentMode || value is WindowInsetsType || value == null) {
       super.writeValue(stream, value)
       return
     }
 
     fun logNewInstanceFailure(apiName: String, value: Any, exception: Throwable?) {
       Log.w(
-          "PigeonProxyApiBaseCodec",
-          "Failed to create new Dart proxy instance of $apiName: $value. $exception")
+        "PigeonProxyApiBaseCodec",
+        "Failed to create new Dart proxy instance of $apiName: $value. $exception"
+      )
     }
 
     if (value is android.webkit.WebResourceRequest) {
@@ -726,188 +691,218 @@ private class AndroidWebkitLibraryPigeonProxyApiBaseCodec(
           logNewInstanceFailure("WebResourceRequest", value, it.exceptionOrNull())
         }
       }
-    } else if (value is android.webkit.WebResourceResponse) {
+    }
+     else if (value is android.webkit.WebResourceResponse) {
       registrar.getPigeonApiWebResourceResponse().pigeon_newInstance(value) {
         if (it.isFailure) {
           logNewInstanceFailure("WebResourceResponse", value, it.exceptionOrNull())
         }
       }
-    } else if (value is android.webkit.WebResourceError) {
+    }
+     else if (value is android.webkit.WebResourceError) {
       registrar.getPigeonApiWebResourceError().pigeon_newInstance(value) {
         if (it.isFailure) {
           logNewInstanceFailure("WebResourceError", value, it.exceptionOrNull())
         }
       }
-    } else if (value is androidx.webkit.WebResourceErrorCompat) {
+    }
+     else if (value is androidx.webkit.WebResourceErrorCompat) {
       registrar.getPigeonApiWebResourceErrorCompat().pigeon_newInstance(value) {
         if (it.isFailure) {
           logNewInstanceFailure("WebResourceErrorCompat", value, it.exceptionOrNull())
         }
       }
-    } else if (value is WebViewPoint) {
+    }
+     else if (value is WebViewPoint) {
       registrar.getPigeonApiWebViewPoint().pigeon_newInstance(value) {
         if (it.isFailure) {
           logNewInstanceFailure("WebViewPoint", value, it.exceptionOrNull())
         }
       }
-    } else if (value is android.webkit.ConsoleMessage) {
+    }
+     else if (value is android.webkit.ConsoleMessage) {
       registrar.getPigeonApiConsoleMessage().pigeon_newInstance(value) {
         if (it.isFailure) {
           logNewInstanceFailure("ConsoleMessage", value, it.exceptionOrNull())
         }
       }
-    } else if (value is android.webkit.CookieManager) {
+    }
+     else if (value is android.webkit.CookieManager) {
       registrar.getPigeonApiCookieManager().pigeon_newInstance(value) {
         if (it.isFailure) {
           logNewInstanceFailure("CookieManager", value, it.exceptionOrNull())
         }
       }
-    } else if (value is android.webkit.WebView) {
+    }
+     else if (value is android.webkit.WebView) {
       registrar.getPigeonApiWebView().pigeon_newInstance(value) {
         if (it.isFailure) {
           logNewInstanceFailure("WebView", value, it.exceptionOrNull())
         }
       }
-    } else if (value is android.webkit.WebSettings) {
+    }
+     else if (value is android.webkit.WebSettings) {
       registrar.getPigeonApiWebSettings().pigeon_newInstance(value) {
         if (it.isFailure) {
           logNewInstanceFailure("WebSettings", value, it.exceptionOrNull())
         }
       }
-    } else if (value is JavaScriptChannel) {
+    }
+     else if (value is JavaScriptChannel) {
       registrar.getPigeonApiJavaScriptChannel().pigeon_newInstance(value) {
         if (it.isFailure) {
           logNewInstanceFailure("JavaScriptChannel", value, it.exceptionOrNull())
         }
       }
-    } else if (value is android.webkit.WebViewClient) {
+    }
+     else if (value is android.webkit.WebViewClient) {
       registrar.getPigeonApiWebViewClient().pigeon_newInstance(value) {
         if (it.isFailure) {
           logNewInstanceFailure("WebViewClient", value, it.exceptionOrNull())
         }
       }
-    } else if (value is android.webkit.DownloadListener) {
+    }
+     else if (value is android.webkit.DownloadListener) {
       registrar.getPigeonApiDownloadListener().pigeon_newInstance(value) {
         if (it.isFailure) {
           logNewInstanceFailure("DownloadListener", value, it.exceptionOrNull())
         }
       }
-    } else if (value
-        is io.flutter.plugins.webviewflutter.WebChromeClientProxyApi.WebChromeClientImpl) {
+    }
+     else if (value is io.flutter.plugins.webviewflutter.WebChromeClientProxyApi.WebChromeClientImpl) {
       registrar.getPigeonApiWebChromeClient().pigeon_newInstance(value) {
         if (it.isFailure) {
           logNewInstanceFailure("WebChromeClient", value, it.exceptionOrNull())
         }
       }
-    } else if (value is io.flutter.plugins.webviewflutter.FlutterAssetManager) {
+    }
+     else if (value is io.flutter.plugins.webviewflutter.FlutterAssetManager) {
       registrar.getPigeonApiFlutterAssetManager().pigeon_newInstance(value) {
         if (it.isFailure) {
           logNewInstanceFailure("FlutterAssetManager", value, it.exceptionOrNull())
         }
       }
-    } else if (value is android.webkit.WebStorage) {
+    }
+     else if (value is android.webkit.WebStorage) {
       registrar.getPigeonApiWebStorage().pigeon_newInstance(value) {
         if (it.isFailure) {
           logNewInstanceFailure("WebStorage", value, it.exceptionOrNull())
         }
       }
-    } else if (value is android.webkit.WebChromeClient.FileChooserParams) {
+    }
+     else if (value is android.webkit.WebChromeClient.FileChooserParams) {
       registrar.getPigeonApiFileChooserParams().pigeon_newInstance(value) {
         if (it.isFailure) {
           logNewInstanceFailure("FileChooserParams", value, it.exceptionOrNull())
         }
       }
-    } else if (value is android.webkit.PermissionRequest) {
+    }
+     else if (value is android.webkit.PermissionRequest) {
       registrar.getPigeonApiPermissionRequest().pigeon_newInstance(value) {
         if (it.isFailure) {
           logNewInstanceFailure("PermissionRequest", value, it.exceptionOrNull())
         }
       }
-    } else if (value is android.webkit.WebChromeClient.CustomViewCallback) {
+    }
+     else if (value is android.webkit.WebChromeClient.CustomViewCallback) {
       registrar.getPigeonApiCustomViewCallback().pigeon_newInstance(value) {
         if (it.isFailure) {
           logNewInstanceFailure("CustomViewCallback", value, it.exceptionOrNull())
         }
       }
-    } else if (value is android.view.View) {
+    }
+     else if (value is android.view.View) {
       registrar.getPigeonApiView().pigeon_newInstance(value) {
         if (it.isFailure) {
           logNewInstanceFailure("View", value, it.exceptionOrNull())
         }
       }
-    } else if (value is android.webkit.GeolocationPermissions.Callback) {
+    }
+     else if (value is android.webkit.GeolocationPermissions.Callback) {
       registrar.getPigeonApiGeolocationPermissionsCallback().pigeon_newInstance(value) {
         if (it.isFailure) {
           logNewInstanceFailure("GeolocationPermissionsCallback", value, it.exceptionOrNull())
         }
       }
-    } else if (value is android.webkit.HttpAuthHandler) {
+    }
+     else if (value is android.webkit.HttpAuthHandler) {
       registrar.getPigeonApiHttpAuthHandler().pigeon_newInstance(value) {
         if (it.isFailure) {
           logNewInstanceFailure("HttpAuthHandler", value, it.exceptionOrNull())
         }
       }
-    } else if (value is android.os.Message) {
+    }
+     else if (value is android.os.Message) {
       registrar.getPigeonApiAndroidMessage().pigeon_newInstance(value) {
         if (it.isFailure) {
           logNewInstanceFailure("AndroidMessage", value, it.exceptionOrNull())
         }
       }
-    } else if (value is android.webkit.ClientCertRequest) {
+    }
+     else if (value is android.webkit.ClientCertRequest) {
       registrar.getPigeonApiClientCertRequest().pigeon_newInstance(value) {
         if (it.isFailure) {
           logNewInstanceFailure("ClientCertRequest", value, it.exceptionOrNull())
         }
       }
-    } else if (value is java.security.PrivateKey) {
+    }
+     else if (value is java.security.PrivateKey) {
       registrar.getPigeonApiPrivateKey().pigeon_newInstance(value) {
         if (it.isFailure) {
           logNewInstanceFailure("PrivateKey", value, it.exceptionOrNull())
         }
       }
-    } else if (value is java.security.cert.X509Certificate) {
+    }
+     else if (value is java.security.cert.X509Certificate) {
       registrar.getPigeonApiX509Certificate().pigeon_newInstance(value) {
         if (it.isFailure) {
           logNewInstanceFailure("X509Certificate", value, it.exceptionOrNull())
         }
       }
-    } else if (value is android.webkit.SslErrorHandler) {
+    }
+     else if (value is android.webkit.SslErrorHandler) {
       registrar.getPigeonApiSslErrorHandler().pigeon_newInstance(value) {
         if (it.isFailure) {
           logNewInstanceFailure("SslErrorHandler", value, it.exceptionOrNull())
         }
       }
-    } else if (value is android.net.http.SslError) {
+    }
+     else if (value is android.net.http.SslError) {
       registrar.getPigeonApiSslError().pigeon_newInstance(value) {
         if (it.isFailure) {
           logNewInstanceFailure("SslError", value, it.exceptionOrNull())
         }
       }
-    } else if (value is android.net.http.SslCertificate.DName) {
+    }
+     else if (value is android.net.http.SslCertificate.DName) {
       registrar.getPigeonApiSslCertificateDName().pigeon_newInstance(value) {
         if (it.isFailure) {
           logNewInstanceFailure("SslCertificateDName", value, it.exceptionOrNull())
         }
       }
-    } else if (value is android.net.http.SslCertificate) {
+    }
+     else if (value is android.net.http.SslCertificate) {
       registrar.getPigeonApiSslCertificate().pigeon_newInstance(value) {
         if (it.isFailure) {
           logNewInstanceFailure("SslCertificate", value, it.exceptionOrNull())
         }
       }
-    } else if (value is java.security.cert.Certificate) {
+    }
+     else if (value is java.security.cert.Certificate) {
       registrar.getPigeonApiCertificate().pigeon_newInstance(value) {
         if (it.isFailure) {
           logNewInstanceFailure("Certificate", value, it.exceptionOrNull())
         }
       }
-    } else if (value is androidx.webkit.WebSettingsCompat) {
+    }
+     else if (value is androidx.webkit.WebSettingsCompat) {
       registrar.getPigeonApiWebSettingsCompat().pigeon_newInstance(value) {
         if (it.isFailure) {
           logNewInstanceFailure("WebSettingsCompat", value, it.exceptionOrNull())
         }
       }
-    } else if (value is androidx.webkit.WebViewFeature) {
+    }
+     else if (value is androidx.webkit.WebViewFeature) {
       registrar.getPigeonApiWebViewFeature().pigeon_newInstance(value) {
         if (it.isFailure) {
           logNewInstanceFailure("WebViewFeature", value, it.exceptionOrNull())
@@ -920,9 +915,7 @@ private class AndroidWebkitLibraryPigeonProxyApiBaseCodec(
         stream.write(128)
         writeValue(stream, registrar.instanceManager.getIdentifierForStrongReference(value))
       }
-      else ->
-          throw IllegalArgumentException(
-              "Unsupported value: '$value' of type '${value.javaClass.name}'")
+      else -> throw IllegalArgumentException("Unsupported value: '$value' of type '${value.javaClass.name}'")
     }
   }
 }
@@ -934,31 +927,29 @@ private class AndroidWebkitLibraryPigeonProxyApiBaseCodec(
  */
 enum class FileChooserMode(val raw: Int) {
   /**
-   * Open single file and requires that the file exists before allowing the user to pick it.
+   * Open single file and requires that the file exists before allowing the
+   * user to pick it.
    *
-   * See
-   * https://developer.android.com/reference/android/webkit/WebChromeClient.FileChooserParams#MODE_OPEN.
+   * See https://developer.android.com/reference/android/webkit/WebChromeClient.FileChooserParams#MODE_OPEN.
    */
   OPEN(0),
   /**
    * Similar to [open] but allows multiple files to be selected.
    *
-   * See
-   * https://developer.android.com/reference/android/webkit/WebChromeClient.FileChooserParams#MODE_OPEN_MULTIPLE.
+   * See https://developer.android.com/reference/android/webkit/WebChromeClient.FileChooserParams#MODE_OPEN_MULTIPLE.
    */
   OPEN_MULTIPLE(1),
   /**
    * Allows picking a nonexistent file and saving it.
    *
-   * See
-   * https://developer.android.com/reference/android/webkit/WebChromeClient.FileChooserParams#MODE_SAVE.
+   * See https://developer.android.com/reference/android/webkit/WebChromeClient.FileChooserParams#MODE_SAVE.
    */
   SAVE(2),
   /**
    * Indicates a `FileChooserMode` with an unknown mode.
    *
-   * This does not represent an actual value provided by the platform and only indicates a value was
-   * provided that isn't currently supported.
+   * This does not represent an actual value provided by the platform and only
+   * indicates a value was provided that isn't currently supported.
    */
   UNKNOWN(3);
 
@@ -1008,8 +999,8 @@ enum class ConsoleMessageLevel(val raw: Int) {
   /**
    * Indicates a message with an unknown level.
    *
-   * This does not represent an actual value provided by the platform and only indicates a value was
-   * provided that isn't currently supported.
+   * This does not represent an actual value provided by the platform and only
+   * indicates a value was provided that isn't currently supported.
    */
   UNKNOWN(5);
 
@@ -1026,11 +1017,14 @@ enum class ConsoleMessageLevel(val raw: Int) {
  * See https://developer.android.com/reference/android/view/View#OVER_SCROLL_ALWAYS.
  */
 enum class OverScrollMode(val raw: Int) {
-  /** Always allow a user to over-scroll this view, provided it is a view that can scroll. */
+  /**
+   * Always allow a user to over-scroll this view, provided it is a view that
+   * can scroll.
+   */
   ALWAYS(0),
   /**
-   * Allow a user to over-scroll this view only if the content is large enough to meaningfully
-   * scroll, provided it is a view that can scroll.
+   * Allow a user to over-scroll this view only if the content is large enough
+   * to meaningfully scroll, provided it is a view that can scroll.
    */
   IF_CONTENT_SCROLLS(1),
   /** Never allow a user to over-scroll this view. */
@@ -1080,16 +1074,19 @@ enum class SslErrorType(val raw: Int) {
  */
 enum class MixedContentMode(val raw: Int) {
   /**
-   * The WebView will allow a secure origin to load content from any other origin, even if that
-   * origin is insecure.
+   * The WebView will allow a secure origin to load content from any other
+   * origin, even if that origin is insecure.
    */
   ALWAYS_ALLOW(0),
   /**
-   * The WebView will attempt to be compatible with the approach of a modern web browser with regard
-   * to mixed content.
+   * The WebView will attempt to be compatible with the approach of a modern
+   * web browser with regard to mixed content.
    */
   COMPATIBILITY_MODE(1),
-  /** The WebView will not allow a secure origin to load content from an insecure origin. */
+  /**
+   * The WebView will not allow a secure origin to load content from an
+   * insecure origin.
+   */
   NEVER_ALLOW(2);
 
   companion object {
@@ -1108,8 +1105,8 @@ enum class WindowInsetsType(val raw: Int) {
   /**
    * All system bars.
    *
-   * Includes statusBars(), captionBar() as well as navigationBars(), systemOverlays(), but not
-   * ime().
+   * Includes statusBars(), captionBar() as well as navigationBars(),
+   * systemOverlays(), but not ime().
    */
   SYSTEM_BARS(0),
   /** An inset type representing the area that used by DisplayCutout. */
@@ -1126,9 +1123,10 @@ enum class WindowInsetsType(val raw: Int) {
   /**
    * An insets type representing the system gesture insets.
    *
-   * The system gesture insets represent the area of a window where system gestures have priority
-   * and may consume some or all touch input, e.g. due to the a system bar occupying it, or it being
-   * reserved for touch-only gestures.
+   * The system gesture insets represent the area of a window where system
+   * gestures have priority and may consume some or all touch input, e.g. due
+   * to the a system bar occupying it, or it being reserved for touch-only
+   * gestures.
    */
   SYSTEM_GESTURES(7),
   TAPPABLE_ELEMENT(8);
@@ -1139,33 +1137,43 @@ enum class WindowInsetsType(val raw: Int) {
     }
   }
 }
-
 private open class AndroidWebkitLibraryPigeonCodec : StandardMessageCodec() {
   override fun readValueOfType(type: Byte, buffer: ByteBuffer): Any? {
     return when (type) {
       129.toByte() -> {
-        return (readValue(buffer) as Long?)?.let { FileChooserMode.ofRaw(it.toInt()) }
+        return (readValue(buffer) as Long?)?.let {
+          FileChooserMode.ofRaw(it.toInt())
+        }
       }
       130.toByte() -> {
-        return (readValue(buffer) as Long?)?.let { ConsoleMessageLevel.ofRaw(it.toInt()) }
+        return (readValue(buffer) as Long?)?.let {
+          ConsoleMessageLevel.ofRaw(it.toInt())
+        }
       }
       131.toByte() -> {
-        return (readValue(buffer) as Long?)?.let { OverScrollMode.ofRaw(it.toInt()) }
+        return (readValue(buffer) as Long?)?.let {
+          OverScrollMode.ofRaw(it.toInt())
+        }
       }
       132.toByte() -> {
-        return (readValue(buffer) as Long?)?.let { SslErrorType.ofRaw(it.toInt()) }
+        return (readValue(buffer) as Long?)?.let {
+          SslErrorType.ofRaw(it.toInt())
+        }
       }
       133.toByte() -> {
-        return (readValue(buffer) as Long?)?.let { MixedContentMode.ofRaw(it.toInt()) }
+        return (readValue(buffer) as Long?)?.let {
+          MixedContentMode.ofRaw(it.toInt())
+        }
       }
       134.toByte() -> {
-        return (readValue(buffer) as Long?)?.let { WindowInsetsType.ofRaw(it.toInt()) }
+        return (readValue(buffer) as Long?)?.let {
+          WindowInsetsType.ofRaw(it.toInt())
+        }
       }
       else -> super.readValueOfType(type, buffer)
     }
   }
-
-  override fun writeValue(stream: ByteArrayOutputStream, value: Any?) {
+  override fun writeValue(stream: ByteArrayOutputStream, value: Any?)   {
     when (value) {
       is FileChooserMode -> {
         stream.write(129)
@@ -1202,9 +1210,7 @@ private open class AndroidWebkitLibraryPigeonCodec : StandardMessageCodec() {
  * See https://developer.android.com/reference/android/webkit/WebResourceRequest.
  */
 @Suppress("UNCHECKED_CAST")
-abstract class PigeonApiWebResourceRequest(
-    open val pigeonRegistrar: AndroidWebkitLibraryPigeonProxyApiRegistrar
-) {
+abstract class PigeonApiWebResourceRequest(open val pigeonRegistrar: AndroidWebkitLibraryPigeonProxyApiRegistrar) {
   /** The URL for which the resource request was made. */
   abstract fun url(pigeon_instance: android.webkit.WebResourceRequest): String
 
@@ -1221,25 +1227,20 @@ abstract class PigeonApiWebResourceRequest(
   abstract fun method(pigeon_instance: android.webkit.WebResourceRequest): String
 
   /** The headers associated with the request. */
-  abstract fun requestHeaders(
-      pigeon_instance: android.webkit.WebResourceRequest
-  ): Map<String, String>?
+  abstract fun requestHeaders(pigeon_instance: android.webkit.WebResourceRequest): Map<String, String>?
 
   @Suppress("LocalVariableName", "FunctionName")
   /** Creates a Dart instance of WebResourceRequest and attaches it to [pigeon_instanceArg]. */
-  fun pigeon_newInstance(
-      pigeon_instanceArg: android.webkit.WebResourceRequest,
-      callback: (Result<Unit>) -> Unit
-  ) {
+  fun pigeon_newInstance(pigeon_instanceArg: android.webkit.WebResourceRequest, callback: (Result<Unit>) -> Unit)
+{
     if (pigeonRegistrar.ignoreCallsToDart) {
       callback(
           Result.failure(
               AndroidWebKitError("ignore-calls-error", "Calls to Dart are being ignored.", "")))
-    } else if (pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
+    }     else if (pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
       callback(Result.success(Unit))
-    } else {
-      val pigeon_identifierArg =
-          pigeonRegistrar.instanceManager.addHostCreatedInstance(pigeon_instanceArg)
+    }     else {
+      val pigeon_identifierArg = pigeonRegistrar.instanceManager.addHostCreatedInstance(pigeon_instanceArg)
       val urlArg = url(pigeon_instanceArg)
       val isForMainFrameArg = isForMainFrame(pigeon_instanceArg)
       val isRedirectArg = isRedirect(pigeon_instanceArg)
@@ -1248,34 +1249,22 @@ abstract class PigeonApiWebResourceRequest(
       val requestHeadersArg = requestHeaders(pigeon_instanceArg)
       val binaryMessenger = pigeonRegistrar.binaryMessenger
       val codec = pigeonRegistrar.codec
-      val channelName =
-          "dev.flutter.pigeon.webview_flutter_android.WebResourceRequest.pigeon_newInstance"
+      val channelName = "dev.flutter.pigeon.webview_flutter_android.WebResourceRequest.pigeon_newInstance"
       val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
-      channel.send(
-          listOf(
-              pigeon_identifierArg,
-              urlArg,
-              isForMainFrameArg,
-              isRedirectArg,
-              hasGestureArg,
-              methodArg,
-              requestHeadersArg)) {
-            if (it is List<*>) {
-              if (it.size > 1) {
-                callback(
-                    Result.failure(
-                        AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
-              } else {
-                callback(Result.success(Unit))
-              }
-            } else {
-              callback(
-                  Result.failure(
-                      AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
-            }
+      channel.send(listOf(pigeon_identifierArg, urlArg, isForMainFrameArg, isRedirectArg, hasGestureArg, methodArg, requestHeadersArg)) {
+        if (it is List<*>) {
+          if (it.size > 1) {
+            callback(Result.failure(AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
+          } else {
+            callback(Result.success(Unit))
           }
+        } else {
+          callback(Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
+        } 
+      }
     }
   }
+
 }
 /**
  * Encapsulates a resource response.
@@ -1283,59 +1272,50 @@ abstract class PigeonApiWebResourceRequest(
  * See https://developer.android.com/reference/android/webkit/WebResourceResponse.
  */
 @Suppress("UNCHECKED_CAST")
-abstract class PigeonApiWebResourceResponse(
-    open val pigeonRegistrar: AndroidWebkitLibraryPigeonProxyApiRegistrar
-) {
+abstract class PigeonApiWebResourceResponse(open val pigeonRegistrar: AndroidWebkitLibraryPigeonProxyApiRegistrar) {
   /** The resource response's status code. */
   abstract fun statusCode(pigeon_instance: android.webkit.WebResourceResponse): Long
 
   @Suppress("LocalVariableName", "FunctionName")
   /** Creates a Dart instance of WebResourceResponse and attaches it to [pigeon_instanceArg]. */
-  fun pigeon_newInstance(
-      pigeon_instanceArg: android.webkit.WebResourceResponse,
-      callback: (Result<Unit>) -> Unit
-  ) {
+  fun pigeon_newInstance(pigeon_instanceArg: android.webkit.WebResourceResponse, callback: (Result<Unit>) -> Unit)
+{
     if (pigeonRegistrar.ignoreCallsToDart) {
       callback(
           Result.failure(
               AndroidWebKitError("ignore-calls-error", "Calls to Dart are being ignored.", "")))
-    } else if (pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
+    }     else if (pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
       callback(Result.success(Unit))
-    } else {
-      val pigeon_identifierArg =
-          pigeonRegistrar.instanceManager.addHostCreatedInstance(pigeon_instanceArg)
+    }     else {
+      val pigeon_identifierArg = pigeonRegistrar.instanceManager.addHostCreatedInstance(pigeon_instanceArg)
       val statusCodeArg = statusCode(pigeon_instanceArg)
       val binaryMessenger = pigeonRegistrar.binaryMessenger
       val codec = pigeonRegistrar.codec
-      val channelName =
-          "dev.flutter.pigeon.webview_flutter_android.WebResourceResponse.pigeon_newInstance"
+      val channelName = "dev.flutter.pigeon.webview_flutter_android.WebResourceResponse.pigeon_newInstance"
       val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
       channel.send(listOf(pigeon_identifierArg, statusCodeArg)) {
         if (it is List<*>) {
           if (it.size > 1) {
-            callback(
-                Result.failure(
-                    AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
+            callback(Result.failure(AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
           } else {
             callback(Result.success(Unit))
           }
         } else {
-          callback(
-              Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
-        }
+          callback(Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
+        } 
       }
     }
   }
+
 }
 /**
- * Encapsulates information about errors that occurred during loading of web resources.
+ * Encapsulates information about errors that occurred during loading of web
+ * resources.
  *
  * See https://developer.android.com/reference/android/webkit/WebResourceError.
  */
 @Suppress("UNCHECKED_CAST")
-abstract class PigeonApiWebResourceError(
-    open val pigeonRegistrar: AndroidWebkitLibraryPigeonProxyApiRegistrar
-) {
+abstract class PigeonApiWebResourceError(open val pigeonRegistrar: AndroidWebkitLibraryPigeonProxyApiRegistrar) {
   /** The error code of the error. */
   abstract fun errorCode(pigeon_instance: android.webkit.WebResourceError): Long
 
@@ -1344,52 +1324,45 @@ abstract class PigeonApiWebResourceError(
 
   @Suppress("LocalVariableName", "FunctionName")
   /** Creates a Dart instance of WebResourceError and attaches it to [pigeon_instanceArg]. */
-  fun pigeon_newInstance(
-      pigeon_instanceArg: android.webkit.WebResourceError,
-      callback: (Result<Unit>) -> Unit
-  ) {
+  fun pigeon_newInstance(pigeon_instanceArg: android.webkit.WebResourceError, callback: (Result<Unit>) -> Unit)
+{
     if (pigeonRegistrar.ignoreCallsToDart) {
       callback(
           Result.failure(
               AndroidWebKitError("ignore-calls-error", "Calls to Dart are being ignored.", "")))
-    } else if (pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
+    }     else if (pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
       callback(Result.success(Unit))
-    } else {
-      val pigeon_identifierArg =
-          pigeonRegistrar.instanceManager.addHostCreatedInstance(pigeon_instanceArg)
+    }     else {
+      val pigeon_identifierArg = pigeonRegistrar.instanceManager.addHostCreatedInstance(pigeon_instanceArg)
       val errorCodeArg = errorCode(pigeon_instanceArg)
       val descriptionArg = description(pigeon_instanceArg)
       val binaryMessenger = pigeonRegistrar.binaryMessenger
       val codec = pigeonRegistrar.codec
-      val channelName =
-          "dev.flutter.pigeon.webview_flutter_android.WebResourceError.pigeon_newInstance"
+      val channelName = "dev.flutter.pigeon.webview_flutter_android.WebResourceError.pigeon_newInstance"
       val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
       channel.send(listOf(pigeon_identifierArg, errorCodeArg, descriptionArg)) {
         if (it is List<*>) {
           if (it.size > 1) {
-            callback(
-                Result.failure(
-                    AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
+            callback(Result.failure(AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
           } else {
             callback(Result.success(Unit))
           }
         } else {
-          callback(
-              Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
-        }
+          callback(Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
+        } 
       }
     }
   }
+
 }
 /**
- * Encapsulates information about errors that occurred during loading of web resources.
+ * Encapsulates information about errors that occurred during loading of web
+ * resources.
  *
  * See https://developer.android.com/reference/androidx/webkit/WebResourceErrorCompat.
  */
 @Suppress("UNCHECKED_CAST")
-abstract class PigeonApiWebResourceErrorCompat(
-    open val pigeonRegistrar: AndroidWebkitLibraryPigeonProxyApiRegistrar
-) {
+abstract class PigeonApiWebResourceErrorCompat(open val pigeonRegistrar: AndroidWebkitLibraryPigeonProxyApiRegistrar) {
   /** The error code of the error. */
   abstract fun errorCode(pigeon_instance: androidx.webkit.WebResourceErrorCompat): Long
 
@@ -1398,42 +1371,36 @@ abstract class PigeonApiWebResourceErrorCompat(
 
   @Suppress("LocalVariableName", "FunctionName")
   /** Creates a Dart instance of WebResourceErrorCompat and attaches it to [pigeon_instanceArg]. */
-  fun pigeon_newInstance(
-      pigeon_instanceArg: androidx.webkit.WebResourceErrorCompat,
-      callback: (Result<Unit>) -> Unit
-  ) {
+  fun pigeon_newInstance(pigeon_instanceArg: androidx.webkit.WebResourceErrorCompat, callback: (Result<Unit>) -> Unit)
+{
     if (pigeonRegistrar.ignoreCallsToDart) {
       callback(
           Result.failure(
               AndroidWebKitError("ignore-calls-error", "Calls to Dart are being ignored.", "")))
-    } else if (pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
+    }     else if (pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
       callback(Result.success(Unit))
-    } else {
-      val pigeon_identifierArg =
-          pigeonRegistrar.instanceManager.addHostCreatedInstance(pigeon_instanceArg)
+    }     else {
+      val pigeon_identifierArg = pigeonRegistrar.instanceManager.addHostCreatedInstance(pigeon_instanceArg)
       val errorCodeArg = errorCode(pigeon_instanceArg)
       val descriptionArg = description(pigeon_instanceArg)
       val binaryMessenger = pigeonRegistrar.binaryMessenger
       val codec = pigeonRegistrar.codec
-      val channelName =
-          "dev.flutter.pigeon.webview_flutter_android.WebResourceErrorCompat.pigeon_newInstance"
+      val channelName = "dev.flutter.pigeon.webview_flutter_android.WebResourceErrorCompat.pigeon_newInstance"
       val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
       channel.send(listOf(pigeon_identifierArg, errorCodeArg, descriptionArg)) {
         if (it is List<*>) {
           if (it.size > 1) {
-            callback(
-                Result.failure(
-                    AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
+            callback(Result.failure(AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
           } else {
             callback(Result.success(Unit))
           }
         } else {
-          callback(
-              Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
-        }
+          callback(Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
+        } 
       }
     }
   }
+
 }
 /**
  * Represents a position on a web page.
@@ -1441,25 +1408,23 @@ abstract class PigeonApiWebResourceErrorCompat(
  * This is a custom class created for convenience of the wrapper.
  */
 @Suppress("UNCHECKED_CAST")
-abstract class PigeonApiWebViewPoint(
-    open val pigeonRegistrar: AndroidWebkitLibraryPigeonProxyApiRegistrar
-) {
+abstract class PigeonApiWebViewPoint(open val pigeonRegistrar: AndroidWebkitLibraryPigeonProxyApiRegistrar) {
   abstract fun x(pigeon_instance: WebViewPoint): Long
 
   abstract fun y(pigeon_instance: WebViewPoint): Long
 
   @Suppress("LocalVariableName", "FunctionName")
   /** Creates a Dart instance of WebViewPoint and attaches it to [pigeon_instanceArg]. */
-  fun pigeon_newInstance(pigeon_instanceArg: WebViewPoint, callback: (Result<Unit>) -> Unit) {
+  fun pigeon_newInstance(pigeon_instanceArg: WebViewPoint, callback: (Result<Unit>) -> Unit)
+{
     if (pigeonRegistrar.ignoreCallsToDart) {
       callback(
           Result.failure(
               AndroidWebKitError("ignore-calls-error", "Calls to Dart are being ignored.", "")))
-    } else if (pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
+    }     else if (pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
       callback(Result.success(Unit))
-    } else {
-      val pigeon_identifierArg =
-          pigeonRegistrar.instanceManager.addHostCreatedInstance(pigeon_instanceArg)
+    }     else {
+      val pigeon_identifierArg = pigeonRegistrar.instanceManager.addHostCreatedInstance(pigeon_instanceArg)
       val xArg = x(pigeon_instanceArg)
       val yArg = y(pigeon_instanceArg)
       val binaryMessenger = pigeonRegistrar.binaryMessenger
@@ -1469,19 +1434,17 @@ abstract class PigeonApiWebViewPoint(
       channel.send(listOf(pigeon_identifierArg, xArg, yArg)) {
         if (it is List<*>) {
           if (it.size > 1) {
-            callback(
-                Result.failure(
-                    AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
+            callback(Result.failure(AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
           } else {
             callback(Result.success(Unit))
           }
         } else {
-          callback(
-              Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
-        }
+          callback(Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
+        } 
       }
     }
   }
+
 }
 /**
  * Represents a JavaScript console message from WebCore.
@@ -1489,9 +1452,7 @@ abstract class PigeonApiWebViewPoint(
  * See https://developer.android.com/reference/android/webkit/ConsoleMessage
  */
 @Suppress("UNCHECKED_CAST")
-abstract class PigeonApiConsoleMessage(
-    open val pigeonRegistrar: AndroidWebkitLibraryPigeonProxyApiRegistrar
-) {
+abstract class PigeonApiConsoleMessage(open val pigeonRegistrar: AndroidWebkitLibraryPigeonProxyApiRegistrar) {
   abstract fun lineNumber(pigeon_instance: android.webkit.ConsoleMessage): Long
 
   abstract fun message(pigeon_instance: android.webkit.ConsoleMessage): String
@@ -1502,44 +1463,38 @@ abstract class PigeonApiConsoleMessage(
 
   @Suppress("LocalVariableName", "FunctionName")
   /** Creates a Dart instance of ConsoleMessage and attaches it to [pigeon_instanceArg]. */
-  fun pigeon_newInstance(
-      pigeon_instanceArg: android.webkit.ConsoleMessage,
-      callback: (Result<Unit>) -> Unit
-  ) {
+  fun pigeon_newInstance(pigeon_instanceArg: android.webkit.ConsoleMessage, callback: (Result<Unit>) -> Unit)
+{
     if (pigeonRegistrar.ignoreCallsToDart) {
       callback(
           Result.failure(
               AndroidWebKitError("ignore-calls-error", "Calls to Dart are being ignored.", "")))
-    } else if (pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
+    }     else if (pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
       callback(Result.success(Unit))
-    } else {
-      val pigeon_identifierArg =
-          pigeonRegistrar.instanceManager.addHostCreatedInstance(pigeon_instanceArg)
+    }     else {
+      val pigeon_identifierArg = pigeonRegistrar.instanceManager.addHostCreatedInstance(pigeon_instanceArg)
       val lineNumberArg = lineNumber(pigeon_instanceArg)
       val messageArg = message(pigeon_instanceArg)
       val levelArg = level(pigeon_instanceArg)
       val sourceIdArg = sourceId(pigeon_instanceArg)
       val binaryMessenger = pigeonRegistrar.binaryMessenger
       val codec = pigeonRegistrar.codec
-      val channelName =
-          "dev.flutter.pigeon.webview_flutter_android.ConsoleMessage.pigeon_newInstance"
+      val channelName = "dev.flutter.pigeon.webview_flutter_android.ConsoleMessage.pigeon_newInstance"
       val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
       channel.send(listOf(pigeon_identifierArg, lineNumberArg, messageArg, levelArg, sourceIdArg)) {
         if (it is List<*>) {
           if (it.size > 1) {
-            callback(
-                Result.failure(
-                    AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
+            callback(Result.failure(AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
           } else {
             callback(Result.success(Unit))
           }
         } else {
-          callback(
-              Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
-        }
+          callback(Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
+        } 
       }
     }
   }
+
 }
 /**
  * Manages the cookies used by an application's `WebView` instances.
@@ -1547,36 +1502,26 @@ abstract class PigeonApiConsoleMessage(
  * See https://developer.android.com/reference/android/webkit/CookieManager.
  */
 @Suppress("UNCHECKED_CAST")
-abstract class PigeonApiCookieManager(
-    open val pigeonRegistrar: AndroidWebkitLibraryPigeonProxyApiRegistrar
-) {
+abstract class PigeonApiCookieManager(open val pigeonRegistrar: AndroidWebkitLibraryPigeonProxyApiRegistrar) {
   abstract fun instance(): android.webkit.CookieManager
 
   /** Sets a single cookie (key-value pair) for the given URL. */
   abstract fun setCookie(pigeon_instance: android.webkit.CookieManager, url: String, value: String)
 
   /** Removes all cookies. */
-  abstract fun removeAllCookies(
-      pigeon_instance: android.webkit.CookieManager,
-      callback: (Result<Boolean>) -> Unit
-  )
+  abstract fun removeAllCookies(pigeon_instance: android.webkit.CookieManager, callback: (Result<Boolean>) -> Unit)
 
   /** Sets whether the `WebView` should allow third party cookies to be set. */
-  abstract fun setAcceptThirdPartyCookies(
-      pigeon_instance: android.webkit.CookieManager,
-      webView: android.webkit.WebView,
-      accept: Boolean
-  )
+  abstract fun setAcceptThirdPartyCookies(pigeon_instance: android.webkit.CookieManager, webView: android.webkit.WebView, accept: Boolean)
 
   /**
    * Gets all the cookies for the given URL.
    *
-   * This may return multiple key-value pairs if multiple cookies are associated with this URL, in
-   * which case each cookie will be delimited by "; " characters (semicolon followed by a space).
+   * This may return multiple key-value pairs if multiple cookies are associated with this URL,
+   * in which case each cookie will be delimited by "; " characters (semicolon followed by a space).
    * Each key-value pair will be of the form "key=value".
    *
-   * Note: Any cookies set with the "Partitioned" attribute will only be returned for the top-level
-   * partition of url.
+   * Note: Any cookies set with the "Partitioned" attribute will only be returned for the top-level partition of url.
    */
   abstract fun getCookies(pigeon_instance: android.webkit.CookieManager, url: String): String?
 
@@ -1585,23 +1530,17 @@ abstract class PigeonApiCookieManager(
     fun setUpMessageHandlers(binaryMessenger: BinaryMessenger, api: PigeonApiCookieManager?) {
       val codec = api?.pigeonRegistrar?.codec ?: AndroidWebkitLibraryPigeonCodec()
       run {
-        val channel =
-            BasicMessageChannel<Any?>(
-                binaryMessenger,
-                "dev.flutter.pigeon.webview_flutter_android.CookieManager.instance",
-                codec)
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.CookieManager.instance", codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val pigeon_identifierArg = args[0] as Long
-            val wrapped: List<Any?> =
-                try {
-                  api.pigeonRegistrar.instanceManager.addDartCreatedInstance(
-                      api.instance(), pigeon_identifierArg)
-                  listOf(null)
-                } catch (exception: Throwable) {
-                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-                }
+            val wrapped: List<Any?> = try {
+              api.pigeonRegistrar.instanceManager.addDartCreatedInstance(api.instance(), pigeon_identifierArg)
+              listOf(null)
+            } catch (exception: Throwable) {
+              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+            }
             reply.reply(wrapped)
           }
         } else {
@@ -1609,24 +1548,19 @@ abstract class PigeonApiCookieManager(
         }
       }
       run {
-        val channel =
-            BasicMessageChannel<Any?>(
-                binaryMessenger,
-                "dev.flutter.pigeon.webview_flutter_android.CookieManager.setCookie",
-                codec)
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.CookieManager.setCookie", codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val pigeon_instanceArg = args[0] as android.webkit.CookieManager
             val urlArg = args[1] as String
             val valueArg = args[2] as String
-            val wrapped: List<Any?> =
-                try {
-                  api.setCookie(pigeon_instanceArg, urlArg, valueArg)
-                  listOf(null)
-                } catch (exception: Throwable) {
-                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-                }
+            val wrapped: List<Any?> = try {
+              api.setCookie(pigeon_instanceArg, urlArg, valueArg)
+              listOf(null)
+            } catch (exception: Throwable) {
+              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+            }
             reply.reply(wrapped)
           }
         } else {
@@ -1634,11 +1568,7 @@ abstract class PigeonApiCookieManager(
         }
       }
       run {
-        val channel =
-            BasicMessageChannel<Any?>(
-                binaryMessenger,
-                "dev.flutter.pigeon.webview_flutter_android.CookieManager.removeAllCookies",
-                codec)
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.CookieManager.removeAllCookies", codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
@@ -1658,24 +1588,19 @@ abstract class PigeonApiCookieManager(
         }
       }
       run {
-        val channel =
-            BasicMessageChannel<Any?>(
-                binaryMessenger,
-                "dev.flutter.pigeon.webview_flutter_android.CookieManager.setAcceptThirdPartyCookies",
-                codec)
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.CookieManager.setAcceptThirdPartyCookies", codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val pigeon_instanceArg = args[0] as android.webkit.CookieManager
             val webViewArg = args[1] as android.webkit.WebView
             val acceptArg = args[2] as Boolean
-            val wrapped: List<Any?> =
-                try {
-                  api.setAcceptThirdPartyCookies(pigeon_instanceArg, webViewArg, acceptArg)
-                  listOf(null)
-                } catch (exception: Throwable) {
-                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-                }
+            val wrapped: List<Any?> = try {
+              api.setAcceptThirdPartyCookies(pigeon_instanceArg, webViewArg, acceptArg)
+              listOf(null)
+            } catch (exception: Throwable) {
+              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+            }
             reply.reply(wrapped)
           }
         } else {
@@ -1683,22 +1608,17 @@ abstract class PigeonApiCookieManager(
         }
       }
       run {
-        val channel =
-            BasicMessageChannel<Any?>(
-                binaryMessenger,
-                "dev.flutter.pigeon.webview_flutter_android.CookieManager.getCookies",
-                codec)
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.CookieManager.getCookies", codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val pigeon_instanceArg = args[0] as android.webkit.CookieManager
             val urlArg = args[1] as String
-            val wrapped: List<Any?> =
-                try {
-                  listOf(api.getCookies(pigeon_instanceArg, urlArg))
-                } catch (exception: Throwable) {
-                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-                }
+            val wrapped: List<Any?> = try {
+              listOf(api.getCookies(pigeon_instanceArg, urlArg))
+            } catch (exception: Throwable) {
+              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+            }
             reply.reply(wrapped)
           }
         } else {
@@ -1710,40 +1630,34 @@ abstract class PigeonApiCookieManager(
 
   @Suppress("LocalVariableName", "FunctionName")
   /** Creates a Dart instance of CookieManager and attaches it to [pigeon_instanceArg]. */
-  fun pigeon_newInstance(
-      pigeon_instanceArg: android.webkit.CookieManager,
-      callback: (Result<Unit>) -> Unit
-  ) {
+  fun pigeon_newInstance(pigeon_instanceArg: android.webkit.CookieManager, callback: (Result<Unit>) -> Unit)
+{
     if (pigeonRegistrar.ignoreCallsToDart) {
       callback(
           Result.failure(
               AndroidWebKitError("ignore-calls-error", "Calls to Dart are being ignored.", "")))
-    } else if (pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
+    }     else if (pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
       callback(Result.success(Unit))
-    } else {
-      val pigeon_identifierArg =
-          pigeonRegistrar.instanceManager.addHostCreatedInstance(pigeon_instanceArg)
+    }     else {
+      val pigeon_identifierArg = pigeonRegistrar.instanceManager.addHostCreatedInstance(pigeon_instanceArg)
       val binaryMessenger = pigeonRegistrar.binaryMessenger
       val codec = pigeonRegistrar.codec
-      val channelName =
-          "dev.flutter.pigeon.webview_flutter_android.CookieManager.pigeon_newInstance"
+      val channelName = "dev.flutter.pigeon.webview_flutter_android.CookieManager.pigeon_newInstance"
       val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
       channel.send(listOf(pigeon_identifierArg)) {
         if (it is List<*>) {
           if (it.size > 1) {
-            callback(
-                Result.failure(
-                    AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
+            callback(Result.failure(AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
           } else {
             callback(Result.success(Unit))
           }
         } else {
-          callback(
-              Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
-        }
+          callback(Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
+        } 
       }
     }
   }
+
 }
 /**
  * A View that displays web pages.
@@ -1751,38 +1665,23 @@ abstract class PigeonApiCookieManager(
  * See https://developer.android.com/reference/android/webkit/WebView.
  */
 @Suppress("UNCHECKED_CAST")
-abstract class PigeonApiWebView(
-    open val pigeonRegistrar: AndroidWebkitLibraryPigeonProxyApiRegistrar
-) {
+abstract class PigeonApiWebView(open val pigeonRegistrar: AndroidWebkitLibraryPigeonProxyApiRegistrar) {
   abstract fun pigeon_defaultConstructor(): android.webkit.WebView
 
   /** The WebSettings object used to control the settings for this WebView. */
   abstract fun settings(pigeon_instance: android.webkit.WebView): android.webkit.WebSettings
 
   /** Loads the given data into this WebView using a 'data' scheme URL. */
-  abstract fun loadData(
-      pigeon_instance: android.webkit.WebView,
-      data: String,
-      mimeType: String?,
-      encoding: String?
-  )
+  abstract fun loadData(pigeon_instance: android.webkit.WebView, data: String, mimeType: String?, encoding: String?)
 
-  /** Loads the given data into this WebView, using baseUrl as the base URL for the content. */
-  abstract fun loadDataWithBaseUrl(
-      pigeon_instance: android.webkit.WebView,
-      baseUrl: String?,
-      data: String,
-      mimeType: String?,
-      encoding: String?,
-      historyUrl: String?
-  )
+  /**
+   * Loads the given data into this WebView, using baseUrl as the base URL for
+   * the content.
+   */
+  abstract fun loadDataWithBaseUrl(pigeon_instance: android.webkit.WebView, baseUrl: String?, data: String, mimeType: String?, encoding: String?, historyUrl: String?)
 
   /** Loads the given URL. */
-  abstract fun loadUrl(
-      pigeon_instance: android.webkit.WebView,
-      url: String,
-      headers: Map<String, String>
-  )
+  abstract fun loadUrl(pigeon_instance: android.webkit.WebView, url: String, headers: Map<String, String>)
 
   /** Loads the URL with postData using "POST" method into this WebView. */
   abstract fun postUrl(pigeon_instance: android.webkit.WebView, url: String, data: ByteArray)
@@ -1808,51 +1707,41 @@ abstract class PigeonApiWebView(
   /** Clears the resource cache. */
   abstract fun clearCache(pigeon_instance: android.webkit.WebView, includeDiskFiles: Boolean)
 
-  /** Asynchronously evaluates JavaScript in the context of the currently displayed page. */
-  abstract fun evaluateJavascript(
-      pigeon_instance: android.webkit.WebView,
-      javascriptString: String,
-      callback: (Result<String?>) -> Unit
-  )
+  /**
+   * Asynchronously evaluates JavaScript in the context of the currently
+   * displayed page.
+   */
+  abstract fun evaluateJavascript(pigeon_instance: android.webkit.WebView, javascriptString: String, callback: (Result<String?>) -> Unit)
 
   /** Gets the title for the current page. */
   abstract fun getTitle(pigeon_instance: android.webkit.WebView): String?
 
   /**
-   * Enables debugging of web contents (HTML / CSS / JavaScript) loaded into any WebViews of this
-   * application.
+   * Enables debugging of web contents (HTML / CSS / JavaScript) loaded into
+   * any WebViews of this application.
    */
   abstract fun setWebContentsDebuggingEnabled(enabled: Boolean)
 
-  /** Sets the WebViewClient that will receive various notifications and requests. */
-  abstract fun setWebViewClient(
-      pigeon_instance: android.webkit.WebView,
-      client: android.webkit.WebViewClient?
-  )
+  /**
+   * Sets the WebViewClient that will receive various notifications and
+   * requests.
+   */
+  abstract fun setWebViewClient(pigeon_instance: android.webkit.WebView, client: android.webkit.WebViewClient?)
 
   /** Injects the supplied Java object into this WebView. */
-  abstract fun addJavaScriptChannel(
-      pigeon_instance: android.webkit.WebView,
-      channel: JavaScriptChannel
-  )
+  abstract fun addJavaScriptChannel(pigeon_instance: android.webkit.WebView, channel: JavaScriptChannel)
 
   /** Removes a previously injected Java object from this WebView. */
   abstract fun removeJavaScriptChannel(pigeon_instance: android.webkit.WebView, name: String)
 
   /**
-   * Registers the interface to be used when content can not be handled by the rendering engine, and
-   * should be downloaded instead.
+   * Registers the interface to be used when content can not be handled by the
+   * rendering engine, and should be downloaded instead.
    */
-  abstract fun setDownloadListener(
-      pigeon_instance: android.webkit.WebView,
-      listener: android.webkit.DownloadListener?
-  )
+  abstract fun setDownloadListener(pigeon_instance: android.webkit.WebView, listener: android.webkit.DownloadListener?)
 
   /** Sets the chrome handler. */
-  abstract fun setWebChromeClient(
-      pigeon_instance: android.webkit.WebView,
-      client: io.flutter.plugins.webviewflutter.WebChromeClientProxyApi.WebChromeClientImpl?
-  )
+  abstract fun setWebChromeClient(pigeon_instance: android.webkit.WebView, client: io.flutter.plugins.webviewflutter.WebChromeClientProxyApi.WebChromeClientImpl?)
 
   /** Sets the background color for this view. */
   abstract fun setBackgroundColor(pigeon_instance: android.webkit.WebView, color: Long)
@@ -1865,23 +1754,17 @@ abstract class PigeonApiWebView(
     fun setUpMessageHandlers(binaryMessenger: BinaryMessenger, api: PigeonApiWebView?) {
       val codec = api?.pigeonRegistrar?.codec ?: AndroidWebkitLibraryPigeonCodec()
       run {
-        val channel =
-            BasicMessageChannel<Any?>(
-                binaryMessenger,
-                "dev.flutter.pigeon.webview_flutter_android.WebView.pigeon_defaultConstructor",
-                codec)
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.WebView.pigeon_defaultConstructor", codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val pigeon_identifierArg = args[0] as Long
-            val wrapped: List<Any?> =
-                try {
-                  api.pigeonRegistrar.instanceManager.addDartCreatedInstance(
-                      api.pigeon_defaultConstructor(), pigeon_identifierArg)
-                  listOf(null)
-                } catch (exception: Throwable) {
-                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-                }
+            val wrapped: List<Any?> = try {
+              api.pigeonRegistrar.instanceManager.addDartCreatedInstance(api.pigeon_defaultConstructor(), pigeon_identifierArg)
+              listOf(null)
+            } catch (exception: Throwable) {
+              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+            }
             reply.reply(wrapped)
           }
         } else {
@@ -1889,24 +1772,18 @@ abstract class PigeonApiWebView(
         }
       }
       run {
-        val channel =
-            BasicMessageChannel<Any?>(
-                binaryMessenger,
-                "dev.flutter.pigeon.webview_flutter_android.WebView.settings",
-                codec)
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.WebView.settings", codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val pigeon_instanceArg = args[0] as android.webkit.WebView
             val pigeon_identifierArg = args[1] as Long
-            val wrapped: List<Any?> =
-                try {
-                  api.pigeonRegistrar.instanceManager.addDartCreatedInstance(
-                      api.settings(pigeon_instanceArg), pigeon_identifierArg)
-                  listOf(null)
-                } catch (exception: Throwable) {
-                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-                }
+            val wrapped: List<Any?> = try {
+              api.pigeonRegistrar.instanceManager.addDartCreatedInstance(api.settings(pigeon_instanceArg), pigeon_identifierArg)
+              listOf(null)
+            } catch (exception: Throwable) {
+              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+            }
             reply.reply(wrapped)
           }
         } else {
@@ -1914,11 +1791,7 @@ abstract class PigeonApiWebView(
         }
       }
       run {
-        val channel =
-            BasicMessageChannel<Any?>(
-                binaryMessenger,
-                "dev.flutter.pigeon.webview_flutter_android.WebView.loadData",
-                codec)
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.WebView.loadData", codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
@@ -1926,13 +1799,12 @@ abstract class PigeonApiWebView(
             val dataArg = args[1] as String
             val mimeTypeArg = args[2] as String?
             val encodingArg = args[3] as String?
-            val wrapped: List<Any?> =
-                try {
-                  api.loadData(pigeon_instanceArg, dataArg, mimeTypeArg, encodingArg)
-                  listOf(null)
-                } catch (exception: Throwable) {
-                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-                }
+            val wrapped: List<Any?> = try {
+              api.loadData(pigeon_instanceArg, dataArg, mimeTypeArg, encodingArg)
+              listOf(null)
+            } catch (exception: Throwable) {
+              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+            }
             reply.reply(wrapped)
           }
         } else {
@@ -1940,11 +1812,7 @@ abstract class PigeonApiWebView(
         }
       }
       run {
-        val channel =
-            BasicMessageChannel<Any?>(
-                binaryMessenger,
-                "dev.flutter.pigeon.webview_flutter_android.WebView.loadDataWithBaseUrl",
-                codec)
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.WebView.loadDataWithBaseUrl", codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
@@ -1954,19 +1822,12 @@ abstract class PigeonApiWebView(
             val mimeTypeArg = args[3] as String?
             val encodingArg = args[4] as String?
             val historyUrlArg = args[5] as String?
-            val wrapped: List<Any?> =
-                try {
-                  api.loadDataWithBaseUrl(
-                      pigeon_instanceArg,
-                      baseUrlArg,
-                      dataArg,
-                      mimeTypeArg,
-                      encodingArg,
-                      historyUrlArg)
-                  listOf(null)
-                } catch (exception: Throwable) {
-                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-                }
+            val wrapped: List<Any?> = try {
+              api.loadDataWithBaseUrl(pigeon_instanceArg, baseUrlArg, dataArg, mimeTypeArg, encodingArg, historyUrlArg)
+              listOf(null)
+            } catch (exception: Throwable) {
+              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+            }
             reply.reply(wrapped)
           }
         } else {
@@ -1974,24 +1835,19 @@ abstract class PigeonApiWebView(
         }
       }
       run {
-        val channel =
-            BasicMessageChannel<Any?>(
-                binaryMessenger,
-                "dev.flutter.pigeon.webview_flutter_android.WebView.loadUrl",
-                codec)
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.WebView.loadUrl", codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val pigeon_instanceArg = args[0] as android.webkit.WebView
             val urlArg = args[1] as String
             val headersArg = args[2] as Map<String, String>
-            val wrapped: List<Any?> =
-                try {
-                  api.loadUrl(pigeon_instanceArg, urlArg, headersArg)
-                  listOf(null)
-                } catch (exception: Throwable) {
-                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-                }
+            val wrapped: List<Any?> = try {
+              api.loadUrl(pigeon_instanceArg, urlArg, headersArg)
+              listOf(null)
+            } catch (exception: Throwable) {
+              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+            }
             reply.reply(wrapped)
           }
         } else {
@@ -1999,24 +1855,19 @@ abstract class PigeonApiWebView(
         }
       }
       run {
-        val channel =
-            BasicMessageChannel<Any?>(
-                binaryMessenger,
-                "dev.flutter.pigeon.webview_flutter_android.WebView.postUrl",
-                codec)
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.WebView.postUrl", codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val pigeon_instanceArg = args[0] as android.webkit.WebView
             val urlArg = args[1] as String
             val dataArg = args[2] as ByteArray
-            val wrapped: List<Any?> =
-                try {
-                  api.postUrl(pigeon_instanceArg, urlArg, dataArg)
-                  listOf(null)
-                } catch (exception: Throwable) {
-                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-                }
+            val wrapped: List<Any?> = try {
+              api.postUrl(pigeon_instanceArg, urlArg, dataArg)
+              listOf(null)
+            } catch (exception: Throwable) {
+              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+            }
             reply.reply(wrapped)
           }
         } else {
@@ -2024,19 +1875,16 @@ abstract class PigeonApiWebView(
         }
       }
       run {
-        val channel =
-            BasicMessageChannel<Any?>(
-                binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.WebView.getUrl", codec)
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.WebView.getUrl", codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val pigeon_instanceArg = args[0] as android.webkit.WebView
-            val wrapped: List<Any?> =
-                try {
-                  listOf(api.getUrl(pigeon_instanceArg))
-                } catch (exception: Throwable) {
-                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-                }
+            val wrapped: List<Any?> = try {
+              listOf(api.getUrl(pigeon_instanceArg))
+            } catch (exception: Throwable) {
+              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+            }
             reply.reply(wrapped)
           }
         } else {
@@ -2044,21 +1892,16 @@ abstract class PigeonApiWebView(
         }
       }
       run {
-        val channel =
-            BasicMessageChannel<Any?>(
-                binaryMessenger,
-                "dev.flutter.pigeon.webview_flutter_android.WebView.canGoBack",
-                codec)
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.WebView.canGoBack", codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val pigeon_instanceArg = args[0] as android.webkit.WebView
-            val wrapped: List<Any?> =
-                try {
-                  listOf(api.canGoBack(pigeon_instanceArg))
-                } catch (exception: Throwable) {
-                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-                }
+            val wrapped: List<Any?> = try {
+              listOf(api.canGoBack(pigeon_instanceArg))
+            } catch (exception: Throwable) {
+              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+            }
             reply.reply(wrapped)
           }
         } else {
@@ -2066,21 +1909,16 @@ abstract class PigeonApiWebView(
         }
       }
       run {
-        val channel =
-            BasicMessageChannel<Any?>(
-                binaryMessenger,
-                "dev.flutter.pigeon.webview_flutter_android.WebView.canGoForward",
-                codec)
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.WebView.canGoForward", codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val pigeon_instanceArg = args[0] as android.webkit.WebView
-            val wrapped: List<Any?> =
-                try {
-                  listOf(api.canGoForward(pigeon_instanceArg))
-                } catch (exception: Throwable) {
-                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-                }
+            val wrapped: List<Any?> = try {
+              listOf(api.canGoForward(pigeon_instanceArg))
+            } catch (exception: Throwable) {
+              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+            }
             reply.reply(wrapped)
           }
         } else {
@@ -2088,20 +1926,17 @@ abstract class PigeonApiWebView(
         }
       }
       run {
-        val channel =
-            BasicMessageChannel<Any?>(
-                binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.WebView.goBack", codec)
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.WebView.goBack", codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val pigeon_instanceArg = args[0] as android.webkit.WebView
-            val wrapped: List<Any?> =
-                try {
-                  api.goBack(pigeon_instanceArg)
-                  listOf(null)
-                } catch (exception: Throwable) {
-                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-                }
+            val wrapped: List<Any?> = try {
+              api.goBack(pigeon_instanceArg)
+              listOf(null)
+            } catch (exception: Throwable) {
+              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+            }
             reply.reply(wrapped)
           }
         } else {
@@ -2109,22 +1944,17 @@ abstract class PigeonApiWebView(
         }
       }
       run {
-        val channel =
-            BasicMessageChannel<Any?>(
-                binaryMessenger,
-                "dev.flutter.pigeon.webview_flutter_android.WebView.goForward",
-                codec)
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.WebView.goForward", codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val pigeon_instanceArg = args[0] as android.webkit.WebView
-            val wrapped: List<Any?> =
-                try {
-                  api.goForward(pigeon_instanceArg)
-                  listOf(null)
-                } catch (exception: Throwable) {
-                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-                }
+            val wrapped: List<Any?> = try {
+              api.goForward(pigeon_instanceArg)
+              listOf(null)
+            } catch (exception: Throwable) {
+              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+            }
             reply.reply(wrapped)
           }
         } else {
@@ -2132,20 +1962,17 @@ abstract class PigeonApiWebView(
         }
       }
       run {
-        val channel =
-            BasicMessageChannel<Any?>(
-                binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.WebView.reload", codec)
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.WebView.reload", codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val pigeon_instanceArg = args[0] as android.webkit.WebView
-            val wrapped: List<Any?> =
-                try {
-                  api.reload(pigeon_instanceArg)
-                  listOf(null)
-                } catch (exception: Throwable) {
-                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-                }
+            val wrapped: List<Any?> = try {
+              api.reload(pigeon_instanceArg)
+              listOf(null)
+            } catch (exception: Throwable) {
+              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+            }
             reply.reply(wrapped)
           }
         } else {
@@ -2153,23 +1980,18 @@ abstract class PigeonApiWebView(
         }
       }
       run {
-        val channel =
-            BasicMessageChannel<Any?>(
-                binaryMessenger,
-                "dev.flutter.pigeon.webview_flutter_android.WebView.clearCache",
-                codec)
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.WebView.clearCache", codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val pigeon_instanceArg = args[0] as android.webkit.WebView
             val includeDiskFilesArg = args[1] as Boolean
-            val wrapped: List<Any?> =
-                try {
-                  api.clearCache(pigeon_instanceArg, includeDiskFilesArg)
-                  listOf(null)
-                } catch (exception: Throwable) {
-                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-                }
+            val wrapped: List<Any?> = try {
+              api.clearCache(pigeon_instanceArg, includeDiskFilesArg)
+              listOf(null)
+            } catch (exception: Throwable) {
+              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+            }
             reply.reply(wrapped)
           }
         } else {
@@ -2177,18 +1999,13 @@ abstract class PigeonApiWebView(
         }
       }
       run {
-        val channel =
-            BasicMessageChannel<Any?>(
-                binaryMessenger,
-                "dev.flutter.pigeon.webview_flutter_android.WebView.evaluateJavascript",
-                codec)
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.WebView.evaluateJavascript", codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val pigeon_instanceArg = args[0] as android.webkit.WebView
             val javascriptStringArg = args[1] as String
-            api.evaluateJavascript(pigeon_instanceArg, javascriptStringArg) {
-                result: Result<String?> ->
+            api.evaluateJavascript(pigeon_instanceArg, javascriptStringArg) { result: Result<String?> ->
               val error = result.exceptionOrNull()
               if (error != null) {
                 reply.reply(AndroidWebkitLibraryPigeonUtils.wrapError(error))
@@ -2203,21 +2020,16 @@ abstract class PigeonApiWebView(
         }
       }
       run {
-        val channel =
-            BasicMessageChannel<Any?>(
-                binaryMessenger,
-                "dev.flutter.pigeon.webview_flutter_android.WebView.getTitle",
-                codec)
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.WebView.getTitle", codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val pigeon_instanceArg = args[0] as android.webkit.WebView
-            val wrapped: List<Any?> =
-                try {
-                  listOf(api.getTitle(pigeon_instanceArg))
-                } catch (exception: Throwable) {
-                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-                }
+            val wrapped: List<Any?> = try {
+              listOf(api.getTitle(pigeon_instanceArg))
+            } catch (exception: Throwable) {
+              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+            }
             reply.reply(wrapped)
           }
         } else {
@@ -2225,22 +2037,17 @@ abstract class PigeonApiWebView(
         }
       }
       run {
-        val channel =
-            BasicMessageChannel<Any?>(
-                binaryMessenger,
-                "dev.flutter.pigeon.webview_flutter_android.WebView.setWebContentsDebuggingEnabled",
-                codec)
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.WebView.setWebContentsDebuggingEnabled", codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val enabledArg = args[0] as Boolean
-            val wrapped: List<Any?> =
-                try {
-                  api.setWebContentsDebuggingEnabled(enabledArg)
-                  listOf(null)
-                } catch (exception: Throwable) {
-                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-                }
+            val wrapped: List<Any?> = try {
+              api.setWebContentsDebuggingEnabled(enabledArg)
+              listOf(null)
+            } catch (exception: Throwable) {
+              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+            }
             reply.reply(wrapped)
           }
         } else {
@@ -2248,23 +2055,18 @@ abstract class PigeonApiWebView(
         }
       }
       run {
-        val channel =
-            BasicMessageChannel<Any?>(
-                binaryMessenger,
-                "dev.flutter.pigeon.webview_flutter_android.WebView.setWebViewClient",
-                codec)
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.WebView.setWebViewClient", codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val pigeon_instanceArg = args[0] as android.webkit.WebView
             val clientArg = args[1] as android.webkit.WebViewClient?
-            val wrapped: List<Any?> =
-                try {
-                  api.setWebViewClient(pigeon_instanceArg, clientArg)
-                  listOf(null)
-                } catch (exception: Throwable) {
-                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-                }
+            val wrapped: List<Any?> = try {
+              api.setWebViewClient(pigeon_instanceArg, clientArg)
+              listOf(null)
+            } catch (exception: Throwable) {
+              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+            }
             reply.reply(wrapped)
           }
         } else {
@@ -2272,23 +2074,18 @@ abstract class PigeonApiWebView(
         }
       }
       run {
-        val channel =
-            BasicMessageChannel<Any?>(
-                binaryMessenger,
-                "dev.flutter.pigeon.webview_flutter_android.WebView.addJavaScriptChannel",
-                codec)
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.WebView.addJavaScriptChannel", codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val pigeon_instanceArg = args[0] as android.webkit.WebView
             val channelArg = args[1] as JavaScriptChannel
-            val wrapped: List<Any?> =
-                try {
-                  api.addJavaScriptChannel(pigeon_instanceArg, channelArg)
-                  listOf(null)
-                } catch (exception: Throwable) {
-                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-                }
+            val wrapped: List<Any?> = try {
+              api.addJavaScriptChannel(pigeon_instanceArg, channelArg)
+              listOf(null)
+            } catch (exception: Throwable) {
+              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+            }
             reply.reply(wrapped)
           }
         } else {
@@ -2296,23 +2093,18 @@ abstract class PigeonApiWebView(
         }
       }
       run {
-        val channel =
-            BasicMessageChannel<Any?>(
-                binaryMessenger,
-                "dev.flutter.pigeon.webview_flutter_android.WebView.removeJavaScriptChannel",
-                codec)
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.WebView.removeJavaScriptChannel", codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val pigeon_instanceArg = args[0] as android.webkit.WebView
             val nameArg = args[1] as String
-            val wrapped: List<Any?> =
-                try {
-                  api.removeJavaScriptChannel(pigeon_instanceArg, nameArg)
-                  listOf(null)
-                } catch (exception: Throwable) {
-                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-                }
+            val wrapped: List<Any?> = try {
+              api.removeJavaScriptChannel(pigeon_instanceArg, nameArg)
+              listOf(null)
+            } catch (exception: Throwable) {
+              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+            }
             reply.reply(wrapped)
           }
         } else {
@@ -2320,23 +2112,18 @@ abstract class PigeonApiWebView(
         }
       }
       run {
-        val channel =
-            BasicMessageChannel<Any?>(
-                binaryMessenger,
-                "dev.flutter.pigeon.webview_flutter_android.WebView.setDownloadListener",
-                codec)
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.WebView.setDownloadListener", codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val pigeon_instanceArg = args[0] as android.webkit.WebView
             val listenerArg = args[1] as android.webkit.DownloadListener?
-            val wrapped: List<Any?> =
-                try {
-                  api.setDownloadListener(pigeon_instanceArg, listenerArg)
-                  listOf(null)
-                } catch (exception: Throwable) {
-                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-                }
+            val wrapped: List<Any?> = try {
+              api.setDownloadListener(pigeon_instanceArg, listenerArg)
+              listOf(null)
+            } catch (exception: Throwable) {
+              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+            }
             reply.reply(wrapped)
           }
         } else {
@@ -2344,26 +2131,18 @@ abstract class PigeonApiWebView(
         }
       }
       run {
-        val channel =
-            BasicMessageChannel<Any?>(
-                binaryMessenger,
-                "dev.flutter.pigeon.webview_flutter_android.WebView.setWebChromeClient",
-                codec)
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.WebView.setWebChromeClient", codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val pigeon_instanceArg = args[0] as android.webkit.WebView
-            val clientArg =
-                args[1]
-                    as
-                    io.flutter.plugins.webviewflutter.WebChromeClientProxyApi.WebChromeClientImpl?
-            val wrapped: List<Any?> =
-                try {
-                  api.setWebChromeClient(pigeon_instanceArg, clientArg)
-                  listOf(null)
-                } catch (exception: Throwable) {
-                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-                }
+            val clientArg = args[1] as io.flutter.plugins.webviewflutter.WebChromeClientProxyApi.WebChromeClientImpl?
+            val wrapped: List<Any?> = try {
+              api.setWebChromeClient(pigeon_instanceArg, clientArg)
+              listOf(null)
+            } catch (exception: Throwable) {
+              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+            }
             reply.reply(wrapped)
           }
         } else {
@@ -2371,23 +2150,18 @@ abstract class PigeonApiWebView(
         }
       }
       run {
-        val channel =
-            BasicMessageChannel<Any?>(
-                binaryMessenger,
-                "dev.flutter.pigeon.webview_flutter_android.WebView.setBackgroundColor",
-                codec)
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.WebView.setBackgroundColor", codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val pigeon_instanceArg = args[0] as android.webkit.WebView
             val colorArg = args[1] as Long
-            val wrapped: List<Any?> =
-                try {
-                  api.setBackgroundColor(pigeon_instanceArg, colorArg)
-                  listOf(null)
-                } catch (exception: Throwable) {
-                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-                }
+            val wrapped: List<Any?> = try {
+              api.setBackgroundColor(pigeon_instanceArg, colorArg)
+              listOf(null)
+            } catch (exception: Throwable) {
+              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+            }
             reply.reply(wrapped)
           }
         } else {
@@ -2395,22 +2169,17 @@ abstract class PigeonApiWebView(
         }
       }
       run {
-        val channel =
-            BasicMessageChannel<Any?>(
-                binaryMessenger,
-                "dev.flutter.pigeon.webview_flutter_android.WebView.destroy",
-                codec)
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.WebView.destroy", codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val pigeon_instanceArg = args[0] as android.webkit.WebView
-            val wrapped: List<Any?> =
-                try {
-                  api.destroy(pigeon_instanceArg)
-                  listOf(null)
-                } catch (exception: Throwable) {
-                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-                }
+            val wrapped: List<Any?> = try {
+              api.destroy(pigeon_instanceArg)
+              listOf(null)
+            } catch (exception: Throwable) {
+              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+            }
             reply.reply(wrapped)
           }
         } else {
@@ -2422,19 +2191,16 @@ abstract class PigeonApiWebView(
 
   @Suppress("LocalVariableName", "FunctionName")
   /** Creates a Dart instance of WebView and attaches it to [pigeon_instanceArg]. */
-  fun pigeon_newInstance(
-      pigeon_instanceArg: android.webkit.WebView,
-      callback: (Result<Unit>) -> Unit
-  ) {
+  fun pigeon_newInstance(pigeon_instanceArg: android.webkit.WebView, callback: (Result<Unit>) -> Unit)
+{
     if (pigeonRegistrar.ignoreCallsToDart) {
       callback(
           Result.failure(
               AndroidWebKitError("ignore-calls-error", "Calls to Dart are being ignored.", "")))
-    } else if (pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
+    }     else if (pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
       callback(Result.success(Unit))
-    } else {
-      val pigeon_identifierArg =
-          pigeonRegistrar.instanceManager.addHostCreatedInstance(pigeon_instanceArg)
+    }     else {
+      val pigeon_identifierArg = pigeonRegistrar.instanceManager.addHostCreatedInstance(pigeon_instanceArg)
       val binaryMessenger = pigeonRegistrar.binaryMessenger
       val codec = pigeonRegistrar.codec
       val channelName = "dev.flutter.pigeon.webview_flutter_android.WebView.pigeon_newInstance"
@@ -2442,44 +2208,32 @@ abstract class PigeonApiWebView(
       channel.send(listOf(pigeon_identifierArg)) {
         if (it is List<*>) {
           if (it.size > 1) {
-            callback(
-                Result.failure(
-                    AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
+            callback(Result.failure(AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
           } else {
             callback(Result.success(Unit))
           }
         } else {
-          callback(
-              Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
-        }
+          callback(Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
+        } 
       }
     }
   }
 
   /**
-   * This is called in response to an internal scroll in this view (i.e., the view scrolled its own
-   * contents).
+   * This is called in response to an internal scroll in this view (i.e., the
+   * view scrolled its own contents).
    */
-  fun onScrollChanged(
-      pigeon_instanceArg: android.webkit.WebView,
-      leftArg: Long,
-      topArg: Long,
-      oldLeftArg: Long,
-      oldTopArg: Long,
-      callback: (Result<Unit>) -> Unit
-  ) {
+  fun onScrollChanged(pigeon_instanceArg: android.webkit.WebView, leftArg: Long, topArg: Long, oldLeftArg: Long, oldTopArg: Long, callback: (Result<Unit>) -> Unit)
+{
     if (pigeonRegistrar.ignoreCallsToDart) {
       callback(
           Result.failure(
               AndroidWebKitError("ignore-calls-error", "Calls to Dart are being ignored.", "")))
       return
-    } else if (!pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
+    }     else if (!pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
       callback(
           Result.failure(
-              AndroidWebKitError(
-                  "missing-instance-error",
-                  "Callback to `WebView.onScrollChanged` failed because native instance was not in the instance manager.",
-                  "")))
+              AndroidWebKitError("missing-instance-error", "Callback to `WebView.onScrollChanged` failed because native instance was not in the instance manager.", "")))
       return
     }
     val binaryMessenger = pigeonRegistrar.binaryMessenger
@@ -2489,23 +2243,23 @@ abstract class PigeonApiWebView(
     channel.send(listOf(pigeon_instanceArg, leftArg, topArg, oldLeftArg, oldTopArg)) {
       if (it is List<*>) {
         if (it.size > 1) {
-          callback(
-              Result.failure(
-                  AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
+          callback(Result.failure(AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
         } else {
           callback(Result.success(Unit))
         }
       } else {
         callback(Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
-      }
+      } 
     }
   }
 
   @Suppress("FunctionName")
   /** An implementation of [PigeonApiView] used to access callback methods */
-  fun pigeon_getPigeonApiView(): PigeonApiView {
+  fun pigeon_getPigeonApiView(): PigeonApiView
+  {
     return pigeonRegistrar.getPigeonApiView()
   }
+
 }
 /**
  * Manages settings state for a `WebView`.
@@ -2513,68 +2267,52 @@ abstract class PigeonApiWebView(
  * See https://developer.android.com/reference/android/webkit/WebSettings.
  */
 @Suppress("UNCHECKED_CAST")
-abstract class PigeonApiWebSettings(
-    open val pigeonRegistrar: AndroidWebkitLibraryPigeonProxyApiRegistrar
-) {
+abstract class PigeonApiWebSettings(open val pigeonRegistrar: AndroidWebkitLibraryPigeonProxyApiRegistrar) {
   /** Sets whether the DOM storage API is enabled. */
   abstract fun setDomStorageEnabled(pigeon_instance: android.webkit.WebSettings, flag: Boolean)
 
   /** Tells JavaScript to open windows automatically. */
-  abstract fun setJavaScriptCanOpenWindowsAutomatically(
-      pigeon_instance: android.webkit.WebSettings,
-      flag: Boolean
-  )
+  abstract fun setJavaScriptCanOpenWindowsAutomatically(pigeon_instance: android.webkit.WebSettings, flag: Boolean)
 
   /** Sets whether the WebView whether supports multiple windows. */
-  abstract fun setSupportMultipleWindows(
-      pigeon_instance: android.webkit.WebSettings,
-      support: Boolean
-  )
+  abstract fun setSupportMultipleWindows(pigeon_instance: android.webkit.WebSettings, support: Boolean)
 
   /** Tells the WebView to enable JavaScript execution. */
   abstract fun setJavaScriptEnabled(pigeon_instance: android.webkit.WebSettings, flag: Boolean)
 
   /** Sets the WebView's user-agent string. */
-  abstract fun setUserAgentString(
-      pigeon_instance: android.webkit.WebSettings,
-      userAgentString: String?
-  )
+  abstract fun setUserAgentString(pigeon_instance: android.webkit.WebSettings, userAgentString: String?)
 
   /** Sets whether the WebView requires a user gesture to play media. */
-  abstract fun setMediaPlaybackRequiresUserGesture(
-      pigeon_instance: android.webkit.WebSettings,
-      require: Boolean
-  )
+  abstract fun setMediaPlaybackRequiresUserGesture(pigeon_instance: android.webkit.WebSettings, require: Boolean)
 
   /**
-   * Sets whether the WebView should support zooming using its on-screen zoom controls and gestures.
+   * Sets whether the WebView should support zooming using its on-screen zoom
+   * controls and gestures.
    */
   abstract fun setSupportZoom(pigeon_instance: android.webkit.WebSettings, support: Boolean)
 
   /**
-   * Sets whether the WebView loads pages in overview mode, that is, zooms out the content to fit on
-   * screen by width.
+   * Sets whether the WebView loads pages in overview mode, that is, zooms out
+   * the content to fit on screen by width.
    */
-  abstract fun setLoadWithOverviewMode(
-      pigeon_instance: android.webkit.WebSettings,
-      overview: Boolean
-  )
+  abstract fun setLoadWithOverviewMode(pigeon_instance: android.webkit.WebSettings, overview: Boolean)
 
   /**
-   * Sets whether the WebView should enable support for the "viewport" HTML meta tag or should use a
-   * wide viewport.
+   * Sets whether the WebView should enable support for the "viewport" HTML
+   * meta tag or should use a wide viewport.
    */
   abstract fun setUseWideViewPort(pigeon_instance: android.webkit.WebSettings, use: Boolean)
 
   /**
-   * Sets whether the WebView should display on-screen zoom controls when using the built-in zoom
-   * mechanisms.
+   * Sets whether the WebView should display on-screen zoom controls when using
+   * the built-in zoom mechanisms.
    */
   abstract fun setDisplayZoomControls(pigeon_instance: android.webkit.WebSettings, enabled: Boolean)
 
   /**
-   * Sets whether the WebView should display on-screen zoom controls when using the built-in zoom
-   * mechanisms.
+   * Sets whether the WebView should display on-screen zoom controls when using
+   * the built-in zoom mechanisms.
    */
   abstract fun setBuiltInZoomControls(pigeon_instance: android.webkit.WebSettings, enabled: Boolean)
 
@@ -2594,33 +2332,25 @@ abstract class PigeonApiWebSettings(
   abstract fun getUserAgentString(pigeon_instance: android.webkit.WebSettings): String
 
   /** Configures the WebView's behavior when handling mixed content. */
-  abstract fun setMixedContentMode(
-      pigeon_instance: android.webkit.WebSettings,
-      mode: MixedContentMode
-  )
+  abstract fun setMixedContentMode(pigeon_instance: android.webkit.WebSettings, mode: MixedContentMode)
 
   companion object {
     @Suppress("LocalVariableName")
     fun setUpMessageHandlers(binaryMessenger: BinaryMessenger, api: PigeonApiWebSettings?) {
       val codec = api?.pigeonRegistrar?.codec ?: AndroidWebkitLibraryPigeonCodec()
       run {
-        val channel =
-            BasicMessageChannel<Any?>(
-                binaryMessenger,
-                "dev.flutter.pigeon.webview_flutter_android.WebSettings.setDomStorageEnabled",
-                codec)
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.WebSettings.setDomStorageEnabled", codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val pigeon_instanceArg = args[0] as android.webkit.WebSettings
             val flagArg = args[1] as Boolean
-            val wrapped: List<Any?> =
-                try {
-                  api.setDomStorageEnabled(pigeon_instanceArg, flagArg)
-                  listOf(null)
-                } catch (exception: Throwable) {
-                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-                }
+            val wrapped: List<Any?> = try {
+              api.setDomStorageEnabled(pigeon_instanceArg, flagArg)
+              listOf(null)
+            } catch (exception: Throwable) {
+              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+            }
             reply.reply(wrapped)
           }
         } else {
@@ -2628,23 +2358,18 @@ abstract class PigeonApiWebSettings(
         }
       }
       run {
-        val channel =
-            BasicMessageChannel<Any?>(
-                binaryMessenger,
-                "dev.flutter.pigeon.webview_flutter_android.WebSettings.setJavaScriptCanOpenWindowsAutomatically",
-                codec)
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.WebSettings.setJavaScriptCanOpenWindowsAutomatically", codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val pigeon_instanceArg = args[0] as android.webkit.WebSettings
             val flagArg = args[1] as Boolean
-            val wrapped: List<Any?> =
-                try {
-                  api.setJavaScriptCanOpenWindowsAutomatically(pigeon_instanceArg, flagArg)
-                  listOf(null)
-                } catch (exception: Throwable) {
-                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-                }
+            val wrapped: List<Any?> = try {
+              api.setJavaScriptCanOpenWindowsAutomatically(pigeon_instanceArg, flagArg)
+              listOf(null)
+            } catch (exception: Throwable) {
+              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+            }
             reply.reply(wrapped)
           }
         } else {
@@ -2652,23 +2377,18 @@ abstract class PigeonApiWebSettings(
         }
       }
       run {
-        val channel =
-            BasicMessageChannel<Any?>(
-                binaryMessenger,
-                "dev.flutter.pigeon.webview_flutter_android.WebSettings.setSupportMultipleWindows",
-                codec)
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.WebSettings.setSupportMultipleWindows", codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val pigeon_instanceArg = args[0] as android.webkit.WebSettings
             val supportArg = args[1] as Boolean
-            val wrapped: List<Any?> =
-                try {
-                  api.setSupportMultipleWindows(pigeon_instanceArg, supportArg)
-                  listOf(null)
-                } catch (exception: Throwable) {
-                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-                }
+            val wrapped: List<Any?> = try {
+              api.setSupportMultipleWindows(pigeon_instanceArg, supportArg)
+              listOf(null)
+            } catch (exception: Throwable) {
+              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+            }
             reply.reply(wrapped)
           }
         } else {
@@ -2676,23 +2396,18 @@ abstract class PigeonApiWebSettings(
         }
       }
       run {
-        val channel =
-            BasicMessageChannel<Any?>(
-                binaryMessenger,
-                "dev.flutter.pigeon.webview_flutter_android.WebSettings.setJavaScriptEnabled",
-                codec)
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.WebSettings.setJavaScriptEnabled", codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val pigeon_instanceArg = args[0] as android.webkit.WebSettings
             val flagArg = args[1] as Boolean
-            val wrapped: List<Any?> =
-                try {
-                  api.setJavaScriptEnabled(pigeon_instanceArg, flagArg)
-                  listOf(null)
-                } catch (exception: Throwable) {
-                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-                }
+            val wrapped: List<Any?> = try {
+              api.setJavaScriptEnabled(pigeon_instanceArg, flagArg)
+              listOf(null)
+            } catch (exception: Throwable) {
+              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+            }
             reply.reply(wrapped)
           }
         } else {
@@ -2700,23 +2415,18 @@ abstract class PigeonApiWebSettings(
         }
       }
       run {
-        val channel =
-            BasicMessageChannel<Any?>(
-                binaryMessenger,
-                "dev.flutter.pigeon.webview_flutter_android.WebSettings.setUserAgentString",
-                codec)
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.WebSettings.setUserAgentString", codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val pigeon_instanceArg = args[0] as android.webkit.WebSettings
             val userAgentStringArg = args[1] as String?
-            val wrapped: List<Any?> =
-                try {
-                  api.setUserAgentString(pigeon_instanceArg, userAgentStringArg)
-                  listOf(null)
-                } catch (exception: Throwable) {
-                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-                }
+            val wrapped: List<Any?> = try {
+              api.setUserAgentString(pigeon_instanceArg, userAgentStringArg)
+              listOf(null)
+            } catch (exception: Throwable) {
+              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+            }
             reply.reply(wrapped)
           }
         } else {
@@ -2724,23 +2434,18 @@ abstract class PigeonApiWebSettings(
         }
       }
       run {
-        val channel =
-            BasicMessageChannel<Any?>(
-                binaryMessenger,
-                "dev.flutter.pigeon.webview_flutter_android.WebSettings.setMediaPlaybackRequiresUserGesture",
-                codec)
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.WebSettings.setMediaPlaybackRequiresUserGesture", codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val pigeon_instanceArg = args[0] as android.webkit.WebSettings
             val requireArg = args[1] as Boolean
-            val wrapped: List<Any?> =
-                try {
-                  api.setMediaPlaybackRequiresUserGesture(pigeon_instanceArg, requireArg)
-                  listOf(null)
-                } catch (exception: Throwable) {
-                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-                }
+            val wrapped: List<Any?> = try {
+              api.setMediaPlaybackRequiresUserGesture(pigeon_instanceArg, requireArg)
+              listOf(null)
+            } catch (exception: Throwable) {
+              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+            }
             reply.reply(wrapped)
           }
         } else {
@@ -2748,23 +2453,18 @@ abstract class PigeonApiWebSettings(
         }
       }
       run {
-        val channel =
-            BasicMessageChannel<Any?>(
-                binaryMessenger,
-                "dev.flutter.pigeon.webview_flutter_android.WebSettings.setSupportZoom",
-                codec)
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.WebSettings.setSupportZoom", codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val pigeon_instanceArg = args[0] as android.webkit.WebSettings
             val supportArg = args[1] as Boolean
-            val wrapped: List<Any?> =
-                try {
-                  api.setSupportZoom(pigeon_instanceArg, supportArg)
-                  listOf(null)
-                } catch (exception: Throwable) {
-                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-                }
+            val wrapped: List<Any?> = try {
+              api.setSupportZoom(pigeon_instanceArg, supportArg)
+              listOf(null)
+            } catch (exception: Throwable) {
+              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+            }
             reply.reply(wrapped)
           }
         } else {
@@ -2772,23 +2472,18 @@ abstract class PigeonApiWebSettings(
         }
       }
       run {
-        val channel =
-            BasicMessageChannel<Any?>(
-                binaryMessenger,
-                "dev.flutter.pigeon.webview_flutter_android.WebSettings.setLoadWithOverviewMode",
-                codec)
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.WebSettings.setLoadWithOverviewMode", codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val pigeon_instanceArg = args[0] as android.webkit.WebSettings
             val overviewArg = args[1] as Boolean
-            val wrapped: List<Any?> =
-                try {
-                  api.setLoadWithOverviewMode(pigeon_instanceArg, overviewArg)
-                  listOf(null)
-                } catch (exception: Throwable) {
-                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-                }
+            val wrapped: List<Any?> = try {
+              api.setLoadWithOverviewMode(pigeon_instanceArg, overviewArg)
+              listOf(null)
+            } catch (exception: Throwable) {
+              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+            }
             reply.reply(wrapped)
           }
         } else {
@@ -2796,23 +2491,18 @@ abstract class PigeonApiWebSettings(
         }
       }
       run {
-        val channel =
-            BasicMessageChannel<Any?>(
-                binaryMessenger,
-                "dev.flutter.pigeon.webview_flutter_android.WebSettings.setUseWideViewPort",
-                codec)
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.WebSettings.setUseWideViewPort", codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val pigeon_instanceArg = args[0] as android.webkit.WebSettings
             val useArg = args[1] as Boolean
-            val wrapped: List<Any?> =
-                try {
-                  api.setUseWideViewPort(pigeon_instanceArg, useArg)
-                  listOf(null)
-                } catch (exception: Throwable) {
-                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-                }
+            val wrapped: List<Any?> = try {
+              api.setUseWideViewPort(pigeon_instanceArg, useArg)
+              listOf(null)
+            } catch (exception: Throwable) {
+              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+            }
             reply.reply(wrapped)
           }
         } else {
@@ -2820,23 +2510,18 @@ abstract class PigeonApiWebSettings(
         }
       }
       run {
-        val channel =
-            BasicMessageChannel<Any?>(
-                binaryMessenger,
-                "dev.flutter.pigeon.webview_flutter_android.WebSettings.setDisplayZoomControls",
-                codec)
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.WebSettings.setDisplayZoomControls", codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val pigeon_instanceArg = args[0] as android.webkit.WebSettings
             val enabledArg = args[1] as Boolean
-            val wrapped: List<Any?> =
-                try {
-                  api.setDisplayZoomControls(pigeon_instanceArg, enabledArg)
-                  listOf(null)
-                } catch (exception: Throwable) {
-                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-                }
+            val wrapped: List<Any?> = try {
+              api.setDisplayZoomControls(pigeon_instanceArg, enabledArg)
+              listOf(null)
+            } catch (exception: Throwable) {
+              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+            }
             reply.reply(wrapped)
           }
         } else {
@@ -2844,23 +2529,18 @@ abstract class PigeonApiWebSettings(
         }
       }
       run {
-        val channel =
-            BasicMessageChannel<Any?>(
-                binaryMessenger,
-                "dev.flutter.pigeon.webview_flutter_android.WebSettings.setBuiltInZoomControls",
-                codec)
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.WebSettings.setBuiltInZoomControls", codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val pigeon_instanceArg = args[0] as android.webkit.WebSettings
             val enabledArg = args[1] as Boolean
-            val wrapped: List<Any?> =
-                try {
-                  api.setBuiltInZoomControls(pigeon_instanceArg, enabledArg)
-                  listOf(null)
-                } catch (exception: Throwable) {
-                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-                }
+            val wrapped: List<Any?> = try {
+              api.setBuiltInZoomControls(pigeon_instanceArg, enabledArg)
+              listOf(null)
+            } catch (exception: Throwable) {
+              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+            }
             reply.reply(wrapped)
           }
         } else {
@@ -2868,23 +2548,18 @@ abstract class PigeonApiWebSettings(
         }
       }
       run {
-        val channel =
-            BasicMessageChannel<Any?>(
-                binaryMessenger,
-                "dev.flutter.pigeon.webview_flutter_android.WebSettings.setAllowFileAccess",
-                codec)
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.WebSettings.setAllowFileAccess", codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val pigeon_instanceArg = args[0] as android.webkit.WebSettings
             val enabledArg = args[1] as Boolean
-            val wrapped: List<Any?> =
-                try {
-                  api.setAllowFileAccess(pigeon_instanceArg, enabledArg)
-                  listOf(null)
-                } catch (exception: Throwable) {
-                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-                }
+            val wrapped: List<Any?> = try {
+              api.setAllowFileAccess(pigeon_instanceArg, enabledArg)
+              listOf(null)
+            } catch (exception: Throwable) {
+              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+            }
             reply.reply(wrapped)
           }
         } else {
@@ -2892,23 +2567,18 @@ abstract class PigeonApiWebSettings(
         }
       }
       run {
-        val channel =
-            BasicMessageChannel<Any?>(
-                binaryMessenger,
-                "dev.flutter.pigeon.webview_flutter_android.WebSettings.setAllowContentAccess",
-                codec)
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.WebSettings.setAllowContentAccess", codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val pigeon_instanceArg = args[0] as android.webkit.WebSettings
             val enabledArg = args[1] as Boolean
-            val wrapped: List<Any?> =
-                try {
-                  api.setAllowContentAccess(pigeon_instanceArg, enabledArg)
-                  listOf(null)
-                } catch (exception: Throwable) {
-                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-                }
+            val wrapped: List<Any?> = try {
+              api.setAllowContentAccess(pigeon_instanceArg, enabledArg)
+              listOf(null)
+            } catch (exception: Throwable) {
+              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+            }
             reply.reply(wrapped)
           }
         } else {
@@ -2916,23 +2586,18 @@ abstract class PigeonApiWebSettings(
         }
       }
       run {
-        val channel =
-            BasicMessageChannel<Any?>(
-                binaryMessenger,
-                "dev.flutter.pigeon.webview_flutter_android.WebSettings.setGeolocationEnabled",
-                codec)
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.WebSettings.setGeolocationEnabled", codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val pigeon_instanceArg = args[0] as android.webkit.WebSettings
             val enabledArg = args[1] as Boolean
-            val wrapped: List<Any?> =
-                try {
-                  api.setGeolocationEnabled(pigeon_instanceArg, enabledArg)
-                  listOf(null)
-                } catch (exception: Throwable) {
-                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-                }
+            val wrapped: List<Any?> = try {
+              api.setGeolocationEnabled(pigeon_instanceArg, enabledArg)
+              listOf(null)
+            } catch (exception: Throwable) {
+              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+            }
             reply.reply(wrapped)
           }
         } else {
@@ -2940,23 +2605,18 @@ abstract class PigeonApiWebSettings(
         }
       }
       run {
-        val channel =
-            BasicMessageChannel<Any?>(
-                binaryMessenger,
-                "dev.flutter.pigeon.webview_flutter_android.WebSettings.setTextZoom",
-                codec)
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.WebSettings.setTextZoom", codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val pigeon_instanceArg = args[0] as android.webkit.WebSettings
             val textZoomArg = args[1] as Long
-            val wrapped: List<Any?> =
-                try {
-                  api.setTextZoom(pigeon_instanceArg, textZoomArg)
-                  listOf(null)
-                } catch (exception: Throwable) {
-                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-                }
+            val wrapped: List<Any?> = try {
+              api.setTextZoom(pigeon_instanceArg, textZoomArg)
+              listOf(null)
+            } catch (exception: Throwable) {
+              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+            }
             reply.reply(wrapped)
           }
         } else {
@@ -2964,21 +2624,16 @@ abstract class PigeonApiWebSettings(
         }
       }
       run {
-        val channel =
-            BasicMessageChannel<Any?>(
-                binaryMessenger,
-                "dev.flutter.pigeon.webview_flutter_android.WebSettings.getUserAgentString",
-                codec)
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.WebSettings.getUserAgentString", codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val pigeon_instanceArg = args[0] as android.webkit.WebSettings
-            val wrapped: List<Any?> =
-                try {
-                  listOf(api.getUserAgentString(pigeon_instanceArg))
-                } catch (exception: Throwable) {
-                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-                }
+            val wrapped: List<Any?> = try {
+              listOf(api.getUserAgentString(pigeon_instanceArg))
+            } catch (exception: Throwable) {
+              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+            }
             reply.reply(wrapped)
           }
         } else {
@@ -2986,23 +2641,18 @@ abstract class PigeonApiWebSettings(
         }
       }
       run {
-        val channel =
-            BasicMessageChannel<Any?>(
-                binaryMessenger,
-                "dev.flutter.pigeon.webview_flutter_android.WebSettings.setMixedContentMode",
-                codec)
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.WebSettings.setMixedContentMode", codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val pigeon_instanceArg = args[0] as android.webkit.WebSettings
             val modeArg = args[1] as MixedContentMode
-            val wrapped: List<Any?> =
-                try {
-                  api.setMixedContentMode(pigeon_instanceArg, modeArg)
-                  listOf(null)
-                } catch (exception: Throwable) {
-                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-                }
+            val wrapped: List<Any?> = try {
+              api.setMixedContentMode(pigeon_instanceArg, modeArg)
+              listOf(null)
+            } catch (exception: Throwable) {
+              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+            }
             reply.reply(wrapped)
           }
         } else {
@@ -3014,19 +2664,16 @@ abstract class PigeonApiWebSettings(
 
   @Suppress("LocalVariableName", "FunctionName")
   /** Creates a Dart instance of WebSettings and attaches it to [pigeon_instanceArg]. */
-  fun pigeon_newInstance(
-      pigeon_instanceArg: android.webkit.WebSettings,
-      callback: (Result<Unit>) -> Unit
-  ) {
+  fun pigeon_newInstance(pigeon_instanceArg: android.webkit.WebSettings, callback: (Result<Unit>) -> Unit)
+{
     if (pigeonRegistrar.ignoreCallsToDart) {
       callback(
           Result.failure(
               AndroidWebKitError("ignore-calls-error", "Calls to Dart are being ignored.", "")))
-    } else if (pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
+    }     else if (pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
       callback(Result.success(Unit))
-    } else {
-      val pigeon_identifierArg =
-          pigeonRegistrar.instanceManager.addHostCreatedInstance(pigeon_instanceArg)
+    }     else {
+      val pigeon_identifierArg = pigeonRegistrar.instanceManager.addHostCreatedInstance(pigeon_instanceArg)
       val binaryMessenger = pigeonRegistrar.binaryMessenger
       val codec = pigeonRegistrar.codec
       val channelName = "dev.flutter.pigeon.webview_flutter_android.WebSettings.pigeon_newInstance"
@@ -3034,19 +2681,17 @@ abstract class PigeonApiWebSettings(
       channel.send(listOf(pigeon_identifierArg)) {
         if (it is List<*>) {
           if (it.size > 1) {
-            callback(
-                Result.failure(
-                    AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
+            callback(Result.failure(AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
           } else {
             callback(Result.success(Unit))
           }
         } else {
-          callback(
-              Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
-        }
+          callback(Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
+        } 
       }
     }
   }
+
 }
 /**
  * A JavaScript interface for exposing Javascript callbacks to Dart.
@@ -3055,9 +2700,7 @@ abstract class PigeonApiWebSettings(
  * [JavascriptInterface](https://developer.android.com/reference/android/webkit/JavascriptInterface).
  */
 @Suppress("UNCHECKED_CAST")
-abstract class PigeonApiJavaScriptChannel(
-    open val pigeonRegistrar: AndroidWebkitLibraryPigeonProxyApiRegistrar
-) {
+abstract class PigeonApiJavaScriptChannel(open val pigeonRegistrar: AndroidWebkitLibraryPigeonProxyApiRegistrar) {
   abstract fun pigeon_defaultConstructor(channelName: String): JavaScriptChannel
 
   companion object {
@@ -3065,24 +2708,18 @@ abstract class PigeonApiJavaScriptChannel(
     fun setUpMessageHandlers(binaryMessenger: BinaryMessenger, api: PigeonApiJavaScriptChannel?) {
       val codec = api?.pigeonRegistrar?.codec ?: AndroidWebkitLibraryPigeonCodec()
       run {
-        val channel =
-            BasicMessageChannel<Any?>(
-                binaryMessenger,
-                "dev.flutter.pigeon.webview_flutter_android.JavaScriptChannel.pigeon_defaultConstructor",
-                codec)
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.JavaScriptChannel.pigeon_defaultConstructor", codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val pigeon_identifierArg = args[0] as Long
             val channelNameArg = args[1] as String
-            val wrapped: List<Any?> =
-                try {
-                  api.pigeonRegistrar.instanceManager.addDartCreatedInstance(
-                      api.pigeon_defaultConstructor(channelNameArg), pigeon_identifierArg)
-                  listOf(null)
-                } catch (exception: Throwable) {
-                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-                }
+            val wrapped: List<Any?> = try {
+              api.pigeonRegistrar.instanceManager.addDartCreatedInstance(api.pigeon_defaultConstructor(channelNameArg), pigeon_identifierArg)
+              listOf(null)
+            } catch (exception: Throwable) {
+              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+            }
             reply.reply(wrapped)
           }
         } else {
@@ -3094,41 +2731,33 @@ abstract class PigeonApiJavaScriptChannel(
 
   @Suppress("LocalVariableName", "FunctionName")
   /** Creates a Dart instance of JavaScriptChannel and attaches it to [pigeon_instanceArg]. */
-  fun pigeon_newInstance(pigeon_instanceArg: JavaScriptChannel, callback: (Result<Unit>) -> Unit) {
+  fun pigeon_newInstance(pigeon_instanceArg: JavaScriptChannel, callback: (Result<Unit>) -> Unit)
+{
     if (pigeonRegistrar.ignoreCallsToDart) {
       callback(
           Result.failure(
               AndroidWebKitError("ignore-calls-error", "Calls to Dart are being ignored.", "")))
-    } else if (pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
+    }     else if (pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
       callback(Result.success(Unit))
-    } else {
+    }     else {
       callback(
           Result.failure(
-              AndroidWebKitError(
-                  "new-instance-error",
-                  "Attempting to create a new Dart instance of JavaScriptChannel, but the class has a nonnull callback method.",
-                  "")))
+              AndroidWebKitError("new-instance-error", "Attempting to create a new Dart instance of JavaScriptChannel, but the class has a nonnull callback method.", "")))
     }
   }
 
   /** Handles callbacks messages from JavaScript. */
-  fun postMessage(
-      pigeon_instanceArg: JavaScriptChannel,
-      messageArg: String,
-      callback: (Result<Unit>) -> Unit
-  ) {
+  fun postMessage(pigeon_instanceArg: JavaScriptChannel, messageArg: String, callback: (Result<Unit>) -> Unit)
+{
     if (pigeonRegistrar.ignoreCallsToDart) {
       callback(
           Result.failure(
               AndroidWebKitError("ignore-calls-error", "Calls to Dart are being ignored.", "")))
       return
-    } else if (!pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
+    }     else if (!pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
       callback(
           Result.failure(
-              AndroidWebKitError(
-                  "missing-instance-error",
-                  "Callback to `JavaScriptChannel.postMessage` failed because native instance was not in the instance manager.",
-                  "")))
+              AndroidWebKitError("missing-instance-error", "Callback to `JavaScriptChannel.postMessage` failed because native instance was not in the instance manager.", "")))
       return
     }
     val binaryMessenger = pigeonRegistrar.binaryMessenger
@@ -3138,17 +2767,16 @@ abstract class PigeonApiJavaScriptChannel(
     channel.send(listOf(pigeon_instanceArg, messageArg)) {
       if (it is List<*>) {
         if (it.size > 1) {
-          callback(
-              Result.failure(
-                  AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
+          callback(Result.failure(AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
         } else {
           callback(Result.success(Unit))
         }
       } else {
         callback(Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
-      }
+      } 
     }
   }
+
 }
 /**
  * Receives various notifications and requests from a `WebView`.
@@ -3156,51 +2784,41 @@ abstract class PigeonApiJavaScriptChannel(
  * See https://developer.android.com/reference/android/webkit/WebViewClient.
  */
 @Suppress("UNCHECKED_CAST")
-abstract class PigeonApiWebViewClient(
-    open val pigeonRegistrar: AndroidWebkitLibraryPigeonProxyApiRegistrar
-) {
+abstract class PigeonApiWebViewClient(open val pigeonRegistrar: AndroidWebkitLibraryPigeonProxyApiRegistrar) {
   abstract fun pigeon_defaultConstructor(): android.webkit.WebViewClient
 
   /**
    * Sets the required synchronous return value for the Java method,
    * `WebViewClient.shouldOverrideUrlLoading(...)`.
    *
-   * The Java method, `WebViewClient.shouldOverrideUrlLoading(...)`, requires a boolean to be
-   * returned and this method sets the returned value for all calls to the Java method.
+   * The Java method, `WebViewClient.shouldOverrideUrlLoading(...)`, requires
+   * a boolean to be returned and this method sets the returned value for all
+   * calls to the Java method.
    *
-   * Setting this to true causes the current [WebView] to abort loading any URL received by
-   * [requestLoading] or [urlLoading], while setting this to false causes the [WebView] to continue
-   * loading a URL as usual.
+   * Setting this to true causes the current [WebView] to abort loading any URL
+   * received by [requestLoading] or [urlLoading], while setting this to false
+   * causes the [WebView] to continue loading a URL as usual.
    *
    * Defaults to false.
    */
-  abstract fun setSynchronousReturnValueForShouldOverrideUrlLoading(
-      pigeon_instance: android.webkit.WebViewClient,
-      value: Boolean
-  )
+  abstract fun setSynchronousReturnValueForShouldOverrideUrlLoading(pigeon_instance: android.webkit.WebViewClient, value: Boolean)
 
   companion object {
     @Suppress("LocalVariableName")
     fun setUpMessageHandlers(binaryMessenger: BinaryMessenger, api: PigeonApiWebViewClient?) {
       val codec = api?.pigeonRegistrar?.codec ?: AndroidWebkitLibraryPigeonCodec()
       run {
-        val channel =
-            BasicMessageChannel<Any?>(
-                binaryMessenger,
-                "dev.flutter.pigeon.webview_flutter_android.WebViewClient.pigeon_defaultConstructor",
-                codec)
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.WebViewClient.pigeon_defaultConstructor", codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val pigeon_identifierArg = args[0] as Long
-            val wrapped: List<Any?> =
-                try {
-                  api.pigeonRegistrar.instanceManager.addDartCreatedInstance(
-                      api.pigeon_defaultConstructor(), pigeon_identifierArg)
-                  listOf(null)
-                } catch (exception: Throwable) {
-                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-                }
+            val wrapped: List<Any?> = try {
+              api.pigeonRegistrar.instanceManager.addDartCreatedInstance(api.pigeon_defaultConstructor(), pigeon_identifierArg)
+              listOf(null)
+            } catch (exception: Throwable) {
+              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+            }
             reply.reply(wrapped)
           }
         } else {
@@ -3208,24 +2826,18 @@ abstract class PigeonApiWebViewClient(
         }
       }
       run {
-        val channel =
-            BasicMessageChannel<Any?>(
-                binaryMessenger,
-                "dev.flutter.pigeon.webview_flutter_android.WebViewClient.setSynchronousReturnValueForShouldOverrideUrlLoading",
-                codec)
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.WebViewClient.setSynchronousReturnValueForShouldOverrideUrlLoading", codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val pigeon_instanceArg = args[0] as android.webkit.WebViewClient
             val valueArg = args[1] as Boolean
-            val wrapped: List<Any?> =
-                try {
-                  api.setSynchronousReturnValueForShouldOverrideUrlLoading(
-                      pigeon_instanceArg, valueArg)
-                  listOf(null)
-                } catch (exception: Throwable) {
-                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-                }
+            val wrapped: List<Any?> = try {
+              api.setSynchronousReturnValueForShouldOverrideUrlLoading(pigeon_instanceArg, valueArg)
+              listOf(null)
+            } catch (exception: Throwable) {
+              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+            }
             reply.reply(wrapped)
           }
         } else {
@@ -3237,60 +2849,46 @@ abstract class PigeonApiWebViewClient(
 
   @Suppress("LocalVariableName", "FunctionName")
   /** Creates a Dart instance of WebViewClient and attaches it to [pigeon_instanceArg]. */
-  fun pigeon_newInstance(
-      pigeon_instanceArg: android.webkit.WebViewClient,
-      callback: (Result<Unit>) -> Unit
-  ) {
+  fun pigeon_newInstance(pigeon_instanceArg: android.webkit.WebViewClient, callback: (Result<Unit>) -> Unit)
+{
     if (pigeonRegistrar.ignoreCallsToDart) {
       callback(
           Result.failure(
               AndroidWebKitError("ignore-calls-error", "Calls to Dart are being ignored.", "")))
-    } else if (pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
+    }     else if (pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
       callback(Result.success(Unit))
-    } else {
-      val pigeon_identifierArg =
-          pigeonRegistrar.instanceManager.addHostCreatedInstance(pigeon_instanceArg)
+    }     else {
+      val pigeon_identifierArg = pigeonRegistrar.instanceManager.addHostCreatedInstance(pigeon_instanceArg)
       val binaryMessenger = pigeonRegistrar.binaryMessenger
       val codec = pigeonRegistrar.codec
-      val channelName =
-          "dev.flutter.pigeon.webview_flutter_android.WebViewClient.pigeon_newInstance"
+      val channelName = "dev.flutter.pigeon.webview_flutter_android.WebViewClient.pigeon_newInstance"
       val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
       channel.send(listOf(pigeon_identifierArg)) {
         if (it is List<*>) {
           if (it.size > 1) {
-            callback(
-                Result.failure(
-                    AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
+            callback(Result.failure(AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
           } else {
             callback(Result.success(Unit))
           }
         } else {
-          callback(
-              Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
-        }
+          callback(Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
+        } 
       }
     }
   }
 
   /** Notify the host application that a page has started loading. */
-  fun onPageStarted(
-      pigeon_instanceArg: android.webkit.WebViewClient,
-      webViewArg: android.webkit.WebView,
-      urlArg: String,
-      callback: (Result<Unit>) -> Unit
-  ) {
+  fun onPageStarted(pigeon_instanceArg: android.webkit.WebViewClient, webViewArg: android.webkit.WebView, urlArg: String, callback: (Result<Unit>) -> Unit)
+{
     if (pigeonRegistrar.ignoreCallsToDart) {
       callback(
           Result.failure(
               AndroidWebKitError("ignore-calls-error", "Calls to Dart are being ignored.", "")))
       return
-    } else if (!pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
+    }     else if (!pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
       callback(
           Result.failure(
-              AndroidWebKitError(
-                  "missing-instance-error",
-                  "Callback to `WebViewClient.onPageStarted` failed because native instance was not in the instance manager.",
-                  "")))
+              AndroidWebKitError("missing-instance-error", "Callback to `WebViewClient.onPageStarted` failed because native instance was not in the instance manager.", "")))
       return
     }
     val binaryMessenger = pigeonRegistrar.binaryMessenger
@@ -3300,37 +2898,28 @@ abstract class PigeonApiWebViewClient(
     channel.send(listOf(pigeon_instanceArg, webViewArg, urlArg)) {
       if (it is List<*>) {
         if (it.size > 1) {
-          callback(
-              Result.failure(
-                  AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
+          callback(Result.failure(AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
         } else {
           callback(Result.success(Unit))
         }
       } else {
         callback(Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
-      }
+      } 
     }
   }
 
   /** Notify the host application that a page has finished loading. */
-  fun onPageFinished(
-      pigeon_instanceArg: android.webkit.WebViewClient,
-      webViewArg: android.webkit.WebView,
-      urlArg: String,
-      callback: (Result<Unit>) -> Unit
-  ) {
+  fun onPageFinished(pigeon_instanceArg: android.webkit.WebViewClient, webViewArg: android.webkit.WebView, urlArg: String, callback: (Result<Unit>) -> Unit)
+{
     if (pigeonRegistrar.ignoreCallsToDart) {
       callback(
           Result.failure(
               AndroidWebKitError("ignore-calls-error", "Calls to Dart are being ignored.", "")))
       return
-    } else if (!pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
+    }     else if (!pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
       callback(
           Result.failure(
-              AndroidWebKitError(
-                  "missing-instance-error",
-                  "Callback to `WebViewClient.onPageFinished` failed because native instance was not in the instance manager.",
-                  "")))
+              AndroidWebKitError("missing-instance-error", "Callback to `WebViewClient.onPageFinished` failed because native instance was not in the instance manager.", "")))
       return
     }
     val binaryMessenger = pigeonRegistrar.binaryMessenger
@@ -3340,41 +2929,31 @@ abstract class PigeonApiWebViewClient(
     channel.send(listOf(pigeon_instanceArg, webViewArg, urlArg)) {
       if (it is List<*>) {
         if (it.size > 1) {
-          callback(
-              Result.failure(
-                  AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
+          callback(Result.failure(AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
         } else {
           callback(Result.success(Unit))
         }
       } else {
         callback(Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
-      }
+      } 
     }
   }
 
   /**
-   * Notify the host application that an HTTP error has been received from the server while loading
-   * a resource.
+   * Notify the host application that an HTTP error has been received from the
+   * server while loading a resource.
    */
-  fun onReceivedHttpError(
-      pigeon_instanceArg: android.webkit.WebViewClient,
-      webViewArg: android.webkit.WebView,
-      requestArg: android.webkit.WebResourceRequest,
-      responseArg: android.webkit.WebResourceResponse,
-      callback: (Result<Unit>) -> Unit
-  ) {
+  fun onReceivedHttpError(pigeon_instanceArg: android.webkit.WebViewClient, webViewArg: android.webkit.WebView, requestArg: android.webkit.WebResourceRequest, responseArg: android.webkit.WebResourceResponse, callback: (Result<Unit>) -> Unit)
+{
     if (pigeonRegistrar.ignoreCallsToDart) {
       callback(
           Result.failure(
               AndroidWebKitError("ignore-calls-error", "Calls to Dart are being ignored.", "")))
       return
-    } else if (!pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
+    }     else if (!pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
       callback(
           Result.failure(
-              AndroidWebKitError(
-                  "missing-instance-error",
-                  "Callback to `WebViewClient.onReceivedHttpError` failed because native instance was not in the instance manager.",
-                  "")))
+              AndroidWebKitError("missing-instance-error", "Callback to `WebViewClient.onReceivedHttpError` failed because native instance was not in the instance manager.", "")))
       return
     }
     val binaryMessenger = pigeonRegistrar.binaryMessenger
@@ -3384,124 +2963,93 @@ abstract class PigeonApiWebViewClient(
     channel.send(listOf(pigeon_instanceArg, webViewArg, requestArg, responseArg)) {
       if (it is List<*>) {
         if (it.size > 1) {
-          callback(
-              Result.failure(
-                  AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
+          callback(Result.failure(AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
         } else {
           callback(Result.success(Unit))
         }
       } else {
         callback(Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
-      }
+      } 
     }
   }
 
   /** Report web resource loading error to the host application. */
-  fun onReceivedRequestError(
-      pigeon_instanceArg: android.webkit.WebViewClient,
-      webViewArg: android.webkit.WebView,
-      requestArg: android.webkit.WebResourceRequest,
-      errorArg: android.webkit.WebResourceError,
-      callback: (Result<Unit>) -> Unit
-  ) {
+  fun onReceivedRequestError(pigeon_instanceArg: android.webkit.WebViewClient, webViewArg: android.webkit.WebView, requestArg: android.webkit.WebResourceRequest, errorArg: android.webkit.WebResourceError, callback: (Result<Unit>) -> Unit)
+{
     if (pigeonRegistrar.ignoreCallsToDart) {
       callback(
           Result.failure(
               AndroidWebKitError("ignore-calls-error", "Calls to Dart are being ignored.", "")))
       return
-    } else if (!pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
+    }     else if (!pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
       callback(
           Result.failure(
-              AndroidWebKitError(
-                  "missing-instance-error",
-                  "Callback to `WebViewClient.onReceivedRequestError` failed because native instance was not in the instance manager.",
-                  "")))
+              AndroidWebKitError("missing-instance-error", "Callback to `WebViewClient.onReceivedRequestError` failed because native instance was not in the instance manager.", "")))
       return
     }
     val binaryMessenger = pigeonRegistrar.binaryMessenger
     val codec = pigeonRegistrar.codec
-    val channelName =
-        "dev.flutter.pigeon.webview_flutter_android.WebViewClient.onReceivedRequestError"
+    val channelName = "dev.flutter.pigeon.webview_flutter_android.WebViewClient.onReceivedRequestError"
     val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
     channel.send(listOf(pigeon_instanceArg, webViewArg, requestArg, errorArg)) {
       if (it is List<*>) {
         if (it.size > 1) {
-          callback(
-              Result.failure(
-                  AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
+          callback(Result.failure(AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
         } else {
           callback(Result.success(Unit))
         }
       } else {
         callback(Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
-      }
+      } 
     }
   }
 
   /** Report web resource loading error to the host application. */
-  fun onReceivedRequestErrorCompat(
-      pigeon_instanceArg: android.webkit.WebViewClient,
-      webViewArg: android.webkit.WebView,
-      requestArg: android.webkit.WebResourceRequest,
-      errorArg: androidx.webkit.WebResourceErrorCompat,
-      callback: (Result<Unit>) -> Unit
-  ) {
+  fun onReceivedRequestErrorCompat(pigeon_instanceArg: android.webkit.WebViewClient, webViewArg: android.webkit.WebView, requestArg: android.webkit.WebResourceRequest, errorArg: androidx.webkit.WebResourceErrorCompat, callback: (Result<Unit>) -> Unit)
+{
     if (pigeonRegistrar.ignoreCallsToDart) {
       callback(
           Result.failure(
               AndroidWebKitError("ignore-calls-error", "Calls to Dart are being ignored.", "")))
       return
-    } else if (!pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
+    }     else if (!pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
       callback(
           Result.failure(
-              AndroidWebKitError(
-                  "missing-instance-error",
-                  "Callback to `WebViewClient.onReceivedRequestErrorCompat` failed because native instance was not in the instance manager.",
-                  "")))
+              AndroidWebKitError("missing-instance-error", "Callback to `WebViewClient.onReceivedRequestErrorCompat` failed because native instance was not in the instance manager.", "")))
       return
     }
     val binaryMessenger = pigeonRegistrar.binaryMessenger
     val codec = pigeonRegistrar.codec
-    val channelName =
-        "dev.flutter.pigeon.webview_flutter_android.WebViewClient.onReceivedRequestErrorCompat"
+    val channelName = "dev.flutter.pigeon.webview_flutter_android.WebViewClient.onReceivedRequestErrorCompat"
     val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
     channel.send(listOf(pigeon_instanceArg, webViewArg, requestArg, errorArg)) {
       if (it is List<*>) {
         if (it.size > 1) {
-          callback(
-              Result.failure(
-                  AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
+          callback(Result.failure(AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
         } else {
           callback(Result.success(Unit))
         }
       } else {
         callback(Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
-      }
+      } 
     }
   }
 
   /**
-   * Give the host application a chance to take control when a URL is about to be loaded in the
-   * current WebView.
+   * Give the host application a chance to take control when a URL is about to
+   * be loaded in the current WebView.
    */
-  fun requestLoading(
-      pigeon_instanceArg: android.webkit.WebViewClient,
-      webViewArg: android.webkit.WebView,
-      requestArg: android.webkit.WebResourceRequest,
-      callback: (Result<Unit>) -> Unit
-  ) {
+  fun requestLoading(pigeon_instanceArg: android.webkit.WebViewClient, webViewArg: android.webkit.WebView, requestArg: android.webkit.WebResourceRequest, callback: (Result<Unit>) -> Unit)
+{
     if (pigeonRegistrar.ignoreCallsToDart) {
       callback(
           Result.failure(
               AndroidWebKitError("ignore-calls-error", "Calls to Dart are being ignored.", "")))
       return
-    } else if (!pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
+    }     else if (!pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
       callback(
           Result.failure(
-              AndroidWebKitError(
-                  "missing-instance-error",
-                  "Callback to `WebViewClient.requestLoading` failed because native instance was not in the instance manager.",
-                  "")))
+              AndroidWebKitError("missing-instance-error", "Callback to `WebViewClient.requestLoading` failed because native instance was not in the instance manager.", "")))
       return
     }
     val binaryMessenger = pigeonRegistrar.binaryMessenger
@@ -3511,82 +3059,31 @@ abstract class PigeonApiWebViewClient(
     channel.send(listOf(pigeon_instanceArg, webViewArg, requestArg)) {
       if (it is List<*>) {
         if (it.size > 1) {
-          callback(
-              Result.failure(
-                  AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
+          callback(Result.failure(AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
         } else {
           callback(Result.success(Unit))
         }
       } else {
         callback(Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
-      }
+      } 
     }
   }
 
   /**
-   * Notifies Dart that the page requested a new window (`target=_blank` /
-   * `window.open`).
+   * Give the host application a chance to take control when a URL is about to
+   * be loaded in the current WebView.
    */
-  fun onCreateWindow(
-      pigeon_instanceArg: android.webkit.WebViewClient,
-      urlArg: String,
-      callback: (Result<Unit>) -> Unit
-  ) {
+  fun urlLoading(pigeon_instanceArg: android.webkit.WebViewClient, webViewArg: android.webkit.WebView, urlArg: String, callback: (Result<Unit>) -> Unit)
+{
     if (pigeonRegistrar.ignoreCallsToDart) {
       callback(
           Result.failure(
               AndroidWebKitError("ignore-calls-error", "Calls to Dart are being ignored.", "")))
       return
-    } else if (!pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
+    }     else if (!pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
       callback(
           Result.failure(
-              AndroidWebKitError(
-                  "missing-instance-error",
-                  "Callback to `WebViewClient.onCreateWindow` failed because native instance was not in the instance manager.",
-                  "")))
-      return
-    }
-    val binaryMessenger = pigeonRegistrar.binaryMessenger
-    val codec = pigeonRegistrar.codec
-    val channelName = "dev.flutter.pigeon.webview_flutter_android.WebViewClient.onCreateWindow"
-    val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
-    channel.send(listOf(pigeon_instanceArg, urlArg)) {
-      if (it is List<*>) {
-        if (it.size > 1) {
-          callback(
-              Result.failure(
-                  AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
-        } else {
-          callback(Result.success(Unit))
-        }
-      } else {
-        callback(Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
-      }
-    }
-  }
-
-  /**
-   * Give the host application a chance to take control when a URL is about to be loaded in the
-   * current WebView.
-   */
-  fun urlLoading(
-      pigeon_instanceArg: android.webkit.WebViewClient,
-      webViewArg: android.webkit.WebView,
-      urlArg: String,
-      callback: (Result<Unit>) -> Unit
-  ) {
-    if (pigeonRegistrar.ignoreCallsToDart) {
-      callback(
-          Result.failure(
-              AndroidWebKitError("ignore-calls-error", "Calls to Dart are being ignored.", "")))
-      return
-    } else if (!pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
-      callback(
-          Result.failure(
-              AndroidWebKitError(
-                  "missing-instance-error",
-                  "Callback to `WebViewClient.urlLoading` failed because native instance was not in the instance manager.",
-                  "")))
+              AndroidWebKitError("missing-instance-error", "Callback to `WebViewClient.urlLoading` failed because native instance was not in the instance manager.", "")))
       return
     }
     val binaryMessenger = pigeonRegistrar.binaryMessenger
@@ -3596,126 +3093,130 @@ abstract class PigeonApiWebViewClient(
     channel.send(listOf(pigeon_instanceArg, webViewArg, urlArg)) {
       if (it is List<*>) {
         if (it.size > 1) {
-          callback(
-              Result.failure(
-                  AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
+          callback(Result.failure(AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
         } else {
           callback(Result.success(Unit))
         }
       } else {
         callback(Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
-      }
-    }
-  }
-
-  /** Notify the host application to update its visited links database. */
-  fun doUpdateVisitedHistory(
-      pigeon_instanceArg: android.webkit.WebViewClient,
-      webViewArg: android.webkit.WebView,
-      urlArg: String,
-      isReloadArg: Boolean,
-      callback: (Result<Unit>) -> Unit
-  ) {
-    if (pigeonRegistrar.ignoreCallsToDart) {
-      callback(
-          Result.failure(
-              AndroidWebKitError("ignore-calls-error", "Calls to Dart are being ignored.", "")))
-      return
-    } else if (!pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
-      callback(
-          Result.failure(
-              AndroidWebKitError(
-                  "missing-instance-error",
-                  "Callback to `WebViewClient.doUpdateVisitedHistory` failed because native instance was not in the instance manager.",
-                  "")))
-      return
-    }
-    val binaryMessenger = pigeonRegistrar.binaryMessenger
-    val codec = pigeonRegistrar.codec
-    val channelName =
-        "dev.flutter.pigeon.webview_flutter_android.WebViewClient.doUpdateVisitedHistory"
-    val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
-    channel.send(listOf(pigeon_instanceArg, webViewArg, urlArg, isReloadArg)) {
-      if (it is List<*>) {
-        if (it.size > 1) {
-          callback(
-              Result.failure(
-                  AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
-        } else {
-          callback(Result.success(Unit))
-        }
-      } else {
-        callback(Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
-      }
-    }
-  }
-
-  /** Notifies the host application that the WebView received an HTTP authentication request. */
-  fun onReceivedHttpAuthRequest(
-      pigeon_instanceArg: android.webkit.WebViewClient,
-      webViewArg: android.webkit.WebView,
-      handlerArg: android.webkit.HttpAuthHandler,
-      hostArg: String,
-      realmArg: String,
-      callback: (Result<Unit>) -> Unit
-  ) {
-    if (pigeonRegistrar.ignoreCallsToDart) {
-      callback(
-          Result.failure(
-              AndroidWebKitError("ignore-calls-error", "Calls to Dart are being ignored.", "")))
-      return
-    } else if (!pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
-      callback(
-          Result.failure(
-              AndroidWebKitError(
-                  "missing-instance-error",
-                  "Callback to `WebViewClient.onReceivedHttpAuthRequest` failed because native instance was not in the instance manager.",
-                  "")))
-      return
-    }
-    val binaryMessenger = pigeonRegistrar.binaryMessenger
-    val codec = pigeonRegistrar.codec
-    val channelName =
-        "dev.flutter.pigeon.webview_flutter_android.WebViewClient.onReceivedHttpAuthRequest"
-    val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
-    channel.send(listOf(pigeon_instanceArg, webViewArg, handlerArg, hostArg, realmArg)) {
-      if (it is List<*>) {
-        if (it.size > 1) {
-          callback(
-              Result.failure(
-                  AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
-        } else {
-          callback(Result.success(Unit))
-        }
-      } else {
-        callback(Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
-      }
+      } 
     }
   }
 
   /**
-   * Ask the host application if the browser should resend data as the requested page was a result
-   * of a POST.
+   * Notifies the host that the page requested a new window
+   * (`target=_blank` / `window.open`).
    */
-  fun onFormResubmission(
-      pigeon_instanceArg: android.webkit.WebViewClient,
-      viewArg: android.webkit.WebView,
-      dontResendArg: android.os.Message,
-      resendArg: android.os.Message,
-      callback: (Result<Unit>) -> Unit
-  ) {
+  fun onCreateWindow(pigeon_instanceArg: android.webkit.WebViewClient, urlArg: String, callback: (Result<Unit>) -> Unit)
+{
     if (pigeonRegistrar.ignoreCallsToDart) {
       callback(
           Result.failure(
               AndroidWebKitError("ignore-calls-error", "Calls to Dart are being ignored.", "")))
       return
-    } else if (!pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
+    }     else if (!pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
       callback(
           Result.failure(
-              AndroidWebKitError(
-                  "missing-instance-error",
-                  "Callback to `WebViewClient.onFormResubmission` failed because native instance was not in the instance manager.",
-                  "")))
+              AndroidWebKitError("missing-instance-error", "Callback to `WebViewClient.onCreateWindow` failed because native instance was not in the instance manager.", "")))
+      return
+    }
+    val binaryMessenger = pigeonRegistrar.binaryMessenger
+    val codec = pigeonRegistrar.codec
+    val channelName = "dev.flutter.pigeon.webview_flutter_android.WebViewClient.onCreateWindow"
+    val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
+    channel.send(listOf(pigeon_instanceArg, urlArg)) {
+      if (it is List<*>) {
+        if (it.size > 1) {
+          callback(Result.failure(AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
+        } else {
+          callback(Result.success(Unit))
+        }
+      } else {
+        callback(Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
+      } 
+    }
+  }
+
+  /** Notify the host application to update its visited links database. */
+  fun doUpdateVisitedHistory(pigeon_instanceArg: android.webkit.WebViewClient, webViewArg: android.webkit.WebView, urlArg: String, isReloadArg: Boolean, callback: (Result<Unit>) -> Unit)
+{
+    if (pigeonRegistrar.ignoreCallsToDart) {
+      callback(
+          Result.failure(
+              AndroidWebKitError("ignore-calls-error", "Calls to Dart are being ignored.", "")))
+      return
+    }     else if (!pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
+      callback(
+          Result.failure(
+              AndroidWebKitError("missing-instance-error", "Callback to `WebViewClient.doUpdateVisitedHistory` failed because native instance was not in the instance manager.", "")))
+      return
+    }
+    val binaryMessenger = pigeonRegistrar.binaryMessenger
+    val codec = pigeonRegistrar.codec
+    val channelName = "dev.flutter.pigeon.webview_flutter_android.WebViewClient.doUpdateVisitedHistory"
+    val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
+    channel.send(listOf(pigeon_instanceArg, webViewArg, urlArg, isReloadArg)) {
+      if (it is List<*>) {
+        if (it.size > 1) {
+          callback(Result.failure(AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
+        } else {
+          callback(Result.success(Unit))
+        }
+      } else {
+        callback(Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
+      } 
+    }
+  }
+
+  /**
+   * Notifies the host application that the WebView received an HTTP
+   * authentication request.
+   */
+  fun onReceivedHttpAuthRequest(pigeon_instanceArg: android.webkit.WebViewClient, webViewArg: android.webkit.WebView, handlerArg: android.webkit.HttpAuthHandler, hostArg: String, realmArg: String, callback: (Result<Unit>) -> Unit)
+{
+    if (pigeonRegistrar.ignoreCallsToDart) {
+      callback(
+          Result.failure(
+              AndroidWebKitError("ignore-calls-error", "Calls to Dart are being ignored.", "")))
+      return
+    }     else if (!pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
+      callback(
+          Result.failure(
+              AndroidWebKitError("missing-instance-error", "Callback to `WebViewClient.onReceivedHttpAuthRequest` failed because native instance was not in the instance manager.", "")))
+      return
+    }
+    val binaryMessenger = pigeonRegistrar.binaryMessenger
+    val codec = pigeonRegistrar.codec
+    val channelName = "dev.flutter.pigeon.webview_flutter_android.WebViewClient.onReceivedHttpAuthRequest"
+    val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
+    channel.send(listOf(pigeon_instanceArg, webViewArg, handlerArg, hostArg, realmArg)) {
+      if (it is List<*>) {
+        if (it.size > 1) {
+          callback(Result.failure(AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
+        } else {
+          callback(Result.success(Unit))
+        }
+      } else {
+        callback(Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
+      } 
+    }
+  }
+
+  /**
+   * Ask the host application if the browser should resend data as the
+   * requested page was a result of a POST.
+   */
+  fun onFormResubmission(pigeon_instanceArg: android.webkit.WebViewClient, viewArg: android.webkit.WebView, dontResendArg: android.os.Message, resendArg: android.os.Message, callback: (Result<Unit>) -> Unit)
+{
+    if (pigeonRegistrar.ignoreCallsToDart) {
+      callback(
+          Result.failure(
+              AndroidWebKitError("ignore-calls-error", "Calls to Dart are being ignored.", "")))
+      return
+    }     else if (!pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
+      callback(
+          Result.failure(
+              AndroidWebKitError("missing-instance-error", "Callback to `WebViewClient.onFormResubmission` failed because native instance was not in the instance manager.", "")))
       return
     }
     val binaryMessenger = pigeonRegistrar.binaryMessenger
@@ -3725,39 +3226,31 @@ abstract class PigeonApiWebViewClient(
     channel.send(listOf(pigeon_instanceArg, viewArg, dontResendArg, resendArg)) {
       if (it is List<*>) {
         if (it.size > 1) {
-          callback(
-              Result.failure(
-                  AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
+          callback(Result.failure(AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
         } else {
           callback(Result.success(Unit))
         }
       } else {
         callback(Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
-      }
+      } 
     }
   }
 
   /**
-   * Notify the host application that the WebView will load the resource specified by the given url.
+   * Notify the host application that the WebView will load the resource
+   * specified by the given url.
    */
-  fun onLoadResource(
-      pigeon_instanceArg: android.webkit.WebViewClient,
-      viewArg: android.webkit.WebView,
-      urlArg: String,
-      callback: (Result<Unit>) -> Unit
-  ) {
+  fun onLoadResource(pigeon_instanceArg: android.webkit.WebViewClient, viewArg: android.webkit.WebView, urlArg: String, callback: (Result<Unit>) -> Unit)
+{
     if (pigeonRegistrar.ignoreCallsToDart) {
       callback(
           Result.failure(
               AndroidWebKitError("ignore-calls-error", "Calls to Dart are being ignored.", "")))
       return
-    } else if (!pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
+    }     else if (!pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
       callback(
           Result.failure(
-              AndroidWebKitError(
-                  "missing-instance-error",
-                  "Callback to `WebViewClient.onLoadResource` failed because native instance was not in the instance manager.",
-                  "")))
+              AndroidWebKitError("missing-instance-error", "Callback to `WebViewClient.onLoadResource` failed because native instance was not in the instance manager.", "")))
       return
     }
     val binaryMessenger = pigeonRegistrar.binaryMessenger
@@ -3767,40 +3260,31 @@ abstract class PigeonApiWebViewClient(
     channel.send(listOf(pigeon_instanceArg, viewArg, urlArg)) {
       if (it is List<*>) {
         if (it.size > 1) {
-          callback(
-              Result.failure(
-                  AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
+          callback(Result.failure(AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
         } else {
           callback(Result.success(Unit))
         }
       } else {
         callback(Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
-      }
+      } 
     }
   }
 
   /**
-   * Notify the host application that WebView content left over from previous page navigations will
-   * no longer be drawn.
+   * Notify the host application that WebView content left over from previous
+   * page navigations will no longer be drawn.
    */
-  fun onPageCommitVisible(
-      pigeon_instanceArg: android.webkit.WebViewClient,
-      viewArg: android.webkit.WebView,
-      urlArg: String,
-      callback: (Result<Unit>) -> Unit
-  ) {
+  fun onPageCommitVisible(pigeon_instanceArg: android.webkit.WebViewClient, viewArg: android.webkit.WebView, urlArg: String, callback: (Result<Unit>) -> Unit)
+{
     if (pigeonRegistrar.ignoreCallsToDart) {
       callback(
           Result.failure(
               AndroidWebKitError("ignore-calls-error", "Calls to Dart are being ignored.", "")))
       return
-    } else if (!pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
+    }     else if (!pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
       callback(
           Result.failure(
-              AndroidWebKitError(
-                  "missing-instance-error",
-                  "Callback to `WebViewClient.onPageCommitVisible` failed because native instance was not in the instance manager.",
-                  "")))
+              AndroidWebKitError("missing-instance-error", "Callback to `WebViewClient.onPageCommitVisible` failed because native instance was not in the instance manager.", "")))
       return
     }
     val binaryMessenger = pigeonRegistrar.binaryMessenger
@@ -3810,124 +3294,96 @@ abstract class PigeonApiWebViewClient(
     channel.send(listOf(pigeon_instanceArg, viewArg, urlArg)) {
       if (it is List<*>) {
         if (it.size > 1) {
-          callback(
-              Result.failure(
-                  AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
+          callback(Result.failure(AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
         } else {
           callback(Result.success(Unit))
         }
       } else {
         callback(Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
-      }
+      } 
     }
   }
 
   /** Notify the host application to handle a SSL client certificate request. */
-  fun onReceivedClientCertRequest(
-      pigeon_instanceArg: android.webkit.WebViewClient,
-      viewArg: android.webkit.WebView,
-      requestArg: android.webkit.ClientCertRequest,
-      callback: (Result<Unit>) -> Unit
-  ) {
+  fun onReceivedClientCertRequest(pigeon_instanceArg: android.webkit.WebViewClient, viewArg: android.webkit.WebView, requestArg: android.webkit.ClientCertRequest, callback: (Result<Unit>) -> Unit)
+{
     if (pigeonRegistrar.ignoreCallsToDart) {
       callback(
           Result.failure(
               AndroidWebKitError("ignore-calls-error", "Calls to Dart are being ignored.", "")))
       return
-    } else if (!pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
+    }     else if (!pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
       callback(
           Result.failure(
-              AndroidWebKitError(
-                  "missing-instance-error",
-                  "Callback to `WebViewClient.onReceivedClientCertRequest` failed because native instance was not in the instance manager.",
-                  "")))
+              AndroidWebKitError("missing-instance-error", "Callback to `WebViewClient.onReceivedClientCertRequest` failed because native instance was not in the instance manager.", "")))
       return
     }
     val binaryMessenger = pigeonRegistrar.binaryMessenger
     val codec = pigeonRegistrar.codec
-    val channelName =
-        "dev.flutter.pigeon.webview_flutter_android.WebViewClient.onReceivedClientCertRequest"
+    val channelName = "dev.flutter.pigeon.webview_flutter_android.WebViewClient.onReceivedClientCertRequest"
     val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
     channel.send(listOf(pigeon_instanceArg, viewArg, requestArg)) {
       if (it is List<*>) {
         if (it.size > 1) {
-          callback(
-              Result.failure(
-                  AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
+          callback(Result.failure(AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
         } else {
           callback(Result.success(Unit))
         }
       } else {
         callback(Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
-      }
+      } 
     }
   }
 
   /**
-   * Notify the host application that a request to automatically log in the user has been processed.
+   * Notify the host application that a request to automatically log in the
+   * user has been processed.
    */
-  fun onReceivedLoginRequest(
-      pigeon_instanceArg: android.webkit.WebViewClient,
-      viewArg: android.webkit.WebView,
-      realmArg: String,
-      accountArg: String?,
-      argsArg: String,
-      callback: (Result<Unit>) -> Unit
-  ) {
+  fun onReceivedLoginRequest(pigeon_instanceArg: android.webkit.WebViewClient, viewArg: android.webkit.WebView, realmArg: String, accountArg: String?, argsArg: String, callback: (Result<Unit>) -> Unit)
+{
     if (pigeonRegistrar.ignoreCallsToDart) {
       callback(
           Result.failure(
               AndroidWebKitError("ignore-calls-error", "Calls to Dart are being ignored.", "")))
       return
-    } else if (!pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
+    }     else if (!pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
       callback(
           Result.failure(
-              AndroidWebKitError(
-                  "missing-instance-error",
-                  "Callback to `WebViewClient.onReceivedLoginRequest` failed because native instance was not in the instance manager.",
-                  "")))
+              AndroidWebKitError("missing-instance-error", "Callback to `WebViewClient.onReceivedLoginRequest` failed because native instance was not in the instance manager.", "")))
       return
     }
     val binaryMessenger = pigeonRegistrar.binaryMessenger
     val codec = pigeonRegistrar.codec
-    val channelName =
-        "dev.flutter.pigeon.webview_flutter_android.WebViewClient.onReceivedLoginRequest"
+    val channelName = "dev.flutter.pigeon.webview_flutter_android.WebViewClient.onReceivedLoginRequest"
     val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
     channel.send(listOf(pigeon_instanceArg, viewArg, realmArg, accountArg, argsArg)) {
       if (it is List<*>) {
         if (it.size > 1) {
-          callback(
-              Result.failure(
-                  AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
+          callback(Result.failure(AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
         } else {
           callback(Result.success(Unit))
         }
       } else {
         callback(Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
-      }
+      } 
     }
   }
 
-  /** Notifies the host application that an SSL error occurred while loading a resource. */
-  fun onReceivedSslError(
-      pigeon_instanceArg: android.webkit.WebViewClient,
-      viewArg: android.webkit.WebView,
-      handlerArg: android.webkit.SslErrorHandler,
-      errorArg: android.net.http.SslError,
-      callback: (Result<Unit>) -> Unit
-  ) {
+  /**
+   * Notifies the host application that an SSL error occurred while loading a
+   * resource.
+   */
+  fun onReceivedSslError(pigeon_instanceArg: android.webkit.WebViewClient, viewArg: android.webkit.WebView, handlerArg: android.webkit.SslErrorHandler, errorArg: android.net.http.SslError, callback: (Result<Unit>) -> Unit)
+{
     if (pigeonRegistrar.ignoreCallsToDart) {
       callback(
           Result.failure(
               AndroidWebKitError("ignore-calls-error", "Calls to Dart are being ignored.", "")))
       return
-    } else if (!pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
+    }     else if (!pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
       callback(
           Result.failure(
-              AndroidWebKitError(
-                  "missing-instance-error",
-                  "Callback to `WebViewClient.onReceivedSslError` failed because native instance was not in the instance manager.",
-                  "")))
+              AndroidWebKitError("missing-instance-error", "Callback to `WebViewClient.onReceivedSslError` failed because native instance was not in the instance manager.", "")))
       return
     }
     val binaryMessenger = pigeonRegistrar.binaryMessenger
@@ -3937,38 +3393,31 @@ abstract class PigeonApiWebViewClient(
     channel.send(listOf(pigeon_instanceArg, viewArg, handlerArg, errorArg)) {
       if (it is List<*>) {
         if (it.size > 1) {
-          callback(
-              Result.failure(
-                  AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
+          callback(Result.failure(AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
         } else {
           callback(Result.success(Unit))
         }
       } else {
         callback(Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
-      }
+      } 
     }
   }
 
-  /** Notify the host application that the scale applied to the WebView has changed. */
-  fun onScaleChanged(
-      pigeon_instanceArg: android.webkit.WebViewClient,
-      viewArg: android.webkit.WebView,
-      oldScaleArg: Double,
-      newScaleArg: Double,
-      callback: (Result<Unit>) -> Unit
-  ) {
+  /**
+   * Notify the host application that the scale applied to the WebView has
+   * changed.
+   */
+  fun onScaleChanged(pigeon_instanceArg: android.webkit.WebViewClient, viewArg: android.webkit.WebView, oldScaleArg: Double, newScaleArg: Double, callback: (Result<Unit>) -> Unit)
+{
     if (pigeonRegistrar.ignoreCallsToDart) {
       callback(
           Result.failure(
               AndroidWebKitError("ignore-calls-error", "Calls to Dart are being ignored.", "")))
       return
-    } else if (!pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
+    }     else if (!pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
       callback(
           Result.failure(
-              AndroidWebKitError(
-                  "missing-instance-error",
-                  "Callback to `WebViewClient.onScaleChanged` failed because native instance was not in the instance manager.",
-                  "")))
+              AndroidWebKitError("missing-instance-error", "Callback to `WebViewClient.onScaleChanged` failed because native instance was not in the instance manager.", "")))
       return
     }
     val binaryMessenger = pigeonRegistrar.binaryMessenger
@@ -3978,17 +3427,16 @@ abstract class PigeonApiWebViewClient(
     channel.send(listOf(pigeon_instanceArg, viewArg, oldScaleArg, newScaleArg)) {
       if (it is List<*>) {
         if (it.size > 1) {
-          callback(
-              Result.failure(
-                  AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
+          callback(Result.failure(AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
         } else {
           callback(Result.success(Unit))
         }
       } else {
         callback(Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
-      }
+      } 
     }
   }
+
 }
 /**
  * Handles notifications that a file should be downloaded.
@@ -3996,9 +3444,7 @@ abstract class PigeonApiWebViewClient(
  * See https://developer.android.com/reference/android/webkit/DownloadListener.
  */
 @Suppress("UNCHECKED_CAST")
-abstract class PigeonApiDownloadListener(
-    open val pigeonRegistrar: AndroidWebkitLibraryPigeonProxyApiRegistrar
-) {
+abstract class PigeonApiDownloadListener(open val pigeonRegistrar: AndroidWebkitLibraryPigeonProxyApiRegistrar) {
   abstract fun pigeon_defaultConstructor(): android.webkit.DownloadListener
 
   companion object {
@@ -4006,23 +3452,17 @@ abstract class PigeonApiDownloadListener(
     fun setUpMessageHandlers(binaryMessenger: BinaryMessenger, api: PigeonApiDownloadListener?) {
       val codec = api?.pigeonRegistrar?.codec ?: AndroidWebkitLibraryPigeonCodec()
       run {
-        val channel =
-            BasicMessageChannel<Any?>(
-                binaryMessenger,
-                "dev.flutter.pigeon.webview_flutter_android.DownloadListener.pigeon_defaultConstructor",
-                codec)
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.DownloadListener.pigeon_defaultConstructor", codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val pigeon_identifierArg = args[0] as Long
-            val wrapped: List<Any?> =
-                try {
-                  api.pigeonRegistrar.instanceManager.addDartCreatedInstance(
-                      api.pigeon_defaultConstructor(), pigeon_identifierArg)
-                  listOf(null)
-                } catch (exception: Throwable) {
-                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-                }
+            val wrapped: List<Any?> = try {
+              api.pigeonRegistrar.instanceManager.addDartCreatedInstance(api.pigeon_defaultConstructor(), pigeon_identifierArg)
+              listOf(null)
+            } catch (exception: Throwable) {
+              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+            }
             reply.reply(wrapped)
           }
         } else {
@@ -4034,209 +3474,166 @@ abstract class PigeonApiDownloadListener(
 
   @Suppress("LocalVariableName", "FunctionName")
   /** Creates a Dart instance of DownloadListener and attaches it to [pigeon_instanceArg]. */
-  fun pigeon_newInstance(
-      pigeon_instanceArg: android.webkit.DownloadListener,
-      callback: (Result<Unit>) -> Unit
-  ) {
+  fun pigeon_newInstance(pigeon_instanceArg: android.webkit.DownloadListener, callback: (Result<Unit>) -> Unit)
+{
     if (pigeonRegistrar.ignoreCallsToDart) {
       callback(
           Result.failure(
               AndroidWebKitError("ignore-calls-error", "Calls to Dart are being ignored.", "")))
-    } else if (pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
+    }     else if (pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
       callback(Result.success(Unit))
-    } else {
+    }     else {
       callback(
           Result.failure(
-              AndroidWebKitError(
-                  "new-instance-error",
-                  "Attempting to create a new Dart instance of DownloadListener, but the class has a nonnull callback method.",
-                  "")))
+              AndroidWebKitError("new-instance-error", "Attempting to create a new Dart instance of DownloadListener, but the class has a nonnull callback method.", "")))
     }
   }
 
   /** Notify the host application that a file should be downloaded. */
-  fun onDownloadStart(
-      pigeon_instanceArg: android.webkit.DownloadListener,
-      urlArg: String,
-      userAgentArg: String,
-      contentDispositionArg: String,
-      mimetypeArg: String,
-      contentLengthArg: Long,
-      callback: (Result<Unit>) -> Unit
-  ) {
+  fun onDownloadStart(pigeon_instanceArg: android.webkit.DownloadListener, urlArg: String, userAgentArg: String, contentDispositionArg: String, mimetypeArg: String, contentLengthArg: Long, callback: (Result<Unit>) -> Unit)
+{
     if (pigeonRegistrar.ignoreCallsToDart) {
       callback(
           Result.failure(
               AndroidWebKitError("ignore-calls-error", "Calls to Dart are being ignored.", "")))
       return
-    } else if (!pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
+    }     else if (!pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
       callback(
           Result.failure(
-              AndroidWebKitError(
-                  "missing-instance-error",
-                  "Callback to `DownloadListener.onDownloadStart` failed because native instance was not in the instance manager.",
-                  "")))
+              AndroidWebKitError("missing-instance-error", "Callback to `DownloadListener.onDownloadStart` failed because native instance was not in the instance manager.", "")))
       return
     }
     val binaryMessenger = pigeonRegistrar.binaryMessenger
     val codec = pigeonRegistrar.codec
     val channelName = "dev.flutter.pigeon.webview_flutter_android.DownloadListener.onDownloadStart"
     val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
-    channel.send(
-        listOf(
-            pigeon_instanceArg,
-            urlArg,
-            userAgentArg,
-            contentDispositionArg,
-            mimetypeArg,
-            contentLengthArg)) {
-          if (it is List<*>) {
-            if (it.size > 1) {
-              callback(
-                  Result.failure(
-                      AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
-            } else {
-              callback(Result.success(Unit))
-            }
-          } else {
-            callback(
-                Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
-          }
+    channel.send(listOf(pigeon_instanceArg, urlArg, userAgentArg, contentDispositionArg, mimetypeArg, contentLengthArg)) {
+      if (it is List<*>) {
+        if (it.size > 1) {
+          callback(Result.failure(AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
+        } else {
+          callback(Result.success(Unit))
         }
+      } else {
+        callback(Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
+      } 
+    }
   }
+
 }
 /**
- * Handles notification of JavaScript dialogs, favicons, titles, and the progress.
+ * Handles notification of JavaScript dialogs, favicons, titles, and the
+ * progress.
  *
  * See https://developer.android.com/reference/android/webkit/WebChromeClient.
  */
 @Suppress("UNCHECKED_CAST")
-abstract class PigeonApiWebChromeClient(
-    open val pigeonRegistrar: AndroidWebkitLibraryPigeonProxyApiRegistrar
-) {
-  abstract fun pigeon_defaultConstructor():
-      io.flutter.plugins.webviewflutter.WebChromeClientProxyApi.WebChromeClientImpl
+abstract class PigeonApiWebChromeClient(open val pigeonRegistrar: AndroidWebkitLibraryPigeonProxyApiRegistrar) {
+  abstract fun pigeon_defaultConstructor(): io.flutter.plugins.webviewflutter.WebChromeClientProxyApi.WebChromeClientImpl
 
   /**
    * Sets the required synchronous return value for the Java method,
    * `WebChromeClient.onShowFileChooser(...)`.
    *
-   * The Java method, `WebChromeClient.onShowFileChooser(...)`, requires a boolean to be returned
-   * and this method sets the returned value for all calls to the Java method.
+   * The Java method, `WebChromeClient.onShowFileChooser(...)`, requires
+   * a boolean to be returned and this method sets the returned value for all
+   * calls to the Java method.
    *
-   * Setting this to true indicates that all file chooser requests should be handled by
-   * `onShowFileChooser` and the returned list of Strings will be returned to the WebView.
-   * Otherwise, the client will use the default handling and the returned value in
-   * `onShowFileChooser` will be ignored.
+   * Setting this to true indicates that all file chooser requests should be
+   * handled by `onShowFileChooser` and the returned list of Strings will be
+   * returned to the WebView. Otherwise, the client will use the default
+   * handling and the returned value in `onShowFileChooser` will be ignored.
    *
    * Requires `onShowFileChooser` to be nonnull.
    *
    * Defaults to false.
    */
-  abstract fun setSynchronousReturnValueForOnShowFileChooser(
-      pigeon_instance:
-          io.flutter.plugins.webviewflutter.WebChromeClientProxyApi.WebChromeClientImpl,
-      value: Boolean
-  )
+  abstract fun setSynchronousReturnValueForOnShowFileChooser(pigeon_instance: io.flutter.plugins.webviewflutter.WebChromeClientProxyApi.WebChromeClientImpl, value: Boolean)
 
   /**
    * Sets the required synchronous return value for the Java method,
    * `WebChromeClient.onConsoleMessage(...)`.
    *
-   * The Java method, `WebChromeClient.onConsoleMessage(...)`, requires a boolean to be returned and
-   * this method sets the returned value for all calls to the Java method.
+   * The Java method, `WebChromeClient.onConsoleMessage(...)`, requires
+   * a boolean to be returned and this method sets the returned value for all
+   * calls to the Java method.
    *
-   * Setting this to true indicates that the client is handling all console messages.
+   * Setting this to true indicates that the client is handling all console
+   * messages.
    *
    * Requires `onConsoleMessage` to be nonnull.
    *
    * Defaults to false.
    */
-  abstract fun setSynchronousReturnValueForOnConsoleMessage(
-      pigeon_instance:
-          io.flutter.plugins.webviewflutter.WebChromeClientProxyApi.WebChromeClientImpl,
-      value: Boolean
-  )
+  abstract fun setSynchronousReturnValueForOnConsoleMessage(pigeon_instance: io.flutter.plugins.webviewflutter.WebChromeClientProxyApi.WebChromeClientImpl, value: Boolean)
 
   /**
    * Sets the required synchronous return value for the Java method,
    * `WebChromeClient.onJsAlert(...)`.
    *
-   * The Java method, `WebChromeClient.onJsAlert(...)`, requires a boolean to be returned and this
-   * method sets the returned value for all calls to the Java method.
+   * The Java method, `WebChromeClient.onJsAlert(...)`, requires a boolean to
+   * be returned and this method sets the returned value for all calls to the
+   * Java method.
    *
-   * Setting this to true indicates that the client is handling all console messages.
+   * Setting this to true indicates that the client is handling all console
+   * messages.
    *
    * Requires `onJsAlert` to be nonnull.
    *
    * Defaults to false.
    */
-  abstract fun setSynchronousReturnValueForOnJsAlert(
-      pigeon_instance:
-          io.flutter.plugins.webviewflutter.WebChromeClientProxyApi.WebChromeClientImpl,
-      value: Boolean
-  )
+  abstract fun setSynchronousReturnValueForOnJsAlert(pigeon_instance: io.flutter.plugins.webviewflutter.WebChromeClientProxyApi.WebChromeClientImpl, value: Boolean)
 
   /**
    * Sets the required synchronous return value for the Java method,
    * `WebChromeClient.onJsConfirm(...)`.
    *
-   * The Java method, `WebChromeClient.onJsConfirm(...)`, requires a boolean to be returned and this
-   * method sets the returned value for all calls to the Java method.
+   * The Java method, `WebChromeClient.onJsConfirm(...)`, requires a boolean to
+   * be returned and this method sets the returned value for all calls to the
+   * Java method.
    *
-   * Setting this to true indicates that the client is handling all console messages.
+   * Setting this to true indicates that the client is handling all console
+   * messages.
    *
    * Requires `onJsConfirm` to be nonnull.
    *
    * Defaults to false.
    */
-  abstract fun setSynchronousReturnValueForOnJsConfirm(
-      pigeon_instance:
-          io.flutter.plugins.webviewflutter.WebChromeClientProxyApi.WebChromeClientImpl,
-      value: Boolean
-  )
+  abstract fun setSynchronousReturnValueForOnJsConfirm(pigeon_instance: io.flutter.plugins.webviewflutter.WebChromeClientProxyApi.WebChromeClientImpl, value: Boolean)
 
   /**
    * Sets the required synchronous return value for the Java method,
    * `WebChromeClient.onJsPrompt(...)`.
    *
-   * The Java method, `WebChromeClient.onJsPrompt(...)`, requires a boolean to be returned and this
-   * method sets the returned value for all calls to the Java method.
+   * The Java method, `WebChromeClient.onJsPrompt(...)`, requires a boolean to
+   * be returned and this method sets the returned value for all calls to the
+   * Java method.
    *
-   * Setting this to true indicates that the client is handling all console messages.
+   * Setting this to true indicates that the client is handling all console
+   * messages.
    *
    * Requires `onJsPrompt` to be nonnull.
    *
    * Defaults to false.
    */
-  abstract fun setSynchronousReturnValueForOnJsPrompt(
-      pigeon_instance:
-          io.flutter.plugins.webviewflutter.WebChromeClientProxyApi.WebChromeClientImpl,
-      value: Boolean
-  )
+  abstract fun setSynchronousReturnValueForOnJsPrompt(pigeon_instance: io.flutter.plugins.webviewflutter.WebChromeClientProxyApi.WebChromeClientImpl, value: Boolean)
 
   companion object {
     @Suppress("LocalVariableName")
     fun setUpMessageHandlers(binaryMessenger: BinaryMessenger, api: PigeonApiWebChromeClient?) {
       val codec = api?.pigeonRegistrar?.codec ?: AndroidWebkitLibraryPigeonCodec()
       run {
-        val channel =
-            BasicMessageChannel<Any?>(
-                binaryMessenger,
-                "dev.flutter.pigeon.webview_flutter_android.WebChromeClient.pigeon_defaultConstructor",
-                codec)
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.WebChromeClient.pigeon_defaultConstructor", codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val pigeon_identifierArg = args[0] as Long
-            val wrapped: List<Any?> =
-                try {
-                  api.pigeonRegistrar.instanceManager.addDartCreatedInstance(
-                      api.pigeon_defaultConstructor(), pigeon_identifierArg)
-                  listOf(null)
-                } catch (exception: Throwable) {
-                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-                }
+            val wrapped: List<Any?> = try {
+              api.pigeonRegistrar.instanceManager.addDartCreatedInstance(api.pigeon_defaultConstructor(), pigeon_identifierArg)
+              listOf(null)
+            } catch (exception: Throwable) {
+              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+            }
             reply.reply(wrapped)
           }
         } else {
@@ -4244,25 +3641,18 @@ abstract class PigeonApiWebChromeClient(
         }
       }
       run {
-        val channel =
-            BasicMessageChannel<Any?>(
-                binaryMessenger,
-                "dev.flutter.pigeon.webview_flutter_android.WebChromeClient.setSynchronousReturnValueForOnShowFileChooser",
-                codec)
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.WebChromeClient.setSynchronousReturnValueForOnShowFileChooser", codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
-            val pigeon_instanceArg =
-                args[0]
-                    as io.flutter.plugins.webviewflutter.WebChromeClientProxyApi.WebChromeClientImpl
+            val pigeon_instanceArg = args[0] as io.flutter.plugins.webviewflutter.WebChromeClientProxyApi.WebChromeClientImpl
             val valueArg = args[1] as Boolean
-            val wrapped: List<Any?> =
-                try {
-                  api.setSynchronousReturnValueForOnShowFileChooser(pigeon_instanceArg, valueArg)
-                  listOf(null)
-                } catch (exception: Throwable) {
-                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-                }
+            val wrapped: List<Any?> = try {
+              api.setSynchronousReturnValueForOnShowFileChooser(pigeon_instanceArg, valueArg)
+              listOf(null)
+            } catch (exception: Throwable) {
+              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+            }
             reply.reply(wrapped)
           }
         } else {
@@ -4270,25 +3660,18 @@ abstract class PigeonApiWebChromeClient(
         }
       }
       run {
-        val channel =
-            BasicMessageChannel<Any?>(
-                binaryMessenger,
-                "dev.flutter.pigeon.webview_flutter_android.WebChromeClient.setSynchronousReturnValueForOnConsoleMessage",
-                codec)
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.WebChromeClient.setSynchronousReturnValueForOnConsoleMessage", codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
-            val pigeon_instanceArg =
-                args[0]
-                    as io.flutter.plugins.webviewflutter.WebChromeClientProxyApi.WebChromeClientImpl
+            val pigeon_instanceArg = args[0] as io.flutter.plugins.webviewflutter.WebChromeClientProxyApi.WebChromeClientImpl
             val valueArg = args[1] as Boolean
-            val wrapped: List<Any?> =
-                try {
-                  api.setSynchronousReturnValueForOnConsoleMessage(pigeon_instanceArg, valueArg)
-                  listOf(null)
-                } catch (exception: Throwable) {
-                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-                }
+            val wrapped: List<Any?> = try {
+              api.setSynchronousReturnValueForOnConsoleMessage(pigeon_instanceArg, valueArg)
+              listOf(null)
+            } catch (exception: Throwable) {
+              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+            }
             reply.reply(wrapped)
           }
         } else {
@@ -4296,25 +3679,18 @@ abstract class PigeonApiWebChromeClient(
         }
       }
       run {
-        val channel =
-            BasicMessageChannel<Any?>(
-                binaryMessenger,
-                "dev.flutter.pigeon.webview_flutter_android.WebChromeClient.setSynchronousReturnValueForOnJsAlert",
-                codec)
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.WebChromeClient.setSynchronousReturnValueForOnJsAlert", codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
-            val pigeon_instanceArg =
-                args[0]
-                    as io.flutter.plugins.webviewflutter.WebChromeClientProxyApi.WebChromeClientImpl
+            val pigeon_instanceArg = args[0] as io.flutter.plugins.webviewflutter.WebChromeClientProxyApi.WebChromeClientImpl
             val valueArg = args[1] as Boolean
-            val wrapped: List<Any?> =
-                try {
-                  api.setSynchronousReturnValueForOnJsAlert(pigeon_instanceArg, valueArg)
-                  listOf(null)
-                } catch (exception: Throwable) {
-                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-                }
+            val wrapped: List<Any?> = try {
+              api.setSynchronousReturnValueForOnJsAlert(pigeon_instanceArg, valueArg)
+              listOf(null)
+            } catch (exception: Throwable) {
+              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+            }
             reply.reply(wrapped)
           }
         } else {
@@ -4322,25 +3698,18 @@ abstract class PigeonApiWebChromeClient(
         }
       }
       run {
-        val channel =
-            BasicMessageChannel<Any?>(
-                binaryMessenger,
-                "dev.flutter.pigeon.webview_flutter_android.WebChromeClient.setSynchronousReturnValueForOnJsConfirm",
-                codec)
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.WebChromeClient.setSynchronousReturnValueForOnJsConfirm", codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
-            val pigeon_instanceArg =
-                args[0]
-                    as io.flutter.plugins.webviewflutter.WebChromeClientProxyApi.WebChromeClientImpl
+            val pigeon_instanceArg = args[0] as io.flutter.plugins.webviewflutter.WebChromeClientProxyApi.WebChromeClientImpl
             val valueArg = args[1] as Boolean
-            val wrapped: List<Any?> =
-                try {
-                  api.setSynchronousReturnValueForOnJsConfirm(pigeon_instanceArg, valueArg)
-                  listOf(null)
-                } catch (exception: Throwable) {
-                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-                }
+            val wrapped: List<Any?> = try {
+              api.setSynchronousReturnValueForOnJsConfirm(pigeon_instanceArg, valueArg)
+              listOf(null)
+            } catch (exception: Throwable) {
+              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+            }
             reply.reply(wrapped)
           }
         } else {
@@ -4348,25 +3717,18 @@ abstract class PigeonApiWebChromeClient(
         }
       }
       run {
-        val channel =
-            BasicMessageChannel<Any?>(
-                binaryMessenger,
-                "dev.flutter.pigeon.webview_flutter_android.WebChromeClient.setSynchronousReturnValueForOnJsPrompt",
-                codec)
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.WebChromeClient.setSynchronousReturnValueForOnJsPrompt", codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
-            val pigeon_instanceArg =
-                args[0]
-                    as io.flutter.plugins.webviewflutter.WebChromeClientProxyApi.WebChromeClientImpl
+            val pigeon_instanceArg = args[0] as io.flutter.plugins.webviewflutter.WebChromeClientProxyApi.WebChromeClientImpl
             val valueArg = args[1] as Boolean
-            val wrapped: List<Any?> =
-                try {
-                  api.setSynchronousReturnValueForOnJsPrompt(pigeon_instanceArg, valueArg)
-                  listOf(null)
-                } catch (exception: Throwable) {
-                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-                }
+            val wrapped: List<Any?> = try {
+              api.setSynchronousReturnValueForOnJsPrompt(pigeon_instanceArg, valueArg)
+              listOf(null)
+            } catch (exception: Throwable) {
+              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+            }
             reply.reply(wrapped)
           }
         } else {
@@ -4378,47 +3740,33 @@ abstract class PigeonApiWebChromeClient(
 
   @Suppress("LocalVariableName", "FunctionName")
   /** Creates a Dart instance of WebChromeClient and attaches it to [pigeon_instanceArg]. */
-  fun pigeon_newInstance(
-      pigeon_instanceArg:
-          io.flutter.plugins.webviewflutter.WebChromeClientProxyApi.WebChromeClientImpl,
-      callback: (Result<Unit>) -> Unit
-  ) {
+  fun pigeon_newInstance(pigeon_instanceArg: io.flutter.plugins.webviewflutter.WebChromeClientProxyApi.WebChromeClientImpl, callback: (Result<Unit>) -> Unit)
+{
     if (pigeonRegistrar.ignoreCallsToDart) {
       callback(
           Result.failure(
               AndroidWebKitError("ignore-calls-error", "Calls to Dart are being ignored.", "")))
-    } else if (pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
+    }     else if (pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
       callback(Result.success(Unit))
-    } else {
+    }     else {
       callback(
           Result.failure(
-              AndroidWebKitError(
-                  "new-instance-error",
-                  "Attempting to create a new Dart instance of WebChromeClient, but the class has a nonnull callback method.",
-                  "")))
+              AndroidWebKitError("new-instance-error", "Attempting to create a new Dart instance of WebChromeClient, but the class has a nonnull callback method.", "")))
     }
   }
 
   /** Tell the host application the current progress of loading a page. */
-  fun onProgressChanged(
-      pigeon_instanceArg:
-          io.flutter.plugins.webviewflutter.WebChromeClientProxyApi.WebChromeClientImpl,
-      webViewArg: android.webkit.WebView,
-      progressArg: Long,
-      callback: (Result<Unit>) -> Unit
-  ) {
+  fun onProgressChanged(pigeon_instanceArg: io.flutter.plugins.webviewflutter.WebChromeClientProxyApi.WebChromeClientImpl, webViewArg: android.webkit.WebView, progressArg: Long, callback: (Result<Unit>) -> Unit)
+{
     if (pigeonRegistrar.ignoreCallsToDart) {
       callback(
           Result.failure(
               AndroidWebKitError("ignore-calls-error", "Calls to Dart are being ignored.", "")))
       return
-    } else if (!pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
+    }     else if (!pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
       callback(
           Result.failure(
-              AndroidWebKitError(
-                  "missing-instance-error",
-                  "Callback to `WebChromeClient.onProgressChanged` failed because native instance was not in the instance manager.",
-                  "")))
+              AndroidWebKitError("missing-instance-error", "Callback to `WebChromeClient.onProgressChanged` failed because native instance was not in the instance manager.", "")))
       return
     }
     val binaryMessenger = pigeonRegistrar.binaryMessenger
@@ -4428,38 +3776,28 @@ abstract class PigeonApiWebChromeClient(
     channel.send(listOf(pigeon_instanceArg, webViewArg, progressArg)) {
       if (it is List<*>) {
         if (it.size > 1) {
-          callback(
-              Result.failure(
-                  AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
+          callback(Result.failure(AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
         } else {
           callback(Result.success(Unit))
         }
       } else {
         callback(Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
-      }
+      } 
     }
   }
 
   /** Tell the client to show a file chooser. */
-  fun onShowFileChooser(
-      pigeon_instanceArg:
-          io.flutter.plugins.webviewflutter.WebChromeClientProxyApi.WebChromeClientImpl,
-      webViewArg: android.webkit.WebView,
-      paramsArg: android.webkit.WebChromeClient.FileChooserParams,
-      callback: (Result<List<String>>) -> Unit
-  ) {
+  fun onShowFileChooser(pigeon_instanceArg: io.flutter.plugins.webviewflutter.WebChromeClientProxyApi.WebChromeClientImpl, webViewArg: android.webkit.WebView, paramsArg: android.webkit.WebChromeClient.FileChooserParams, callback: (Result<List<String>>) -> Unit)
+{
     if (pigeonRegistrar.ignoreCallsToDart) {
       callback(
           Result.failure(
               AndroidWebKitError("ignore-calls-error", "Calls to Dart are being ignored.", "")))
       return
-    } else if (!pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
+    }     else if (!pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
       callback(
           Result.failure(
-              AndroidWebKitError(
-                  "missing-instance-error",
-                  "Callback to `WebChromeClient.onShowFileChooser` failed because native instance was not in the instance manager.",
-                  "")))
+              AndroidWebKitError("missing-instance-error", "Callback to `WebChromeClient.onShowFileChooser` failed because native instance was not in the instance manager.", "")))
       return
     }
     val binaryMessenger = pigeonRegistrar.binaryMessenger
@@ -4469,90 +3807,66 @@ abstract class PigeonApiWebChromeClient(
     channel.send(listOf(pigeon_instanceArg, webViewArg, paramsArg)) {
       if (it is List<*>) {
         if (it.size > 1) {
-          callback(
-              Result.failure(
-                  AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
+          callback(Result.failure(AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
         } else if (it[0] == null) {
-          callback(
-              Result.failure(
-                  AndroidWebKitError(
-                      "null-error",
-                      "Flutter api returned null value for non-null return value.",
-                      "")))
+          callback(Result.failure(AndroidWebKitError("null-error", "Flutter api returned null value for non-null return value.", "")))
         } else {
           val output = it[0] as List<String>
           callback(Result.success(output))
         }
       } else {
         callback(Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
-      }
+      } 
     }
   }
 
   /**
-   * Notify the host application that web content is requesting permission to access the specified
-   * resources and the permission currently isn't granted or denied.
+   * Notify the host application that web content is requesting permission to
+   * access the specified resources and the permission currently isn't granted
+   * or denied.
    */
-  fun onPermissionRequest(
-      pigeon_instanceArg:
-          io.flutter.plugins.webviewflutter.WebChromeClientProxyApi.WebChromeClientImpl,
-      requestArg: android.webkit.PermissionRequest,
-      callback: (Result<Unit>) -> Unit
-  ) {
+  fun onPermissionRequest(pigeon_instanceArg: io.flutter.plugins.webviewflutter.WebChromeClientProxyApi.WebChromeClientImpl, requestArg: android.webkit.PermissionRequest, callback: (Result<Unit>) -> Unit)
+{
     if (pigeonRegistrar.ignoreCallsToDart) {
       callback(
           Result.failure(
               AndroidWebKitError("ignore-calls-error", "Calls to Dart are being ignored.", "")))
       return
-    } else if (!pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
+    }     else if (!pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
       callback(
           Result.failure(
-              AndroidWebKitError(
-                  "missing-instance-error",
-                  "Callback to `WebChromeClient.onPermissionRequest` failed because native instance was not in the instance manager.",
-                  "")))
+              AndroidWebKitError("missing-instance-error", "Callback to `WebChromeClient.onPermissionRequest` failed because native instance was not in the instance manager.", "")))
       return
     }
     val binaryMessenger = pigeonRegistrar.binaryMessenger
     val codec = pigeonRegistrar.codec
-    val channelName =
-        "dev.flutter.pigeon.webview_flutter_android.WebChromeClient.onPermissionRequest"
+    val channelName = "dev.flutter.pigeon.webview_flutter_android.WebChromeClient.onPermissionRequest"
     val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
     channel.send(listOf(pigeon_instanceArg, requestArg)) {
       if (it is List<*>) {
         if (it.size > 1) {
-          callback(
-              Result.failure(
-                  AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
+          callback(Result.failure(AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
         } else {
           callback(Result.success(Unit))
         }
       } else {
         callback(Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
-      }
+      } 
     }
   }
 
   /** Callback to Dart function `WebChromeClient.onShowCustomView`. */
-  fun onShowCustomView(
-      pigeon_instanceArg:
-          io.flutter.plugins.webviewflutter.WebChromeClientProxyApi.WebChromeClientImpl,
-      viewArg: android.view.View,
-      callbackArg: android.webkit.WebChromeClient.CustomViewCallback,
-      callback: (Result<Unit>) -> Unit
-  ) {
+  fun onShowCustomView(pigeon_instanceArg: io.flutter.plugins.webviewflutter.WebChromeClientProxyApi.WebChromeClientImpl, viewArg: android.view.View, callbackArg: android.webkit.WebChromeClient.CustomViewCallback, callback: (Result<Unit>) -> Unit)
+{
     if (pigeonRegistrar.ignoreCallsToDart) {
       callback(
           Result.failure(
               AndroidWebKitError("ignore-calls-error", "Calls to Dart are being ignored.", "")))
       return
-    } else if (!pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
+    }     else if (!pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
       callback(
           Result.failure(
-              AndroidWebKitError(
-                  "missing-instance-error",
-                  "Callback to `WebChromeClient.onShowCustomView` failed because native instance was not in the instance manager.",
-                  "")))
+              AndroidWebKitError("missing-instance-error", "Callback to `WebChromeClient.onShowCustomView` failed because native instance was not in the instance manager.", "")))
       return
     }
     val binaryMessenger = pigeonRegistrar.binaryMessenger
@@ -4562,36 +3876,31 @@ abstract class PigeonApiWebChromeClient(
     channel.send(listOf(pigeon_instanceArg, viewArg, callbackArg)) {
       if (it is List<*>) {
         if (it.size > 1) {
-          callback(
-              Result.failure(
-                  AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
+          callback(Result.failure(AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
         } else {
           callback(Result.success(Unit))
         }
       } else {
         callback(Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
-      }
+      } 
     }
   }
 
-  /** Notify the host application that the current page has entered full screen mode. */
-  fun onHideCustomView(
-      pigeon_instanceArg:
-          io.flutter.plugins.webviewflutter.WebChromeClientProxyApi.WebChromeClientImpl,
-      callback: (Result<Unit>) -> Unit
-  ) {
+  /**
+   * Notify the host application that the current page has entered full screen
+   * mode.
+   */
+  fun onHideCustomView(pigeon_instanceArg: io.flutter.plugins.webviewflutter.WebChromeClientProxyApi.WebChromeClientImpl, callback: (Result<Unit>) -> Unit)
+{
     if (pigeonRegistrar.ignoreCallsToDart) {
       callback(
           Result.failure(
               AndroidWebKitError("ignore-calls-error", "Calls to Dart are being ignored.", "")))
       return
-    } else if (!pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
+    }     else if (!pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
       callback(
           Result.failure(
-              AndroidWebKitError(
-                  "missing-instance-error",
-                  "Callback to `WebChromeClient.onHideCustomView` failed because native instance was not in the instance manager.",
-                  "")))
+              AndroidWebKitError("missing-instance-error", "Callback to `WebChromeClient.onHideCustomView` failed because native instance was not in the instance manager.", "")))
       return
     }
     val binaryMessenger = pigeonRegistrar.binaryMessenger
@@ -4601,125 +3910,98 @@ abstract class PigeonApiWebChromeClient(
     channel.send(listOf(pigeon_instanceArg)) {
       if (it is List<*>) {
         if (it.size > 1) {
-          callback(
-              Result.failure(
-                  AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
+          callback(Result.failure(AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
         } else {
           callback(Result.success(Unit))
         }
       } else {
         callback(Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
-      }
+      } 
     }
   }
 
   /**
-   * Notify the host application that web content from the specified origin is attempting to use the
-   * Geolocation API, but no permission state is currently set for that origin.
+   * Notify the host application that web content from the specified origin is
+   * attempting to use the Geolocation API, but no permission state is
+   * currently set for that origin.
    */
-  fun onGeolocationPermissionsShowPrompt(
-      pigeon_instanceArg:
-          io.flutter.plugins.webviewflutter.WebChromeClientProxyApi.WebChromeClientImpl,
-      originArg: String,
-      callbackArg: android.webkit.GeolocationPermissions.Callback,
-      callback: (Result<Unit>) -> Unit
-  ) {
+  fun onGeolocationPermissionsShowPrompt(pigeon_instanceArg: io.flutter.plugins.webviewflutter.WebChromeClientProxyApi.WebChromeClientImpl, originArg: String, callbackArg: android.webkit.GeolocationPermissions.Callback, callback: (Result<Unit>) -> Unit)
+{
     if (pigeonRegistrar.ignoreCallsToDart) {
       callback(
           Result.failure(
               AndroidWebKitError("ignore-calls-error", "Calls to Dart are being ignored.", "")))
       return
-    } else if (!pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
+    }     else if (!pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
       callback(
           Result.failure(
-              AndroidWebKitError(
-                  "missing-instance-error",
-                  "Callback to `WebChromeClient.onGeolocationPermissionsShowPrompt` failed because native instance was not in the instance manager.",
-                  "")))
+              AndroidWebKitError("missing-instance-error", "Callback to `WebChromeClient.onGeolocationPermissionsShowPrompt` failed because native instance was not in the instance manager.", "")))
       return
     }
     val binaryMessenger = pigeonRegistrar.binaryMessenger
     val codec = pigeonRegistrar.codec
-    val channelName =
-        "dev.flutter.pigeon.webview_flutter_android.WebChromeClient.onGeolocationPermissionsShowPrompt"
+    val channelName = "dev.flutter.pigeon.webview_flutter_android.WebChromeClient.onGeolocationPermissionsShowPrompt"
     val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
     channel.send(listOf(pigeon_instanceArg, originArg, callbackArg)) {
       if (it is List<*>) {
         if (it.size > 1) {
-          callback(
-              Result.failure(
-                  AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
+          callback(Result.failure(AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
         } else {
           callback(Result.success(Unit))
         }
       } else {
         callback(Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
-      }
+      } 
     }
   }
 
   /**
-   * Notify the host application that a request for Geolocation permissions, made with a previous
-   * call to `onGeolocationPermissionsShowPrompt` has been canceled.
+   * Notify the host application that a request for Geolocation permissions,
+   * made with a previous call to `onGeolocationPermissionsShowPrompt` has been
+   * canceled.
    */
-  fun onGeolocationPermissionsHidePrompt(
-      pigeon_instanceArg:
-          io.flutter.plugins.webviewflutter.WebChromeClientProxyApi.WebChromeClientImpl,
-      callback: (Result<Unit>) -> Unit
-  ) {
+  fun onGeolocationPermissionsHidePrompt(pigeon_instanceArg: io.flutter.plugins.webviewflutter.WebChromeClientProxyApi.WebChromeClientImpl, callback: (Result<Unit>) -> Unit)
+{
     if (pigeonRegistrar.ignoreCallsToDart) {
       callback(
           Result.failure(
               AndroidWebKitError("ignore-calls-error", "Calls to Dart are being ignored.", "")))
       return
-    } else if (!pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
+    }     else if (!pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
       callback(
           Result.failure(
-              AndroidWebKitError(
-                  "missing-instance-error",
-                  "Callback to `WebChromeClient.onGeolocationPermissionsHidePrompt` failed because native instance was not in the instance manager.",
-                  "")))
+              AndroidWebKitError("missing-instance-error", "Callback to `WebChromeClient.onGeolocationPermissionsHidePrompt` failed because native instance was not in the instance manager.", "")))
       return
     }
     val binaryMessenger = pigeonRegistrar.binaryMessenger
     val codec = pigeonRegistrar.codec
-    val channelName =
-        "dev.flutter.pigeon.webview_flutter_android.WebChromeClient.onGeolocationPermissionsHidePrompt"
+    val channelName = "dev.flutter.pigeon.webview_flutter_android.WebChromeClient.onGeolocationPermissionsHidePrompt"
     val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
     channel.send(listOf(pigeon_instanceArg)) {
       if (it is List<*>) {
         if (it.size > 1) {
-          callback(
-              Result.failure(
-                  AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
+          callback(Result.failure(AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
         } else {
           callback(Result.success(Unit))
         }
       } else {
         callback(Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
-      }
+      } 
     }
   }
 
   /** Report a JavaScript console message to the host application. */
-  fun onConsoleMessage(
-      pigeon_instanceArg:
-          io.flutter.plugins.webviewflutter.WebChromeClientProxyApi.WebChromeClientImpl,
-      messageArg: android.webkit.ConsoleMessage,
-      callback: (Result<Unit>) -> Unit
-  ) {
+  fun onConsoleMessage(pigeon_instanceArg: io.flutter.plugins.webviewflutter.WebChromeClientProxyApi.WebChromeClientImpl, messageArg: android.webkit.ConsoleMessage, callback: (Result<Unit>) -> Unit)
+{
     if (pigeonRegistrar.ignoreCallsToDart) {
       callback(
           Result.failure(
               AndroidWebKitError("ignore-calls-error", "Calls to Dart are being ignored.", "")))
       return
-    } else if (!pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
+    }     else if (!pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
       callback(
           Result.failure(
-              AndroidWebKitError(
-                  "missing-instance-error",
-                  "Callback to `WebChromeClient.onConsoleMessage` failed because native instance was not in the instance manager.",
-                  "")))
+              AndroidWebKitError("missing-instance-error", "Callback to `WebChromeClient.onConsoleMessage` failed because native instance was not in the instance manager.", "")))
       return
     }
     val binaryMessenger = pigeonRegistrar.binaryMessenger
@@ -4729,41 +4011,31 @@ abstract class PigeonApiWebChromeClient(
     channel.send(listOf(pigeon_instanceArg, messageArg)) {
       if (it is List<*>) {
         if (it.size > 1) {
-          callback(
-              Result.failure(
-                  AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
+          callback(Result.failure(AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
         } else {
           callback(Result.success(Unit))
         }
       } else {
         callback(Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
-      }
+      } 
     }
   }
 
   /**
-   * Notify the host application that the web page wants to display a JavaScript `alert()` dialog.
+   * Notify the host application that the web page wants to display a
+   * JavaScript `alert()` dialog.
    */
-  fun onJsAlert(
-      pigeon_instanceArg:
-          io.flutter.plugins.webviewflutter.WebChromeClientProxyApi.WebChromeClientImpl,
-      webViewArg: android.webkit.WebView,
-      urlArg: String,
-      messageArg: String,
-      callback: (Result<Unit>) -> Unit
-  ) {
+  fun onJsAlert(pigeon_instanceArg: io.flutter.plugins.webviewflutter.WebChromeClientProxyApi.WebChromeClientImpl, webViewArg: android.webkit.WebView, urlArg: String, messageArg: String, callback: (Result<Unit>) -> Unit)
+{
     if (pigeonRegistrar.ignoreCallsToDart) {
       callback(
           Result.failure(
               AndroidWebKitError("ignore-calls-error", "Calls to Dart are being ignored.", "")))
       return
-    } else if (!pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
+    }     else if (!pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
       callback(
           Result.failure(
-              AndroidWebKitError(
-                  "missing-instance-error",
-                  "Callback to `WebChromeClient.onJsAlert` failed because native instance was not in the instance manager.",
-                  "")))
+              AndroidWebKitError("missing-instance-error", "Callback to `WebChromeClient.onJsAlert` failed because native instance was not in the instance manager.", "")))
       return
     }
     val binaryMessenger = pigeonRegistrar.binaryMessenger
@@ -4773,41 +4045,31 @@ abstract class PigeonApiWebChromeClient(
     channel.send(listOf(pigeon_instanceArg, webViewArg, urlArg, messageArg)) {
       if (it is List<*>) {
         if (it.size > 1) {
-          callback(
-              Result.failure(
-                  AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
+          callback(Result.failure(AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
         } else {
           callback(Result.success(Unit))
         }
       } else {
         callback(Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
-      }
+      } 
     }
   }
 
   /**
-   * Notify the host application that the web page wants to display a JavaScript `confirm()` dialog.
+   * Notify the host application that the web page wants to display a
+   * JavaScript `confirm()` dialog.
    */
-  fun onJsConfirm(
-      pigeon_instanceArg:
-          io.flutter.plugins.webviewflutter.WebChromeClientProxyApi.WebChromeClientImpl,
-      webViewArg: android.webkit.WebView,
-      urlArg: String,
-      messageArg: String,
-      callback: (Result<Boolean>) -> Unit
-  ) {
+  fun onJsConfirm(pigeon_instanceArg: io.flutter.plugins.webviewflutter.WebChromeClientProxyApi.WebChromeClientImpl, webViewArg: android.webkit.WebView, urlArg: String, messageArg: String, callback: (Result<Boolean>) -> Unit)
+{
     if (pigeonRegistrar.ignoreCallsToDart) {
       callback(
           Result.failure(
               AndroidWebKitError("ignore-calls-error", "Calls to Dart are being ignored.", "")))
       return
-    } else if (!pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
+    }     else if (!pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
       callback(
           Result.failure(
-              AndroidWebKitError(
-                  "missing-instance-error",
-                  "Callback to `WebChromeClient.onJsConfirm` failed because native instance was not in the instance manager.",
-                  "")))
+              AndroidWebKitError("missing-instance-error", "Callback to `WebChromeClient.onJsConfirm` failed because native instance was not in the instance manager.", "")))
       return
     }
     val binaryMessenger = pigeonRegistrar.binaryMessenger
@@ -4817,50 +4079,34 @@ abstract class PigeonApiWebChromeClient(
     channel.send(listOf(pigeon_instanceArg, webViewArg, urlArg, messageArg)) {
       if (it is List<*>) {
         if (it.size > 1) {
-          callback(
-              Result.failure(
-                  AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
+          callback(Result.failure(AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
         } else if (it[0] == null) {
-          callback(
-              Result.failure(
-                  AndroidWebKitError(
-                      "null-error",
-                      "Flutter api returned null value for non-null return value.",
-                      "")))
+          callback(Result.failure(AndroidWebKitError("null-error", "Flutter api returned null value for non-null return value.", "")))
         } else {
           val output = it[0] as Boolean
           callback(Result.success(output))
         }
       } else {
         callback(Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
-      }
+      } 
     }
   }
 
   /**
-   * Notify the host application that the web page wants to display a JavaScript `prompt()` dialog.
+   * Notify the host application that the web page wants to display a
+   * JavaScript `prompt()` dialog.
    */
-  fun onJsPrompt(
-      pigeon_instanceArg:
-          io.flutter.plugins.webviewflutter.WebChromeClientProxyApi.WebChromeClientImpl,
-      webViewArg: android.webkit.WebView,
-      urlArg: String,
-      messageArg: String,
-      defaultValueArg: String,
-      callback: (Result<String?>) -> Unit
-  ) {
+  fun onJsPrompt(pigeon_instanceArg: io.flutter.plugins.webviewflutter.WebChromeClientProxyApi.WebChromeClientImpl, webViewArg: android.webkit.WebView, urlArg: String, messageArg: String, defaultValueArg: String, callback: (Result<String?>) -> Unit)
+{
     if (pigeonRegistrar.ignoreCallsToDart) {
       callback(
           Result.failure(
               AndroidWebKitError("ignore-calls-error", "Calls to Dart are being ignored.", "")))
       return
-    } else if (!pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
+    }     else if (!pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
       callback(
           Result.failure(
-              AndroidWebKitError(
-                  "missing-instance-error",
-                  "Callback to `WebChromeClient.onJsPrompt` failed because native instance was not in the instance manager.",
-                  "")))
+              AndroidWebKitError("missing-instance-error", "Callback to `WebChromeClient.onJsPrompt` failed because native instance was not in the instance manager.", "")))
       return
     }
     val binaryMessenger = pigeonRegistrar.binaryMessenger
@@ -4870,18 +4116,17 @@ abstract class PigeonApiWebChromeClient(
     channel.send(listOf(pigeon_instanceArg, webViewArg, urlArg, messageArg, defaultValueArg)) {
       if (it is List<*>) {
         if (it.size > 1) {
-          callback(
-              Result.failure(
-                  AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
+          callback(Result.failure(AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
         } else {
           val output = it[0] as String?
           callback(Result.success(output))
         }
       } else {
         callback(Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
-      }
+      } 
     }
   }
+
 }
 /**
  * Provides access to the assets registered as part of the App bundle.
@@ -4889,9 +4134,7 @@ abstract class PigeonApiWebChromeClient(
  * Convenience class for accessing Flutter asset resources.
  */
 @Suppress("UNCHECKED_CAST")
-abstract class PigeonApiFlutterAssetManager(
-    open val pigeonRegistrar: AndroidWebkitLibraryPigeonProxyApiRegistrar
-) {
+abstract class PigeonApiFlutterAssetManager(open val pigeonRegistrar: AndroidWebkitLibraryPigeonProxyApiRegistrar) {
   /** The global instance of the `FlutterAssetManager`. */
   abstract fun instance(): io.flutter.plugins.webviewflutter.FlutterAssetManager
 
@@ -4900,46 +4143,35 @@ abstract class PigeonApiFlutterAssetManager(
    *
    * Throws an IOException in case I/O operations were interrupted.
    */
-  abstract fun list(
-      pigeon_instance: io.flutter.plugins.webviewflutter.FlutterAssetManager,
-      path: String
-  ): List<String>
+  abstract fun list(pigeon_instance: io.flutter.plugins.webviewflutter.FlutterAssetManager, path: String): List<String>
 
   /**
    * Gets the relative file path to the Flutter asset with the given name, including the file's
    * extension, e.g., "myImage.jpg".
    *
-   * The returned file path is relative to the Android app's standard asset's directory. Therefore,
-   * the returned path is appropriate to pass to Android's AssetManager, but the path is not
-   * appropriate to load as an absolute path.
+   * The returned file path is relative to the Android app's standard asset's
+   * directory. Therefore, the returned path is appropriate to pass to
+   * Android's AssetManager, but the path is not appropriate to load as an
+   * absolute path.
    */
-  abstract fun getAssetFilePathByName(
-      pigeon_instance: io.flutter.plugins.webviewflutter.FlutterAssetManager,
-      name: String
-  ): String
+  abstract fun getAssetFilePathByName(pigeon_instance: io.flutter.plugins.webviewflutter.FlutterAssetManager, name: String): String
 
   companion object {
     @Suppress("LocalVariableName")
     fun setUpMessageHandlers(binaryMessenger: BinaryMessenger, api: PigeonApiFlutterAssetManager?) {
       val codec = api?.pigeonRegistrar?.codec ?: AndroidWebkitLibraryPigeonCodec()
       run {
-        val channel =
-            BasicMessageChannel<Any?>(
-                binaryMessenger,
-                "dev.flutter.pigeon.webview_flutter_android.FlutterAssetManager.instance",
-                codec)
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.FlutterAssetManager.instance", codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val pigeon_identifierArg = args[0] as Long
-            val wrapped: List<Any?> =
-                try {
-                  api.pigeonRegistrar.instanceManager.addDartCreatedInstance(
-                      api.instance(), pigeon_identifierArg)
-                  listOf(null)
-                } catch (exception: Throwable) {
-                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-                }
+            val wrapped: List<Any?> = try {
+              api.pigeonRegistrar.instanceManager.addDartCreatedInstance(api.instance(), pigeon_identifierArg)
+              listOf(null)
+            } catch (exception: Throwable) {
+              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+            }
             reply.reply(wrapped)
           }
         } else {
@@ -4947,23 +4179,17 @@ abstract class PigeonApiFlutterAssetManager(
         }
       }
       run {
-        val channel =
-            BasicMessageChannel<Any?>(
-                binaryMessenger,
-                "dev.flutter.pigeon.webview_flutter_android.FlutterAssetManager.list",
-                codec)
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.FlutterAssetManager.list", codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
-            val pigeon_instanceArg =
-                args[0] as io.flutter.plugins.webviewflutter.FlutterAssetManager
+            val pigeon_instanceArg = args[0] as io.flutter.plugins.webviewflutter.FlutterAssetManager
             val pathArg = args[1] as String
-            val wrapped: List<Any?> =
-                try {
-                  listOf(api.list(pigeon_instanceArg, pathArg))
-                } catch (exception: Throwable) {
-                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-                }
+            val wrapped: List<Any?> = try {
+              listOf(api.list(pigeon_instanceArg, pathArg))
+            } catch (exception: Throwable) {
+              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+            }
             reply.reply(wrapped)
           }
         } else {
@@ -4971,23 +4197,17 @@ abstract class PigeonApiFlutterAssetManager(
         }
       }
       run {
-        val channel =
-            BasicMessageChannel<Any?>(
-                binaryMessenger,
-                "dev.flutter.pigeon.webview_flutter_android.FlutterAssetManager.getAssetFilePathByName",
-                codec)
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.FlutterAssetManager.getAssetFilePathByName", codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
-            val pigeon_instanceArg =
-                args[0] as io.flutter.plugins.webviewflutter.FlutterAssetManager
+            val pigeon_instanceArg = args[0] as io.flutter.plugins.webviewflutter.FlutterAssetManager
             val nameArg = args[1] as String
-            val wrapped: List<Any?> =
-                try {
-                  listOf(api.getAssetFilePathByName(pigeon_instanceArg, nameArg))
-                } catch (exception: Throwable) {
-                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-                }
+            val wrapped: List<Any?> = try {
+              listOf(api.getAssetFilePathByName(pigeon_instanceArg, nameArg))
+            } catch (exception: Throwable) {
+              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+            }
             reply.reply(wrapped)
           }
         } else {
@@ -4999,50 +4219,43 @@ abstract class PigeonApiFlutterAssetManager(
 
   @Suppress("LocalVariableName", "FunctionName")
   /** Creates a Dart instance of FlutterAssetManager and attaches it to [pigeon_instanceArg]. */
-  fun pigeon_newInstance(
-      pigeon_instanceArg: io.flutter.plugins.webviewflutter.FlutterAssetManager,
-      callback: (Result<Unit>) -> Unit
-  ) {
+  fun pigeon_newInstance(pigeon_instanceArg: io.flutter.plugins.webviewflutter.FlutterAssetManager, callback: (Result<Unit>) -> Unit)
+{
     if (pigeonRegistrar.ignoreCallsToDart) {
       callback(
           Result.failure(
               AndroidWebKitError("ignore-calls-error", "Calls to Dart are being ignored.", "")))
-    } else if (pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
+    }     else if (pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
       callback(Result.success(Unit))
-    } else {
-      val pigeon_identifierArg =
-          pigeonRegistrar.instanceManager.addHostCreatedInstance(pigeon_instanceArg)
+    }     else {
+      val pigeon_identifierArg = pigeonRegistrar.instanceManager.addHostCreatedInstance(pigeon_instanceArg)
       val binaryMessenger = pigeonRegistrar.binaryMessenger
       val codec = pigeonRegistrar.codec
-      val channelName =
-          "dev.flutter.pigeon.webview_flutter_android.FlutterAssetManager.pigeon_newInstance"
+      val channelName = "dev.flutter.pigeon.webview_flutter_android.FlutterAssetManager.pigeon_newInstance"
       val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
       channel.send(listOf(pigeon_identifierArg)) {
         if (it is List<*>) {
           if (it.size > 1) {
-            callback(
-                Result.failure(
-                    AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
+            callback(Result.failure(AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
           } else {
             callback(Result.success(Unit))
           }
         } else {
-          callback(
-              Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
-        }
+          callback(Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
+        } 
       }
     }
   }
+
 }
 /**
- * This class is used to manage the JavaScript storage APIs provided by the WebView.
+ * This class is used to manage the JavaScript storage APIs provided by the
+ * WebView.
  *
  * See https://developer.android.com/reference/android/webkit/WebStorage.
  */
 @Suppress("UNCHECKED_CAST")
-abstract class PigeonApiWebStorage(
-    open val pigeonRegistrar: AndroidWebkitLibraryPigeonProxyApiRegistrar
-) {
+abstract class PigeonApiWebStorage(open val pigeonRegistrar: AndroidWebkitLibraryPigeonProxyApiRegistrar) {
   abstract fun instance(): android.webkit.WebStorage
 
   /** Clears all storage currently being used by the JavaScript storage APIs. */
@@ -5053,23 +4266,17 @@ abstract class PigeonApiWebStorage(
     fun setUpMessageHandlers(binaryMessenger: BinaryMessenger, api: PigeonApiWebStorage?) {
       val codec = api?.pigeonRegistrar?.codec ?: AndroidWebkitLibraryPigeonCodec()
       run {
-        val channel =
-            BasicMessageChannel<Any?>(
-                binaryMessenger,
-                "dev.flutter.pigeon.webview_flutter_android.WebStorage.instance",
-                codec)
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.WebStorage.instance", codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val pigeon_identifierArg = args[0] as Long
-            val wrapped: List<Any?> =
-                try {
-                  api.pigeonRegistrar.instanceManager.addDartCreatedInstance(
-                      api.instance(), pigeon_identifierArg)
-                  listOf(null)
-                } catch (exception: Throwable) {
-                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-                }
+            val wrapped: List<Any?> = try {
+              api.pigeonRegistrar.instanceManager.addDartCreatedInstance(api.instance(), pigeon_identifierArg)
+              listOf(null)
+            } catch (exception: Throwable) {
+              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+            }
             reply.reply(wrapped)
           }
         } else {
@@ -5077,22 +4284,17 @@ abstract class PigeonApiWebStorage(
         }
       }
       run {
-        val channel =
-            BasicMessageChannel<Any?>(
-                binaryMessenger,
-                "dev.flutter.pigeon.webview_flutter_android.WebStorage.deleteAllData",
-                codec)
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.WebStorage.deleteAllData", codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val pigeon_instanceArg = args[0] as android.webkit.WebStorage
-            val wrapped: List<Any?> =
-                try {
-                  api.deleteAllData(pigeon_instanceArg)
-                  listOf(null)
-                } catch (exception: Throwable) {
-                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-                }
+            val wrapped: List<Any?> = try {
+              api.deleteAllData(pigeon_instanceArg)
+              listOf(null)
+            } catch (exception: Throwable) {
+              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+            }
             reply.reply(wrapped)
           }
         } else {
@@ -5104,19 +4306,16 @@ abstract class PigeonApiWebStorage(
 
   @Suppress("LocalVariableName", "FunctionName")
   /** Creates a Dart instance of WebStorage and attaches it to [pigeon_instanceArg]. */
-  fun pigeon_newInstance(
-      pigeon_instanceArg: android.webkit.WebStorage,
-      callback: (Result<Unit>) -> Unit
-  ) {
+  fun pigeon_newInstance(pigeon_instanceArg: android.webkit.WebStorage, callback: (Result<Unit>) -> Unit)
+{
     if (pigeonRegistrar.ignoreCallsToDart) {
       callback(
           Result.failure(
               AndroidWebKitError("ignore-calls-error", "Calls to Dart are being ignored.", "")))
-    } else if (pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
+    }     else if (pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
       callback(Result.success(Unit))
-    } else {
-      val pigeon_identifierArg =
-          pigeonRegistrar.instanceManager.addHostCreatedInstance(pigeon_instanceArg)
+    }     else {
+      val pigeon_identifierArg = pigeonRegistrar.instanceManager.addHostCreatedInstance(pigeon_instanceArg)
       val binaryMessenger = pigeonRegistrar.binaryMessenger
       val codec = pigeonRegistrar.codec
       val channelName = "dev.flutter.pigeon.webview_flutter_android.WebStorage.pigeon_newInstance"
@@ -5124,19 +4323,17 @@ abstract class PigeonApiWebStorage(
       channel.send(listOf(pigeon_identifierArg)) {
         if (it is List<*>) {
           if (it.size > 1) {
-            callback(
-                Result.failure(
-                    AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
+            callback(Result.failure(AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
           } else {
             callback(Result.success(Unit))
           }
         } else {
-          callback(
-              Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
-        }
+          callback(Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
+        } 
       }
     }
   }
+
 }
 /**
  * Parameters used in the `WebChromeClient.onShowFileChooser` method.
@@ -5144,90 +4341,68 @@ abstract class PigeonApiWebStorage(
  * See https://developer.android.com/reference/android/webkit/WebChromeClient.FileChooserParams.
  */
 @Suppress("UNCHECKED_CAST")
-abstract class PigeonApiFileChooserParams(
-    open val pigeonRegistrar: AndroidWebkitLibraryPigeonProxyApiRegistrar
-) {
+abstract class PigeonApiFileChooserParams(open val pigeonRegistrar: AndroidWebkitLibraryPigeonProxyApiRegistrar) {
   /** Preference for a live media captured value (e.g. Camera, Microphone). */
-  abstract fun isCaptureEnabled(
-      pigeon_instance: android.webkit.WebChromeClient.FileChooserParams
-  ): Boolean
+  abstract fun isCaptureEnabled(pigeon_instance: android.webkit.WebChromeClient.FileChooserParams): Boolean
 
   /** An array of acceptable MIME types. */
-  abstract fun acceptTypes(
-      pigeon_instance: android.webkit.WebChromeClient.FileChooserParams
-  ): List<String>
+  abstract fun acceptTypes(pigeon_instance: android.webkit.WebChromeClient.FileChooserParams): List<String>
 
   /** File chooser mode. */
-  abstract fun mode(
-      pigeon_instance: android.webkit.WebChromeClient.FileChooserParams
-  ): FileChooserMode
+  abstract fun mode(pigeon_instance: android.webkit.WebChromeClient.FileChooserParams): FileChooserMode
 
   /** File name of a default selection if specified, or null. */
-  abstract fun filenameHint(
-      pigeon_instance: android.webkit.WebChromeClient.FileChooserParams
-  ): String?
+  abstract fun filenameHint(pigeon_instance: android.webkit.WebChromeClient.FileChooserParams): String?
 
   @Suppress("LocalVariableName", "FunctionName")
   /** Creates a Dart instance of FileChooserParams and attaches it to [pigeon_instanceArg]. */
-  fun pigeon_newInstance(
-      pigeon_instanceArg: android.webkit.WebChromeClient.FileChooserParams,
-      callback: (Result<Unit>) -> Unit
-  ) {
+  fun pigeon_newInstance(pigeon_instanceArg: android.webkit.WebChromeClient.FileChooserParams, callback: (Result<Unit>) -> Unit)
+{
     if (pigeonRegistrar.ignoreCallsToDart) {
       callback(
           Result.failure(
               AndroidWebKitError("ignore-calls-error", "Calls to Dart are being ignored.", "")))
-    } else if (pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
+    }     else if (pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
       callback(Result.success(Unit))
-    } else {
-      val pigeon_identifierArg =
-          pigeonRegistrar.instanceManager.addHostCreatedInstance(pigeon_instanceArg)
+    }     else {
+      val pigeon_identifierArg = pigeonRegistrar.instanceManager.addHostCreatedInstance(pigeon_instanceArg)
       val isCaptureEnabledArg = isCaptureEnabled(pigeon_instanceArg)
       val acceptTypesArg = acceptTypes(pigeon_instanceArg)
       val modeArg = mode(pigeon_instanceArg)
       val filenameHintArg = filenameHint(pigeon_instanceArg)
       val binaryMessenger = pigeonRegistrar.binaryMessenger
       val codec = pigeonRegistrar.codec
-      val channelName =
-          "dev.flutter.pigeon.webview_flutter_android.FileChooserParams.pigeon_newInstance"
+      val channelName = "dev.flutter.pigeon.webview_flutter_android.FileChooserParams.pigeon_newInstance"
       val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
-      channel.send(
-          listOf(
-              pigeon_identifierArg,
-              isCaptureEnabledArg,
-              acceptTypesArg,
-              modeArg,
-              filenameHintArg)) {
-            if (it is List<*>) {
-              if (it.size > 1) {
-                callback(
-                    Result.failure(
-                        AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
-              } else {
-                callback(Result.success(Unit))
-              }
-            } else {
-              callback(
-                  Result.failure(
-                      AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
-            }
+      channel.send(listOf(pigeon_identifierArg, isCaptureEnabledArg, acceptTypesArg, modeArg, filenameHintArg)) {
+        if (it is List<*>) {
+          if (it.size > 1) {
+            callback(Result.failure(AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
+          } else {
+            callback(Result.success(Unit))
           }
+        } else {
+          callback(Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
+        } 
+      }
     }
   }
+
 }
 /**
- * This class defines a permission request and is used when web content requests access to protected
- * resources.
+ * This class defines a permission request and is used when web content
+ * requests access to protected resources.
  *
  * See https://developer.android.com/reference/android/webkit/PermissionRequest.
  */
 @Suppress("UNCHECKED_CAST")
-abstract class PigeonApiPermissionRequest(
-    open val pigeonRegistrar: AndroidWebkitLibraryPigeonProxyApiRegistrar
-) {
+abstract class PigeonApiPermissionRequest(open val pigeonRegistrar: AndroidWebkitLibraryPigeonProxyApiRegistrar) {
   abstract fun resources(pigeon_instance: android.webkit.PermissionRequest): List<String>
 
-  /** Call this method to grant origin the permission to access the given resources. */
+  /**
+   * Call this method to grant origin the permission to access the given
+   * resources.
+   */
   abstract fun grant(pigeon_instance: android.webkit.PermissionRequest, resources: List<String>)
 
   /** Call this method to deny the request. */
@@ -5238,23 +4413,18 @@ abstract class PigeonApiPermissionRequest(
     fun setUpMessageHandlers(binaryMessenger: BinaryMessenger, api: PigeonApiPermissionRequest?) {
       val codec = api?.pigeonRegistrar?.codec ?: AndroidWebkitLibraryPigeonCodec()
       run {
-        val channel =
-            BasicMessageChannel<Any?>(
-                binaryMessenger,
-                "dev.flutter.pigeon.webview_flutter_android.PermissionRequest.grant",
-                codec)
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.PermissionRequest.grant", codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val pigeon_instanceArg = args[0] as android.webkit.PermissionRequest
             val resourcesArg = args[1] as List<String>
-            val wrapped: List<Any?> =
-                try {
-                  api.grant(pigeon_instanceArg, resourcesArg)
-                  listOf(null)
-                } catch (exception: Throwable) {
-                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-                }
+            val wrapped: List<Any?> = try {
+              api.grant(pigeon_instanceArg, resourcesArg)
+              listOf(null)
+            } catch (exception: Throwable) {
+              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+            }
             reply.reply(wrapped)
           }
         } else {
@@ -5262,22 +4432,17 @@ abstract class PigeonApiPermissionRequest(
         }
       }
       run {
-        val channel =
-            BasicMessageChannel<Any?>(
-                binaryMessenger,
-                "dev.flutter.pigeon.webview_flutter_android.PermissionRequest.deny",
-                codec)
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.PermissionRequest.deny", codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val pigeon_instanceArg = args[0] as android.webkit.PermissionRequest
-            val wrapped: List<Any?> =
-                try {
-                  api.deny(pigeon_instanceArg)
-                  listOf(null)
-                } catch (exception: Throwable) {
-                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-                }
+            val wrapped: List<Any?> = try {
+              api.deny(pigeon_instanceArg)
+              listOf(null)
+            } catch (exception: Throwable) {
+              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+            }
             reply.reply(wrapped)
           }
         } else {
@@ -5289,78 +4454,63 @@ abstract class PigeonApiPermissionRequest(
 
   @Suppress("LocalVariableName", "FunctionName")
   /** Creates a Dart instance of PermissionRequest and attaches it to [pigeon_instanceArg]. */
-  fun pigeon_newInstance(
-      pigeon_instanceArg: android.webkit.PermissionRequest,
-      callback: (Result<Unit>) -> Unit
-  ) {
+  fun pigeon_newInstance(pigeon_instanceArg: android.webkit.PermissionRequest, callback: (Result<Unit>) -> Unit)
+{
     if (pigeonRegistrar.ignoreCallsToDart) {
       callback(
           Result.failure(
               AndroidWebKitError("ignore-calls-error", "Calls to Dart are being ignored.", "")))
-    } else if (pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
+    }     else if (pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
       callback(Result.success(Unit))
-    } else {
-      val pigeon_identifierArg =
-          pigeonRegistrar.instanceManager.addHostCreatedInstance(pigeon_instanceArg)
+    }     else {
+      val pigeon_identifierArg = pigeonRegistrar.instanceManager.addHostCreatedInstance(pigeon_instanceArg)
       val resourcesArg = resources(pigeon_instanceArg)
       val binaryMessenger = pigeonRegistrar.binaryMessenger
       val codec = pigeonRegistrar.codec
-      val channelName =
-          "dev.flutter.pigeon.webview_flutter_android.PermissionRequest.pigeon_newInstance"
+      val channelName = "dev.flutter.pigeon.webview_flutter_android.PermissionRequest.pigeon_newInstance"
       val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
       channel.send(listOf(pigeon_identifierArg, resourcesArg)) {
         if (it is List<*>) {
           if (it.size > 1) {
-            callback(
-                Result.failure(
-                    AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
+            callback(Result.failure(AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
           } else {
             callback(Result.success(Unit))
           }
         } else {
-          callback(
-              Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
-        }
+          callback(Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
+        } 
       }
     }
   }
+
 }
 /**
- * A callback interface used by the host application to notify the current page that its custom view
- * has been dismissed.
+ * A callback interface used by the host application to notify the current page
+ * that its custom view has been dismissed.
  *
  * See https://developer.android.com/reference/android/webkit/WebChromeClient.CustomViewCallback.
  */
 @Suppress("UNCHECKED_CAST")
-abstract class PigeonApiCustomViewCallback(
-    open val pigeonRegistrar: AndroidWebkitLibraryPigeonProxyApiRegistrar
-) {
+abstract class PigeonApiCustomViewCallback(open val pigeonRegistrar: AndroidWebkitLibraryPigeonProxyApiRegistrar) {
   /** Invoked when the host application dismisses the custom view. */
-  abstract fun onCustomViewHidden(
-      pigeon_instance: android.webkit.WebChromeClient.CustomViewCallback
-  )
+  abstract fun onCustomViewHidden(pigeon_instance: android.webkit.WebChromeClient.CustomViewCallback)
 
   companion object {
     @Suppress("LocalVariableName")
     fun setUpMessageHandlers(binaryMessenger: BinaryMessenger, api: PigeonApiCustomViewCallback?) {
       val codec = api?.pigeonRegistrar?.codec ?: AndroidWebkitLibraryPigeonCodec()
       run {
-        val channel =
-            BasicMessageChannel<Any?>(
-                binaryMessenger,
-                "dev.flutter.pigeon.webview_flutter_android.CustomViewCallback.onCustomViewHidden",
-                codec)
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.CustomViewCallback.onCustomViewHidden", codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val pigeon_instanceArg = args[0] as android.webkit.WebChromeClient.CustomViewCallback
-            val wrapped: List<Any?> =
-                try {
-                  api.onCustomViewHidden(pigeon_instanceArg)
-                  listOf(null)
-                } catch (exception: Throwable) {
-                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-                }
+            val wrapped: List<Any?> = try {
+              api.onCustomViewHidden(pigeon_instanceArg)
+              listOf(null)
+            } catch (exception: Throwable) {
+              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+            }
             reply.reply(wrapped)
           }
         } else {
@@ -5372,50 +4522,43 @@ abstract class PigeonApiCustomViewCallback(
 
   @Suppress("LocalVariableName", "FunctionName")
   /** Creates a Dart instance of CustomViewCallback and attaches it to [pigeon_instanceArg]. */
-  fun pigeon_newInstance(
-      pigeon_instanceArg: android.webkit.WebChromeClient.CustomViewCallback,
-      callback: (Result<Unit>) -> Unit
-  ) {
+  fun pigeon_newInstance(pigeon_instanceArg: android.webkit.WebChromeClient.CustomViewCallback, callback: (Result<Unit>) -> Unit)
+{
     if (pigeonRegistrar.ignoreCallsToDart) {
       callback(
           Result.failure(
               AndroidWebKitError("ignore-calls-error", "Calls to Dart are being ignored.", "")))
-    } else if (pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
+    }     else if (pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
       callback(Result.success(Unit))
-    } else {
-      val pigeon_identifierArg =
-          pigeonRegistrar.instanceManager.addHostCreatedInstance(pigeon_instanceArg)
+    }     else {
+      val pigeon_identifierArg = pigeonRegistrar.instanceManager.addHostCreatedInstance(pigeon_instanceArg)
       val binaryMessenger = pigeonRegistrar.binaryMessenger
       val codec = pigeonRegistrar.codec
-      val channelName =
-          "dev.flutter.pigeon.webview_flutter_android.CustomViewCallback.pigeon_newInstance"
+      val channelName = "dev.flutter.pigeon.webview_flutter_android.CustomViewCallback.pigeon_newInstance"
       val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
       channel.send(listOf(pigeon_identifierArg)) {
         if (it is List<*>) {
           if (it.size > 1) {
-            callback(
-                Result.failure(
-                    AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
+            callback(Result.failure(AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
           } else {
             callback(Result.success(Unit))
           }
         } else {
-          callback(
-              Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
-        }
+          callback(Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
+        } 
       }
     }
   }
+
 }
 /**
- * This class represents the basic building block for user interface components.
+ * This class represents the basic building block for user interface
+ * components.
  *
  * See https://developer.android.com/reference/android/view/View.
  */
 @Suppress("UNCHECKED_CAST")
-abstract class PigeonApiView(
-    open val pigeonRegistrar: AndroidWebkitLibraryPigeonProxyApiRegistrar
-) {
+abstract class PigeonApiView(open val pigeonRegistrar: AndroidWebkitLibraryPigeonProxyApiRegistrar) {
   /** Set the scrolled position of your view. */
   abstract fun scrollTo(pigeon_instance: android.view.View, x: Long, y: Long)
 
@@ -5443,38 +4586,33 @@ abstract class PigeonApiView(
   abstract fun setOverScrollMode(pigeon_instance: android.view.View, mode: OverScrollMode)
 
   /**
-   * Sets the listener to the native method `ViewCompat.setOnApplyWindowInsetsListener` to mark the
-   * passed insets to zero.
+   * Sets the listener to the native method
+   * `ViewCompat.setOnApplyWindowInsetsListener` to mark the passed insets to
+   * zero.
    *
-   * This is a convenience method because `View.OnApplyWindowInsetsListener` requires implementing a
-   * callback that requires a synchronous return value.
+   * This is a convenience method because `View.OnApplyWindowInsetsListener`
+   * requires implementing a callback that requires a synchronous return value.
    */
-  abstract fun setInsetListenerToSetInsetsToZero(
-      pigeon_instance: android.view.View,
-      types: List<WindowInsetsType>
-  )
+  abstract fun setInsetListenerToSetInsetsToZero(pigeon_instance: android.view.View, types: List<WindowInsetsType>)
 
   companion object {
     @Suppress("LocalVariableName")
     fun setUpMessageHandlers(binaryMessenger: BinaryMessenger, api: PigeonApiView?) {
       val codec = api?.pigeonRegistrar?.codec ?: AndroidWebkitLibraryPigeonCodec()
       run {
-        val channel =
-            BasicMessageChannel<Any?>(
-                binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.View.scrollTo", codec)
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.View.scrollTo", codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val pigeon_instanceArg = args[0] as android.view.View
             val xArg = args[1] as Long
             val yArg = args[2] as Long
-            val wrapped: List<Any?> =
-                try {
-                  api.scrollTo(pigeon_instanceArg, xArg, yArg)
-                  listOf(null)
-                } catch (exception: Throwable) {
-                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-                }
+            val wrapped: List<Any?> = try {
+              api.scrollTo(pigeon_instanceArg, xArg, yArg)
+              listOf(null)
+            } catch (exception: Throwable) {
+              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+            }
             reply.reply(wrapped)
           }
         } else {
@@ -5482,22 +4620,19 @@ abstract class PigeonApiView(
         }
       }
       run {
-        val channel =
-            BasicMessageChannel<Any?>(
-                binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.View.scrollBy", codec)
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.View.scrollBy", codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val pigeon_instanceArg = args[0] as android.view.View
             val xArg = args[1] as Long
             val yArg = args[2] as Long
-            val wrapped: List<Any?> =
-                try {
-                  api.scrollBy(pigeon_instanceArg, xArg, yArg)
-                  listOf(null)
-                } catch (exception: Throwable) {
-                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-                }
+            val wrapped: List<Any?> = try {
+              api.scrollBy(pigeon_instanceArg, xArg, yArg)
+              listOf(null)
+            } catch (exception: Throwable) {
+              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+            }
             reply.reply(wrapped)
           }
         } else {
@@ -5505,21 +4640,16 @@ abstract class PigeonApiView(
         }
       }
       run {
-        val channel =
-            BasicMessageChannel<Any?>(
-                binaryMessenger,
-                "dev.flutter.pigeon.webview_flutter_android.View.getScrollPosition",
-                codec)
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.View.getScrollPosition", codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val pigeon_instanceArg = args[0] as android.view.View
-            val wrapped: List<Any?> =
-                try {
-                  listOf(api.getScrollPosition(pigeon_instanceArg))
-                } catch (exception: Throwable) {
-                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-                }
+            val wrapped: List<Any?> = try {
+              listOf(api.getScrollPosition(pigeon_instanceArg))
+            } catch (exception: Throwable) {
+              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+            }
             reply.reply(wrapped)
           }
         } else {
@@ -5527,23 +4657,18 @@ abstract class PigeonApiView(
         }
       }
       run {
-        val channel =
-            BasicMessageChannel<Any?>(
-                binaryMessenger,
-                "dev.flutter.pigeon.webview_flutter_android.View.setVerticalScrollBarEnabled",
-                codec)
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.View.setVerticalScrollBarEnabled", codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val pigeon_instanceArg = args[0] as android.view.View
             val enabledArg = args[1] as Boolean
-            val wrapped: List<Any?> =
-                try {
-                  api.setVerticalScrollBarEnabled(pigeon_instanceArg, enabledArg)
-                  listOf(null)
-                } catch (exception: Throwable) {
-                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-                }
+            val wrapped: List<Any?> = try {
+              api.setVerticalScrollBarEnabled(pigeon_instanceArg, enabledArg)
+              listOf(null)
+            } catch (exception: Throwable) {
+              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+            }
             reply.reply(wrapped)
           }
         } else {
@@ -5551,23 +4676,18 @@ abstract class PigeonApiView(
         }
       }
       run {
-        val channel =
-            BasicMessageChannel<Any?>(
-                binaryMessenger,
-                "dev.flutter.pigeon.webview_flutter_android.View.setHorizontalScrollBarEnabled",
-                codec)
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.View.setHorizontalScrollBarEnabled", codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val pigeon_instanceArg = args[0] as android.view.View
             val enabledArg = args[1] as Boolean
-            val wrapped: List<Any?> =
-                try {
-                  api.setHorizontalScrollBarEnabled(pigeon_instanceArg, enabledArg)
-                  listOf(null)
-                } catch (exception: Throwable) {
-                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-                }
+            val wrapped: List<Any?> = try {
+              api.setHorizontalScrollBarEnabled(pigeon_instanceArg, enabledArg)
+              listOf(null)
+            } catch (exception: Throwable) {
+              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+            }
             reply.reply(wrapped)
           }
         } else {
@@ -5575,23 +4695,18 @@ abstract class PigeonApiView(
         }
       }
       run {
-        val channel =
-            BasicMessageChannel<Any?>(
-                binaryMessenger,
-                "dev.flutter.pigeon.webview_flutter_android.View.setOverScrollMode",
-                codec)
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.View.setOverScrollMode", codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val pigeon_instanceArg = args[0] as android.view.View
             val modeArg = args[1] as OverScrollMode
-            val wrapped: List<Any?> =
-                try {
-                  api.setOverScrollMode(pigeon_instanceArg, modeArg)
-                  listOf(null)
-                } catch (exception: Throwable) {
-                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-                }
+            val wrapped: List<Any?> = try {
+              api.setOverScrollMode(pigeon_instanceArg, modeArg)
+              listOf(null)
+            } catch (exception: Throwable) {
+              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+            }
             reply.reply(wrapped)
           }
         } else {
@@ -5599,23 +4714,18 @@ abstract class PigeonApiView(
         }
       }
       run {
-        val channel =
-            BasicMessageChannel<Any?>(
-                binaryMessenger,
-                "dev.flutter.pigeon.webview_flutter_android.View.setInsetListenerToSetInsetsToZero",
-                codec)
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.View.setInsetListenerToSetInsetsToZero", codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val pigeon_instanceArg = args[0] as android.view.View
             val typesArg = args[1] as List<WindowInsetsType>
-            val wrapped: List<Any?> =
-                try {
-                  api.setInsetListenerToSetInsetsToZero(pigeon_instanceArg, typesArg)
-                  listOf(null)
-                } catch (exception: Throwable) {
-                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-                }
+            val wrapped: List<Any?> = try {
+              api.setInsetListenerToSetInsetsToZero(pigeon_instanceArg, typesArg)
+              listOf(null)
+            } catch (exception: Throwable) {
+              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+            }
             reply.reply(wrapped)
           }
         } else {
@@ -5627,16 +4737,16 @@ abstract class PigeonApiView(
 
   @Suppress("LocalVariableName", "FunctionName")
   /** Creates a Dart instance of View and attaches it to [pigeon_instanceArg]. */
-  fun pigeon_newInstance(pigeon_instanceArg: android.view.View, callback: (Result<Unit>) -> Unit) {
+  fun pigeon_newInstance(pigeon_instanceArg: android.view.View, callback: (Result<Unit>) -> Unit)
+{
     if (pigeonRegistrar.ignoreCallsToDart) {
       callback(
           Result.failure(
               AndroidWebKitError("ignore-calls-error", "Calls to Dart are being ignored.", "")))
-    } else if (pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
+    }     else if (pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
       callback(Result.success(Unit))
-    } else {
-      val pigeon_identifierArg =
-          pigeonRegistrar.instanceManager.addHostCreatedInstance(pigeon_instanceArg)
+    }     else {
+      val pigeon_identifierArg = pigeonRegistrar.instanceManager.addHostCreatedInstance(pigeon_instanceArg)
       val binaryMessenger = pigeonRegistrar.binaryMessenger
       val codec = pigeonRegistrar.codec
       val channelName = "dev.flutter.pigeon.webview_flutter_android.View.pigeon_newInstance"
@@ -5644,51 +4754,35 @@ abstract class PigeonApiView(
       channel.send(listOf(pigeon_identifierArg)) {
         if (it is List<*>) {
           if (it.size > 1) {
-            callback(
-                Result.failure(
-                    AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
+            callback(Result.failure(AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
           } else {
             callback(Result.success(Unit))
           }
         } else {
-          callback(
-              Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
-        }
+          callback(Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
+        } 
       }
     }
   }
+
 }
 /**
- * A callback interface used by the host application to set the Geolocation permission state for an
- * origin.
+ * A callback interface used by the host application to set the Geolocation
+ * permission state for an origin.
  *
  * See https://developer.android.com/reference/android/webkit/GeolocationPermissions.Callback.
  */
 @Suppress("UNCHECKED_CAST")
-abstract class PigeonApiGeolocationPermissionsCallback(
-    open val pigeonRegistrar: AndroidWebkitLibraryPigeonProxyApiRegistrar
-) {
+abstract class PigeonApiGeolocationPermissionsCallback(open val pigeonRegistrar: AndroidWebkitLibraryPigeonProxyApiRegistrar) {
   /** Sets the Geolocation permission state for the supplied origin. */
-  abstract fun invoke(
-      pigeon_instance: android.webkit.GeolocationPermissions.Callback,
-      origin: String,
-      allow: Boolean,
-      retain: Boolean
-  )
+  abstract fun invoke(pigeon_instance: android.webkit.GeolocationPermissions.Callback, origin: String, allow: Boolean, retain: Boolean)
 
   companion object {
     @Suppress("LocalVariableName")
-    fun setUpMessageHandlers(
-        binaryMessenger: BinaryMessenger,
-        api: PigeonApiGeolocationPermissionsCallback?
-    ) {
+    fun setUpMessageHandlers(binaryMessenger: BinaryMessenger, api: PigeonApiGeolocationPermissionsCallback?) {
       val codec = api?.pigeonRegistrar?.codec ?: AndroidWebkitLibraryPigeonCodec()
       run {
-        val channel =
-            BasicMessageChannel<Any?>(
-                binaryMessenger,
-                "dev.flutter.pigeon.webview_flutter_android.GeolocationPermissionsCallback.invoke",
-                codec)
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.GeolocationPermissionsCallback.invoke", codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
@@ -5696,13 +4790,12 @@ abstract class PigeonApiGeolocationPermissionsCallback(
             val originArg = args[1] as String
             val allowArg = args[2] as Boolean
             val retainArg = args[3] as Boolean
-            val wrapped: List<Any?> =
-                try {
-                  api.invoke(pigeon_instanceArg, originArg, allowArg, retainArg)
-                  listOf(null)
-                } catch (exception: Throwable) {
-                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-                }
+            val wrapped: List<Any?> = try {
+              api.invoke(pigeon_instanceArg, originArg, allowArg, retainArg)
+              listOf(null)
+            } catch (exception: Throwable) {
+              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+            }
             reply.reply(wrapped)
           }
         } else {
@@ -5713,44 +4806,35 @@ abstract class PigeonApiGeolocationPermissionsCallback(
   }
 
   @Suppress("LocalVariableName", "FunctionName")
-  /**
-   * Creates a Dart instance of GeolocationPermissionsCallback and attaches it to
-   * [pigeon_instanceArg].
-   */
-  fun pigeon_newInstance(
-      pigeon_instanceArg: android.webkit.GeolocationPermissions.Callback,
-      callback: (Result<Unit>) -> Unit
-  ) {
+  /** Creates a Dart instance of GeolocationPermissionsCallback and attaches it to [pigeon_instanceArg]. */
+  fun pigeon_newInstance(pigeon_instanceArg: android.webkit.GeolocationPermissions.Callback, callback: (Result<Unit>) -> Unit)
+{
     if (pigeonRegistrar.ignoreCallsToDart) {
       callback(
           Result.failure(
               AndroidWebKitError("ignore-calls-error", "Calls to Dart are being ignored.", "")))
-    } else if (pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
+    }     else if (pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
       callback(Result.success(Unit))
-    } else {
-      val pigeon_identifierArg =
-          pigeonRegistrar.instanceManager.addHostCreatedInstance(pigeon_instanceArg)
+    }     else {
+      val pigeon_identifierArg = pigeonRegistrar.instanceManager.addHostCreatedInstance(pigeon_instanceArg)
       val binaryMessenger = pigeonRegistrar.binaryMessenger
       val codec = pigeonRegistrar.codec
-      val channelName =
-          "dev.flutter.pigeon.webview_flutter_android.GeolocationPermissionsCallback.pigeon_newInstance"
+      val channelName = "dev.flutter.pigeon.webview_flutter_android.GeolocationPermissionsCallback.pigeon_newInstance"
       val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
       channel.send(listOf(pigeon_identifierArg)) {
         if (it is List<*>) {
           if (it.size > 1) {
-            callback(
-                Result.failure(
-                    AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
+            callback(Result.failure(AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
           } else {
             callback(Result.success(Unit))
           }
         } else {
-          callback(
-              Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
-        }
+          callback(Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
+        } 
       }
     }
   }
+
 }
 /**
  * Represents a request for HTTP authentication.
@@ -5758,45 +4842,38 @@ abstract class PigeonApiGeolocationPermissionsCallback(
  * See https://developer.android.com/reference/android/webkit/HttpAuthHandler.
  */
 @Suppress("UNCHECKED_CAST")
-abstract class PigeonApiHttpAuthHandler(
-    open val pigeonRegistrar: AndroidWebkitLibraryPigeonProxyApiRegistrar
-) {
+abstract class PigeonApiHttpAuthHandler(open val pigeonRegistrar: AndroidWebkitLibraryPigeonProxyApiRegistrar) {
   /**
-   * Gets whether the credentials stored for the current host (i.e. the host for which
-   * `WebViewClient.onReceivedHttpAuthRequest` was called) are suitable for use.
+   * Gets whether the credentials stored for the current host (i.e. the host
+   * for which `WebViewClient.onReceivedHttpAuthRequest` was called) are
+   * suitable for use.
    */
   abstract fun useHttpAuthUsernamePassword(pigeon_instance: android.webkit.HttpAuthHandler): Boolean
 
   /** Instructs the WebView to cancel the authentication request.. */
   abstract fun cancel(pigeon_instance: android.webkit.HttpAuthHandler)
 
-  /** Instructs the WebView to proceed with the authentication with the given credentials. */
-  abstract fun proceed(
-      pigeon_instance: android.webkit.HttpAuthHandler,
-      username: String,
-      password: String
-  )
+  /**
+   * Instructs the WebView to proceed with the authentication with the given
+   * credentials.
+   */
+  abstract fun proceed(pigeon_instance: android.webkit.HttpAuthHandler, username: String, password: String)
 
   companion object {
     @Suppress("LocalVariableName")
     fun setUpMessageHandlers(binaryMessenger: BinaryMessenger, api: PigeonApiHttpAuthHandler?) {
       val codec = api?.pigeonRegistrar?.codec ?: AndroidWebkitLibraryPigeonCodec()
       run {
-        val channel =
-            BasicMessageChannel<Any?>(
-                binaryMessenger,
-                "dev.flutter.pigeon.webview_flutter_android.HttpAuthHandler.useHttpAuthUsernamePassword",
-                codec)
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.HttpAuthHandler.useHttpAuthUsernamePassword", codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val pigeon_instanceArg = args[0] as android.webkit.HttpAuthHandler
-            val wrapped: List<Any?> =
-                try {
-                  listOf(api.useHttpAuthUsernamePassword(pigeon_instanceArg))
-                } catch (exception: Throwable) {
-                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-                }
+            val wrapped: List<Any?> = try {
+              listOf(api.useHttpAuthUsernamePassword(pigeon_instanceArg))
+            } catch (exception: Throwable) {
+              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+            }
             reply.reply(wrapped)
           }
         } else {
@@ -5804,22 +4881,17 @@ abstract class PigeonApiHttpAuthHandler(
         }
       }
       run {
-        val channel =
-            BasicMessageChannel<Any?>(
-                binaryMessenger,
-                "dev.flutter.pigeon.webview_flutter_android.HttpAuthHandler.cancel",
-                codec)
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.HttpAuthHandler.cancel", codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val pigeon_instanceArg = args[0] as android.webkit.HttpAuthHandler
-            val wrapped: List<Any?> =
-                try {
-                  api.cancel(pigeon_instanceArg)
-                  listOf(null)
-                } catch (exception: Throwable) {
-                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-                }
+            val wrapped: List<Any?> = try {
+              api.cancel(pigeon_instanceArg)
+              listOf(null)
+            } catch (exception: Throwable) {
+              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+            }
             reply.reply(wrapped)
           }
         } else {
@@ -5827,24 +4899,19 @@ abstract class PigeonApiHttpAuthHandler(
         }
       }
       run {
-        val channel =
-            BasicMessageChannel<Any?>(
-                binaryMessenger,
-                "dev.flutter.pigeon.webview_flutter_android.HttpAuthHandler.proceed",
-                codec)
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.HttpAuthHandler.proceed", codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val pigeon_instanceArg = args[0] as android.webkit.HttpAuthHandler
             val usernameArg = args[1] as String
             val passwordArg = args[2] as String
-            val wrapped: List<Any?> =
-                try {
-                  api.proceed(pigeon_instanceArg, usernameArg, passwordArg)
-                  listOf(null)
-                } catch (exception: Throwable) {
-                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-                }
+            val wrapped: List<Any?> = try {
+              api.proceed(pigeon_instanceArg, usernameArg, passwordArg)
+              listOf(null)
+            } catch (exception: Throwable) {
+              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+            }
             reply.reply(wrapped)
           }
         } else {
@@ -5856,53 +4923,46 @@ abstract class PigeonApiHttpAuthHandler(
 
   @Suppress("LocalVariableName", "FunctionName")
   /** Creates a Dart instance of HttpAuthHandler and attaches it to [pigeon_instanceArg]. */
-  fun pigeon_newInstance(
-      pigeon_instanceArg: android.webkit.HttpAuthHandler,
-      callback: (Result<Unit>) -> Unit
-  ) {
+  fun pigeon_newInstance(pigeon_instanceArg: android.webkit.HttpAuthHandler, callback: (Result<Unit>) -> Unit)
+{
     if (pigeonRegistrar.ignoreCallsToDart) {
       callback(
           Result.failure(
               AndroidWebKitError("ignore-calls-error", "Calls to Dart are being ignored.", "")))
-    } else if (pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
+    }     else if (pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
       callback(Result.success(Unit))
-    } else {
-      val pigeon_identifierArg =
-          pigeonRegistrar.instanceManager.addHostCreatedInstance(pigeon_instanceArg)
+    }     else {
+      val pigeon_identifierArg = pigeonRegistrar.instanceManager.addHostCreatedInstance(pigeon_instanceArg)
       val binaryMessenger = pigeonRegistrar.binaryMessenger
       val codec = pigeonRegistrar.codec
-      val channelName =
-          "dev.flutter.pigeon.webview_flutter_android.HttpAuthHandler.pigeon_newInstance"
+      val channelName = "dev.flutter.pigeon.webview_flutter_android.HttpAuthHandler.pigeon_newInstance"
       val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
       channel.send(listOf(pigeon_identifierArg)) {
         if (it is List<*>) {
           if (it.size > 1) {
-            callback(
-                Result.failure(
-                    AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
+            callback(Result.failure(AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
           } else {
             callback(Result.success(Unit))
           }
         } else {
-          callback(
-              Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
-        }
+          callback(Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
+        } 
       }
     }
   }
+
 }
 /**
- * Defines a message containing a description and arbitrary data object that can be sent to a
- * `Handler`.
+ * Defines a message containing a description and arbitrary data object that
+ * can be sent to a `Handler`.
  *
  * See https://developer.android.com/reference/android/os/Message.
  */
 @Suppress("UNCHECKED_CAST")
-abstract class PigeonApiAndroidMessage(
-    open val pigeonRegistrar: AndroidWebkitLibraryPigeonProxyApiRegistrar
-) {
+abstract class PigeonApiAndroidMessage(open val pigeonRegistrar: AndroidWebkitLibraryPigeonProxyApiRegistrar) {
   /**
-   * Sends this message to the Android native `Handler` specified by getTarget().
+   * Sends this message to the Android native `Handler` specified by
+   * getTarget().
    *
    * Throws a null pointer exception if this field has not been set.
    */
@@ -5913,22 +4973,17 @@ abstract class PigeonApiAndroidMessage(
     fun setUpMessageHandlers(binaryMessenger: BinaryMessenger, api: PigeonApiAndroidMessage?) {
       val codec = api?.pigeonRegistrar?.codec ?: AndroidWebkitLibraryPigeonCodec()
       run {
-        val channel =
-            BasicMessageChannel<Any?>(
-                binaryMessenger,
-                "dev.flutter.pigeon.webview_flutter_android.AndroidMessage.sendToTarget",
-                codec)
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.AndroidMessage.sendToTarget", codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val pigeon_instanceArg = args[0] as android.os.Message
-            val wrapped: List<Any?> =
-                try {
-                  api.sendToTarget(pigeon_instanceArg)
-                  listOf(null)
-                } catch (exception: Throwable) {
-                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-                }
+            val wrapped: List<Any?> = try {
+              api.sendToTarget(pigeon_instanceArg)
+              listOf(null)
+            } catch (exception: Throwable) {
+              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+            }
             reply.reply(wrapped)
           }
         } else {
@@ -5940,48 +4995,43 @@ abstract class PigeonApiAndroidMessage(
 
   @Suppress("LocalVariableName", "FunctionName")
   /** Creates a Dart instance of AndroidMessage and attaches it to [pigeon_instanceArg]. */
-  fun pigeon_newInstance(pigeon_instanceArg: android.os.Message, callback: (Result<Unit>) -> Unit) {
+  fun pigeon_newInstance(pigeon_instanceArg: android.os.Message, callback: (Result<Unit>) -> Unit)
+{
     if (pigeonRegistrar.ignoreCallsToDart) {
       callback(
           Result.failure(
               AndroidWebKitError("ignore-calls-error", "Calls to Dart are being ignored.", "")))
-    } else if (pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
+    }     else if (pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
       callback(Result.success(Unit))
-    } else {
-      val pigeon_identifierArg =
-          pigeonRegistrar.instanceManager.addHostCreatedInstance(pigeon_instanceArg)
+    }     else {
+      val pigeon_identifierArg = pigeonRegistrar.instanceManager.addHostCreatedInstance(pigeon_instanceArg)
       val binaryMessenger = pigeonRegistrar.binaryMessenger
       val codec = pigeonRegistrar.codec
-      val channelName =
-          "dev.flutter.pigeon.webview_flutter_android.AndroidMessage.pigeon_newInstance"
+      val channelName = "dev.flutter.pigeon.webview_flutter_android.AndroidMessage.pigeon_newInstance"
       val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
       channel.send(listOf(pigeon_identifierArg)) {
         if (it is List<*>) {
           if (it.size > 1) {
-            callback(
-                Result.failure(
-                    AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
+            callback(Result.failure(AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
           } else {
             callback(Result.success(Unit))
           }
         } else {
-          callback(
-              Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
-        }
+          callback(Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
+        } 
       }
     }
   }
+
 }
 /**
- * Defines a message containing a description and arbitrary data object that can be sent to a
- * `Handler`.
+ * Defines a message containing a description and arbitrary data object that
+ * can be sent to a `Handler`.
  *
  * See https://developer.android.com/reference/android/webkit/ClientCertRequest.
  */
 @Suppress("UNCHECKED_CAST")
-abstract class PigeonApiClientCertRequest(
-    open val pigeonRegistrar: AndroidWebkitLibraryPigeonProxyApiRegistrar
-) {
+abstract class PigeonApiClientCertRequest(open val pigeonRegistrar: AndroidWebkitLibraryPigeonProxyApiRegistrar) {
   /** Cancel this request. */
   abstract fun cancel(pigeon_instance: android.webkit.ClientCertRequest)
 
@@ -5989,33 +5039,24 @@ abstract class PigeonApiClientCertRequest(
   abstract fun ignore(pigeon_instance: android.webkit.ClientCertRequest)
 
   /** Proceed with the specified private key and client certificate chain. */
-  abstract fun proceed(
-      pigeon_instance: android.webkit.ClientCertRequest,
-      privateKey: java.security.PrivateKey,
-      chain: List<java.security.cert.X509Certificate>
-  )
+  abstract fun proceed(pigeon_instance: android.webkit.ClientCertRequest, privateKey: java.security.PrivateKey, chain: List<java.security.cert.X509Certificate>)
 
   companion object {
     @Suppress("LocalVariableName")
     fun setUpMessageHandlers(binaryMessenger: BinaryMessenger, api: PigeonApiClientCertRequest?) {
       val codec = api?.pigeonRegistrar?.codec ?: AndroidWebkitLibraryPigeonCodec()
       run {
-        val channel =
-            BasicMessageChannel<Any?>(
-                binaryMessenger,
-                "dev.flutter.pigeon.webview_flutter_android.ClientCertRequest.cancel",
-                codec)
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.ClientCertRequest.cancel", codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val pigeon_instanceArg = args[0] as android.webkit.ClientCertRequest
-            val wrapped: List<Any?> =
-                try {
-                  api.cancel(pigeon_instanceArg)
-                  listOf(null)
-                } catch (exception: Throwable) {
-                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-                }
+            val wrapped: List<Any?> = try {
+              api.cancel(pigeon_instanceArg)
+              listOf(null)
+            } catch (exception: Throwable) {
+              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+            }
             reply.reply(wrapped)
           }
         } else {
@@ -6023,22 +5064,17 @@ abstract class PigeonApiClientCertRequest(
         }
       }
       run {
-        val channel =
-            BasicMessageChannel<Any?>(
-                binaryMessenger,
-                "dev.flutter.pigeon.webview_flutter_android.ClientCertRequest.ignore",
-                codec)
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.ClientCertRequest.ignore", codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val pigeon_instanceArg = args[0] as android.webkit.ClientCertRequest
-            val wrapped: List<Any?> =
-                try {
-                  api.ignore(pigeon_instanceArg)
-                  listOf(null)
-                } catch (exception: Throwable) {
-                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-                }
+            val wrapped: List<Any?> = try {
+              api.ignore(pigeon_instanceArg)
+              listOf(null)
+            } catch (exception: Throwable) {
+              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+            }
             reply.reply(wrapped)
           }
         } else {
@@ -6046,24 +5082,19 @@ abstract class PigeonApiClientCertRequest(
         }
       }
       run {
-        val channel =
-            BasicMessageChannel<Any?>(
-                binaryMessenger,
-                "dev.flutter.pigeon.webview_flutter_android.ClientCertRequest.proceed",
-                codec)
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.ClientCertRequest.proceed", codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val pigeon_instanceArg = args[0] as android.webkit.ClientCertRequest
             val privateKeyArg = args[1] as java.security.PrivateKey
             val chainArg = args[2] as List<java.security.cert.X509Certificate>
-            val wrapped: List<Any?> =
-                try {
-                  api.proceed(pigeon_instanceArg, privateKeyArg, chainArg)
-                  listOf(null)
-                } catch (exception: Throwable) {
-                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-                }
+            val wrapped: List<Any?> = try {
+              api.proceed(pigeon_instanceArg, privateKeyArg, chainArg)
+              listOf(null)
+            } catch (exception: Throwable) {
+              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+            }
             reply.reply(wrapped)
           }
         } else {
@@ -6075,68 +5106,57 @@ abstract class PigeonApiClientCertRequest(
 
   @Suppress("LocalVariableName", "FunctionName")
   /** Creates a Dart instance of ClientCertRequest and attaches it to [pigeon_instanceArg]. */
-  fun pigeon_newInstance(
-      pigeon_instanceArg: android.webkit.ClientCertRequest,
-      callback: (Result<Unit>) -> Unit
-  ) {
+  fun pigeon_newInstance(pigeon_instanceArg: android.webkit.ClientCertRequest, callback: (Result<Unit>) -> Unit)
+{
     if (pigeonRegistrar.ignoreCallsToDart) {
       callback(
           Result.failure(
               AndroidWebKitError("ignore-calls-error", "Calls to Dart are being ignored.", "")))
-    } else if (pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
+    }     else if (pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
       callback(Result.success(Unit))
-    } else {
-      val pigeon_identifierArg =
-          pigeonRegistrar.instanceManager.addHostCreatedInstance(pigeon_instanceArg)
+    }     else {
+      val pigeon_identifierArg = pigeonRegistrar.instanceManager.addHostCreatedInstance(pigeon_instanceArg)
       val binaryMessenger = pigeonRegistrar.binaryMessenger
       val codec = pigeonRegistrar.codec
-      val channelName =
-          "dev.flutter.pigeon.webview_flutter_android.ClientCertRequest.pigeon_newInstance"
+      val channelName = "dev.flutter.pigeon.webview_flutter_android.ClientCertRequest.pigeon_newInstance"
       val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
       channel.send(listOf(pigeon_identifierArg)) {
         if (it is List<*>) {
           if (it.size > 1) {
-            callback(
-                Result.failure(
-                    AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
+            callback(Result.failure(AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
           } else {
             callback(Result.success(Unit))
           }
         } else {
-          callback(
-              Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
-        }
+          callback(Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
+        } 
       }
     }
   }
+
 }
 /**
  * A private key.
  *
- * The purpose of this interface is to group (and provide type safety for) all private key
- * interfaces.
+ * The purpose of this interface is to group (and provide type safety for) all
+ * private key interfaces.
  *
  * See https://developer.android.com/reference/java/security/PrivateKey.
  */
 @Suppress("UNCHECKED_CAST")
-open class PigeonApiPrivateKey(
-    open val pigeonRegistrar: AndroidWebkitLibraryPigeonProxyApiRegistrar
-) {
+open class PigeonApiPrivateKey(open val pigeonRegistrar: AndroidWebkitLibraryPigeonProxyApiRegistrar) {
   @Suppress("LocalVariableName", "FunctionName")
   /** Creates a Dart instance of PrivateKey and attaches it to [pigeon_instanceArg]. */
-  fun pigeon_newInstance(
-      pigeon_instanceArg: java.security.PrivateKey,
-      callback: (Result<Unit>) -> Unit
-  ) {
+  fun pigeon_newInstance(pigeon_instanceArg: java.security.PrivateKey, callback: (Result<Unit>) -> Unit)
+{
     if (pigeonRegistrar.ignoreCallsToDart) {
       callback(
           Result.failure(
               AndroidWebKitError("ignore-calls-error", "Calls to Dart are being ignored.", "")))
-    } else if (pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
+    }     else if (pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
       callback(Result.success(Unit))
-    } else {
-      val pigeon_identifierArg =
-          pigeonRegistrar.instanceManager.addHostCreatedInstance(pigeon_instanceArg)
+    }     else {
+      val pigeon_identifierArg = pigeonRegistrar.instanceManager.addHostCreatedInstance(pigeon_instanceArg)
       val binaryMessenger = pigeonRegistrar.binaryMessenger
       val codec = pigeonRegistrar.codec
       val channelName = "dev.flutter.pigeon.webview_flutter_android.PrivateKey.pigeon_newInstance"
@@ -6144,73 +5164,65 @@ open class PigeonApiPrivateKey(
       channel.send(listOf(pigeon_identifierArg)) {
         if (it is List<*>) {
           if (it.size > 1) {
-            callback(
-                Result.failure(
-                    AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
+            callback(Result.failure(AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
           } else {
             callback(Result.success(Unit))
           }
         } else {
-          callback(
-              Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
-        }
+          callback(Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
+        } 
       }
     }
   }
+
 }
 /**
  * Abstract class for X.509 certificates.
  *
- * This provides a standard way to access all the attributes of an X.509 certificate.
+ * This provides a standard way to access all the attributes of an X.509
+ * certificate.
  *
  * See https://developer.android.com/reference/java/security/cert/X509Certificate.
  */
 @Suppress("UNCHECKED_CAST")
-open class PigeonApiX509Certificate(
-    open val pigeonRegistrar: AndroidWebkitLibraryPigeonProxyApiRegistrar
-) {
+open class PigeonApiX509Certificate(open val pigeonRegistrar: AndroidWebkitLibraryPigeonProxyApiRegistrar) {
   @Suppress("LocalVariableName", "FunctionName")
   /** Creates a Dart instance of X509Certificate and attaches it to [pigeon_instanceArg]. */
-  fun pigeon_newInstance(
-      pigeon_instanceArg: java.security.cert.X509Certificate,
-      callback: (Result<Unit>) -> Unit
-  ) {
+  fun pigeon_newInstance(pigeon_instanceArg: java.security.cert.X509Certificate, callback: (Result<Unit>) -> Unit)
+{
     if (pigeonRegistrar.ignoreCallsToDart) {
       callback(
           Result.failure(
               AndroidWebKitError("ignore-calls-error", "Calls to Dart are being ignored.", "")))
-    } else if (pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
+    }     else if (pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
       callback(Result.success(Unit))
-    } else {
-      val pigeon_identifierArg =
-          pigeonRegistrar.instanceManager.addHostCreatedInstance(pigeon_instanceArg)
+    }     else {
+      val pigeon_identifierArg = pigeonRegistrar.instanceManager.addHostCreatedInstance(pigeon_instanceArg)
       val binaryMessenger = pigeonRegistrar.binaryMessenger
       val codec = pigeonRegistrar.codec
-      val channelName =
-          "dev.flutter.pigeon.webview_flutter_android.X509Certificate.pigeon_newInstance"
+      val channelName = "dev.flutter.pigeon.webview_flutter_android.X509Certificate.pigeon_newInstance"
       val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
       channel.send(listOf(pigeon_identifierArg)) {
         if (it is List<*>) {
           if (it.size > 1) {
-            callback(
-                Result.failure(
-                    AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
+            callback(Result.failure(AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
           } else {
             callback(Result.success(Unit))
           }
         } else {
-          callback(
-              Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
-        }
+          callback(Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
+        } 
       }
     }
   }
 
   @Suppress("FunctionName")
   /** An implementation of [PigeonApiCertificate] used to access callback methods */
-  fun pigeon_getPigeonApiCertificate(): PigeonApiCertificate {
+  fun pigeon_getPigeonApiCertificate(): PigeonApiCertificate
+  {
     return pigeonRegistrar.getPigeonApiCertificate()
   }
+
 }
 /**
  * Represents a request for handling an SSL error.
@@ -6218,18 +5230,16 @@ open class PigeonApiX509Certificate(
  * See https://developer.android.com/reference/android/webkit/SslErrorHandler.
  */
 @Suppress("UNCHECKED_CAST")
-abstract class PigeonApiSslErrorHandler(
-    open val pigeonRegistrar: AndroidWebkitLibraryPigeonProxyApiRegistrar
-) {
+abstract class PigeonApiSslErrorHandler(open val pigeonRegistrar: AndroidWebkitLibraryPigeonProxyApiRegistrar) {
   /**
-   * Instructs the WebView that encountered the SSL certificate error to terminate communication
-   * with the server.
+   * Instructs the WebView that encountered the SSL certificate error to
+   * terminate communication with the server.
    */
   abstract fun cancel(pigeon_instance: android.webkit.SslErrorHandler)
 
   /**
-   * Instructs the WebView that encountered the SSL certificate error to ignore the error and
-   * continue communicating with the server.
+   * Instructs the WebView that encountered the SSL certificate error to ignore
+   * the error and continue communicating with the server.
    */
   abstract fun proceed(pigeon_instance: android.webkit.SslErrorHandler)
 
@@ -6238,22 +5248,17 @@ abstract class PigeonApiSslErrorHandler(
     fun setUpMessageHandlers(binaryMessenger: BinaryMessenger, api: PigeonApiSslErrorHandler?) {
       val codec = api?.pigeonRegistrar?.codec ?: AndroidWebkitLibraryPigeonCodec()
       run {
-        val channel =
-            BasicMessageChannel<Any?>(
-                binaryMessenger,
-                "dev.flutter.pigeon.webview_flutter_android.SslErrorHandler.cancel",
-                codec)
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.SslErrorHandler.cancel", codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val pigeon_instanceArg = args[0] as android.webkit.SslErrorHandler
-            val wrapped: List<Any?> =
-                try {
-                  api.cancel(pigeon_instanceArg)
-                  listOf(null)
-                } catch (exception: Throwable) {
-                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-                }
+            val wrapped: List<Any?> = try {
+              api.cancel(pigeon_instanceArg)
+              listOf(null)
+            } catch (exception: Throwable) {
+              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+            }
             reply.reply(wrapped)
           }
         } else {
@@ -6261,22 +5266,17 @@ abstract class PigeonApiSslErrorHandler(
         }
       }
       run {
-        val channel =
-            BasicMessageChannel<Any?>(
-                binaryMessenger,
-                "dev.flutter.pigeon.webview_flutter_android.SslErrorHandler.proceed",
-                codec)
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.SslErrorHandler.proceed", codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val pigeon_instanceArg = args[0] as android.webkit.SslErrorHandler
-            val wrapped: List<Any?> =
-                try {
-                  api.proceed(pigeon_instanceArg)
-                  listOf(null)
-                } catch (exception: Throwable) {
-                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-                }
+            val wrapped: List<Any?> = try {
+              api.proceed(pigeon_instanceArg)
+              listOf(null)
+            } catch (exception: Throwable) {
+              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+            }
             reply.reply(wrapped)
           }
         } else {
@@ -6288,54 +5288,45 @@ abstract class PigeonApiSslErrorHandler(
 
   @Suppress("LocalVariableName", "FunctionName")
   /** Creates a Dart instance of SslErrorHandler and attaches it to [pigeon_instanceArg]. */
-  fun pigeon_newInstance(
-      pigeon_instanceArg: android.webkit.SslErrorHandler,
-      callback: (Result<Unit>) -> Unit
-  ) {
+  fun pigeon_newInstance(pigeon_instanceArg: android.webkit.SslErrorHandler, callback: (Result<Unit>) -> Unit)
+{
     if (pigeonRegistrar.ignoreCallsToDart) {
       callback(
           Result.failure(
               AndroidWebKitError("ignore-calls-error", "Calls to Dart are being ignored.", "")))
-    } else if (pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
+    }     else if (pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
       callback(Result.success(Unit))
-    } else {
-      val pigeon_identifierArg =
-          pigeonRegistrar.instanceManager.addHostCreatedInstance(pigeon_instanceArg)
+    }     else {
+      val pigeon_identifierArg = pigeonRegistrar.instanceManager.addHostCreatedInstance(pigeon_instanceArg)
       val binaryMessenger = pigeonRegistrar.binaryMessenger
       val codec = pigeonRegistrar.codec
-      val channelName =
-          "dev.flutter.pigeon.webview_flutter_android.SslErrorHandler.pigeon_newInstance"
+      val channelName = "dev.flutter.pigeon.webview_flutter_android.SslErrorHandler.pigeon_newInstance"
       val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
       channel.send(listOf(pigeon_identifierArg)) {
         if (it is List<*>) {
           if (it.size > 1) {
-            callback(
-                Result.failure(
-                    AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
+            callback(Result.failure(AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
           } else {
             callback(Result.success(Unit))
           }
         } else {
-          callback(
-              Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
-        }
+          callback(Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
+        } 
       }
     }
   }
+
 }
 /**
- * This class represents a set of one or more SSL errors and the associated SSL certificate.
+ * This class represents a set of one or more SSL errors and the associated SSL
+ * certificate.
  *
  * See https://developer.android.com/reference/android/net/http/SslError.
  */
 @Suppress("UNCHECKED_CAST")
-abstract class PigeonApiSslError(
-    open val pigeonRegistrar: AndroidWebkitLibraryPigeonProxyApiRegistrar
-) {
+abstract class PigeonApiSslError(open val pigeonRegistrar: AndroidWebkitLibraryPigeonProxyApiRegistrar) {
   /** Gets the SSL certificate associated with this object. */
-  abstract fun certificate(
-      pigeon_instance: android.net.http.SslError
-  ): android.net.http.SslCertificate
+  abstract fun certificate(pigeon_instance: android.net.http.SslError): android.net.http.SslCertificate
 
   /** Gets the URL associated with this object. */
   abstract fun url(pigeon_instance: android.net.http.SslError): String
@@ -6351,21 +5342,16 @@ abstract class PigeonApiSslError(
     fun setUpMessageHandlers(binaryMessenger: BinaryMessenger, api: PigeonApiSslError?) {
       val codec = api?.pigeonRegistrar?.codec ?: AndroidWebkitLibraryPigeonCodec()
       run {
-        val channel =
-            BasicMessageChannel<Any?>(
-                binaryMessenger,
-                "dev.flutter.pigeon.webview_flutter_android.SslError.getPrimaryError",
-                codec)
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.SslError.getPrimaryError", codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val pigeon_instanceArg = args[0] as android.net.http.SslError
-            val wrapped: List<Any?> =
-                try {
-                  listOf(api.getPrimaryError(pigeon_instanceArg))
-                } catch (exception: Throwable) {
-                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-                }
+            val wrapped: List<Any?> = try {
+              listOf(api.getPrimaryError(pigeon_instanceArg))
+            } catch (exception: Throwable) {
+              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+            }
             reply.reply(wrapped)
           }
         } else {
@@ -6373,22 +5359,17 @@ abstract class PigeonApiSslError(
         }
       }
       run {
-        val channel =
-            BasicMessageChannel<Any?>(
-                binaryMessenger,
-                "dev.flutter.pigeon.webview_flutter_android.SslError.hasError",
-                codec)
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.SslError.hasError", codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val pigeon_instanceArg = args[0] as android.net.http.SslError
             val errorArg = args[1] as SslErrorType
-            val wrapped: List<Any?> =
-                try {
-                  listOf(api.hasError(pigeon_instanceArg, errorArg))
-                } catch (exception: Throwable) {
-                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-                }
+            val wrapped: List<Any?> = try {
+              listOf(api.hasError(pigeon_instanceArg, errorArg))
+            } catch (exception: Throwable) {
+              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+            }
             reply.reply(wrapped)
           }
         } else {
@@ -6400,19 +5381,16 @@ abstract class PigeonApiSslError(
 
   @Suppress("LocalVariableName", "FunctionName")
   /** Creates a Dart instance of SslError and attaches it to [pigeon_instanceArg]. */
-  fun pigeon_newInstance(
-      pigeon_instanceArg: android.net.http.SslError,
-      callback: (Result<Unit>) -> Unit
-  ) {
+  fun pigeon_newInstance(pigeon_instanceArg: android.net.http.SslError, callback: (Result<Unit>) -> Unit)
+{
     if (pigeonRegistrar.ignoreCallsToDart) {
       callback(
           Result.failure(
               AndroidWebKitError("ignore-calls-error", "Calls to Dart are being ignored.", "")))
-    } else if (pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
+    }     else if (pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
       callback(Result.success(Unit))
-    } else {
-      val pigeon_identifierArg =
-          pigeonRegistrar.instanceManager.addHostCreatedInstance(pigeon_instanceArg)
+    }     else {
+      val pigeon_identifierArg = pigeonRegistrar.instanceManager.addHostCreatedInstance(pigeon_instanceArg)
       val certificateArg = certificate(pigeon_instanceArg)
       val urlArg = url(pigeon_instanceArg)
       val binaryMessenger = pigeonRegistrar.binaryMessenger
@@ -6422,30 +5400,28 @@ abstract class PigeonApiSslError(
       channel.send(listOf(pigeon_identifierArg, certificateArg, urlArg)) {
         if (it is List<*>) {
           if (it.size > 1) {
-            callback(
-                Result.failure(
-                    AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
+            callback(Result.failure(AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
           } else {
             callback(Result.success(Unit))
           }
         } else {
-          callback(
-              Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
-        }
+          callback(Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
+        } 
       }
     }
   }
+
 }
 /**
  * A distinguished name helper class.
  *
- * A 3-tuple of: the most specific common name (CN) the most specific organization (O) the most
- * specific organizational unit (OU)
+ * A 3-tuple of:
+ * the most specific common name (CN)
+ * the most specific organization (O)
+ * the most specific organizational unit (OU)
  */
 @Suppress("UNCHECKED_CAST")
-abstract class PigeonApiSslCertificateDName(
-    open val pigeonRegistrar: AndroidWebkitLibraryPigeonProxyApiRegistrar
-) {
+abstract class PigeonApiSslCertificateDName(open val pigeonRegistrar: AndroidWebkitLibraryPigeonProxyApiRegistrar) {
   /** The most specific Common-name (CN) component of this name. */
   abstract fun getCName(pigeon_instance: android.net.http.SslCertificate.DName): String
 
@@ -6463,21 +5439,16 @@ abstract class PigeonApiSslCertificateDName(
     fun setUpMessageHandlers(binaryMessenger: BinaryMessenger, api: PigeonApiSslCertificateDName?) {
       val codec = api?.pigeonRegistrar?.codec ?: AndroidWebkitLibraryPigeonCodec()
       run {
-        val channel =
-            BasicMessageChannel<Any?>(
-                binaryMessenger,
-                "dev.flutter.pigeon.webview_flutter_android.SslCertificateDName.getCName",
-                codec)
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.SslCertificateDName.getCName", codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val pigeon_instanceArg = args[0] as android.net.http.SslCertificate.DName
-            val wrapped: List<Any?> =
-                try {
-                  listOf(api.getCName(pigeon_instanceArg))
-                } catch (exception: Throwable) {
-                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-                }
+            val wrapped: List<Any?> = try {
+              listOf(api.getCName(pigeon_instanceArg))
+            } catch (exception: Throwable) {
+              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+            }
             reply.reply(wrapped)
           }
         } else {
@@ -6485,21 +5456,16 @@ abstract class PigeonApiSslCertificateDName(
         }
       }
       run {
-        val channel =
-            BasicMessageChannel<Any?>(
-                binaryMessenger,
-                "dev.flutter.pigeon.webview_flutter_android.SslCertificateDName.getDName",
-                codec)
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.SslCertificateDName.getDName", codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val pigeon_instanceArg = args[0] as android.net.http.SslCertificate.DName
-            val wrapped: List<Any?> =
-                try {
-                  listOf(api.getDName(pigeon_instanceArg))
-                } catch (exception: Throwable) {
-                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-                }
+            val wrapped: List<Any?> = try {
+              listOf(api.getDName(pigeon_instanceArg))
+            } catch (exception: Throwable) {
+              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+            }
             reply.reply(wrapped)
           }
         } else {
@@ -6507,21 +5473,16 @@ abstract class PigeonApiSslCertificateDName(
         }
       }
       run {
-        val channel =
-            BasicMessageChannel<Any?>(
-                binaryMessenger,
-                "dev.flutter.pigeon.webview_flutter_android.SslCertificateDName.getOName",
-                codec)
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.SslCertificateDName.getOName", codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val pigeon_instanceArg = args[0] as android.net.http.SslCertificate.DName
-            val wrapped: List<Any?> =
-                try {
-                  listOf(api.getOName(pigeon_instanceArg))
-                } catch (exception: Throwable) {
-                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-                }
+            val wrapped: List<Any?> = try {
+              listOf(api.getOName(pigeon_instanceArg))
+            } catch (exception: Throwable) {
+              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+            }
             reply.reply(wrapped)
           }
         } else {
@@ -6529,21 +5490,16 @@ abstract class PigeonApiSslCertificateDName(
         }
       }
       run {
-        val channel =
-            BasicMessageChannel<Any?>(
-                binaryMessenger,
-                "dev.flutter.pigeon.webview_flutter_android.SslCertificateDName.getUName",
-                codec)
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.SslCertificateDName.getUName", codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val pigeon_instanceArg = args[0] as android.net.http.SslCertificate.DName
-            val wrapped: List<Any?> =
-                try {
-                  listOf(api.getUName(pigeon_instanceArg))
-                } catch (exception: Throwable) {
-                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-                }
+            val wrapped: List<Any?> = try {
+              listOf(api.getUName(pigeon_instanceArg))
+            } catch (exception: Throwable) {
+              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+            }
             reply.reply(wrapped)
           }
         } else {
@@ -6555,40 +5511,34 @@ abstract class PigeonApiSslCertificateDName(
 
   @Suppress("LocalVariableName", "FunctionName")
   /** Creates a Dart instance of SslCertificateDName and attaches it to [pigeon_instanceArg]. */
-  fun pigeon_newInstance(
-      pigeon_instanceArg: android.net.http.SslCertificate.DName,
-      callback: (Result<Unit>) -> Unit
-  ) {
+  fun pigeon_newInstance(pigeon_instanceArg: android.net.http.SslCertificate.DName, callback: (Result<Unit>) -> Unit)
+{
     if (pigeonRegistrar.ignoreCallsToDart) {
       callback(
           Result.failure(
               AndroidWebKitError("ignore-calls-error", "Calls to Dart are being ignored.", "")))
-    } else if (pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
+    }     else if (pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
       callback(Result.success(Unit))
-    } else {
-      val pigeon_identifierArg =
-          pigeonRegistrar.instanceManager.addHostCreatedInstance(pigeon_instanceArg)
+    }     else {
+      val pigeon_identifierArg = pigeonRegistrar.instanceManager.addHostCreatedInstance(pigeon_instanceArg)
       val binaryMessenger = pigeonRegistrar.binaryMessenger
       val codec = pigeonRegistrar.codec
-      val channelName =
-          "dev.flutter.pigeon.webview_flutter_android.SslCertificateDName.pigeon_newInstance"
+      val channelName = "dev.flutter.pigeon.webview_flutter_android.SslCertificateDName.pigeon_newInstance"
       val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
       channel.send(listOf(pigeon_identifierArg)) {
         if (it is List<*>) {
           if (it.size > 1) {
-            callback(
-                Result.failure(
-                    AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
+            callback(Result.failure(AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
           } else {
             callback(Result.success(Unit))
           }
         } else {
-          callback(
-              Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
-        }
+          callback(Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
+        } 
       }
     }
   }
+
 }
 /**
  * SSL certificate info (certificate details) class.
@@ -6596,56 +5546,48 @@ abstract class PigeonApiSslCertificateDName(
  * See https://developer.android.com/reference/android/net/http/SslCertificate.
  */
 @Suppress("UNCHECKED_CAST")
-abstract class PigeonApiSslCertificate(
-    open val pigeonRegistrar: AndroidWebkitLibraryPigeonProxyApiRegistrar
-) {
+abstract class PigeonApiSslCertificate(open val pigeonRegistrar: AndroidWebkitLibraryPigeonProxyApiRegistrar) {
   /** Issued-by distinguished name or null if none has been set. */
-  abstract fun getIssuedBy(
-      pigeon_instance: android.net.http.SslCertificate
-  ): android.net.http.SslCertificate.DName?
+  abstract fun getIssuedBy(pigeon_instance: android.net.http.SslCertificate): android.net.http.SslCertificate.DName?
 
   /** Issued-to distinguished name or null if none has been set. */
-  abstract fun getIssuedTo(
-      pigeon_instance: android.net.http.SslCertificate
-  ): android.net.http.SslCertificate.DName?
-
-  /** Not-after date from the certificate validity period or null if none has been set. */
-  abstract fun getValidNotAfterMsSinceEpoch(pigeon_instance: android.net.http.SslCertificate): Long?
-
-  /** Not-before date from the certificate validity period or null if none has been set. */
-  abstract fun getValidNotBeforeMsSinceEpoch(
-      pigeon_instance: android.net.http.SslCertificate
-  ): Long?
+  abstract fun getIssuedTo(pigeon_instance: android.net.http.SslCertificate): android.net.http.SslCertificate.DName?
 
   /**
-   * The X509Certificate used to create this SslCertificate or null if no certificate was provided.
+   * Not-after date from the certificate validity period or null if none has been
+   * set.
+   */
+  abstract fun getValidNotAfterMsSinceEpoch(pigeon_instance: android.net.http.SslCertificate): Long?
+
+  /**
+   * Not-before date from the certificate validity period or null if none has
+   * been set.
+   */
+  abstract fun getValidNotBeforeMsSinceEpoch(pigeon_instance: android.net.http.SslCertificate): Long?
+
+  /**
+   * The X509Certificate used to create this SslCertificate or null if no
+   * certificate was provided.
    *
    * Always returns null on Android versions below Q.
    */
-  abstract fun getX509Certificate(
-      pigeon_instance: android.net.http.SslCertificate
-  ): java.security.cert.X509Certificate?
+  abstract fun getX509Certificate(pigeon_instance: android.net.http.SslCertificate): java.security.cert.X509Certificate?
 
   companion object {
     @Suppress("LocalVariableName")
     fun setUpMessageHandlers(binaryMessenger: BinaryMessenger, api: PigeonApiSslCertificate?) {
       val codec = api?.pigeonRegistrar?.codec ?: AndroidWebkitLibraryPigeonCodec()
       run {
-        val channel =
-            BasicMessageChannel<Any?>(
-                binaryMessenger,
-                "dev.flutter.pigeon.webview_flutter_android.SslCertificate.getIssuedBy",
-                codec)
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.SslCertificate.getIssuedBy", codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val pigeon_instanceArg = args[0] as android.net.http.SslCertificate
-            val wrapped: List<Any?> =
-                try {
-                  listOf(api.getIssuedBy(pigeon_instanceArg))
-                } catch (exception: Throwable) {
-                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-                }
+            val wrapped: List<Any?> = try {
+              listOf(api.getIssuedBy(pigeon_instanceArg))
+            } catch (exception: Throwable) {
+              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+            }
             reply.reply(wrapped)
           }
         } else {
@@ -6653,21 +5595,16 @@ abstract class PigeonApiSslCertificate(
         }
       }
       run {
-        val channel =
-            BasicMessageChannel<Any?>(
-                binaryMessenger,
-                "dev.flutter.pigeon.webview_flutter_android.SslCertificate.getIssuedTo",
-                codec)
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.SslCertificate.getIssuedTo", codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val pigeon_instanceArg = args[0] as android.net.http.SslCertificate
-            val wrapped: List<Any?> =
-                try {
-                  listOf(api.getIssuedTo(pigeon_instanceArg))
-                } catch (exception: Throwable) {
-                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-                }
+            val wrapped: List<Any?> = try {
+              listOf(api.getIssuedTo(pigeon_instanceArg))
+            } catch (exception: Throwable) {
+              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+            }
             reply.reply(wrapped)
           }
         } else {
@@ -6675,21 +5612,16 @@ abstract class PigeonApiSslCertificate(
         }
       }
       run {
-        val channel =
-            BasicMessageChannel<Any?>(
-                binaryMessenger,
-                "dev.flutter.pigeon.webview_flutter_android.SslCertificate.getValidNotAfterMsSinceEpoch",
-                codec)
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.SslCertificate.getValidNotAfterMsSinceEpoch", codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val pigeon_instanceArg = args[0] as android.net.http.SslCertificate
-            val wrapped: List<Any?> =
-                try {
-                  listOf(api.getValidNotAfterMsSinceEpoch(pigeon_instanceArg))
-                } catch (exception: Throwable) {
-                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-                }
+            val wrapped: List<Any?> = try {
+              listOf(api.getValidNotAfterMsSinceEpoch(pigeon_instanceArg))
+            } catch (exception: Throwable) {
+              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+            }
             reply.reply(wrapped)
           }
         } else {
@@ -6697,21 +5629,16 @@ abstract class PigeonApiSslCertificate(
         }
       }
       run {
-        val channel =
-            BasicMessageChannel<Any?>(
-                binaryMessenger,
-                "dev.flutter.pigeon.webview_flutter_android.SslCertificate.getValidNotBeforeMsSinceEpoch",
-                codec)
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.SslCertificate.getValidNotBeforeMsSinceEpoch", codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val pigeon_instanceArg = args[0] as android.net.http.SslCertificate
-            val wrapped: List<Any?> =
-                try {
-                  listOf(api.getValidNotBeforeMsSinceEpoch(pigeon_instanceArg))
-                } catch (exception: Throwable) {
-                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-                }
+            val wrapped: List<Any?> = try {
+              listOf(api.getValidNotBeforeMsSinceEpoch(pigeon_instanceArg))
+            } catch (exception: Throwable) {
+              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+            }
             reply.reply(wrapped)
           }
         } else {
@@ -6719,21 +5646,16 @@ abstract class PigeonApiSslCertificate(
         }
       }
       run {
-        val channel =
-            BasicMessageChannel<Any?>(
-                binaryMessenger,
-                "dev.flutter.pigeon.webview_flutter_android.SslCertificate.getX509Certificate",
-                codec)
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.SslCertificate.getX509Certificate", codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val pigeon_instanceArg = args[0] as android.net.http.SslCertificate
-            val wrapped: List<Any?> =
-                try {
-                  listOf(api.getX509Certificate(pigeon_instanceArg))
-                } catch (exception: Throwable) {
-                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-                }
+            val wrapped: List<Any?> = try {
+              listOf(api.getX509Certificate(pigeon_instanceArg))
+            } catch (exception: Throwable) {
+              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+            }
             reply.reply(wrapped)
           }
         } else {
@@ -6745,40 +5667,34 @@ abstract class PigeonApiSslCertificate(
 
   @Suppress("LocalVariableName", "FunctionName")
   /** Creates a Dart instance of SslCertificate and attaches it to [pigeon_instanceArg]. */
-  fun pigeon_newInstance(
-      pigeon_instanceArg: android.net.http.SslCertificate,
-      callback: (Result<Unit>) -> Unit
-  ) {
+  fun pigeon_newInstance(pigeon_instanceArg: android.net.http.SslCertificate, callback: (Result<Unit>) -> Unit)
+{
     if (pigeonRegistrar.ignoreCallsToDart) {
       callback(
           Result.failure(
               AndroidWebKitError("ignore-calls-error", "Calls to Dart are being ignored.", "")))
-    } else if (pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
+    }     else if (pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
       callback(Result.success(Unit))
-    } else {
-      val pigeon_identifierArg =
-          pigeonRegistrar.instanceManager.addHostCreatedInstance(pigeon_instanceArg)
+    }     else {
+      val pigeon_identifierArg = pigeonRegistrar.instanceManager.addHostCreatedInstance(pigeon_instanceArg)
       val binaryMessenger = pigeonRegistrar.binaryMessenger
       val codec = pigeonRegistrar.codec
-      val channelName =
-          "dev.flutter.pigeon.webview_flutter_android.SslCertificate.pigeon_newInstance"
+      val channelName = "dev.flutter.pigeon.webview_flutter_android.SslCertificate.pigeon_newInstance"
       val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
       channel.send(listOf(pigeon_identifierArg)) {
         if (it is List<*>) {
           if (it.size > 1) {
-            callback(
-                Result.failure(
-                    AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
+            callback(Result.failure(AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
           } else {
             callback(Result.success(Unit))
           }
         } else {
-          callback(
-              Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
-        }
+          callback(Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
+        } 
       }
     }
   }
+
 }
 /**
  * Abstract class for managing a variety of identity certificates.
@@ -6786,9 +5702,7 @@ abstract class PigeonApiSslCertificate(
  * See https://developer.android.com/reference/java/security/cert/Certificate.
  */
 @Suppress("UNCHECKED_CAST")
-abstract class PigeonApiCertificate(
-    open val pigeonRegistrar: AndroidWebkitLibraryPigeonProxyApiRegistrar
-) {
+abstract class PigeonApiCertificate(open val pigeonRegistrar: AndroidWebkitLibraryPigeonProxyApiRegistrar) {
   /** The encoded form of this certificate. */
   abstract fun getEncoded(pigeon_instance: java.security.cert.Certificate): ByteArray
 
@@ -6797,21 +5711,16 @@ abstract class PigeonApiCertificate(
     fun setUpMessageHandlers(binaryMessenger: BinaryMessenger, api: PigeonApiCertificate?) {
       val codec = api?.pigeonRegistrar?.codec ?: AndroidWebkitLibraryPigeonCodec()
       run {
-        val channel =
-            BasicMessageChannel<Any?>(
-                binaryMessenger,
-                "dev.flutter.pigeon.webview_flutter_android.Certificate.getEncoded",
-                codec)
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.Certificate.getEncoded", codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val pigeon_instanceArg = args[0] as java.security.cert.Certificate
-            val wrapped: List<Any?> =
-                try {
-                  listOf(api.getEncoded(pigeon_instanceArg))
-                } catch (exception: Throwable) {
-                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-                }
+            val wrapped: List<Any?> = try {
+              listOf(api.getEncoded(pigeon_instanceArg))
+            } catch (exception: Throwable) {
+              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+            }
             reply.reply(wrapped)
           }
         } else {
@@ -6823,19 +5732,16 @@ abstract class PigeonApiCertificate(
 
   @Suppress("LocalVariableName", "FunctionName")
   /** Creates a Dart instance of Certificate and attaches it to [pigeon_instanceArg]. */
-  fun pigeon_newInstance(
-      pigeon_instanceArg: java.security.cert.Certificate,
-      callback: (Result<Unit>) -> Unit
-  ) {
+  fun pigeon_newInstance(pigeon_instanceArg: java.security.cert.Certificate, callback: (Result<Unit>) -> Unit)
+{
     if (pigeonRegistrar.ignoreCallsToDart) {
       callback(
           Result.failure(
               AndroidWebKitError("ignore-calls-error", "Calls to Dart are being ignored.", "")))
-    } else if (pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
+    }     else if (pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
       callback(Result.success(Unit))
-    } else {
-      val pigeon_identifierArg =
-          pigeonRegistrar.instanceManager.addHostCreatedInstance(pigeon_instanceArg)
+    }     else {
+      val pigeon_identifierArg = pigeonRegistrar.instanceManager.addHostCreatedInstance(pigeon_instanceArg)
       val binaryMessenger = pigeonRegistrar.binaryMessenger
       val codec = pigeonRegistrar.codec
       val channelName = "dev.flutter.pigeon.webview_flutter_android.Certificate.pigeon_newInstance"
@@ -6843,19 +5749,17 @@ abstract class PigeonApiCertificate(
       channel.send(listOf(pigeon_identifierArg)) {
         if (it is List<*>) {
           if (it.size > 1) {
-            callback(
-                Result.failure(
-                    AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
+            callback(Result.failure(AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
           } else {
             callback(Result.success(Unit))
           }
         } else {
-          callback(
-              Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
-        }
+          callback(Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
+        } 
       }
     }
   }
+
 }
 /**
  * Compatibility version of `WebSettings`.
@@ -6863,9 +5767,7 @@ abstract class PigeonApiCertificate(
  * See https://developer.android.com/reference/kotlin/androidx/webkit/WebSettingsCompat.
  */
 @Suppress("UNCHECKED_CAST")
-abstract class PigeonApiWebSettingsCompat(
-    open val pigeonRegistrar: AndroidWebkitLibraryPigeonProxyApiRegistrar
-) {
+abstract class PigeonApiWebSettingsCompat(open val pigeonRegistrar: AndroidWebkitLibraryPigeonProxyApiRegistrar) {
   abstract fun setPaymentRequestEnabled(webSettings: android.webkit.WebSettings, enabled: Boolean)
 
   companion object {
@@ -6873,23 +5775,18 @@ abstract class PigeonApiWebSettingsCompat(
     fun setUpMessageHandlers(binaryMessenger: BinaryMessenger, api: PigeonApiWebSettingsCompat?) {
       val codec = api?.pigeonRegistrar?.codec ?: AndroidWebkitLibraryPigeonCodec()
       run {
-        val channel =
-            BasicMessageChannel<Any?>(
-                binaryMessenger,
-                "dev.flutter.pigeon.webview_flutter_android.WebSettingsCompat.setPaymentRequestEnabled",
-                codec)
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.WebSettingsCompat.setPaymentRequestEnabled", codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val webSettingsArg = args[0] as android.webkit.WebSettings
             val enabledArg = args[1] as Boolean
-            val wrapped: List<Any?> =
-                try {
-                  api.setPaymentRequestEnabled(webSettingsArg, enabledArg)
-                  listOf(null)
-                } catch (exception: Throwable) {
-                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-                }
+            val wrapped: List<Any?> = try {
+              api.setPaymentRequestEnabled(webSettingsArg, enabledArg)
+              listOf(null)
+            } catch (exception: Throwable) {
+              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+            }
             reply.reply(wrapped)
           }
         } else {
@@ -6901,40 +5798,34 @@ abstract class PigeonApiWebSettingsCompat(
 
   @Suppress("LocalVariableName", "FunctionName")
   /** Creates a Dart instance of WebSettingsCompat and attaches it to [pigeon_instanceArg]. */
-  fun pigeon_newInstance(
-      pigeon_instanceArg: androidx.webkit.WebSettingsCompat,
-      callback: (Result<Unit>) -> Unit
-  ) {
+  fun pigeon_newInstance(pigeon_instanceArg: androidx.webkit.WebSettingsCompat, callback: (Result<Unit>) -> Unit)
+{
     if (pigeonRegistrar.ignoreCallsToDart) {
       callback(
           Result.failure(
               AndroidWebKitError("ignore-calls-error", "Calls to Dart are being ignored.", "")))
-    } else if (pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
+    }     else if (pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
       callback(Result.success(Unit))
-    } else {
-      val pigeon_identifierArg =
-          pigeonRegistrar.instanceManager.addHostCreatedInstance(pigeon_instanceArg)
+    }     else {
+      val pigeon_identifierArg = pigeonRegistrar.instanceManager.addHostCreatedInstance(pigeon_instanceArg)
       val binaryMessenger = pigeonRegistrar.binaryMessenger
       val codec = pigeonRegistrar.codec
-      val channelName =
-          "dev.flutter.pigeon.webview_flutter_android.WebSettingsCompat.pigeon_newInstance"
+      val channelName = "dev.flutter.pigeon.webview_flutter_android.WebSettingsCompat.pigeon_newInstance"
       val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
       channel.send(listOf(pigeon_identifierArg)) {
         if (it is List<*>) {
           if (it.size > 1) {
-            callback(
-                Result.failure(
-                    AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
+            callback(Result.failure(AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
           } else {
             callback(Result.success(Unit))
           }
         } else {
-          callback(
-              Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
-        }
+          callback(Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
+        } 
       }
     }
   }
+
 }
 /**
  * Utility class for checking which WebView Support Library features are supported on the device.
@@ -6942,9 +5833,7 @@ abstract class PigeonApiWebSettingsCompat(
  * See https://developer.android.com/reference/kotlin/androidx/webkit/WebViewFeature.
  */
 @Suppress("UNCHECKED_CAST")
-abstract class PigeonApiWebViewFeature(
-    open val pigeonRegistrar: AndroidWebkitLibraryPigeonProxyApiRegistrar
-) {
+abstract class PigeonApiWebViewFeature(open val pigeonRegistrar: AndroidWebkitLibraryPigeonProxyApiRegistrar) {
   abstract fun isFeatureSupported(feature: String): Boolean
 
   companion object {
@@ -6952,21 +5841,16 @@ abstract class PigeonApiWebViewFeature(
     fun setUpMessageHandlers(binaryMessenger: BinaryMessenger, api: PigeonApiWebViewFeature?) {
       val codec = api?.pigeonRegistrar?.codec ?: AndroidWebkitLibraryPigeonCodec()
       run {
-        val channel =
-            BasicMessageChannel<Any?>(
-                binaryMessenger,
-                "dev.flutter.pigeon.webview_flutter_android.WebViewFeature.isFeatureSupported",
-                codec)
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.WebViewFeature.isFeatureSupported", codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val featureArg = args[0] as String
-            val wrapped: List<Any?> =
-                try {
-                  listOf(api.isFeatureSupported(featureArg))
-                } catch (exception: Throwable) {
-                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-                }
+            val wrapped: List<Any?> = try {
+              listOf(api.isFeatureSupported(featureArg))
+            } catch (exception: Throwable) {
+              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+            }
             reply.reply(wrapped)
           }
         } else {
@@ -6978,38 +5862,32 @@ abstract class PigeonApiWebViewFeature(
 
   @Suppress("LocalVariableName", "FunctionName")
   /** Creates a Dart instance of WebViewFeature and attaches it to [pigeon_instanceArg]. */
-  fun pigeon_newInstance(
-      pigeon_instanceArg: androidx.webkit.WebViewFeature,
-      callback: (Result<Unit>) -> Unit
-  ) {
+  fun pigeon_newInstance(pigeon_instanceArg: androidx.webkit.WebViewFeature, callback: (Result<Unit>) -> Unit)
+{
     if (pigeonRegistrar.ignoreCallsToDart) {
       callback(
           Result.failure(
               AndroidWebKitError("ignore-calls-error", "Calls to Dart are being ignored.", "")))
-    } else if (pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
+    }     else if (pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
       callback(Result.success(Unit))
-    } else {
-      val pigeon_identifierArg =
-          pigeonRegistrar.instanceManager.addHostCreatedInstance(pigeon_instanceArg)
+    }     else {
+      val pigeon_identifierArg = pigeonRegistrar.instanceManager.addHostCreatedInstance(pigeon_instanceArg)
       val binaryMessenger = pigeonRegistrar.binaryMessenger
       val codec = pigeonRegistrar.codec
-      val channelName =
-          "dev.flutter.pigeon.webview_flutter_android.WebViewFeature.pigeon_newInstance"
+      val channelName = "dev.flutter.pigeon.webview_flutter_android.WebViewFeature.pigeon_newInstance"
       val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
       channel.send(listOf(pigeon_identifierArg)) {
         if (it is List<*>) {
           if (it.size > 1) {
-            callback(
-                Result.failure(
-                    AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
+            callback(Result.failure(AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
           } else {
             callback(Result.success(Unit))
           }
         } else {
-          callback(
-              Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
-        }
+          callback(Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
+        } 
       }
     }
   }
+
 }

--- a/packages/webview_flutter/webview_flutter_android/android/src/main/java/io/flutter/plugins/webviewflutter/AndroidWebkitLibrary.g.kt
+++ b/packages/webview_flutter/webview_flutter_android/android/src/main/java/io/flutter/plugins/webviewflutter/AndroidWebkitLibrary.g.kt
@@ -10,16 +10,17 @@ package io.flutter.plugins.webviewflutter
 import android.util.Log
 import io.flutter.plugin.common.BasicMessageChannel
 import io.flutter.plugin.common.BinaryMessenger
-import io.flutter.plugin.common.EventChannel
 import io.flutter.plugin.common.MessageCodec
-import io.flutter.plugin.common.StandardMethodCodec
 import io.flutter.plugin.common.StandardMessageCodec
 import java.io.ByteArrayOutputStream
 import java.nio.ByteBuffer
+
 private object AndroidWebkitLibraryPigeonUtils {
 
   fun createConnectionError(channelName: String): AndroidWebKitError {
-    return AndroidWebKitError("channel-error",  "Unable to establish connection on channel: '$channelName'.", "")  }
+    return AndroidWebKitError(
+        "channel-error", "Unable to establish connection on channel: '$channelName'.", "")
+  }
 
   fun wrapResult(result: Any?): List<Any?> {
     return listOf(result)
@@ -27,50 +28,48 @@ private object AndroidWebkitLibraryPigeonUtils {
 
   fun wrapError(exception: Throwable): List<Any?> {
     return if (exception is AndroidWebKitError) {
-      listOf(
-        exception.code,
-        exception.message,
-        exception.details
-      )
+      listOf(exception.code, exception.message, exception.details)
     } else {
       listOf(
-        exception.javaClass.simpleName,
-        exception.toString(),
-        "Cause: " + exception.cause + ", Stacktrace: " + Log.getStackTraceString(exception)
-      )
+          exception.javaClass.simpleName,
+          exception.toString(),
+          "Cause: " + exception.cause + ", Stacktrace: " + Log.getStackTraceString(exception))
     }
   }
 }
 
 /**
  * Error class for passing custom error details to Flutter via a thrown PlatformException.
+ *
  * @property code The error code.
  * @property message The error message.
  * @property details The error details. Must be a datatype supported by the api codec.
  */
-class AndroidWebKitError (
-  val code: String,
-  override val message: String? = null,
-  val details: Any? = null
+class AndroidWebKitError(
+    val code: String,
+    override val message: String? = null,
+    val details: Any? = null
 ) : RuntimeException()
 /**
  * Maintains instances used to communicate with the corresponding objects in Dart.
  *
- * Objects stored in this container are represented by an object in Dart that is also stored in
- * an InstanceManager with the same identifier.
+ * Objects stored in this container are represented by an object in Dart that is also stored in an
+ * InstanceManager with the same identifier.
  *
  * When an instance is added with an identifier, either can be used to retrieve the other.
  *
- * Added instances are added as a weak reference and a strong reference. When the strong
- * reference is removed with [remove] and the weak reference is deallocated, the
- * `finalizationListener.onFinalize` is called with the instance's identifier. However, if the strong
- * reference is removed and then the identifier is retrieved with the intention to pass the identifier
- * to Dart (e.g. calling [getIdentifierForStrongReference]), the strong reference to the instance
- * is recreated. The strong reference will then need to be removed manually again.
+ * Added instances are added as a weak reference and a strong reference. When the strong reference
+ * is removed with [remove] and the weak reference is deallocated, the
+ * `finalizationListener.onFinalize` is called with the instance's identifier. However, if the
+ * strong reference is removed and then the identifier is retrieved with the intention to pass the
+ * identifier to Dart (e.g. calling [getIdentifierForStrongReference]), the strong reference to the
+ * instance is recreated. The strong reference will then need to be removed manually again.
  */
 @Suppress("UNCHECKED_CAST", "MemberVisibilityCanBePrivate")
-class AndroidWebkitLibraryPigeonInstanceManager(private val finalizationListener: PigeonFinalizationListener) {
-  /** Interface for listening when a weak reference of an instance is removed from the manager.  */
+class AndroidWebkitLibraryPigeonInstanceManager(
+    private val finalizationListener: PigeonFinalizationListener
+) {
+  /** Interface for listening when a weak reference of an instance is removed from the manager. */
   interface PigeonFinalizationListener {
     fun onFinalize(identifier: Long)
   }
@@ -139,19 +138,20 @@ class AndroidWebkitLibraryPigeonInstanceManager(private val finalizationListener
     private const val tag = "PigeonInstanceManager"
 
     /**
-     * Instantiate a new manager with a listener for garbage collected weak
-     * references.
+     * Instantiate a new manager with a listener for garbage collected weak references.
      *
      * When the manager is no longer needed, [stopFinalizationListener] must be called.
      */
-    fun create(finalizationListener: PigeonFinalizationListener): AndroidWebkitLibraryPigeonInstanceManager {
+    fun create(
+        finalizationListener: PigeonFinalizationListener
+    ): AndroidWebkitLibraryPigeonInstanceManager {
       return AndroidWebkitLibraryPigeonInstanceManager(finalizationListener)
     }
   }
 
   /**
-   * Removes `identifier` and return its associated strongly referenced instance, if present,
-   * from the manager.
+   * Removes `identifier` and return its associated strongly referenced instance, if present, from
+   * the manager.
    */
   fun <T> remove(identifier: Long): T? {
     logWarningIfFinalizationListenerHasStopped()
@@ -165,15 +165,13 @@ class AndroidWebkitLibraryPigeonInstanceManager(private val finalizationListener
   /**
    * Retrieves the identifier paired with an instance, if present, otherwise `null`.
    *
-   *
    * If the manager contains a strong reference to `instance`, it will return the identifier
    * associated with `instance`. If the manager contains only a weak reference to `instance`, a new
    * strong reference to `instance` will be added and will need to be removed again with [remove].
    *
-   *
    * If this method returns a nonnull identifier, this method also expects the Dart
-   * `AndroidWebkitLibraryPigeonInstanceManager` to have, or recreate, a weak reference to the Dart instance the
-   * identifier is associated with.
+   * `AndroidWebkitLibraryPigeonInstanceManager` to have, or recreate, a weak reference to the Dart
+   * instance the identifier is associated with.
    */
   fun getIdentifierForStrongReference(instance: Any?): Long? {
     logWarningIfFinalizationListenerHasStopped()
@@ -190,9 +188,9 @@ class AndroidWebkitLibraryPigeonInstanceManager(private val finalizationListener
   /**
    * Adds a new instance that was instantiated from Dart.
    *
-   * The same instance can be added multiple times, but each identifier must be unique. This
-   * allows two objects that are equivalent (e.g. the `equals` method returns true and their
-   * hashcodes are equal) to both be added.
+   * The same instance can be added multiple times, but each identifier must be unique. This allows
+   * two objects that are equivalent (e.g. the `equals` method returns true and their hashcodes are
+   * equal) to both be added.
    *
    * [identifier] must be >= 0 and unique.
    */
@@ -204,13 +202,15 @@ class AndroidWebkitLibraryPigeonInstanceManager(private val finalizationListener
   /**
    * Adds a new unique instance that was instantiated from the host platform.
    *
-   * If the manager contains [instance], this returns the corresponding identifier. If the
-   * manager does not contain [instance], this adds the instance and returns a unique
-   * identifier for that [instance].
+   * If the manager contains [instance], this returns the corresponding identifier. If the manager
+   * does not contain [instance], this adds the instance and returns a unique identifier for that
+   * [instance].
    */
   fun addHostCreatedInstance(instance: Any): Long {
     logWarningIfFinalizationListenerHasStopped()
-    require(!containsInstance(instance)) { "Instance of ${instance.javaClass} has already been added." }
+    require(!containsInstance(instance)) {
+      "Instance of ${instance.javaClass} has already been added."
+    }
     val identifier = nextIdentifier++
     addInstance(instance, identifier)
     return identifier
@@ -294,39 +294,43 @@ class AndroidWebkitLibraryPigeonInstanceManager(private val finalizationListener
   private fun logWarningIfFinalizationListenerHasStopped() {
     if (hasFinalizationListenerStopped()) {
       Log.w(
-        tag,
-        "The manager was used after calls to the PigeonFinalizationListener has been stopped."
-      )
+          tag,
+          "The manager was used after calls to the PigeonFinalizationListener has been stopped.")
     }
   }
 }
-
 
 /** Generated API for managing the Dart and native `InstanceManager`s. */
 private class AndroidWebkitLibraryPigeonInstanceManagerApi(val binaryMessenger: BinaryMessenger) {
   companion object {
     /** The codec used by AndroidWebkitLibraryPigeonInstanceManagerApi. */
-    val codec: MessageCodec<Any?> by lazy {
-      AndroidWebkitLibraryPigeonCodec()
-    }
+    val codec: MessageCodec<Any?> by lazy { AndroidWebkitLibraryPigeonCodec() }
 
     /**
-     * Sets up an instance of `AndroidWebkitLibraryPigeonInstanceManagerApi` to handle messages from the
-     * `binaryMessenger`.
+     * Sets up an instance of `AndroidWebkitLibraryPigeonInstanceManagerApi` to handle messages from
+     * the `binaryMessenger`.
      */
-    fun setUpMessageHandlers(binaryMessenger: BinaryMessenger, instanceManager: AndroidWebkitLibraryPigeonInstanceManager?) {
+    fun setUpMessageHandlers(
+        binaryMessenger: BinaryMessenger,
+        instanceManager: AndroidWebkitLibraryPigeonInstanceManager?
+    ) {
       run {
-        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.PigeonInternalInstanceManager.removeStrongReference", codec)
+        val channel =
+            BasicMessageChannel<Any?>(
+                binaryMessenger,
+                "dev.flutter.pigeon.webview_flutter_android.PigeonInternalInstanceManager.removeStrongReference",
+                codec)
         if (instanceManager != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val identifierArg = args[0] as Long
-            val wrapped: List<Any?> = try {
-              instanceManager.remove<Any?>(identifierArg)
-              listOf(null)
-            } catch (exception: Throwable) {
-              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-            }
+            val wrapped: List<Any?> =
+                try {
+                  instanceManager.remove<Any?>(identifierArg)
+                  listOf(null)
+                } catch (exception: Throwable) {
+                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+                }
             reply.reply(wrapped)
           }
         } else {
@@ -334,15 +338,20 @@ private class AndroidWebkitLibraryPigeonInstanceManagerApi(val binaryMessenger: 
         }
       }
       run {
-        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.PigeonInternalInstanceManager.clear", codec)
+        val channel =
+            BasicMessageChannel<Any?>(
+                binaryMessenger,
+                "dev.flutter.pigeon.webview_flutter_android.PigeonInternalInstanceManager.clear",
+                codec)
         if (instanceManager != null) {
           channel.setMessageHandler { _, reply ->
-            val wrapped: List<Any?> = try {
-              instanceManager.clear()
-              listOf(null)
-            } catch (exception: Throwable) {
-              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-            }
+            val wrapped: List<Any?> =
+                try {
+                  instanceManager.clear()
+                  listOf(null)
+                } catch (exception: Throwable) {
+                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+                }
             reply.reply(wrapped)
           }
         } else {
@@ -352,26 +361,28 @@ private class AndroidWebkitLibraryPigeonInstanceManagerApi(val binaryMessenger: 
     }
   }
 
-  fun removeStrongReference(identifierArg: Long, callback: (Result<Unit>) -> Unit)
-{
-    val channelName = "dev.flutter.pigeon.webview_flutter_android.PigeonInternalInstanceManager.removeStrongReference"
+  fun removeStrongReference(identifierArg: Long, callback: (Result<Unit>) -> Unit) {
+    val channelName =
+        "dev.flutter.pigeon.webview_flutter_android.PigeonInternalInstanceManager.removeStrongReference"
     val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
     channel.send(listOf(identifierArg)) {
       if (it is List<*>) {
         if (it.size > 1) {
-          callback(Result.failure(AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
+          callback(
+              Result.failure(
+                  AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
         } else {
           callback(Result.success(Unit))
         }
       } else {
         callback(Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
-      } 
+      }
     }
   }
 }
 /**
- * Provides implementations for each ProxyApi implementation and provides access to resources
- * needed by any implementation.
+ * Provides implementations for each ProxyApi implementation and provides access to resources needed
+ * by any implementation.
  */
 abstract class AndroidWebkitLibraryPigeonProxyApiRegistrar(val binaryMessenger: BinaryMessenger) {
   /** Whether APIs should ignore calling to Dart. */
@@ -388,20 +399,19 @@ abstract class AndroidWebkitLibraryPigeonProxyApiRegistrar(val binaryMessenger: 
 
   init {
     val api = AndroidWebkitLibraryPigeonInstanceManagerApi(binaryMessenger)
-    instanceManager = AndroidWebkitLibraryPigeonInstanceManager.create(
-      object : AndroidWebkitLibraryPigeonInstanceManager.PigeonFinalizationListener {
-        override fun onFinalize(identifier: Long) {
-          api.removeStrongReference(identifier) {
-            if (it.isFailure) {
-              Log.e(
-                "PigeonProxyApiRegistrar",
-                "Failed to remove Dart strong reference with identifier: $identifier"
-              )
-            }
-          }
-        }
-      }
-    )
+    instanceManager =
+        AndroidWebkitLibraryPigeonInstanceManager.create(
+            object : AndroidWebkitLibraryPigeonInstanceManager.PigeonFinalizationListener {
+              override fun onFinalize(identifier: Long) {
+                api.removeStrongReference(identifier) {
+                  if (it.isFailure) {
+                    Log.e(
+                        "PigeonProxyApiRegistrar",
+                        "Failed to remove Dart strong reference with identifier: $identifier")
+                  }
+                }
+              }
+            })
   }
   /**
    * An implementation of [PigeonApiWebResourceRequest] used to add a new Dart instance of
@@ -428,8 +438,8 @@ abstract class AndroidWebkitLibraryPigeonProxyApiRegistrar(val binaryMessenger: 
   abstract fun getPigeonApiWebResourceErrorCompat(): PigeonApiWebResourceErrorCompat
 
   /**
-   * An implementation of [PigeonApiWebViewPoint] used to add a new Dart instance of
-   * `WebViewPoint` to the Dart `InstanceManager`.
+   * An implementation of [PigeonApiWebViewPoint] used to add a new Dart instance of `WebViewPoint`
+   * to the Dart `InstanceManager`.
    */
   abstract fun getPigeonApiWebViewPoint(): PigeonApiWebViewPoint
 
@@ -446,14 +456,14 @@ abstract class AndroidWebkitLibraryPigeonProxyApiRegistrar(val binaryMessenger: 
   abstract fun getPigeonApiCookieManager(): PigeonApiCookieManager
 
   /**
-   * An implementation of [PigeonApiWebView] used to add a new Dart instance of
-   * `WebView` to the Dart `InstanceManager`.
+   * An implementation of [PigeonApiWebView] used to add a new Dart instance of `WebView` to the
+   * Dart `InstanceManager`.
    */
   abstract fun getPigeonApiWebView(): PigeonApiWebView
 
   /**
-   * An implementation of [PigeonApiWebSettings] used to add a new Dart instance of
-   * `WebSettings` to the Dart `InstanceManager`.
+   * An implementation of [PigeonApiWebSettings] used to add a new Dart instance of `WebSettings` to
+   * the Dart `InstanceManager`.
    */
   abstract fun getPigeonApiWebSettings(): PigeonApiWebSettings
 
@@ -488,8 +498,8 @@ abstract class AndroidWebkitLibraryPigeonProxyApiRegistrar(val binaryMessenger: 
   abstract fun getPigeonApiFlutterAssetManager(): PigeonApiFlutterAssetManager
 
   /**
-   * An implementation of [PigeonApiWebStorage] used to add a new Dart instance of
-   * `WebStorage` to the Dart `InstanceManager`.
+   * An implementation of [PigeonApiWebStorage] used to add a new Dart instance of `WebStorage` to
+   * the Dart `InstanceManager`.
    */
   abstract fun getPigeonApiWebStorage(): PigeonApiWebStorage
 
@@ -512,14 +522,14 @@ abstract class AndroidWebkitLibraryPigeonProxyApiRegistrar(val binaryMessenger: 
   abstract fun getPigeonApiCustomViewCallback(): PigeonApiCustomViewCallback
 
   /**
-   * An implementation of [PigeonApiView] used to add a new Dart instance of
-   * `View` to the Dart `InstanceManager`.
+   * An implementation of [PigeonApiView] used to add a new Dart instance of `View` to the Dart
+   * `InstanceManager`.
    */
   abstract fun getPigeonApiView(): PigeonApiView
 
   /**
-   * An implementation of [PigeonApiGeolocationPermissionsCallback] used to add a new Dart instance of
-   * `GeolocationPermissionsCallback` to the Dart `InstanceManager`.
+   * An implementation of [PigeonApiGeolocationPermissionsCallback] used to add a new Dart instance
+   * of `GeolocationPermissionsCallback` to the Dart `InstanceManager`.
    */
   abstract fun getPigeonApiGeolocationPermissionsCallback(): PigeonApiGeolocationPermissionsCallback
 
@@ -542,11 +552,10 @@ abstract class AndroidWebkitLibraryPigeonProxyApiRegistrar(val binaryMessenger: 
   abstract fun getPigeonApiClientCertRequest(): PigeonApiClientCertRequest
 
   /**
-   * An implementation of [PigeonApiPrivateKey] used to add a new Dart instance of
-   * `PrivateKey` to the Dart `InstanceManager`.
+   * An implementation of [PigeonApiPrivateKey] used to add a new Dart instance of `PrivateKey` to
+   * the Dart `InstanceManager`.
    */
-  open fun getPigeonApiPrivateKey(): PigeonApiPrivateKey
-  {
+  open fun getPigeonApiPrivateKey(): PigeonApiPrivateKey {
     return PigeonApiPrivateKey(this)
   }
 
@@ -554,8 +563,7 @@ abstract class AndroidWebkitLibraryPigeonProxyApiRegistrar(val binaryMessenger: 
    * An implementation of [PigeonApiX509Certificate] used to add a new Dart instance of
    * `X509Certificate` to the Dart `InstanceManager`.
    */
-  open fun getPigeonApiX509Certificate(): PigeonApiX509Certificate
-  {
+  open fun getPigeonApiX509Certificate(): PigeonApiX509Certificate {
     return PigeonApiX509Certificate(this)
   }
 
@@ -566,8 +574,8 @@ abstract class AndroidWebkitLibraryPigeonProxyApiRegistrar(val binaryMessenger: 
   abstract fun getPigeonApiSslErrorHandler(): PigeonApiSslErrorHandler
 
   /**
-   * An implementation of [PigeonApiSslError] used to add a new Dart instance of
-   * `SslError` to the Dart `InstanceManager`.
+   * An implementation of [PigeonApiSslError] used to add a new Dart instance of `SslError` to the
+   * Dart `InstanceManager`.
    */
   abstract fun getPigeonApiSslError(): PigeonApiSslError
 
@@ -584,8 +592,8 @@ abstract class AndroidWebkitLibraryPigeonProxyApiRegistrar(val binaryMessenger: 
   abstract fun getPigeonApiSslCertificate(): PigeonApiSslCertificate
 
   /**
-   * An implementation of [PigeonApiCertificate] used to add a new Dart instance of
-   * `Certificate` to the Dart `InstanceManager`.
+   * An implementation of [PigeonApiCertificate] used to add a new Dart instance of `Certificate` to
+   * the Dart `InstanceManager`.
    */
   abstract fun getPigeonApiCertificate(): PigeonApiCertificate
 
@@ -602,31 +610,41 @@ abstract class AndroidWebkitLibraryPigeonProxyApiRegistrar(val binaryMessenger: 
   abstract fun getPigeonApiWebViewFeature(): PigeonApiWebViewFeature
 
   fun setUp() {
-    AndroidWebkitLibraryPigeonInstanceManagerApi.setUpMessageHandlers(binaryMessenger, instanceManager)
+    AndroidWebkitLibraryPigeonInstanceManagerApi.setUpMessageHandlers(
+        binaryMessenger, instanceManager)
     PigeonApiCookieManager.setUpMessageHandlers(binaryMessenger, getPigeonApiCookieManager())
     PigeonApiWebView.setUpMessageHandlers(binaryMessenger, getPigeonApiWebView())
     PigeonApiWebSettings.setUpMessageHandlers(binaryMessenger, getPigeonApiWebSettings())
-    PigeonApiJavaScriptChannel.setUpMessageHandlers(binaryMessenger, getPigeonApiJavaScriptChannel())
+    PigeonApiJavaScriptChannel.setUpMessageHandlers(
+        binaryMessenger, getPigeonApiJavaScriptChannel())
     PigeonApiWebViewClient.setUpMessageHandlers(binaryMessenger, getPigeonApiWebViewClient())
     PigeonApiDownloadListener.setUpMessageHandlers(binaryMessenger, getPigeonApiDownloadListener())
     PigeonApiWebChromeClient.setUpMessageHandlers(binaryMessenger, getPigeonApiWebChromeClient())
-    PigeonApiFlutterAssetManager.setUpMessageHandlers(binaryMessenger, getPigeonApiFlutterAssetManager())
+    PigeonApiFlutterAssetManager.setUpMessageHandlers(
+        binaryMessenger, getPigeonApiFlutterAssetManager())
     PigeonApiWebStorage.setUpMessageHandlers(binaryMessenger, getPigeonApiWebStorage())
-    PigeonApiPermissionRequest.setUpMessageHandlers(binaryMessenger, getPigeonApiPermissionRequest())
-    PigeonApiCustomViewCallback.setUpMessageHandlers(binaryMessenger, getPigeonApiCustomViewCallback())
+    PigeonApiPermissionRequest.setUpMessageHandlers(
+        binaryMessenger, getPigeonApiPermissionRequest())
+    PigeonApiCustomViewCallback.setUpMessageHandlers(
+        binaryMessenger, getPigeonApiCustomViewCallback())
     PigeonApiView.setUpMessageHandlers(binaryMessenger, getPigeonApiView())
-    PigeonApiGeolocationPermissionsCallback.setUpMessageHandlers(binaryMessenger, getPigeonApiGeolocationPermissionsCallback())
+    PigeonApiGeolocationPermissionsCallback.setUpMessageHandlers(
+        binaryMessenger, getPigeonApiGeolocationPermissionsCallback())
     PigeonApiHttpAuthHandler.setUpMessageHandlers(binaryMessenger, getPigeonApiHttpAuthHandler())
     PigeonApiAndroidMessage.setUpMessageHandlers(binaryMessenger, getPigeonApiAndroidMessage())
-    PigeonApiClientCertRequest.setUpMessageHandlers(binaryMessenger, getPigeonApiClientCertRequest())
+    PigeonApiClientCertRequest.setUpMessageHandlers(
+        binaryMessenger, getPigeonApiClientCertRequest())
     PigeonApiSslErrorHandler.setUpMessageHandlers(binaryMessenger, getPigeonApiSslErrorHandler())
     PigeonApiSslError.setUpMessageHandlers(binaryMessenger, getPigeonApiSslError())
-    PigeonApiSslCertificateDName.setUpMessageHandlers(binaryMessenger, getPigeonApiSslCertificateDName())
+    PigeonApiSslCertificateDName.setUpMessageHandlers(
+        binaryMessenger, getPigeonApiSslCertificateDName())
     PigeonApiSslCertificate.setUpMessageHandlers(binaryMessenger, getPigeonApiSslCertificate())
     PigeonApiCertificate.setUpMessageHandlers(binaryMessenger, getPigeonApiCertificate())
-    PigeonApiWebSettingsCompat.setUpMessageHandlers(binaryMessenger, getPigeonApiWebSettingsCompat())
+    PigeonApiWebSettingsCompat.setUpMessageHandlers(
+        binaryMessenger, getPigeonApiWebSettingsCompat())
     PigeonApiWebViewFeature.setUpMessageHandlers(binaryMessenger, getPigeonApiWebViewFeature())
   }
+
   fun tearDown() {
     AndroidWebkitLibraryPigeonInstanceManagerApi.setUpMessageHandlers(binaryMessenger, null)
     PigeonApiCookieManager.setUpMessageHandlers(binaryMessenger, null)
@@ -654,17 +672,17 @@ abstract class AndroidWebkitLibraryPigeonProxyApiRegistrar(val binaryMessenger: 
     PigeonApiWebViewFeature.setUpMessageHandlers(binaryMessenger, null)
   }
 }
-private class AndroidWebkitLibraryPigeonProxyApiBaseCodec(val registrar: AndroidWebkitLibraryPigeonProxyApiRegistrar) : AndroidWebkitLibraryPigeonCodec() {
+
+private class AndroidWebkitLibraryPigeonProxyApiBaseCodec(
+    val registrar: AndroidWebkitLibraryPigeonProxyApiRegistrar
+) : AndroidWebkitLibraryPigeonCodec() {
   override fun readValueOfType(type: Byte, buffer: ByteBuffer): Any? {
     return when (type) {
       128.toByte() -> {
         val identifier: Long = readValue(buffer) as Long
         val instance: Any? = registrar.instanceManager.getInstance(identifier)
         if (instance == null) {
-          Log.e(
-            "PigeonProxyApiBaseCodec",
-            "Failed to find instance with identifier: $identifier"
-          )
+          Log.e("PigeonProxyApiBaseCodec", "Failed to find instance with identifier: $identifier")
         }
         return instance
       }
@@ -673,16 +691,33 @@ private class AndroidWebkitLibraryPigeonProxyApiBaseCodec(val registrar: Android
   }
 
   override fun writeValue(stream: ByteArrayOutputStream, value: Any?) {
-    if (value is Boolean || value is ByteArray || value is Double || value is DoubleArray || value is FloatArray || value is Int || value is IntArray || value is List<*> || value is Long || value is LongArray || value is Map<*, *> || value is String || value is FileChooserMode || value is ConsoleMessageLevel || value is OverScrollMode || value is SslErrorType || value is MixedContentMode || value is WindowInsetsType || value == null) {
+    if (value is Boolean ||
+        value is ByteArray ||
+        value is Double ||
+        value is DoubleArray ||
+        value is FloatArray ||
+        value is Int ||
+        value is IntArray ||
+        value is List<*> ||
+        value is Long ||
+        value is LongArray ||
+        value is Map<*, *> ||
+        value is String ||
+        value is FileChooserMode ||
+        value is ConsoleMessageLevel ||
+        value is OverScrollMode ||
+        value is SslErrorType ||
+        value is MixedContentMode ||
+        value is WindowInsetsType ||
+        value == null) {
       super.writeValue(stream, value)
       return
     }
 
     fun logNewInstanceFailure(apiName: String, value: Any, exception: Throwable?) {
       Log.w(
-        "PigeonProxyApiBaseCodec",
-        "Failed to create new Dart proxy instance of $apiName: $value. $exception"
-      )
+          "PigeonProxyApiBaseCodec",
+          "Failed to create new Dart proxy instance of $apiName: $value. $exception")
     }
 
     if (value is android.webkit.WebResourceRequest) {
@@ -691,218 +726,188 @@ private class AndroidWebkitLibraryPigeonProxyApiBaseCodec(val registrar: Android
           logNewInstanceFailure("WebResourceRequest", value, it.exceptionOrNull())
         }
       }
-    }
-     else if (value is android.webkit.WebResourceResponse) {
+    } else if (value is android.webkit.WebResourceResponse) {
       registrar.getPigeonApiWebResourceResponse().pigeon_newInstance(value) {
         if (it.isFailure) {
           logNewInstanceFailure("WebResourceResponse", value, it.exceptionOrNull())
         }
       }
-    }
-     else if (value is android.webkit.WebResourceError) {
+    } else if (value is android.webkit.WebResourceError) {
       registrar.getPigeonApiWebResourceError().pigeon_newInstance(value) {
         if (it.isFailure) {
           logNewInstanceFailure("WebResourceError", value, it.exceptionOrNull())
         }
       }
-    }
-     else if (value is androidx.webkit.WebResourceErrorCompat) {
+    } else if (value is androidx.webkit.WebResourceErrorCompat) {
       registrar.getPigeonApiWebResourceErrorCompat().pigeon_newInstance(value) {
         if (it.isFailure) {
           logNewInstanceFailure("WebResourceErrorCompat", value, it.exceptionOrNull())
         }
       }
-    }
-     else if (value is WebViewPoint) {
+    } else if (value is WebViewPoint) {
       registrar.getPigeonApiWebViewPoint().pigeon_newInstance(value) {
         if (it.isFailure) {
           logNewInstanceFailure("WebViewPoint", value, it.exceptionOrNull())
         }
       }
-    }
-     else if (value is android.webkit.ConsoleMessage) {
+    } else if (value is android.webkit.ConsoleMessage) {
       registrar.getPigeonApiConsoleMessage().pigeon_newInstance(value) {
         if (it.isFailure) {
           logNewInstanceFailure("ConsoleMessage", value, it.exceptionOrNull())
         }
       }
-    }
-     else if (value is android.webkit.CookieManager) {
+    } else if (value is android.webkit.CookieManager) {
       registrar.getPigeonApiCookieManager().pigeon_newInstance(value) {
         if (it.isFailure) {
           logNewInstanceFailure("CookieManager", value, it.exceptionOrNull())
         }
       }
-    }
-     else if (value is android.webkit.WebView) {
+    } else if (value is android.webkit.WebView) {
       registrar.getPigeonApiWebView().pigeon_newInstance(value) {
         if (it.isFailure) {
           logNewInstanceFailure("WebView", value, it.exceptionOrNull())
         }
       }
-    }
-     else if (value is android.webkit.WebSettings) {
+    } else if (value is android.webkit.WebSettings) {
       registrar.getPigeonApiWebSettings().pigeon_newInstance(value) {
         if (it.isFailure) {
           logNewInstanceFailure("WebSettings", value, it.exceptionOrNull())
         }
       }
-    }
-     else if (value is JavaScriptChannel) {
+    } else if (value is JavaScriptChannel) {
       registrar.getPigeonApiJavaScriptChannel().pigeon_newInstance(value) {
         if (it.isFailure) {
           logNewInstanceFailure("JavaScriptChannel", value, it.exceptionOrNull())
         }
       }
-    }
-     else if (value is android.webkit.WebViewClient) {
+    } else if (value is android.webkit.WebViewClient) {
       registrar.getPigeonApiWebViewClient().pigeon_newInstance(value) {
         if (it.isFailure) {
           logNewInstanceFailure("WebViewClient", value, it.exceptionOrNull())
         }
       }
-    }
-     else if (value is android.webkit.DownloadListener) {
+    } else if (value is android.webkit.DownloadListener) {
       registrar.getPigeonApiDownloadListener().pigeon_newInstance(value) {
         if (it.isFailure) {
           logNewInstanceFailure("DownloadListener", value, it.exceptionOrNull())
         }
       }
-    }
-     else if (value is io.flutter.plugins.webviewflutter.WebChromeClientProxyApi.WebChromeClientImpl) {
+    } else if (value
+        is io.flutter.plugins.webviewflutter.WebChromeClientProxyApi.WebChromeClientImpl) {
       registrar.getPigeonApiWebChromeClient().pigeon_newInstance(value) {
         if (it.isFailure) {
           logNewInstanceFailure("WebChromeClient", value, it.exceptionOrNull())
         }
       }
-    }
-     else if (value is io.flutter.plugins.webviewflutter.FlutterAssetManager) {
+    } else if (value is io.flutter.plugins.webviewflutter.FlutterAssetManager) {
       registrar.getPigeonApiFlutterAssetManager().pigeon_newInstance(value) {
         if (it.isFailure) {
           logNewInstanceFailure("FlutterAssetManager", value, it.exceptionOrNull())
         }
       }
-    }
-     else if (value is android.webkit.WebStorage) {
+    } else if (value is android.webkit.WebStorage) {
       registrar.getPigeonApiWebStorage().pigeon_newInstance(value) {
         if (it.isFailure) {
           logNewInstanceFailure("WebStorage", value, it.exceptionOrNull())
         }
       }
-    }
-     else if (value is android.webkit.WebChromeClient.FileChooserParams) {
+    } else if (value is android.webkit.WebChromeClient.FileChooserParams) {
       registrar.getPigeonApiFileChooserParams().pigeon_newInstance(value) {
         if (it.isFailure) {
           logNewInstanceFailure("FileChooserParams", value, it.exceptionOrNull())
         }
       }
-    }
-     else if (value is android.webkit.PermissionRequest) {
+    } else if (value is android.webkit.PermissionRequest) {
       registrar.getPigeonApiPermissionRequest().pigeon_newInstance(value) {
         if (it.isFailure) {
           logNewInstanceFailure("PermissionRequest", value, it.exceptionOrNull())
         }
       }
-    }
-     else if (value is android.webkit.WebChromeClient.CustomViewCallback) {
+    } else if (value is android.webkit.WebChromeClient.CustomViewCallback) {
       registrar.getPigeonApiCustomViewCallback().pigeon_newInstance(value) {
         if (it.isFailure) {
           logNewInstanceFailure("CustomViewCallback", value, it.exceptionOrNull())
         }
       }
-    }
-     else if (value is android.view.View) {
+    } else if (value is android.view.View) {
       registrar.getPigeonApiView().pigeon_newInstance(value) {
         if (it.isFailure) {
           logNewInstanceFailure("View", value, it.exceptionOrNull())
         }
       }
-    }
-     else if (value is android.webkit.GeolocationPermissions.Callback) {
+    } else if (value is android.webkit.GeolocationPermissions.Callback) {
       registrar.getPigeonApiGeolocationPermissionsCallback().pigeon_newInstance(value) {
         if (it.isFailure) {
           logNewInstanceFailure("GeolocationPermissionsCallback", value, it.exceptionOrNull())
         }
       }
-    }
-     else if (value is android.webkit.HttpAuthHandler) {
+    } else if (value is android.webkit.HttpAuthHandler) {
       registrar.getPigeonApiHttpAuthHandler().pigeon_newInstance(value) {
         if (it.isFailure) {
           logNewInstanceFailure("HttpAuthHandler", value, it.exceptionOrNull())
         }
       }
-    }
-     else if (value is android.os.Message) {
+    } else if (value is android.os.Message) {
       registrar.getPigeonApiAndroidMessage().pigeon_newInstance(value) {
         if (it.isFailure) {
           logNewInstanceFailure("AndroidMessage", value, it.exceptionOrNull())
         }
       }
-    }
-     else if (value is android.webkit.ClientCertRequest) {
+    } else if (value is android.webkit.ClientCertRequest) {
       registrar.getPigeonApiClientCertRequest().pigeon_newInstance(value) {
         if (it.isFailure) {
           logNewInstanceFailure("ClientCertRequest", value, it.exceptionOrNull())
         }
       }
-    }
-     else if (value is java.security.PrivateKey) {
+    } else if (value is java.security.PrivateKey) {
       registrar.getPigeonApiPrivateKey().pigeon_newInstance(value) {
         if (it.isFailure) {
           logNewInstanceFailure("PrivateKey", value, it.exceptionOrNull())
         }
       }
-    }
-     else if (value is java.security.cert.X509Certificate) {
+    } else if (value is java.security.cert.X509Certificate) {
       registrar.getPigeonApiX509Certificate().pigeon_newInstance(value) {
         if (it.isFailure) {
           logNewInstanceFailure("X509Certificate", value, it.exceptionOrNull())
         }
       }
-    }
-     else if (value is android.webkit.SslErrorHandler) {
+    } else if (value is android.webkit.SslErrorHandler) {
       registrar.getPigeonApiSslErrorHandler().pigeon_newInstance(value) {
         if (it.isFailure) {
           logNewInstanceFailure("SslErrorHandler", value, it.exceptionOrNull())
         }
       }
-    }
-     else if (value is android.net.http.SslError) {
+    } else if (value is android.net.http.SslError) {
       registrar.getPigeonApiSslError().pigeon_newInstance(value) {
         if (it.isFailure) {
           logNewInstanceFailure("SslError", value, it.exceptionOrNull())
         }
       }
-    }
-     else if (value is android.net.http.SslCertificate.DName) {
+    } else if (value is android.net.http.SslCertificate.DName) {
       registrar.getPigeonApiSslCertificateDName().pigeon_newInstance(value) {
         if (it.isFailure) {
           logNewInstanceFailure("SslCertificateDName", value, it.exceptionOrNull())
         }
       }
-    }
-     else if (value is android.net.http.SslCertificate) {
+    } else if (value is android.net.http.SslCertificate) {
       registrar.getPigeonApiSslCertificate().pigeon_newInstance(value) {
         if (it.isFailure) {
           logNewInstanceFailure("SslCertificate", value, it.exceptionOrNull())
         }
       }
-    }
-     else if (value is java.security.cert.Certificate) {
+    } else if (value is java.security.cert.Certificate) {
       registrar.getPigeonApiCertificate().pigeon_newInstance(value) {
         if (it.isFailure) {
           logNewInstanceFailure("Certificate", value, it.exceptionOrNull())
         }
       }
-    }
-     else if (value is androidx.webkit.WebSettingsCompat) {
+    } else if (value is androidx.webkit.WebSettingsCompat) {
       registrar.getPigeonApiWebSettingsCompat().pigeon_newInstance(value) {
         if (it.isFailure) {
           logNewInstanceFailure("WebSettingsCompat", value, it.exceptionOrNull())
         }
       }
-    }
-     else if (value is androidx.webkit.WebViewFeature) {
+    } else if (value is androidx.webkit.WebViewFeature) {
       registrar.getPigeonApiWebViewFeature().pigeon_newInstance(value) {
         if (it.isFailure) {
           logNewInstanceFailure("WebViewFeature", value, it.exceptionOrNull())
@@ -915,7 +920,9 @@ private class AndroidWebkitLibraryPigeonProxyApiBaseCodec(val registrar: Android
         stream.write(128)
         writeValue(stream, registrar.instanceManager.getIdentifierForStrongReference(value))
       }
-      else -> throw IllegalArgumentException("Unsupported value: '$value' of type '${value.javaClass.name}'")
+      else ->
+          throw IllegalArgumentException(
+              "Unsupported value: '$value' of type '${value.javaClass.name}'")
     }
   }
 }
@@ -927,29 +934,31 @@ private class AndroidWebkitLibraryPigeonProxyApiBaseCodec(val registrar: Android
  */
 enum class FileChooserMode(val raw: Int) {
   /**
-   * Open single file and requires that the file exists before allowing the
-   * user to pick it.
+   * Open single file and requires that the file exists before allowing the user to pick it.
    *
-   * See https://developer.android.com/reference/android/webkit/WebChromeClient.FileChooserParams#MODE_OPEN.
+   * See
+   * https://developer.android.com/reference/android/webkit/WebChromeClient.FileChooserParams#MODE_OPEN.
    */
   OPEN(0),
   /**
    * Similar to [open] but allows multiple files to be selected.
    *
-   * See https://developer.android.com/reference/android/webkit/WebChromeClient.FileChooserParams#MODE_OPEN_MULTIPLE.
+   * See
+   * https://developer.android.com/reference/android/webkit/WebChromeClient.FileChooserParams#MODE_OPEN_MULTIPLE.
    */
   OPEN_MULTIPLE(1),
   /**
    * Allows picking a nonexistent file and saving it.
    *
-   * See https://developer.android.com/reference/android/webkit/WebChromeClient.FileChooserParams#MODE_SAVE.
+   * See
+   * https://developer.android.com/reference/android/webkit/WebChromeClient.FileChooserParams#MODE_SAVE.
    */
   SAVE(2),
   /**
    * Indicates a `FileChooserMode` with an unknown mode.
    *
-   * This does not represent an actual value provided by the platform and only
-   * indicates a value was provided that isn't currently supported.
+   * This does not represent an actual value provided by the platform and only indicates a value was
+   * provided that isn't currently supported.
    */
   UNKNOWN(3);
 
@@ -999,8 +1008,8 @@ enum class ConsoleMessageLevel(val raw: Int) {
   /**
    * Indicates a message with an unknown level.
    *
-   * This does not represent an actual value provided by the platform and only
-   * indicates a value was provided that isn't currently supported.
+   * This does not represent an actual value provided by the platform and only indicates a value was
+   * provided that isn't currently supported.
    */
   UNKNOWN(5);
 
@@ -1017,14 +1026,11 @@ enum class ConsoleMessageLevel(val raw: Int) {
  * See https://developer.android.com/reference/android/view/View#OVER_SCROLL_ALWAYS.
  */
 enum class OverScrollMode(val raw: Int) {
-  /**
-   * Always allow a user to over-scroll this view, provided it is a view that
-   * can scroll.
-   */
+  /** Always allow a user to over-scroll this view, provided it is a view that can scroll. */
   ALWAYS(0),
   /**
-   * Allow a user to over-scroll this view only if the content is large enough
-   * to meaningfully scroll, provided it is a view that can scroll.
+   * Allow a user to over-scroll this view only if the content is large enough to meaningfully
+   * scroll, provided it is a view that can scroll.
    */
   IF_CONTENT_SCROLLS(1),
   /** Never allow a user to over-scroll this view. */
@@ -1074,19 +1080,16 @@ enum class SslErrorType(val raw: Int) {
  */
 enum class MixedContentMode(val raw: Int) {
   /**
-   * The WebView will allow a secure origin to load content from any other
-   * origin, even if that origin is insecure.
+   * The WebView will allow a secure origin to load content from any other origin, even if that
+   * origin is insecure.
    */
   ALWAYS_ALLOW(0),
   /**
-   * The WebView will attempt to be compatible with the approach of a modern
-   * web browser with regard to mixed content.
+   * The WebView will attempt to be compatible with the approach of a modern web browser with regard
+   * to mixed content.
    */
   COMPATIBILITY_MODE(1),
-  /**
-   * The WebView will not allow a secure origin to load content from an
-   * insecure origin.
-   */
+  /** The WebView will not allow a secure origin to load content from an insecure origin. */
   NEVER_ALLOW(2);
 
   companion object {
@@ -1105,8 +1108,8 @@ enum class WindowInsetsType(val raw: Int) {
   /**
    * All system bars.
    *
-   * Includes statusBars(), captionBar() as well as navigationBars(),
-   * systemOverlays(), but not ime().
+   * Includes statusBars(), captionBar() as well as navigationBars(), systemOverlays(), but not
+   * ime().
    */
   SYSTEM_BARS(0),
   /** An inset type representing the area that used by DisplayCutout. */
@@ -1123,10 +1126,9 @@ enum class WindowInsetsType(val raw: Int) {
   /**
    * An insets type representing the system gesture insets.
    *
-   * The system gesture insets represent the area of a window where system
-   * gestures have priority and may consume some or all touch input, e.g. due
-   * to the a system bar occupying it, or it being reserved for touch-only
-   * gestures.
+   * The system gesture insets represent the area of a window where system gestures have priority
+   * and may consume some or all touch input, e.g. due to the a system bar occupying it, or it being
+   * reserved for touch-only gestures.
    */
   SYSTEM_GESTURES(7),
   TAPPABLE_ELEMENT(8);
@@ -1137,43 +1139,33 @@ enum class WindowInsetsType(val raw: Int) {
     }
   }
 }
+
 private open class AndroidWebkitLibraryPigeonCodec : StandardMessageCodec() {
   override fun readValueOfType(type: Byte, buffer: ByteBuffer): Any? {
     return when (type) {
       129.toByte() -> {
-        return (readValue(buffer) as Long?)?.let {
-          FileChooserMode.ofRaw(it.toInt())
-        }
+        return (readValue(buffer) as Long?)?.let { FileChooserMode.ofRaw(it.toInt()) }
       }
       130.toByte() -> {
-        return (readValue(buffer) as Long?)?.let {
-          ConsoleMessageLevel.ofRaw(it.toInt())
-        }
+        return (readValue(buffer) as Long?)?.let { ConsoleMessageLevel.ofRaw(it.toInt()) }
       }
       131.toByte() -> {
-        return (readValue(buffer) as Long?)?.let {
-          OverScrollMode.ofRaw(it.toInt())
-        }
+        return (readValue(buffer) as Long?)?.let { OverScrollMode.ofRaw(it.toInt()) }
       }
       132.toByte() -> {
-        return (readValue(buffer) as Long?)?.let {
-          SslErrorType.ofRaw(it.toInt())
-        }
+        return (readValue(buffer) as Long?)?.let { SslErrorType.ofRaw(it.toInt()) }
       }
       133.toByte() -> {
-        return (readValue(buffer) as Long?)?.let {
-          MixedContentMode.ofRaw(it.toInt())
-        }
+        return (readValue(buffer) as Long?)?.let { MixedContentMode.ofRaw(it.toInt()) }
       }
       134.toByte() -> {
-        return (readValue(buffer) as Long?)?.let {
-          WindowInsetsType.ofRaw(it.toInt())
-        }
+        return (readValue(buffer) as Long?)?.let { WindowInsetsType.ofRaw(it.toInt()) }
       }
       else -> super.readValueOfType(type, buffer)
     }
   }
-  override fun writeValue(stream: ByteArrayOutputStream, value: Any?)   {
+
+  override fun writeValue(stream: ByteArrayOutputStream, value: Any?) {
     when (value) {
       is FileChooserMode -> {
         stream.write(129)
@@ -1210,7 +1202,9 @@ private open class AndroidWebkitLibraryPigeonCodec : StandardMessageCodec() {
  * See https://developer.android.com/reference/android/webkit/WebResourceRequest.
  */
 @Suppress("UNCHECKED_CAST")
-abstract class PigeonApiWebResourceRequest(open val pigeonRegistrar: AndroidWebkitLibraryPigeonProxyApiRegistrar) {
+abstract class PigeonApiWebResourceRequest(
+    open val pigeonRegistrar: AndroidWebkitLibraryPigeonProxyApiRegistrar
+) {
   /** The URL for which the resource request was made. */
   abstract fun url(pigeon_instance: android.webkit.WebResourceRequest): String
 
@@ -1227,20 +1221,25 @@ abstract class PigeonApiWebResourceRequest(open val pigeonRegistrar: AndroidWebk
   abstract fun method(pigeon_instance: android.webkit.WebResourceRequest): String
 
   /** The headers associated with the request. */
-  abstract fun requestHeaders(pigeon_instance: android.webkit.WebResourceRequest): Map<String, String>?
+  abstract fun requestHeaders(
+      pigeon_instance: android.webkit.WebResourceRequest
+  ): Map<String, String>?
 
   @Suppress("LocalVariableName", "FunctionName")
   /** Creates a Dart instance of WebResourceRequest and attaches it to [pigeon_instanceArg]. */
-  fun pigeon_newInstance(pigeon_instanceArg: android.webkit.WebResourceRequest, callback: (Result<Unit>) -> Unit)
-{
+  fun pigeon_newInstance(
+      pigeon_instanceArg: android.webkit.WebResourceRequest,
+      callback: (Result<Unit>) -> Unit
+  ) {
     if (pigeonRegistrar.ignoreCallsToDart) {
       callback(
           Result.failure(
               AndroidWebKitError("ignore-calls-error", "Calls to Dart are being ignored.", "")))
-    }     else if (pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
+    } else if (pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
       callback(Result.success(Unit))
-    }     else {
-      val pigeon_identifierArg = pigeonRegistrar.instanceManager.addHostCreatedInstance(pigeon_instanceArg)
+    } else {
+      val pigeon_identifierArg =
+          pigeonRegistrar.instanceManager.addHostCreatedInstance(pigeon_instanceArg)
       val urlArg = url(pigeon_instanceArg)
       val isForMainFrameArg = isForMainFrame(pigeon_instanceArg)
       val isRedirectArg = isRedirect(pigeon_instanceArg)
@@ -1249,22 +1248,34 @@ abstract class PigeonApiWebResourceRequest(open val pigeonRegistrar: AndroidWebk
       val requestHeadersArg = requestHeaders(pigeon_instanceArg)
       val binaryMessenger = pigeonRegistrar.binaryMessenger
       val codec = pigeonRegistrar.codec
-      val channelName = "dev.flutter.pigeon.webview_flutter_android.WebResourceRequest.pigeon_newInstance"
+      val channelName =
+          "dev.flutter.pigeon.webview_flutter_android.WebResourceRequest.pigeon_newInstance"
       val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
-      channel.send(listOf(pigeon_identifierArg, urlArg, isForMainFrameArg, isRedirectArg, hasGestureArg, methodArg, requestHeadersArg)) {
-        if (it is List<*>) {
-          if (it.size > 1) {
-            callback(Result.failure(AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
-          } else {
-            callback(Result.success(Unit))
+      channel.send(
+          listOf(
+              pigeon_identifierArg,
+              urlArg,
+              isForMainFrameArg,
+              isRedirectArg,
+              hasGestureArg,
+              methodArg,
+              requestHeadersArg)) {
+            if (it is List<*>) {
+              if (it.size > 1) {
+                callback(
+                    Result.failure(
+                        AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
+              } else {
+                callback(Result.success(Unit))
+              }
+            } else {
+              callback(
+                  Result.failure(
+                      AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
+            }
           }
-        } else {
-          callback(Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
-        } 
-      }
     }
   }
-
 }
 /**
  * Encapsulates a resource response.
@@ -1272,50 +1283,59 @@ abstract class PigeonApiWebResourceRequest(open val pigeonRegistrar: AndroidWebk
  * See https://developer.android.com/reference/android/webkit/WebResourceResponse.
  */
 @Suppress("UNCHECKED_CAST")
-abstract class PigeonApiWebResourceResponse(open val pigeonRegistrar: AndroidWebkitLibraryPigeonProxyApiRegistrar) {
+abstract class PigeonApiWebResourceResponse(
+    open val pigeonRegistrar: AndroidWebkitLibraryPigeonProxyApiRegistrar
+) {
   /** The resource response's status code. */
   abstract fun statusCode(pigeon_instance: android.webkit.WebResourceResponse): Long
 
   @Suppress("LocalVariableName", "FunctionName")
   /** Creates a Dart instance of WebResourceResponse and attaches it to [pigeon_instanceArg]. */
-  fun pigeon_newInstance(pigeon_instanceArg: android.webkit.WebResourceResponse, callback: (Result<Unit>) -> Unit)
-{
+  fun pigeon_newInstance(
+      pigeon_instanceArg: android.webkit.WebResourceResponse,
+      callback: (Result<Unit>) -> Unit
+  ) {
     if (pigeonRegistrar.ignoreCallsToDart) {
       callback(
           Result.failure(
               AndroidWebKitError("ignore-calls-error", "Calls to Dart are being ignored.", "")))
-    }     else if (pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
+    } else if (pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
       callback(Result.success(Unit))
-    }     else {
-      val pigeon_identifierArg = pigeonRegistrar.instanceManager.addHostCreatedInstance(pigeon_instanceArg)
+    } else {
+      val pigeon_identifierArg =
+          pigeonRegistrar.instanceManager.addHostCreatedInstance(pigeon_instanceArg)
       val statusCodeArg = statusCode(pigeon_instanceArg)
       val binaryMessenger = pigeonRegistrar.binaryMessenger
       val codec = pigeonRegistrar.codec
-      val channelName = "dev.flutter.pigeon.webview_flutter_android.WebResourceResponse.pigeon_newInstance"
+      val channelName =
+          "dev.flutter.pigeon.webview_flutter_android.WebResourceResponse.pigeon_newInstance"
       val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
       channel.send(listOf(pigeon_identifierArg, statusCodeArg)) {
         if (it is List<*>) {
           if (it.size > 1) {
-            callback(Result.failure(AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
+            callback(
+                Result.failure(
+                    AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
           } else {
             callback(Result.success(Unit))
           }
         } else {
-          callback(Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
-        } 
+          callback(
+              Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
+        }
       }
     }
   }
-
 }
 /**
- * Encapsulates information about errors that occurred during loading of web
- * resources.
+ * Encapsulates information about errors that occurred during loading of web resources.
  *
  * See https://developer.android.com/reference/android/webkit/WebResourceError.
  */
 @Suppress("UNCHECKED_CAST")
-abstract class PigeonApiWebResourceError(open val pigeonRegistrar: AndroidWebkitLibraryPigeonProxyApiRegistrar) {
+abstract class PigeonApiWebResourceError(
+    open val pigeonRegistrar: AndroidWebkitLibraryPigeonProxyApiRegistrar
+) {
   /** The error code of the error. */
   abstract fun errorCode(pigeon_instance: android.webkit.WebResourceError): Long
 
@@ -1324,45 +1344,52 @@ abstract class PigeonApiWebResourceError(open val pigeonRegistrar: AndroidWebkit
 
   @Suppress("LocalVariableName", "FunctionName")
   /** Creates a Dart instance of WebResourceError and attaches it to [pigeon_instanceArg]. */
-  fun pigeon_newInstance(pigeon_instanceArg: android.webkit.WebResourceError, callback: (Result<Unit>) -> Unit)
-{
+  fun pigeon_newInstance(
+      pigeon_instanceArg: android.webkit.WebResourceError,
+      callback: (Result<Unit>) -> Unit
+  ) {
     if (pigeonRegistrar.ignoreCallsToDart) {
       callback(
           Result.failure(
               AndroidWebKitError("ignore-calls-error", "Calls to Dart are being ignored.", "")))
-    }     else if (pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
+    } else if (pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
       callback(Result.success(Unit))
-    }     else {
-      val pigeon_identifierArg = pigeonRegistrar.instanceManager.addHostCreatedInstance(pigeon_instanceArg)
+    } else {
+      val pigeon_identifierArg =
+          pigeonRegistrar.instanceManager.addHostCreatedInstance(pigeon_instanceArg)
       val errorCodeArg = errorCode(pigeon_instanceArg)
       val descriptionArg = description(pigeon_instanceArg)
       val binaryMessenger = pigeonRegistrar.binaryMessenger
       val codec = pigeonRegistrar.codec
-      val channelName = "dev.flutter.pigeon.webview_flutter_android.WebResourceError.pigeon_newInstance"
+      val channelName =
+          "dev.flutter.pigeon.webview_flutter_android.WebResourceError.pigeon_newInstance"
       val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
       channel.send(listOf(pigeon_identifierArg, errorCodeArg, descriptionArg)) {
         if (it is List<*>) {
           if (it.size > 1) {
-            callback(Result.failure(AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
+            callback(
+                Result.failure(
+                    AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
           } else {
             callback(Result.success(Unit))
           }
         } else {
-          callback(Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
-        } 
+          callback(
+              Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
+        }
       }
     }
   }
-
 }
 /**
- * Encapsulates information about errors that occurred during loading of web
- * resources.
+ * Encapsulates information about errors that occurred during loading of web resources.
  *
  * See https://developer.android.com/reference/androidx/webkit/WebResourceErrorCompat.
  */
 @Suppress("UNCHECKED_CAST")
-abstract class PigeonApiWebResourceErrorCompat(open val pigeonRegistrar: AndroidWebkitLibraryPigeonProxyApiRegistrar) {
+abstract class PigeonApiWebResourceErrorCompat(
+    open val pigeonRegistrar: AndroidWebkitLibraryPigeonProxyApiRegistrar
+) {
   /** The error code of the error. */
   abstract fun errorCode(pigeon_instance: androidx.webkit.WebResourceErrorCompat): Long
 
@@ -1371,36 +1398,42 @@ abstract class PigeonApiWebResourceErrorCompat(open val pigeonRegistrar: Android
 
   @Suppress("LocalVariableName", "FunctionName")
   /** Creates a Dart instance of WebResourceErrorCompat and attaches it to [pigeon_instanceArg]. */
-  fun pigeon_newInstance(pigeon_instanceArg: androidx.webkit.WebResourceErrorCompat, callback: (Result<Unit>) -> Unit)
-{
+  fun pigeon_newInstance(
+      pigeon_instanceArg: androidx.webkit.WebResourceErrorCompat,
+      callback: (Result<Unit>) -> Unit
+  ) {
     if (pigeonRegistrar.ignoreCallsToDart) {
       callback(
           Result.failure(
               AndroidWebKitError("ignore-calls-error", "Calls to Dart are being ignored.", "")))
-    }     else if (pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
+    } else if (pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
       callback(Result.success(Unit))
-    }     else {
-      val pigeon_identifierArg = pigeonRegistrar.instanceManager.addHostCreatedInstance(pigeon_instanceArg)
+    } else {
+      val pigeon_identifierArg =
+          pigeonRegistrar.instanceManager.addHostCreatedInstance(pigeon_instanceArg)
       val errorCodeArg = errorCode(pigeon_instanceArg)
       val descriptionArg = description(pigeon_instanceArg)
       val binaryMessenger = pigeonRegistrar.binaryMessenger
       val codec = pigeonRegistrar.codec
-      val channelName = "dev.flutter.pigeon.webview_flutter_android.WebResourceErrorCompat.pigeon_newInstance"
+      val channelName =
+          "dev.flutter.pigeon.webview_flutter_android.WebResourceErrorCompat.pigeon_newInstance"
       val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
       channel.send(listOf(pigeon_identifierArg, errorCodeArg, descriptionArg)) {
         if (it is List<*>) {
           if (it.size > 1) {
-            callback(Result.failure(AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
+            callback(
+                Result.failure(
+                    AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
           } else {
             callback(Result.success(Unit))
           }
         } else {
-          callback(Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
-        } 
+          callback(
+              Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
+        }
       }
     }
   }
-
 }
 /**
  * Represents a position on a web page.
@@ -1408,23 +1441,25 @@ abstract class PigeonApiWebResourceErrorCompat(open val pigeonRegistrar: Android
  * This is a custom class created for convenience of the wrapper.
  */
 @Suppress("UNCHECKED_CAST")
-abstract class PigeonApiWebViewPoint(open val pigeonRegistrar: AndroidWebkitLibraryPigeonProxyApiRegistrar) {
+abstract class PigeonApiWebViewPoint(
+    open val pigeonRegistrar: AndroidWebkitLibraryPigeonProxyApiRegistrar
+) {
   abstract fun x(pigeon_instance: WebViewPoint): Long
 
   abstract fun y(pigeon_instance: WebViewPoint): Long
 
   @Suppress("LocalVariableName", "FunctionName")
   /** Creates a Dart instance of WebViewPoint and attaches it to [pigeon_instanceArg]. */
-  fun pigeon_newInstance(pigeon_instanceArg: WebViewPoint, callback: (Result<Unit>) -> Unit)
-{
+  fun pigeon_newInstance(pigeon_instanceArg: WebViewPoint, callback: (Result<Unit>) -> Unit) {
     if (pigeonRegistrar.ignoreCallsToDart) {
       callback(
           Result.failure(
               AndroidWebKitError("ignore-calls-error", "Calls to Dart are being ignored.", "")))
-    }     else if (pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
+    } else if (pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
       callback(Result.success(Unit))
-    }     else {
-      val pigeon_identifierArg = pigeonRegistrar.instanceManager.addHostCreatedInstance(pigeon_instanceArg)
+    } else {
+      val pigeon_identifierArg =
+          pigeonRegistrar.instanceManager.addHostCreatedInstance(pigeon_instanceArg)
       val xArg = x(pigeon_instanceArg)
       val yArg = y(pigeon_instanceArg)
       val binaryMessenger = pigeonRegistrar.binaryMessenger
@@ -1434,17 +1469,19 @@ abstract class PigeonApiWebViewPoint(open val pigeonRegistrar: AndroidWebkitLibr
       channel.send(listOf(pigeon_identifierArg, xArg, yArg)) {
         if (it is List<*>) {
           if (it.size > 1) {
-            callback(Result.failure(AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
+            callback(
+                Result.failure(
+                    AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
           } else {
             callback(Result.success(Unit))
           }
         } else {
-          callback(Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
-        } 
+          callback(
+              Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
+        }
       }
     }
   }
-
 }
 /**
  * Represents a JavaScript console message from WebCore.
@@ -1452,7 +1489,9 @@ abstract class PigeonApiWebViewPoint(open val pigeonRegistrar: AndroidWebkitLibr
  * See https://developer.android.com/reference/android/webkit/ConsoleMessage
  */
 @Suppress("UNCHECKED_CAST")
-abstract class PigeonApiConsoleMessage(open val pigeonRegistrar: AndroidWebkitLibraryPigeonProxyApiRegistrar) {
+abstract class PigeonApiConsoleMessage(
+    open val pigeonRegistrar: AndroidWebkitLibraryPigeonProxyApiRegistrar
+) {
   abstract fun lineNumber(pigeon_instance: android.webkit.ConsoleMessage): Long
 
   abstract fun message(pigeon_instance: android.webkit.ConsoleMessage): String
@@ -1463,38 +1502,44 @@ abstract class PigeonApiConsoleMessage(open val pigeonRegistrar: AndroidWebkitLi
 
   @Suppress("LocalVariableName", "FunctionName")
   /** Creates a Dart instance of ConsoleMessage and attaches it to [pigeon_instanceArg]. */
-  fun pigeon_newInstance(pigeon_instanceArg: android.webkit.ConsoleMessage, callback: (Result<Unit>) -> Unit)
-{
+  fun pigeon_newInstance(
+      pigeon_instanceArg: android.webkit.ConsoleMessage,
+      callback: (Result<Unit>) -> Unit
+  ) {
     if (pigeonRegistrar.ignoreCallsToDart) {
       callback(
           Result.failure(
               AndroidWebKitError("ignore-calls-error", "Calls to Dart are being ignored.", "")))
-    }     else if (pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
+    } else if (pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
       callback(Result.success(Unit))
-    }     else {
-      val pigeon_identifierArg = pigeonRegistrar.instanceManager.addHostCreatedInstance(pigeon_instanceArg)
+    } else {
+      val pigeon_identifierArg =
+          pigeonRegistrar.instanceManager.addHostCreatedInstance(pigeon_instanceArg)
       val lineNumberArg = lineNumber(pigeon_instanceArg)
       val messageArg = message(pigeon_instanceArg)
       val levelArg = level(pigeon_instanceArg)
       val sourceIdArg = sourceId(pigeon_instanceArg)
       val binaryMessenger = pigeonRegistrar.binaryMessenger
       val codec = pigeonRegistrar.codec
-      val channelName = "dev.flutter.pigeon.webview_flutter_android.ConsoleMessage.pigeon_newInstance"
+      val channelName =
+          "dev.flutter.pigeon.webview_flutter_android.ConsoleMessage.pigeon_newInstance"
       val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
       channel.send(listOf(pigeon_identifierArg, lineNumberArg, messageArg, levelArg, sourceIdArg)) {
         if (it is List<*>) {
           if (it.size > 1) {
-            callback(Result.failure(AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
+            callback(
+                Result.failure(
+                    AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
           } else {
             callback(Result.success(Unit))
           }
         } else {
-          callback(Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
-        } 
+          callback(
+              Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
+        }
       }
     }
   }
-
 }
 /**
  * Manages the cookies used by an application's `WebView` instances.
@@ -1502,26 +1547,36 @@ abstract class PigeonApiConsoleMessage(open val pigeonRegistrar: AndroidWebkitLi
  * See https://developer.android.com/reference/android/webkit/CookieManager.
  */
 @Suppress("UNCHECKED_CAST")
-abstract class PigeonApiCookieManager(open val pigeonRegistrar: AndroidWebkitLibraryPigeonProxyApiRegistrar) {
+abstract class PigeonApiCookieManager(
+    open val pigeonRegistrar: AndroidWebkitLibraryPigeonProxyApiRegistrar
+) {
   abstract fun instance(): android.webkit.CookieManager
 
   /** Sets a single cookie (key-value pair) for the given URL. */
   abstract fun setCookie(pigeon_instance: android.webkit.CookieManager, url: String, value: String)
 
   /** Removes all cookies. */
-  abstract fun removeAllCookies(pigeon_instance: android.webkit.CookieManager, callback: (Result<Boolean>) -> Unit)
+  abstract fun removeAllCookies(
+      pigeon_instance: android.webkit.CookieManager,
+      callback: (Result<Boolean>) -> Unit
+  )
 
   /** Sets whether the `WebView` should allow third party cookies to be set. */
-  abstract fun setAcceptThirdPartyCookies(pigeon_instance: android.webkit.CookieManager, webView: android.webkit.WebView, accept: Boolean)
+  abstract fun setAcceptThirdPartyCookies(
+      pigeon_instance: android.webkit.CookieManager,
+      webView: android.webkit.WebView,
+      accept: Boolean
+  )
 
   /**
    * Gets all the cookies for the given URL.
    *
-   * This may return multiple key-value pairs if multiple cookies are associated with this URL,
-   * in which case each cookie will be delimited by "; " characters (semicolon followed by a space).
+   * This may return multiple key-value pairs if multiple cookies are associated with this URL, in
+   * which case each cookie will be delimited by "; " characters (semicolon followed by a space).
    * Each key-value pair will be of the form "key=value".
    *
-   * Note: Any cookies set with the "Partitioned" attribute will only be returned for the top-level partition of url.
+   * Note: Any cookies set with the "Partitioned" attribute will only be returned for the top-level
+   * partition of url.
    */
   abstract fun getCookies(pigeon_instance: android.webkit.CookieManager, url: String): String?
 
@@ -1530,17 +1585,23 @@ abstract class PigeonApiCookieManager(open val pigeonRegistrar: AndroidWebkitLib
     fun setUpMessageHandlers(binaryMessenger: BinaryMessenger, api: PigeonApiCookieManager?) {
       val codec = api?.pigeonRegistrar?.codec ?: AndroidWebkitLibraryPigeonCodec()
       run {
-        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.CookieManager.instance", codec)
+        val channel =
+            BasicMessageChannel<Any?>(
+                binaryMessenger,
+                "dev.flutter.pigeon.webview_flutter_android.CookieManager.instance",
+                codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val pigeon_identifierArg = args[0] as Long
-            val wrapped: List<Any?> = try {
-              api.pigeonRegistrar.instanceManager.addDartCreatedInstance(api.instance(), pigeon_identifierArg)
-              listOf(null)
-            } catch (exception: Throwable) {
-              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-            }
+            val wrapped: List<Any?> =
+                try {
+                  api.pigeonRegistrar.instanceManager.addDartCreatedInstance(
+                      api.instance(), pigeon_identifierArg)
+                  listOf(null)
+                } catch (exception: Throwable) {
+                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+                }
             reply.reply(wrapped)
           }
         } else {
@@ -1548,19 +1609,24 @@ abstract class PigeonApiCookieManager(open val pigeonRegistrar: AndroidWebkitLib
         }
       }
       run {
-        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.CookieManager.setCookie", codec)
+        val channel =
+            BasicMessageChannel<Any?>(
+                binaryMessenger,
+                "dev.flutter.pigeon.webview_flutter_android.CookieManager.setCookie",
+                codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val pigeon_instanceArg = args[0] as android.webkit.CookieManager
             val urlArg = args[1] as String
             val valueArg = args[2] as String
-            val wrapped: List<Any?> = try {
-              api.setCookie(pigeon_instanceArg, urlArg, valueArg)
-              listOf(null)
-            } catch (exception: Throwable) {
-              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-            }
+            val wrapped: List<Any?> =
+                try {
+                  api.setCookie(pigeon_instanceArg, urlArg, valueArg)
+                  listOf(null)
+                } catch (exception: Throwable) {
+                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+                }
             reply.reply(wrapped)
           }
         } else {
@@ -1568,7 +1634,11 @@ abstract class PigeonApiCookieManager(open val pigeonRegistrar: AndroidWebkitLib
         }
       }
       run {
-        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.CookieManager.removeAllCookies", codec)
+        val channel =
+            BasicMessageChannel<Any?>(
+                binaryMessenger,
+                "dev.flutter.pigeon.webview_flutter_android.CookieManager.removeAllCookies",
+                codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
@@ -1588,19 +1658,24 @@ abstract class PigeonApiCookieManager(open val pigeonRegistrar: AndroidWebkitLib
         }
       }
       run {
-        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.CookieManager.setAcceptThirdPartyCookies", codec)
+        val channel =
+            BasicMessageChannel<Any?>(
+                binaryMessenger,
+                "dev.flutter.pigeon.webview_flutter_android.CookieManager.setAcceptThirdPartyCookies",
+                codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val pigeon_instanceArg = args[0] as android.webkit.CookieManager
             val webViewArg = args[1] as android.webkit.WebView
             val acceptArg = args[2] as Boolean
-            val wrapped: List<Any?> = try {
-              api.setAcceptThirdPartyCookies(pigeon_instanceArg, webViewArg, acceptArg)
-              listOf(null)
-            } catch (exception: Throwable) {
-              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-            }
+            val wrapped: List<Any?> =
+                try {
+                  api.setAcceptThirdPartyCookies(pigeon_instanceArg, webViewArg, acceptArg)
+                  listOf(null)
+                } catch (exception: Throwable) {
+                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+                }
             reply.reply(wrapped)
           }
         } else {
@@ -1608,17 +1683,22 @@ abstract class PigeonApiCookieManager(open val pigeonRegistrar: AndroidWebkitLib
         }
       }
       run {
-        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.CookieManager.getCookies", codec)
+        val channel =
+            BasicMessageChannel<Any?>(
+                binaryMessenger,
+                "dev.flutter.pigeon.webview_flutter_android.CookieManager.getCookies",
+                codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val pigeon_instanceArg = args[0] as android.webkit.CookieManager
             val urlArg = args[1] as String
-            val wrapped: List<Any?> = try {
-              listOf(api.getCookies(pigeon_instanceArg, urlArg))
-            } catch (exception: Throwable) {
-              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-            }
+            val wrapped: List<Any?> =
+                try {
+                  listOf(api.getCookies(pigeon_instanceArg, urlArg))
+                } catch (exception: Throwable) {
+                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+                }
             reply.reply(wrapped)
           }
         } else {
@@ -1630,34 +1710,40 @@ abstract class PigeonApiCookieManager(open val pigeonRegistrar: AndroidWebkitLib
 
   @Suppress("LocalVariableName", "FunctionName")
   /** Creates a Dart instance of CookieManager and attaches it to [pigeon_instanceArg]. */
-  fun pigeon_newInstance(pigeon_instanceArg: android.webkit.CookieManager, callback: (Result<Unit>) -> Unit)
-{
+  fun pigeon_newInstance(
+      pigeon_instanceArg: android.webkit.CookieManager,
+      callback: (Result<Unit>) -> Unit
+  ) {
     if (pigeonRegistrar.ignoreCallsToDart) {
       callback(
           Result.failure(
               AndroidWebKitError("ignore-calls-error", "Calls to Dart are being ignored.", "")))
-    }     else if (pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
+    } else if (pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
       callback(Result.success(Unit))
-    }     else {
-      val pigeon_identifierArg = pigeonRegistrar.instanceManager.addHostCreatedInstance(pigeon_instanceArg)
+    } else {
+      val pigeon_identifierArg =
+          pigeonRegistrar.instanceManager.addHostCreatedInstance(pigeon_instanceArg)
       val binaryMessenger = pigeonRegistrar.binaryMessenger
       val codec = pigeonRegistrar.codec
-      val channelName = "dev.flutter.pigeon.webview_flutter_android.CookieManager.pigeon_newInstance"
+      val channelName =
+          "dev.flutter.pigeon.webview_flutter_android.CookieManager.pigeon_newInstance"
       val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
       channel.send(listOf(pigeon_identifierArg)) {
         if (it is List<*>) {
           if (it.size > 1) {
-            callback(Result.failure(AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
+            callback(
+                Result.failure(
+                    AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
           } else {
             callback(Result.success(Unit))
           }
         } else {
-          callback(Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
-        } 
+          callback(
+              Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
+        }
       }
     }
   }
-
 }
 /**
  * A View that displays web pages.
@@ -1665,23 +1751,38 @@ abstract class PigeonApiCookieManager(open val pigeonRegistrar: AndroidWebkitLib
  * See https://developer.android.com/reference/android/webkit/WebView.
  */
 @Suppress("UNCHECKED_CAST")
-abstract class PigeonApiWebView(open val pigeonRegistrar: AndroidWebkitLibraryPigeonProxyApiRegistrar) {
+abstract class PigeonApiWebView(
+    open val pigeonRegistrar: AndroidWebkitLibraryPigeonProxyApiRegistrar
+) {
   abstract fun pigeon_defaultConstructor(): android.webkit.WebView
 
   /** The WebSettings object used to control the settings for this WebView. */
   abstract fun settings(pigeon_instance: android.webkit.WebView): android.webkit.WebSettings
 
   /** Loads the given data into this WebView using a 'data' scheme URL. */
-  abstract fun loadData(pigeon_instance: android.webkit.WebView, data: String, mimeType: String?, encoding: String?)
+  abstract fun loadData(
+      pigeon_instance: android.webkit.WebView,
+      data: String,
+      mimeType: String?,
+      encoding: String?
+  )
 
-  /**
-   * Loads the given data into this WebView, using baseUrl as the base URL for
-   * the content.
-   */
-  abstract fun loadDataWithBaseUrl(pigeon_instance: android.webkit.WebView, baseUrl: String?, data: String, mimeType: String?, encoding: String?, historyUrl: String?)
+  /** Loads the given data into this WebView, using baseUrl as the base URL for the content. */
+  abstract fun loadDataWithBaseUrl(
+      pigeon_instance: android.webkit.WebView,
+      baseUrl: String?,
+      data: String,
+      mimeType: String?,
+      encoding: String?,
+      historyUrl: String?
+  )
 
   /** Loads the given URL. */
-  abstract fun loadUrl(pigeon_instance: android.webkit.WebView, url: String, headers: Map<String, String>)
+  abstract fun loadUrl(
+      pigeon_instance: android.webkit.WebView,
+      url: String,
+      headers: Map<String, String>
+  )
 
   /** Loads the URL with postData using "POST" method into this WebView. */
   abstract fun postUrl(pigeon_instance: android.webkit.WebView, url: String, data: ByteArray)
@@ -1707,41 +1808,51 @@ abstract class PigeonApiWebView(open val pigeonRegistrar: AndroidWebkitLibraryPi
   /** Clears the resource cache. */
   abstract fun clearCache(pigeon_instance: android.webkit.WebView, includeDiskFiles: Boolean)
 
-  /**
-   * Asynchronously evaluates JavaScript in the context of the currently
-   * displayed page.
-   */
-  abstract fun evaluateJavascript(pigeon_instance: android.webkit.WebView, javascriptString: String, callback: (Result<String?>) -> Unit)
+  /** Asynchronously evaluates JavaScript in the context of the currently displayed page. */
+  abstract fun evaluateJavascript(
+      pigeon_instance: android.webkit.WebView,
+      javascriptString: String,
+      callback: (Result<String?>) -> Unit
+  )
 
   /** Gets the title for the current page. */
   abstract fun getTitle(pigeon_instance: android.webkit.WebView): String?
 
   /**
-   * Enables debugging of web contents (HTML / CSS / JavaScript) loaded into
-   * any WebViews of this application.
+   * Enables debugging of web contents (HTML / CSS / JavaScript) loaded into any WebViews of this
+   * application.
    */
   abstract fun setWebContentsDebuggingEnabled(enabled: Boolean)
 
-  /**
-   * Sets the WebViewClient that will receive various notifications and
-   * requests.
-   */
-  abstract fun setWebViewClient(pigeon_instance: android.webkit.WebView, client: android.webkit.WebViewClient?)
+  /** Sets the WebViewClient that will receive various notifications and requests. */
+  abstract fun setWebViewClient(
+      pigeon_instance: android.webkit.WebView,
+      client: android.webkit.WebViewClient?
+  )
 
   /** Injects the supplied Java object into this WebView. */
-  abstract fun addJavaScriptChannel(pigeon_instance: android.webkit.WebView, channel: JavaScriptChannel)
+  abstract fun addJavaScriptChannel(
+      pigeon_instance: android.webkit.WebView,
+      channel: JavaScriptChannel
+  )
 
   /** Removes a previously injected Java object from this WebView. */
   abstract fun removeJavaScriptChannel(pigeon_instance: android.webkit.WebView, name: String)
 
   /**
-   * Registers the interface to be used when content can not be handled by the
-   * rendering engine, and should be downloaded instead.
+   * Registers the interface to be used when content can not be handled by the rendering engine, and
+   * should be downloaded instead.
    */
-  abstract fun setDownloadListener(pigeon_instance: android.webkit.WebView, listener: android.webkit.DownloadListener?)
+  abstract fun setDownloadListener(
+      pigeon_instance: android.webkit.WebView,
+      listener: android.webkit.DownloadListener?
+  )
 
   /** Sets the chrome handler. */
-  abstract fun setWebChromeClient(pigeon_instance: android.webkit.WebView, client: io.flutter.plugins.webviewflutter.WebChromeClientProxyApi.WebChromeClientImpl?)
+  abstract fun setWebChromeClient(
+      pigeon_instance: android.webkit.WebView,
+      client: io.flutter.plugins.webviewflutter.WebChromeClientProxyApi.WebChromeClientImpl?
+  )
 
   /** Sets the background color for this view. */
   abstract fun setBackgroundColor(pigeon_instance: android.webkit.WebView, color: Long)
@@ -1754,17 +1865,23 @@ abstract class PigeonApiWebView(open val pigeonRegistrar: AndroidWebkitLibraryPi
     fun setUpMessageHandlers(binaryMessenger: BinaryMessenger, api: PigeonApiWebView?) {
       val codec = api?.pigeonRegistrar?.codec ?: AndroidWebkitLibraryPigeonCodec()
       run {
-        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.WebView.pigeon_defaultConstructor", codec)
+        val channel =
+            BasicMessageChannel<Any?>(
+                binaryMessenger,
+                "dev.flutter.pigeon.webview_flutter_android.WebView.pigeon_defaultConstructor",
+                codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val pigeon_identifierArg = args[0] as Long
-            val wrapped: List<Any?> = try {
-              api.pigeonRegistrar.instanceManager.addDartCreatedInstance(api.pigeon_defaultConstructor(), pigeon_identifierArg)
-              listOf(null)
-            } catch (exception: Throwable) {
-              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-            }
+            val wrapped: List<Any?> =
+                try {
+                  api.pigeonRegistrar.instanceManager.addDartCreatedInstance(
+                      api.pigeon_defaultConstructor(), pigeon_identifierArg)
+                  listOf(null)
+                } catch (exception: Throwable) {
+                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+                }
             reply.reply(wrapped)
           }
         } else {
@@ -1772,18 +1889,24 @@ abstract class PigeonApiWebView(open val pigeonRegistrar: AndroidWebkitLibraryPi
         }
       }
       run {
-        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.WebView.settings", codec)
+        val channel =
+            BasicMessageChannel<Any?>(
+                binaryMessenger,
+                "dev.flutter.pigeon.webview_flutter_android.WebView.settings",
+                codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val pigeon_instanceArg = args[0] as android.webkit.WebView
             val pigeon_identifierArg = args[1] as Long
-            val wrapped: List<Any?> = try {
-              api.pigeonRegistrar.instanceManager.addDartCreatedInstance(api.settings(pigeon_instanceArg), pigeon_identifierArg)
-              listOf(null)
-            } catch (exception: Throwable) {
-              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-            }
+            val wrapped: List<Any?> =
+                try {
+                  api.pigeonRegistrar.instanceManager.addDartCreatedInstance(
+                      api.settings(pigeon_instanceArg), pigeon_identifierArg)
+                  listOf(null)
+                } catch (exception: Throwable) {
+                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+                }
             reply.reply(wrapped)
           }
         } else {
@@ -1791,7 +1914,11 @@ abstract class PigeonApiWebView(open val pigeonRegistrar: AndroidWebkitLibraryPi
         }
       }
       run {
-        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.WebView.loadData", codec)
+        val channel =
+            BasicMessageChannel<Any?>(
+                binaryMessenger,
+                "dev.flutter.pigeon.webview_flutter_android.WebView.loadData",
+                codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
@@ -1799,12 +1926,13 @@ abstract class PigeonApiWebView(open val pigeonRegistrar: AndroidWebkitLibraryPi
             val dataArg = args[1] as String
             val mimeTypeArg = args[2] as String?
             val encodingArg = args[3] as String?
-            val wrapped: List<Any?> = try {
-              api.loadData(pigeon_instanceArg, dataArg, mimeTypeArg, encodingArg)
-              listOf(null)
-            } catch (exception: Throwable) {
-              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-            }
+            val wrapped: List<Any?> =
+                try {
+                  api.loadData(pigeon_instanceArg, dataArg, mimeTypeArg, encodingArg)
+                  listOf(null)
+                } catch (exception: Throwable) {
+                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+                }
             reply.reply(wrapped)
           }
         } else {
@@ -1812,7 +1940,11 @@ abstract class PigeonApiWebView(open val pigeonRegistrar: AndroidWebkitLibraryPi
         }
       }
       run {
-        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.WebView.loadDataWithBaseUrl", codec)
+        val channel =
+            BasicMessageChannel<Any?>(
+                binaryMessenger,
+                "dev.flutter.pigeon.webview_flutter_android.WebView.loadDataWithBaseUrl",
+                codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
@@ -1822,12 +1954,19 @@ abstract class PigeonApiWebView(open val pigeonRegistrar: AndroidWebkitLibraryPi
             val mimeTypeArg = args[3] as String?
             val encodingArg = args[4] as String?
             val historyUrlArg = args[5] as String?
-            val wrapped: List<Any?> = try {
-              api.loadDataWithBaseUrl(pigeon_instanceArg, baseUrlArg, dataArg, mimeTypeArg, encodingArg, historyUrlArg)
-              listOf(null)
-            } catch (exception: Throwable) {
-              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-            }
+            val wrapped: List<Any?> =
+                try {
+                  api.loadDataWithBaseUrl(
+                      pigeon_instanceArg,
+                      baseUrlArg,
+                      dataArg,
+                      mimeTypeArg,
+                      encodingArg,
+                      historyUrlArg)
+                  listOf(null)
+                } catch (exception: Throwable) {
+                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+                }
             reply.reply(wrapped)
           }
         } else {
@@ -1835,19 +1974,24 @@ abstract class PigeonApiWebView(open val pigeonRegistrar: AndroidWebkitLibraryPi
         }
       }
       run {
-        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.WebView.loadUrl", codec)
+        val channel =
+            BasicMessageChannel<Any?>(
+                binaryMessenger,
+                "dev.flutter.pigeon.webview_flutter_android.WebView.loadUrl",
+                codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val pigeon_instanceArg = args[0] as android.webkit.WebView
             val urlArg = args[1] as String
             val headersArg = args[2] as Map<String, String>
-            val wrapped: List<Any?> = try {
-              api.loadUrl(pigeon_instanceArg, urlArg, headersArg)
-              listOf(null)
-            } catch (exception: Throwable) {
-              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-            }
+            val wrapped: List<Any?> =
+                try {
+                  api.loadUrl(pigeon_instanceArg, urlArg, headersArg)
+                  listOf(null)
+                } catch (exception: Throwable) {
+                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+                }
             reply.reply(wrapped)
           }
         } else {
@@ -1855,19 +1999,24 @@ abstract class PigeonApiWebView(open val pigeonRegistrar: AndroidWebkitLibraryPi
         }
       }
       run {
-        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.WebView.postUrl", codec)
+        val channel =
+            BasicMessageChannel<Any?>(
+                binaryMessenger,
+                "dev.flutter.pigeon.webview_flutter_android.WebView.postUrl",
+                codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val pigeon_instanceArg = args[0] as android.webkit.WebView
             val urlArg = args[1] as String
             val dataArg = args[2] as ByteArray
-            val wrapped: List<Any?> = try {
-              api.postUrl(pigeon_instanceArg, urlArg, dataArg)
-              listOf(null)
-            } catch (exception: Throwable) {
-              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-            }
+            val wrapped: List<Any?> =
+                try {
+                  api.postUrl(pigeon_instanceArg, urlArg, dataArg)
+                  listOf(null)
+                } catch (exception: Throwable) {
+                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+                }
             reply.reply(wrapped)
           }
         } else {
@@ -1875,16 +2024,19 @@ abstract class PigeonApiWebView(open val pigeonRegistrar: AndroidWebkitLibraryPi
         }
       }
       run {
-        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.WebView.getUrl", codec)
+        val channel =
+            BasicMessageChannel<Any?>(
+                binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.WebView.getUrl", codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val pigeon_instanceArg = args[0] as android.webkit.WebView
-            val wrapped: List<Any?> = try {
-              listOf(api.getUrl(pigeon_instanceArg))
-            } catch (exception: Throwable) {
-              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-            }
+            val wrapped: List<Any?> =
+                try {
+                  listOf(api.getUrl(pigeon_instanceArg))
+                } catch (exception: Throwable) {
+                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+                }
             reply.reply(wrapped)
           }
         } else {
@@ -1892,16 +2044,21 @@ abstract class PigeonApiWebView(open val pigeonRegistrar: AndroidWebkitLibraryPi
         }
       }
       run {
-        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.WebView.canGoBack", codec)
+        val channel =
+            BasicMessageChannel<Any?>(
+                binaryMessenger,
+                "dev.flutter.pigeon.webview_flutter_android.WebView.canGoBack",
+                codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val pigeon_instanceArg = args[0] as android.webkit.WebView
-            val wrapped: List<Any?> = try {
-              listOf(api.canGoBack(pigeon_instanceArg))
-            } catch (exception: Throwable) {
-              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-            }
+            val wrapped: List<Any?> =
+                try {
+                  listOf(api.canGoBack(pigeon_instanceArg))
+                } catch (exception: Throwable) {
+                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+                }
             reply.reply(wrapped)
           }
         } else {
@@ -1909,16 +2066,21 @@ abstract class PigeonApiWebView(open val pigeonRegistrar: AndroidWebkitLibraryPi
         }
       }
       run {
-        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.WebView.canGoForward", codec)
+        val channel =
+            BasicMessageChannel<Any?>(
+                binaryMessenger,
+                "dev.flutter.pigeon.webview_flutter_android.WebView.canGoForward",
+                codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val pigeon_instanceArg = args[0] as android.webkit.WebView
-            val wrapped: List<Any?> = try {
-              listOf(api.canGoForward(pigeon_instanceArg))
-            } catch (exception: Throwable) {
-              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-            }
+            val wrapped: List<Any?> =
+                try {
+                  listOf(api.canGoForward(pigeon_instanceArg))
+                } catch (exception: Throwable) {
+                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+                }
             reply.reply(wrapped)
           }
         } else {
@@ -1926,17 +2088,20 @@ abstract class PigeonApiWebView(open val pigeonRegistrar: AndroidWebkitLibraryPi
         }
       }
       run {
-        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.WebView.goBack", codec)
+        val channel =
+            BasicMessageChannel<Any?>(
+                binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.WebView.goBack", codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val pigeon_instanceArg = args[0] as android.webkit.WebView
-            val wrapped: List<Any?> = try {
-              api.goBack(pigeon_instanceArg)
-              listOf(null)
-            } catch (exception: Throwable) {
-              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-            }
+            val wrapped: List<Any?> =
+                try {
+                  api.goBack(pigeon_instanceArg)
+                  listOf(null)
+                } catch (exception: Throwable) {
+                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+                }
             reply.reply(wrapped)
           }
         } else {
@@ -1944,17 +2109,22 @@ abstract class PigeonApiWebView(open val pigeonRegistrar: AndroidWebkitLibraryPi
         }
       }
       run {
-        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.WebView.goForward", codec)
+        val channel =
+            BasicMessageChannel<Any?>(
+                binaryMessenger,
+                "dev.flutter.pigeon.webview_flutter_android.WebView.goForward",
+                codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val pigeon_instanceArg = args[0] as android.webkit.WebView
-            val wrapped: List<Any?> = try {
-              api.goForward(pigeon_instanceArg)
-              listOf(null)
-            } catch (exception: Throwable) {
-              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-            }
+            val wrapped: List<Any?> =
+                try {
+                  api.goForward(pigeon_instanceArg)
+                  listOf(null)
+                } catch (exception: Throwable) {
+                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+                }
             reply.reply(wrapped)
           }
         } else {
@@ -1962,17 +2132,20 @@ abstract class PigeonApiWebView(open val pigeonRegistrar: AndroidWebkitLibraryPi
         }
       }
       run {
-        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.WebView.reload", codec)
+        val channel =
+            BasicMessageChannel<Any?>(
+                binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.WebView.reload", codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val pigeon_instanceArg = args[0] as android.webkit.WebView
-            val wrapped: List<Any?> = try {
-              api.reload(pigeon_instanceArg)
-              listOf(null)
-            } catch (exception: Throwable) {
-              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-            }
+            val wrapped: List<Any?> =
+                try {
+                  api.reload(pigeon_instanceArg)
+                  listOf(null)
+                } catch (exception: Throwable) {
+                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+                }
             reply.reply(wrapped)
           }
         } else {
@@ -1980,18 +2153,23 @@ abstract class PigeonApiWebView(open val pigeonRegistrar: AndroidWebkitLibraryPi
         }
       }
       run {
-        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.WebView.clearCache", codec)
+        val channel =
+            BasicMessageChannel<Any?>(
+                binaryMessenger,
+                "dev.flutter.pigeon.webview_flutter_android.WebView.clearCache",
+                codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val pigeon_instanceArg = args[0] as android.webkit.WebView
             val includeDiskFilesArg = args[1] as Boolean
-            val wrapped: List<Any?> = try {
-              api.clearCache(pigeon_instanceArg, includeDiskFilesArg)
-              listOf(null)
-            } catch (exception: Throwable) {
-              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-            }
+            val wrapped: List<Any?> =
+                try {
+                  api.clearCache(pigeon_instanceArg, includeDiskFilesArg)
+                  listOf(null)
+                } catch (exception: Throwable) {
+                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+                }
             reply.reply(wrapped)
           }
         } else {
@@ -1999,13 +2177,18 @@ abstract class PigeonApiWebView(open val pigeonRegistrar: AndroidWebkitLibraryPi
         }
       }
       run {
-        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.WebView.evaluateJavascript", codec)
+        val channel =
+            BasicMessageChannel<Any?>(
+                binaryMessenger,
+                "dev.flutter.pigeon.webview_flutter_android.WebView.evaluateJavascript",
+                codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val pigeon_instanceArg = args[0] as android.webkit.WebView
             val javascriptStringArg = args[1] as String
-            api.evaluateJavascript(pigeon_instanceArg, javascriptStringArg) { result: Result<String?> ->
+            api.evaluateJavascript(pigeon_instanceArg, javascriptStringArg) {
+                result: Result<String?> ->
               val error = result.exceptionOrNull()
               if (error != null) {
                 reply.reply(AndroidWebkitLibraryPigeonUtils.wrapError(error))
@@ -2020,16 +2203,21 @@ abstract class PigeonApiWebView(open val pigeonRegistrar: AndroidWebkitLibraryPi
         }
       }
       run {
-        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.WebView.getTitle", codec)
+        val channel =
+            BasicMessageChannel<Any?>(
+                binaryMessenger,
+                "dev.flutter.pigeon.webview_flutter_android.WebView.getTitle",
+                codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val pigeon_instanceArg = args[0] as android.webkit.WebView
-            val wrapped: List<Any?> = try {
-              listOf(api.getTitle(pigeon_instanceArg))
-            } catch (exception: Throwable) {
-              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-            }
+            val wrapped: List<Any?> =
+                try {
+                  listOf(api.getTitle(pigeon_instanceArg))
+                } catch (exception: Throwable) {
+                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+                }
             reply.reply(wrapped)
           }
         } else {
@@ -2037,17 +2225,22 @@ abstract class PigeonApiWebView(open val pigeonRegistrar: AndroidWebkitLibraryPi
         }
       }
       run {
-        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.WebView.setWebContentsDebuggingEnabled", codec)
+        val channel =
+            BasicMessageChannel<Any?>(
+                binaryMessenger,
+                "dev.flutter.pigeon.webview_flutter_android.WebView.setWebContentsDebuggingEnabled",
+                codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val enabledArg = args[0] as Boolean
-            val wrapped: List<Any?> = try {
-              api.setWebContentsDebuggingEnabled(enabledArg)
-              listOf(null)
-            } catch (exception: Throwable) {
-              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-            }
+            val wrapped: List<Any?> =
+                try {
+                  api.setWebContentsDebuggingEnabled(enabledArg)
+                  listOf(null)
+                } catch (exception: Throwable) {
+                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+                }
             reply.reply(wrapped)
           }
         } else {
@@ -2055,18 +2248,23 @@ abstract class PigeonApiWebView(open val pigeonRegistrar: AndroidWebkitLibraryPi
         }
       }
       run {
-        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.WebView.setWebViewClient", codec)
+        val channel =
+            BasicMessageChannel<Any?>(
+                binaryMessenger,
+                "dev.flutter.pigeon.webview_flutter_android.WebView.setWebViewClient",
+                codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val pigeon_instanceArg = args[0] as android.webkit.WebView
             val clientArg = args[1] as android.webkit.WebViewClient?
-            val wrapped: List<Any?> = try {
-              api.setWebViewClient(pigeon_instanceArg, clientArg)
-              listOf(null)
-            } catch (exception: Throwable) {
-              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-            }
+            val wrapped: List<Any?> =
+                try {
+                  api.setWebViewClient(pigeon_instanceArg, clientArg)
+                  listOf(null)
+                } catch (exception: Throwable) {
+                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+                }
             reply.reply(wrapped)
           }
         } else {
@@ -2074,18 +2272,23 @@ abstract class PigeonApiWebView(open val pigeonRegistrar: AndroidWebkitLibraryPi
         }
       }
       run {
-        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.WebView.addJavaScriptChannel", codec)
+        val channel =
+            BasicMessageChannel<Any?>(
+                binaryMessenger,
+                "dev.flutter.pigeon.webview_flutter_android.WebView.addJavaScriptChannel",
+                codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val pigeon_instanceArg = args[0] as android.webkit.WebView
             val channelArg = args[1] as JavaScriptChannel
-            val wrapped: List<Any?> = try {
-              api.addJavaScriptChannel(pigeon_instanceArg, channelArg)
-              listOf(null)
-            } catch (exception: Throwable) {
-              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-            }
+            val wrapped: List<Any?> =
+                try {
+                  api.addJavaScriptChannel(pigeon_instanceArg, channelArg)
+                  listOf(null)
+                } catch (exception: Throwable) {
+                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+                }
             reply.reply(wrapped)
           }
         } else {
@@ -2093,18 +2296,23 @@ abstract class PigeonApiWebView(open val pigeonRegistrar: AndroidWebkitLibraryPi
         }
       }
       run {
-        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.WebView.removeJavaScriptChannel", codec)
+        val channel =
+            BasicMessageChannel<Any?>(
+                binaryMessenger,
+                "dev.flutter.pigeon.webview_flutter_android.WebView.removeJavaScriptChannel",
+                codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val pigeon_instanceArg = args[0] as android.webkit.WebView
             val nameArg = args[1] as String
-            val wrapped: List<Any?> = try {
-              api.removeJavaScriptChannel(pigeon_instanceArg, nameArg)
-              listOf(null)
-            } catch (exception: Throwable) {
-              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-            }
+            val wrapped: List<Any?> =
+                try {
+                  api.removeJavaScriptChannel(pigeon_instanceArg, nameArg)
+                  listOf(null)
+                } catch (exception: Throwable) {
+                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+                }
             reply.reply(wrapped)
           }
         } else {
@@ -2112,18 +2320,23 @@ abstract class PigeonApiWebView(open val pigeonRegistrar: AndroidWebkitLibraryPi
         }
       }
       run {
-        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.WebView.setDownloadListener", codec)
+        val channel =
+            BasicMessageChannel<Any?>(
+                binaryMessenger,
+                "dev.flutter.pigeon.webview_flutter_android.WebView.setDownloadListener",
+                codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val pigeon_instanceArg = args[0] as android.webkit.WebView
             val listenerArg = args[1] as android.webkit.DownloadListener?
-            val wrapped: List<Any?> = try {
-              api.setDownloadListener(pigeon_instanceArg, listenerArg)
-              listOf(null)
-            } catch (exception: Throwable) {
-              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-            }
+            val wrapped: List<Any?> =
+                try {
+                  api.setDownloadListener(pigeon_instanceArg, listenerArg)
+                  listOf(null)
+                } catch (exception: Throwable) {
+                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+                }
             reply.reply(wrapped)
           }
         } else {
@@ -2131,18 +2344,26 @@ abstract class PigeonApiWebView(open val pigeonRegistrar: AndroidWebkitLibraryPi
         }
       }
       run {
-        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.WebView.setWebChromeClient", codec)
+        val channel =
+            BasicMessageChannel<Any?>(
+                binaryMessenger,
+                "dev.flutter.pigeon.webview_flutter_android.WebView.setWebChromeClient",
+                codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val pigeon_instanceArg = args[0] as android.webkit.WebView
-            val clientArg = args[1] as io.flutter.plugins.webviewflutter.WebChromeClientProxyApi.WebChromeClientImpl?
-            val wrapped: List<Any?> = try {
-              api.setWebChromeClient(pigeon_instanceArg, clientArg)
-              listOf(null)
-            } catch (exception: Throwable) {
-              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-            }
+            val clientArg =
+                args[1]
+                    as
+                    io.flutter.plugins.webviewflutter.WebChromeClientProxyApi.WebChromeClientImpl?
+            val wrapped: List<Any?> =
+                try {
+                  api.setWebChromeClient(pigeon_instanceArg, clientArg)
+                  listOf(null)
+                } catch (exception: Throwable) {
+                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+                }
             reply.reply(wrapped)
           }
         } else {
@@ -2150,18 +2371,23 @@ abstract class PigeonApiWebView(open val pigeonRegistrar: AndroidWebkitLibraryPi
         }
       }
       run {
-        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.WebView.setBackgroundColor", codec)
+        val channel =
+            BasicMessageChannel<Any?>(
+                binaryMessenger,
+                "dev.flutter.pigeon.webview_flutter_android.WebView.setBackgroundColor",
+                codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val pigeon_instanceArg = args[0] as android.webkit.WebView
             val colorArg = args[1] as Long
-            val wrapped: List<Any?> = try {
-              api.setBackgroundColor(pigeon_instanceArg, colorArg)
-              listOf(null)
-            } catch (exception: Throwable) {
-              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-            }
+            val wrapped: List<Any?> =
+                try {
+                  api.setBackgroundColor(pigeon_instanceArg, colorArg)
+                  listOf(null)
+                } catch (exception: Throwable) {
+                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+                }
             reply.reply(wrapped)
           }
         } else {
@@ -2169,17 +2395,22 @@ abstract class PigeonApiWebView(open val pigeonRegistrar: AndroidWebkitLibraryPi
         }
       }
       run {
-        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.WebView.destroy", codec)
+        val channel =
+            BasicMessageChannel<Any?>(
+                binaryMessenger,
+                "dev.flutter.pigeon.webview_flutter_android.WebView.destroy",
+                codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val pigeon_instanceArg = args[0] as android.webkit.WebView
-            val wrapped: List<Any?> = try {
-              api.destroy(pigeon_instanceArg)
-              listOf(null)
-            } catch (exception: Throwable) {
-              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-            }
+            val wrapped: List<Any?> =
+                try {
+                  api.destroy(pigeon_instanceArg)
+                  listOf(null)
+                } catch (exception: Throwable) {
+                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+                }
             reply.reply(wrapped)
           }
         } else {
@@ -2191,16 +2422,19 @@ abstract class PigeonApiWebView(open val pigeonRegistrar: AndroidWebkitLibraryPi
 
   @Suppress("LocalVariableName", "FunctionName")
   /** Creates a Dart instance of WebView and attaches it to [pigeon_instanceArg]. */
-  fun pigeon_newInstance(pigeon_instanceArg: android.webkit.WebView, callback: (Result<Unit>) -> Unit)
-{
+  fun pigeon_newInstance(
+      pigeon_instanceArg: android.webkit.WebView,
+      callback: (Result<Unit>) -> Unit
+  ) {
     if (pigeonRegistrar.ignoreCallsToDart) {
       callback(
           Result.failure(
               AndroidWebKitError("ignore-calls-error", "Calls to Dart are being ignored.", "")))
-    }     else if (pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
+    } else if (pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
       callback(Result.success(Unit))
-    }     else {
-      val pigeon_identifierArg = pigeonRegistrar.instanceManager.addHostCreatedInstance(pigeon_instanceArg)
+    } else {
+      val pigeon_identifierArg =
+          pigeonRegistrar.instanceManager.addHostCreatedInstance(pigeon_instanceArg)
       val binaryMessenger = pigeonRegistrar.binaryMessenger
       val codec = pigeonRegistrar.codec
       val channelName = "dev.flutter.pigeon.webview_flutter_android.WebView.pigeon_newInstance"
@@ -2208,32 +2442,44 @@ abstract class PigeonApiWebView(open val pigeonRegistrar: AndroidWebkitLibraryPi
       channel.send(listOf(pigeon_identifierArg)) {
         if (it is List<*>) {
           if (it.size > 1) {
-            callback(Result.failure(AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
+            callback(
+                Result.failure(
+                    AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
           } else {
             callback(Result.success(Unit))
           }
         } else {
-          callback(Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
-        } 
+          callback(
+              Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
+        }
       }
     }
   }
 
   /**
-   * This is called in response to an internal scroll in this view (i.e., the
-   * view scrolled its own contents).
+   * This is called in response to an internal scroll in this view (i.e., the view scrolled its own
+   * contents).
    */
-  fun onScrollChanged(pigeon_instanceArg: android.webkit.WebView, leftArg: Long, topArg: Long, oldLeftArg: Long, oldTopArg: Long, callback: (Result<Unit>) -> Unit)
-{
+  fun onScrollChanged(
+      pigeon_instanceArg: android.webkit.WebView,
+      leftArg: Long,
+      topArg: Long,
+      oldLeftArg: Long,
+      oldTopArg: Long,
+      callback: (Result<Unit>) -> Unit
+  ) {
     if (pigeonRegistrar.ignoreCallsToDart) {
       callback(
           Result.failure(
               AndroidWebKitError("ignore-calls-error", "Calls to Dart are being ignored.", "")))
       return
-    }     else if (!pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
+    } else if (!pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
       callback(
           Result.failure(
-              AndroidWebKitError("missing-instance-error", "Callback to `WebView.onScrollChanged` failed because native instance was not in the instance manager.", "")))
+              AndroidWebKitError(
+                  "missing-instance-error",
+                  "Callback to `WebView.onScrollChanged` failed because native instance was not in the instance manager.",
+                  "")))
       return
     }
     val binaryMessenger = pigeonRegistrar.binaryMessenger
@@ -2243,23 +2489,23 @@ abstract class PigeonApiWebView(open val pigeonRegistrar: AndroidWebkitLibraryPi
     channel.send(listOf(pigeon_instanceArg, leftArg, topArg, oldLeftArg, oldTopArg)) {
       if (it is List<*>) {
         if (it.size > 1) {
-          callback(Result.failure(AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
+          callback(
+              Result.failure(
+                  AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
         } else {
           callback(Result.success(Unit))
         }
       } else {
         callback(Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
-      } 
+      }
     }
   }
 
   @Suppress("FunctionName")
   /** An implementation of [PigeonApiView] used to access callback methods */
-  fun pigeon_getPigeonApiView(): PigeonApiView
-  {
+  fun pigeon_getPigeonApiView(): PigeonApiView {
     return pigeonRegistrar.getPigeonApiView()
   }
-
 }
 /**
  * Manages settings state for a `WebView`.
@@ -2267,52 +2513,68 @@ abstract class PigeonApiWebView(open val pigeonRegistrar: AndroidWebkitLibraryPi
  * See https://developer.android.com/reference/android/webkit/WebSettings.
  */
 @Suppress("UNCHECKED_CAST")
-abstract class PigeonApiWebSettings(open val pigeonRegistrar: AndroidWebkitLibraryPigeonProxyApiRegistrar) {
+abstract class PigeonApiWebSettings(
+    open val pigeonRegistrar: AndroidWebkitLibraryPigeonProxyApiRegistrar
+) {
   /** Sets whether the DOM storage API is enabled. */
   abstract fun setDomStorageEnabled(pigeon_instance: android.webkit.WebSettings, flag: Boolean)
 
   /** Tells JavaScript to open windows automatically. */
-  abstract fun setJavaScriptCanOpenWindowsAutomatically(pigeon_instance: android.webkit.WebSettings, flag: Boolean)
+  abstract fun setJavaScriptCanOpenWindowsAutomatically(
+      pigeon_instance: android.webkit.WebSettings,
+      flag: Boolean
+  )
 
   /** Sets whether the WebView whether supports multiple windows. */
-  abstract fun setSupportMultipleWindows(pigeon_instance: android.webkit.WebSettings, support: Boolean)
+  abstract fun setSupportMultipleWindows(
+      pigeon_instance: android.webkit.WebSettings,
+      support: Boolean
+  )
 
   /** Tells the WebView to enable JavaScript execution. */
   abstract fun setJavaScriptEnabled(pigeon_instance: android.webkit.WebSettings, flag: Boolean)
 
   /** Sets the WebView's user-agent string. */
-  abstract fun setUserAgentString(pigeon_instance: android.webkit.WebSettings, userAgentString: String?)
+  abstract fun setUserAgentString(
+      pigeon_instance: android.webkit.WebSettings,
+      userAgentString: String?
+  )
 
   /** Sets whether the WebView requires a user gesture to play media. */
-  abstract fun setMediaPlaybackRequiresUserGesture(pigeon_instance: android.webkit.WebSettings, require: Boolean)
+  abstract fun setMediaPlaybackRequiresUserGesture(
+      pigeon_instance: android.webkit.WebSettings,
+      require: Boolean
+  )
 
   /**
-   * Sets whether the WebView should support zooming using its on-screen zoom
-   * controls and gestures.
+   * Sets whether the WebView should support zooming using its on-screen zoom controls and gestures.
    */
   abstract fun setSupportZoom(pigeon_instance: android.webkit.WebSettings, support: Boolean)
 
   /**
-   * Sets whether the WebView loads pages in overview mode, that is, zooms out
-   * the content to fit on screen by width.
+   * Sets whether the WebView loads pages in overview mode, that is, zooms out the content to fit on
+   * screen by width.
    */
-  abstract fun setLoadWithOverviewMode(pigeon_instance: android.webkit.WebSettings, overview: Boolean)
+  abstract fun setLoadWithOverviewMode(
+      pigeon_instance: android.webkit.WebSettings,
+      overview: Boolean
+  )
 
   /**
-   * Sets whether the WebView should enable support for the "viewport" HTML
-   * meta tag or should use a wide viewport.
+   * Sets whether the WebView should enable support for the "viewport" HTML meta tag or should use a
+   * wide viewport.
    */
   abstract fun setUseWideViewPort(pigeon_instance: android.webkit.WebSettings, use: Boolean)
 
   /**
-   * Sets whether the WebView should display on-screen zoom controls when using
-   * the built-in zoom mechanisms.
+   * Sets whether the WebView should display on-screen zoom controls when using the built-in zoom
+   * mechanisms.
    */
   abstract fun setDisplayZoomControls(pigeon_instance: android.webkit.WebSettings, enabled: Boolean)
 
   /**
-   * Sets whether the WebView should display on-screen zoom controls when using
-   * the built-in zoom mechanisms.
+   * Sets whether the WebView should display on-screen zoom controls when using the built-in zoom
+   * mechanisms.
    */
   abstract fun setBuiltInZoomControls(pigeon_instance: android.webkit.WebSettings, enabled: Boolean)
 
@@ -2332,25 +2594,33 @@ abstract class PigeonApiWebSettings(open val pigeonRegistrar: AndroidWebkitLibra
   abstract fun getUserAgentString(pigeon_instance: android.webkit.WebSettings): String
 
   /** Configures the WebView's behavior when handling mixed content. */
-  abstract fun setMixedContentMode(pigeon_instance: android.webkit.WebSettings, mode: MixedContentMode)
+  abstract fun setMixedContentMode(
+      pigeon_instance: android.webkit.WebSettings,
+      mode: MixedContentMode
+  )
 
   companion object {
     @Suppress("LocalVariableName")
     fun setUpMessageHandlers(binaryMessenger: BinaryMessenger, api: PigeonApiWebSettings?) {
       val codec = api?.pigeonRegistrar?.codec ?: AndroidWebkitLibraryPigeonCodec()
       run {
-        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.WebSettings.setDomStorageEnabled", codec)
+        val channel =
+            BasicMessageChannel<Any?>(
+                binaryMessenger,
+                "dev.flutter.pigeon.webview_flutter_android.WebSettings.setDomStorageEnabled",
+                codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val pigeon_instanceArg = args[0] as android.webkit.WebSettings
             val flagArg = args[1] as Boolean
-            val wrapped: List<Any?> = try {
-              api.setDomStorageEnabled(pigeon_instanceArg, flagArg)
-              listOf(null)
-            } catch (exception: Throwable) {
-              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-            }
+            val wrapped: List<Any?> =
+                try {
+                  api.setDomStorageEnabled(pigeon_instanceArg, flagArg)
+                  listOf(null)
+                } catch (exception: Throwable) {
+                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+                }
             reply.reply(wrapped)
           }
         } else {
@@ -2358,18 +2628,23 @@ abstract class PigeonApiWebSettings(open val pigeonRegistrar: AndroidWebkitLibra
         }
       }
       run {
-        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.WebSettings.setJavaScriptCanOpenWindowsAutomatically", codec)
+        val channel =
+            BasicMessageChannel<Any?>(
+                binaryMessenger,
+                "dev.flutter.pigeon.webview_flutter_android.WebSettings.setJavaScriptCanOpenWindowsAutomatically",
+                codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val pigeon_instanceArg = args[0] as android.webkit.WebSettings
             val flagArg = args[1] as Boolean
-            val wrapped: List<Any?> = try {
-              api.setJavaScriptCanOpenWindowsAutomatically(pigeon_instanceArg, flagArg)
-              listOf(null)
-            } catch (exception: Throwable) {
-              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-            }
+            val wrapped: List<Any?> =
+                try {
+                  api.setJavaScriptCanOpenWindowsAutomatically(pigeon_instanceArg, flagArg)
+                  listOf(null)
+                } catch (exception: Throwable) {
+                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+                }
             reply.reply(wrapped)
           }
         } else {
@@ -2377,18 +2652,23 @@ abstract class PigeonApiWebSettings(open val pigeonRegistrar: AndroidWebkitLibra
         }
       }
       run {
-        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.WebSettings.setSupportMultipleWindows", codec)
+        val channel =
+            BasicMessageChannel<Any?>(
+                binaryMessenger,
+                "dev.flutter.pigeon.webview_flutter_android.WebSettings.setSupportMultipleWindows",
+                codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val pigeon_instanceArg = args[0] as android.webkit.WebSettings
             val supportArg = args[1] as Boolean
-            val wrapped: List<Any?> = try {
-              api.setSupportMultipleWindows(pigeon_instanceArg, supportArg)
-              listOf(null)
-            } catch (exception: Throwable) {
-              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-            }
+            val wrapped: List<Any?> =
+                try {
+                  api.setSupportMultipleWindows(pigeon_instanceArg, supportArg)
+                  listOf(null)
+                } catch (exception: Throwable) {
+                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+                }
             reply.reply(wrapped)
           }
         } else {
@@ -2396,18 +2676,23 @@ abstract class PigeonApiWebSettings(open val pigeonRegistrar: AndroidWebkitLibra
         }
       }
       run {
-        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.WebSettings.setJavaScriptEnabled", codec)
+        val channel =
+            BasicMessageChannel<Any?>(
+                binaryMessenger,
+                "dev.flutter.pigeon.webview_flutter_android.WebSettings.setJavaScriptEnabled",
+                codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val pigeon_instanceArg = args[0] as android.webkit.WebSettings
             val flagArg = args[1] as Boolean
-            val wrapped: List<Any?> = try {
-              api.setJavaScriptEnabled(pigeon_instanceArg, flagArg)
-              listOf(null)
-            } catch (exception: Throwable) {
-              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-            }
+            val wrapped: List<Any?> =
+                try {
+                  api.setJavaScriptEnabled(pigeon_instanceArg, flagArg)
+                  listOf(null)
+                } catch (exception: Throwable) {
+                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+                }
             reply.reply(wrapped)
           }
         } else {
@@ -2415,18 +2700,23 @@ abstract class PigeonApiWebSettings(open val pigeonRegistrar: AndroidWebkitLibra
         }
       }
       run {
-        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.WebSettings.setUserAgentString", codec)
+        val channel =
+            BasicMessageChannel<Any?>(
+                binaryMessenger,
+                "dev.flutter.pigeon.webview_flutter_android.WebSettings.setUserAgentString",
+                codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val pigeon_instanceArg = args[0] as android.webkit.WebSettings
             val userAgentStringArg = args[1] as String?
-            val wrapped: List<Any?> = try {
-              api.setUserAgentString(pigeon_instanceArg, userAgentStringArg)
-              listOf(null)
-            } catch (exception: Throwable) {
-              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-            }
+            val wrapped: List<Any?> =
+                try {
+                  api.setUserAgentString(pigeon_instanceArg, userAgentStringArg)
+                  listOf(null)
+                } catch (exception: Throwable) {
+                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+                }
             reply.reply(wrapped)
           }
         } else {
@@ -2434,18 +2724,23 @@ abstract class PigeonApiWebSettings(open val pigeonRegistrar: AndroidWebkitLibra
         }
       }
       run {
-        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.WebSettings.setMediaPlaybackRequiresUserGesture", codec)
+        val channel =
+            BasicMessageChannel<Any?>(
+                binaryMessenger,
+                "dev.flutter.pigeon.webview_flutter_android.WebSettings.setMediaPlaybackRequiresUserGesture",
+                codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val pigeon_instanceArg = args[0] as android.webkit.WebSettings
             val requireArg = args[1] as Boolean
-            val wrapped: List<Any?> = try {
-              api.setMediaPlaybackRequiresUserGesture(pigeon_instanceArg, requireArg)
-              listOf(null)
-            } catch (exception: Throwable) {
-              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-            }
+            val wrapped: List<Any?> =
+                try {
+                  api.setMediaPlaybackRequiresUserGesture(pigeon_instanceArg, requireArg)
+                  listOf(null)
+                } catch (exception: Throwable) {
+                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+                }
             reply.reply(wrapped)
           }
         } else {
@@ -2453,18 +2748,23 @@ abstract class PigeonApiWebSettings(open val pigeonRegistrar: AndroidWebkitLibra
         }
       }
       run {
-        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.WebSettings.setSupportZoom", codec)
+        val channel =
+            BasicMessageChannel<Any?>(
+                binaryMessenger,
+                "dev.flutter.pigeon.webview_flutter_android.WebSettings.setSupportZoom",
+                codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val pigeon_instanceArg = args[0] as android.webkit.WebSettings
             val supportArg = args[1] as Boolean
-            val wrapped: List<Any?> = try {
-              api.setSupportZoom(pigeon_instanceArg, supportArg)
-              listOf(null)
-            } catch (exception: Throwable) {
-              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-            }
+            val wrapped: List<Any?> =
+                try {
+                  api.setSupportZoom(pigeon_instanceArg, supportArg)
+                  listOf(null)
+                } catch (exception: Throwable) {
+                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+                }
             reply.reply(wrapped)
           }
         } else {
@@ -2472,18 +2772,23 @@ abstract class PigeonApiWebSettings(open val pigeonRegistrar: AndroidWebkitLibra
         }
       }
       run {
-        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.WebSettings.setLoadWithOverviewMode", codec)
+        val channel =
+            BasicMessageChannel<Any?>(
+                binaryMessenger,
+                "dev.flutter.pigeon.webview_flutter_android.WebSettings.setLoadWithOverviewMode",
+                codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val pigeon_instanceArg = args[0] as android.webkit.WebSettings
             val overviewArg = args[1] as Boolean
-            val wrapped: List<Any?> = try {
-              api.setLoadWithOverviewMode(pigeon_instanceArg, overviewArg)
-              listOf(null)
-            } catch (exception: Throwable) {
-              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-            }
+            val wrapped: List<Any?> =
+                try {
+                  api.setLoadWithOverviewMode(pigeon_instanceArg, overviewArg)
+                  listOf(null)
+                } catch (exception: Throwable) {
+                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+                }
             reply.reply(wrapped)
           }
         } else {
@@ -2491,18 +2796,23 @@ abstract class PigeonApiWebSettings(open val pigeonRegistrar: AndroidWebkitLibra
         }
       }
       run {
-        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.WebSettings.setUseWideViewPort", codec)
+        val channel =
+            BasicMessageChannel<Any?>(
+                binaryMessenger,
+                "dev.flutter.pigeon.webview_flutter_android.WebSettings.setUseWideViewPort",
+                codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val pigeon_instanceArg = args[0] as android.webkit.WebSettings
             val useArg = args[1] as Boolean
-            val wrapped: List<Any?> = try {
-              api.setUseWideViewPort(pigeon_instanceArg, useArg)
-              listOf(null)
-            } catch (exception: Throwable) {
-              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-            }
+            val wrapped: List<Any?> =
+                try {
+                  api.setUseWideViewPort(pigeon_instanceArg, useArg)
+                  listOf(null)
+                } catch (exception: Throwable) {
+                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+                }
             reply.reply(wrapped)
           }
         } else {
@@ -2510,18 +2820,23 @@ abstract class PigeonApiWebSettings(open val pigeonRegistrar: AndroidWebkitLibra
         }
       }
       run {
-        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.WebSettings.setDisplayZoomControls", codec)
+        val channel =
+            BasicMessageChannel<Any?>(
+                binaryMessenger,
+                "dev.flutter.pigeon.webview_flutter_android.WebSettings.setDisplayZoomControls",
+                codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val pigeon_instanceArg = args[0] as android.webkit.WebSettings
             val enabledArg = args[1] as Boolean
-            val wrapped: List<Any?> = try {
-              api.setDisplayZoomControls(pigeon_instanceArg, enabledArg)
-              listOf(null)
-            } catch (exception: Throwable) {
-              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-            }
+            val wrapped: List<Any?> =
+                try {
+                  api.setDisplayZoomControls(pigeon_instanceArg, enabledArg)
+                  listOf(null)
+                } catch (exception: Throwable) {
+                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+                }
             reply.reply(wrapped)
           }
         } else {
@@ -2529,18 +2844,23 @@ abstract class PigeonApiWebSettings(open val pigeonRegistrar: AndroidWebkitLibra
         }
       }
       run {
-        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.WebSettings.setBuiltInZoomControls", codec)
+        val channel =
+            BasicMessageChannel<Any?>(
+                binaryMessenger,
+                "dev.flutter.pigeon.webview_flutter_android.WebSettings.setBuiltInZoomControls",
+                codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val pigeon_instanceArg = args[0] as android.webkit.WebSettings
             val enabledArg = args[1] as Boolean
-            val wrapped: List<Any?> = try {
-              api.setBuiltInZoomControls(pigeon_instanceArg, enabledArg)
-              listOf(null)
-            } catch (exception: Throwable) {
-              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-            }
+            val wrapped: List<Any?> =
+                try {
+                  api.setBuiltInZoomControls(pigeon_instanceArg, enabledArg)
+                  listOf(null)
+                } catch (exception: Throwable) {
+                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+                }
             reply.reply(wrapped)
           }
         } else {
@@ -2548,18 +2868,23 @@ abstract class PigeonApiWebSettings(open val pigeonRegistrar: AndroidWebkitLibra
         }
       }
       run {
-        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.WebSettings.setAllowFileAccess", codec)
+        val channel =
+            BasicMessageChannel<Any?>(
+                binaryMessenger,
+                "dev.flutter.pigeon.webview_flutter_android.WebSettings.setAllowFileAccess",
+                codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val pigeon_instanceArg = args[0] as android.webkit.WebSettings
             val enabledArg = args[1] as Boolean
-            val wrapped: List<Any?> = try {
-              api.setAllowFileAccess(pigeon_instanceArg, enabledArg)
-              listOf(null)
-            } catch (exception: Throwable) {
-              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-            }
+            val wrapped: List<Any?> =
+                try {
+                  api.setAllowFileAccess(pigeon_instanceArg, enabledArg)
+                  listOf(null)
+                } catch (exception: Throwable) {
+                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+                }
             reply.reply(wrapped)
           }
         } else {
@@ -2567,18 +2892,23 @@ abstract class PigeonApiWebSettings(open val pigeonRegistrar: AndroidWebkitLibra
         }
       }
       run {
-        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.WebSettings.setAllowContentAccess", codec)
+        val channel =
+            BasicMessageChannel<Any?>(
+                binaryMessenger,
+                "dev.flutter.pigeon.webview_flutter_android.WebSettings.setAllowContentAccess",
+                codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val pigeon_instanceArg = args[0] as android.webkit.WebSettings
             val enabledArg = args[1] as Boolean
-            val wrapped: List<Any?> = try {
-              api.setAllowContentAccess(pigeon_instanceArg, enabledArg)
-              listOf(null)
-            } catch (exception: Throwable) {
-              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-            }
+            val wrapped: List<Any?> =
+                try {
+                  api.setAllowContentAccess(pigeon_instanceArg, enabledArg)
+                  listOf(null)
+                } catch (exception: Throwable) {
+                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+                }
             reply.reply(wrapped)
           }
         } else {
@@ -2586,18 +2916,23 @@ abstract class PigeonApiWebSettings(open val pigeonRegistrar: AndroidWebkitLibra
         }
       }
       run {
-        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.WebSettings.setGeolocationEnabled", codec)
+        val channel =
+            BasicMessageChannel<Any?>(
+                binaryMessenger,
+                "dev.flutter.pigeon.webview_flutter_android.WebSettings.setGeolocationEnabled",
+                codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val pigeon_instanceArg = args[0] as android.webkit.WebSettings
             val enabledArg = args[1] as Boolean
-            val wrapped: List<Any?> = try {
-              api.setGeolocationEnabled(pigeon_instanceArg, enabledArg)
-              listOf(null)
-            } catch (exception: Throwable) {
-              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-            }
+            val wrapped: List<Any?> =
+                try {
+                  api.setGeolocationEnabled(pigeon_instanceArg, enabledArg)
+                  listOf(null)
+                } catch (exception: Throwable) {
+                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+                }
             reply.reply(wrapped)
           }
         } else {
@@ -2605,18 +2940,23 @@ abstract class PigeonApiWebSettings(open val pigeonRegistrar: AndroidWebkitLibra
         }
       }
       run {
-        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.WebSettings.setTextZoom", codec)
+        val channel =
+            BasicMessageChannel<Any?>(
+                binaryMessenger,
+                "dev.flutter.pigeon.webview_flutter_android.WebSettings.setTextZoom",
+                codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val pigeon_instanceArg = args[0] as android.webkit.WebSettings
             val textZoomArg = args[1] as Long
-            val wrapped: List<Any?> = try {
-              api.setTextZoom(pigeon_instanceArg, textZoomArg)
-              listOf(null)
-            } catch (exception: Throwable) {
-              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-            }
+            val wrapped: List<Any?> =
+                try {
+                  api.setTextZoom(pigeon_instanceArg, textZoomArg)
+                  listOf(null)
+                } catch (exception: Throwable) {
+                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+                }
             reply.reply(wrapped)
           }
         } else {
@@ -2624,16 +2964,21 @@ abstract class PigeonApiWebSettings(open val pigeonRegistrar: AndroidWebkitLibra
         }
       }
       run {
-        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.WebSettings.getUserAgentString", codec)
+        val channel =
+            BasicMessageChannel<Any?>(
+                binaryMessenger,
+                "dev.flutter.pigeon.webview_flutter_android.WebSettings.getUserAgentString",
+                codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val pigeon_instanceArg = args[0] as android.webkit.WebSettings
-            val wrapped: List<Any?> = try {
-              listOf(api.getUserAgentString(pigeon_instanceArg))
-            } catch (exception: Throwable) {
-              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-            }
+            val wrapped: List<Any?> =
+                try {
+                  listOf(api.getUserAgentString(pigeon_instanceArg))
+                } catch (exception: Throwable) {
+                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+                }
             reply.reply(wrapped)
           }
         } else {
@@ -2641,18 +2986,23 @@ abstract class PigeonApiWebSettings(open val pigeonRegistrar: AndroidWebkitLibra
         }
       }
       run {
-        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.WebSettings.setMixedContentMode", codec)
+        val channel =
+            BasicMessageChannel<Any?>(
+                binaryMessenger,
+                "dev.flutter.pigeon.webview_flutter_android.WebSettings.setMixedContentMode",
+                codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val pigeon_instanceArg = args[0] as android.webkit.WebSettings
             val modeArg = args[1] as MixedContentMode
-            val wrapped: List<Any?> = try {
-              api.setMixedContentMode(pigeon_instanceArg, modeArg)
-              listOf(null)
-            } catch (exception: Throwable) {
-              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-            }
+            val wrapped: List<Any?> =
+                try {
+                  api.setMixedContentMode(pigeon_instanceArg, modeArg)
+                  listOf(null)
+                } catch (exception: Throwable) {
+                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+                }
             reply.reply(wrapped)
           }
         } else {
@@ -2664,16 +3014,19 @@ abstract class PigeonApiWebSettings(open val pigeonRegistrar: AndroidWebkitLibra
 
   @Suppress("LocalVariableName", "FunctionName")
   /** Creates a Dart instance of WebSettings and attaches it to [pigeon_instanceArg]. */
-  fun pigeon_newInstance(pigeon_instanceArg: android.webkit.WebSettings, callback: (Result<Unit>) -> Unit)
-{
+  fun pigeon_newInstance(
+      pigeon_instanceArg: android.webkit.WebSettings,
+      callback: (Result<Unit>) -> Unit
+  ) {
     if (pigeonRegistrar.ignoreCallsToDart) {
       callback(
           Result.failure(
               AndroidWebKitError("ignore-calls-error", "Calls to Dart are being ignored.", "")))
-    }     else if (pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
+    } else if (pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
       callback(Result.success(Unit))
-    }     else {
-      val pigeon_identifierArg = pigeonRegistrar.instanceManager.addHostCreatedInstance(pigeon_instanceArg)
+    } else {
+      val pigeon_identifierArg =
+          pigeonRegistrar.instanceManager.addHostCreatedInstance(pigeon_instanceArg)
       val binaryMessenger = pigeonRegistrar.binaryMessenger
       val codec = pigeonRegistrar.codec
       val channelName = "dev.flutter.pigeon.webview_flutter_android.WebSettings.pigeon_newInstance"
@@ -2681,17 +3034,19 @@ abstract class PigeonApiWebSettings(open val pigeonRegistrar: AndroidWebkitLibra
       channel.send(listOf(pigeon_identifierArg)) {
         if (it is List<*>) {
           if (it.size > 1) {
-            callback(Result.failure(AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
+            callback(
+                Result.failure(
+                    AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
           } else {
             callback(Result.success(Unit))
           }
         } else {
-          callback(Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
-        } 
+          callback(
+              Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
+        }
       }
     }
   }
-
 }
 /**
  * A JavaScript interface for exposing Javascript callbacks to Dart.
@@ -2700,7 +3055,9 @@ abstract class PigeonApiWebSettings(open val pigeonRegistrar: AndroidWebkitLibra
  * [JavascriptInterface](https://developer.android.com/reference/android/webkit/JavascriptInterface).
  */
 @Suppress("UNCHECKED_CAST")
-abstract class PigeonApiJavaScriptChannel(open val pigeonRegistrar: AndroidWebkitLibraryPigeonProxyApiRegistrar) {
+abstract class PigeonApiJavaScriptChannel(
+    open val pigeonRegistrar: AndroidWebkitLibraryPigeonProxyApiRegistrar
+) {
   abstract fun pigeon_defaultConstructor(channelName: String): JavaScriptChannel
 
   companion object {
@@ -2708,18 +3065,24 @@ abstract class PigeonApiJavaScriptChannel(open val pigeonRegistrar: AndroidWebki
     fun setUpMessageHandlers(binaryMessenger: BinaryMessenger, api: PigeonApiJavaScriptChannel?) {
       val codec = api?.pigeonRegistrar?.codec ?: AndroidWebkitLibraryPigeonCodec()
       run {
-        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.JavaScriptChannel.pigeon_defaultConstructor", codec)
+        val channel =
+            BasicMessageChannel<Any?>(
+                binaryMessenger,
+                "dev.flutter.pigeon.webview_flutter_android.JavaScriptChannel.pigeon_defaultConstructor",
+                codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val pigeon_identifierArg = args[0] as Long
             val channelNameArg = args[1] as String
-            val wrapped: List<Any?> = try {
-              api.pigeonRegistrar.instanceManager.addDartCreatedInstance(api.pigeon_defaultConstructor(channelNameArg), pigeon_identifierArg)
-              listOf(null)
-            } catch (exception: Throwable) {
-              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-            }
+            val wrapped: List<Any?> =
+                try {
+                  api.pigeonRegistrar.instanceManager.addDartCreatedInstance(
+                      api.pigeon_defaultConstructor(channelNameArg), pigeon_identifierArg)
+                  listOf(null)
+                } catch (exception: Throwable) {
+                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+                }
             reply.reply(wrapped)
           }
         } else {
@@ -2731,33 +3094,41 @@ abstract class PigeonApiJavaScriptChannel(open val pigeonRegistrar: AndroidWebki
 
   @Suppress("LocalVariableName", "FunctionName")
   /** Creates a Dart instance of JavaScriptChannel and attaches it to [pigeon_instanceArg]. */
-  fun pigeon_newInstance(pigeon_instanceArg: JavaScriptChannel, callback: (Result<Unit>) -> Unit)
-{
+  fun pigeon_newInstance(pigeon_instanceArg: JavaScriptChannel, callback: (Result<Unit>) -> Unit) {
     if (pigeonRegistrar.ignoreCallsToDart) {
       callback(
           Result.failure(
               AndroidWebKitError("ignore-calls-error", "Calls to Dart are being ignored.", "")))
-    }     else if (pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
+    } else if (pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
       callback(Result.success(Unit))
-    }     else {
+    } else {
       callback(
           Result.failure(
-              AndroidWebKitError("new-instance-error", "Attempting to create a new Dart instance of JavaScriptChannel, but the class has a nonnull callback method.", "")))
+              AndroidWebKitError(
+                  "new-instance-error",
+                  "Attempting to create a new Dart instance of JavaScriptChannel, but the class has a nonnull callback method.",
+                  "")))
     }
   }
 
   /** Handles callbacks messages from JavaScript. */
-  fun postMessage(pigeon_instanceArg: JavaScriptChannel, messageArg: String, callback: (Result<Unit>) -> Unit)
-{
+  fun postMessage(
+      pigeon_instanceArg: JavaScriptChannel,
+      messageArg: String,
+      callback: (Result<Unit>) -> Unit
+  ) {
     if (pigeonRegistrar.ignoreCallsToDart) {
       callback(
           Result.failure(
               AndroidWebKitError("ignore-calls-error", "Calls to Dart are being ignored.", "")))
       return
-    }     else if (!pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
+    } else if (!pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
       callback(
           Result.failure(
-              AndroidWebKitError("missing-instance-error", "Callback to `JavaScriptChannel.postMessage` failed because native instance was not in the instance manager.", "")))
+              AndroidWebKitError(
+                  "missing-instance-error",
+                  "Callback to `JavaScriptChannel.postMessage` failed because native instance was not in the instance manager.",
+                  "")))
       return
     }
     val binaryMessenger = pigeonRegistrar.binaryMessenger
@@ -2767,16 +3138,17 @@ abstract class PigeonApiJavaScriptChannel(open val pigeonRegistrar: AndroidWebki
     channel.send(listOf(pigeon_instanceArg, messageArg)) {
       if (it is List<*>) {
         if (it.size > 1) {
-          callback(Result.failure(AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
+          callback(
+              Result.failure(
+                  AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
         } else {
           callback(Result.success(Unit))
         }
       } else {
         callback(Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
-      } 
+      }
     }
   }
-
 }
 /**
  * Receives various notifications and requests from a `WebView`.
@@ -2784,41 +3156,51 @@ abstract class PigeonApiJavaScriptChannel(open val pigeonRegistrar: AndroidWebki
  * See https://developer.android.com/reference/android/webkit/WebViewClient.
  */
 @Suppress("UNCHECKED_CAST")
-abstract class PigeonApiWebViewClient(open val pigeonRegistrar: AndroidWebkitLibraryPigeonProxyApiRegistrar) {
+abstract class PigeonApiWebViewClient(
+    open val pigeonRegistrar: AndroidWebkitLibraryPigeonProxyApiRegistrar
+) {
   abstract fun pigeon_defaultConstructor(): android.webkit.WebViewClient
 
   /**
    * Sets the required synchronous return value for the Java method,
    * `WebViewClient.shouldOverrideUrlLoading(...)`.
    *
-   * The Java method, `WebViewClient.shouldOverrideUrlLoading(...)`, requires
-   * a boolean to be returned and this method sets the returned value for all
-   * calls to the Java method.
+   * The Java method, `WebViewClient.shouldOverrideUrlLoading(...)`, requires a boolean to be
+   * returned and this method sets the returned value for all calls to the Java method.
    *
-   * Setting this to true causes the current [WebView] to abort loading any URL
-   * received by [requestLoading] or [urlLoading], while setting this to false
-   * causes the [WebView] to continue loading a URL as usual.
+   * Setting this to true causes the current [WebView] to abort loading any URL received by
+   * [requestLoading] or [urlLoading], while setting this to false causes the [WebView] to continue
+   * loading a URL as usual.
    *
    * Defaults to false.
    */
-  abstract fun setSynchronousReturnValueForShouldOverrideUrlLoading(pigeon_instance: android.webkit.WebViewClient, value: Boolean)
+  abstract fun setSynchronousReturnValueForShouldOverrideUrlLoading(
+      pigeon_instance: android.webkit.WebViewClient,
+      value: Boolean
+  )
 
   companion object {
     @Suppress("LocalVariableName")
     fun setUpMessageHandlers(binaryMessenger: BinaryMessenger, api: PigeonApiWebViewClient?) {
       val codec = api?.pigeonRegistrar?.codec ?: AndroidWebkitLibraryPigeonCodec()
       run {
-        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.WebViewClient.pigeon_defaultConstructor", codec)
+        val channel =
+            BasicMessageChannel<Any?>(
+                binaryMessenger,
+                "dev.flutter.pigeon.webview_flutter_android.WebViewClient.pigeon_defaultConstructor",
+                codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val pigeon_identifierArg = args[0] as Long
-            val wrapped: List<Any?> = try {
-              api.pigeonRegistrar.instanceManager.addDartCreatedInstance(api.pigeon_defaultConstructor(), pigeon_identifierArg)
-              listOf(null)
-            } catch (exception: Throwable) {
-              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-            }
+            val wrapped: List<Any?> =
+                try {
+                  api.pigeonRegistrar.instanceManager.addDartCreatedInstance(
+                      api.pigeon_defaultConstructor(), pigeon_identifierArg)
+                  listOf(null)
+                } catch (exception: Throwable) {
+                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+                }
             reply.reply(wrapped)
           }
         } else {
@@ -2826,18 +3208,24 @@ abstract class PigeonApiWebViewClient(open val pigeonRegistrar: AndroidWebkitLib
         }
       }
       run {
-        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.WebViewClient.setSynchronousReturnValueForShouldOverrideUrlLoading", codec)
+        val channel =
+            BasicMessageChannel<Any?>(
+                binaryMessenger,
+                "dev.flutter.pigeon.webview_flutter_android.WebViewClient.setSynchronousReturnValueForShouldOverrideUrlLoading",
+                codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val pigeon_instanceArg = args[0] as android.webkit.WebViewClient
             val valueArg = args[1] as Boolean
-            val wrapped: List<Any?> = try {
-              api.setSynchronousReturnValueForShouldOverrideUrlLoading(pigeon_instanceArg, valueArg)
-              listOf(null)
-            } catch (exception: Throwable) {
-              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-            }
+            val wrapped: List<Any?> =
+                try {
+                  api.setSynchronousReturnValueForShouldOverrideUrlLoading(
+                      pigeon_instanceArg, valueArg)
+                  listOf(null)
+                } catch (exception: Throwable) {
+                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+                }
             reply.reply(wrapped)
           }
         } else {
@@ -2849,46 +3237,60 @@ abstract class PigeonApiWebViewClient(open val pigeonRegistrar: AndroidWebkitLib
 
   @Suppress("LocalVariableName", "FunctionName")
   /** Creates a Dart instance of WebViewClient and attaches it to [pigeon_instanceArg]. */
-  fun pigeon_newInstance(pigeon_instanceArg: android.webkit.WebViewClient, callback: (Result<Unit>) -> Unit)
-{
+  fun pigeon_newInstance(
+      pigeon_instanceArg: android.webkit.WebViewClient,
+      callback: (Result<Unit>) -> Unit
+  ) {
     if (pigeonRegistrar.ignoreCallsToDart) {
       callback(
           Result.failure(
               AndroidWebKitError("ignore-calls-error", "Calls to Dart are being ignored.", "")))
-    }     else if (pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
+    } else if (pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
       callback(Result.success(Unit))
-    }     else {
-      val pigeon_identifierArg = pigeonRegistrar.instanceManager.addHostCreatedInstance(pigeon_instanceArg)
+    } else {
+      val pigeon_identifierArg =
+          pigeonRegistrar.instanceManager.addHostCreatedInstance(pigeon_instanceArg)
       val binaryMessenger = pigeonRegistrar.binaryMessenger
       val codec = pigeonRegistrar.codec
-      val channelName = "dev.flutter.pigeon.webview_flutter_android.WebViewClient.pigeon_newInstance"
+      val channelName =
+          "dev.flutter.pigeon.webview_flutter_android.WebViewClient.pigeon_newInstance"
       val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
       channel.send(listOf(pigeon_identifierArg)) {
         if (it is List<*>) {
           if (it.size > 1) {
-            callback(Result.failure(AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
+            callback(
+                Result.failure(
+                    AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
           } else {
             callback(Result.success(Unit))
           }
         } else {
-          callback(Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
-        } 
+          callback(
+              Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
+        }
       }
     }
   }
 
   /** Notify the host application that a page has started loading. */
-  fun onPageStarted(pigeon_instanceArg: android.webkit.WebViewClient, webViewArg: android.webkit.WebView, urlArg: String, callback: (Result<Unit>) -> Unit)
-{
+  fun onPageStarted(
+      pigeon_instanceArg: android.webkit.WebViewClient,
+      webViewArg: android.webkit.WebView,
+      urlArg: String,
+      callback: (Result<Unit>) -> Unit
+  ) {
     if (pigeonRegistrar.ignoreCallsToDart) {
       callback(
           Result.failure(
               AndroidWebKitError("ignore-calls-error", "Calls to Dart are being ignored.", "")))
       return
-    }     else if (!pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
+    } else if (!pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
       callback(
           Result.failure(
-              AndroidWebKitError("missing-instance-error", "Callback to `WebViewClient.onPageStarted` failed because native instance was not in the instance manager.", "")))
+              AndroidWebKitError(
+                  "missing-instance-error",
+                  "Callback to `WebViewClient.onPageStarted` failed because native instance was not in the instance manager.",
+                  "")))
       return
     }
     val binaryMessenger = pigeonRegistrar.binaryMessenger
@@ -2898,28 +3300,37 @@ abstract class PigeonApiWebViewClient(open val pigeonRegistrar: AndroidWebkitLib
     channel.send(listOf(pigeon_instanceArg, webViewArg, urlArg)) {
       if (it is List<*>) {
         if (it.size > 1) {
-          callback(Result.failure(AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
+          callback(
+              Result.failure(
+                  AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
         } else {
           callback(Result.success(Unit))
         }
       } else {
         callback(Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
-      } 
+      }
     }
   }
 
   /** Notify the host application that a page has finished loading. */
-  fun onPageFinished(pigeon_instanceArg: android.webkit.WebViewClient, webViewArg: android.webkit.WebView, urlArg: String, callback: (Result<Unit>) -> Unit)
-{
+  fun onPageFinished(
+      pigeon_instanceArg: android.webkit.WebViewClient,
+      webViewArg: android.webkit.WebView,
+      urlArg: String,
+      callback: (Result<Unit>) -> Unit
+  ) {
     if (pigeonRegistrar.ignoreCallsToDart) {
       callback(
           Result.failure(
               AndroidWebKitError("ignore-calls-error", "Calls to Dart are being ignored.", "")))
       return
-    }     else if (!pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
+    } else if (!pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
       callback(
           Result.failure(
-              AndroidWebKitError("missing-instance-error", "Callback to `WebViewClient.onPageFinished` failed because native instance was not in the instance manager.", "")))
+              AndroidWebKitError(
+                  "missing-instance-error",
+                  "Callback to `WebViewClient.onPageFinished` failed because native instance was not in the instance manager.",
+                  "")))
       return
     }
     val binaryMessenger = pigeonRegistrar.binaryMessenger
@@ -2929,31 +3340,41 @@ abstract class PigeonApiWebViewClient(open val pigeonRegistrar: AndroidWebkitLib
     channel.send(listOf(pigeon_instanceArg, webViewArg, urlArg)) {
       if (it is List<*>) {
         if (it.size > 1) {
-          callback(Result.failure(AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
+          callback(
+              Result.failure(
+                  AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
         } else {
           callback(Result.success(Unit))
         }
       } else {
         callback(Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
-      } 
+      }
     }
   }
 
   /**
-   * Notify the host application that an HTTP error has been received from the
-   * server while loading a resource.
+   * Notify the host application that an HTTP error has been received from the server while loading
+   * a resource.
    */
-  fun onReceivedHttpError(pigeon_instanceArg: android.webkit.WebViewClient, webViewArg: android.webkit.WebView, requestArg: android.webkit.WebResourceRequest, responseArg: android.webkit.WebResourceResponse, callback: (Result<Unit>) -> Unit)
-{
+  fun onReceivedHttpError(
+      pigeon_instanceArg: android.webkit.WebViewClient,
+      webViewArg: android.webkit.WebView,
+      requestArg: android.webkit.WebResourceRequest,
+      responseArg: android.webkit.WebResourceResponse,
+      callback: (Result<Unit>) -> Unit
+  ) {
     if (pigeonRegistrar.ignoreCallsToDart) {
       callback(
           Result.failure(
               AndroidWebKitError("ignore-calls-error", "Calls to Dart are being ignored.", "")))
       return
-    }     else if (!pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
+    } else if (!pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
       callback(
           Result.failure(
-              AndroidWebKitError("missing-instance-error", "Callback to `WebViewClient.onReceivedHttpError` failed because native instance was not in the instance manager.", "")))
+              AndroidWebKitError(
+                  "missing-instance-error",
+                  "Callback to `WebViewClient.onReceivedHttpError` failed because native instance was not in the instance manager.",
+                  "")))
       return
     }
     val binaryMessenger = pigeonRegistrar.binaryMessenger
@@ -2963,93 +3384,124 @@ abstract class PigeonApiWebViewClient(open val pigeonRegistrar: AndroidWebkitLib
     channel.send(listOf(pigeon_instanceArg, webViewArg, requestArg, responseArg)) {
       if (it is List<*>) {
         if (it.size > 1) {
-          callback(Result.failure(AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
+          callback(
+              Result.failure(
+                  AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
         } else {
           callback(Result.success(Unit))
         }
       } else {
         callback(Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
-      } 
+      }
     }
   }
 
   /** Report web resource loading error to the host application. */
-  fun onReceivedRequestError(pigeon_instanceArg: android.webkit.WebViewClient, webViewArg: android.webkit.WebView, requestArg: android.webkit.WebResourceRequest, errorArg: android.webkit.WebResourceError, callback: (Result<Unit>) -> Unit)
-{
+  fun onReceivedRequestError(
+      pigeon_instanceArg: android.webkit.WebViewClient,
+      webViewArg: android.webkit.WebView,
+      requestArg: android.webkit.WebResourceRequest,
+      errorArg: android.webkit.WebResourceError,
+      callback: (Result<Unit>) -> Unit
+  ) {
     if (pigeonRegistrar.ignoreCallsToDart) {
       callback(
           Result.failure(
               AndroidWebKitError("ignore-calls-error", "Calls to Dart are being ignored.", "")))
       return
-    }     else if (!pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
+    } else if (!pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
       callback(
           Result.failure(
-              AndroidWebKitError("missing-instance-error", "Callback to `WebViewClient.onReceivedRequestError` failed because native instance was not in the instance manager.", "")))
+              AndroidWebKitError(
+                  "missing-instance-error",
+                  "Callback to `WebViewClient.onReceivedRequestError` failed because native instance was not in the instance manager.",
+                  "")))
       return
     }
     val binaryMessenger = pigeonRegistrar.binaryMessenger
     val codec = pigeonRegistrar.codec
-    val channelName = "dev.flutter.pigeon.webview_flutter_android.WebViewClient.onReceivedRequestError"
+    val channelName =
+        "dev.flutter.pigeon.webview_flutter_android.WebViewClient.onReceivedRequestError"
     val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
     channel.send(listOf(pigeon_instanceArg, webViewArg, requestArg, errorArg)) {
       if (it is List<*>) {
         if (it.size > 1) {
-          callback(Result.failure(AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
+          callback(
+              Result.failure(
+                  AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
         } else {
           callback(Result.success(Unit))
         }
       } else {
         callback(Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
-      } 
+      }
     }
   }
 
   /** Report web resource loading error to the host application. */
-  fun onReceivedRequestErrorCompat(pigeon_instanceArg: android.webkit.WebViewClient, webViewArg: android.webkit.WebView, requestArg: android.webkit.WebResourceRequest, errorArg: androidx.webkit.WebResourceErrorCompat, callback: (Result<Unit>) -> Unit)
-{
+  fun onReceivedRequestErrorCompat(
+      pigeon_instanceArg: android.webkit.WebViewClient,
+      webViewArg: android.webkit.WebView,
+      requestArg: android.webkit.WebResourceRequest,
+      errorArg: androidx.webkit.WebResourceErrorCompat,
+      callback: (Result<Unit>) -> Unit
+  ) {
     if (pigeonRegistrar.ignoreCallsToDart) {
       callback(
           Result.failure(
               AndroidWebKitError("ignore-calls-error", "Calls to Dart are being ignored.", "")))
       return
-    }     else if (!pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
+    } else if (!pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
       callback(
           Result.failure(
-              AndroidWebKitError("missing-instance-error", "Callback to `WebViewClient.onReceivedRequestErrorCompat` failed because native instance was not in the instance manager.", "")))
+              AndroidWebKitError(
+                  "missing-instance-error",
+                  "Callback to `WebViewClient.onReceivedRequestErrorCompat` failed because native instance was not in the instance manager.",
+                  "")))
       return
     }
     val binaryMessenger = pigeonRegistrar.binaryMessenger
     val codec = pigeonRegistrar.codec
-    val channelName = "dev.flutter.pigeon.webview_flutter_android.WebViewClient.onReceivedRequestErrorCompat"
+    val channelName =
+        "dev.flutter.pigeon.webview_flutter_android.WebViewClient.onReceivedRequestErrorCompat"
     val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
     channel.send(listOf(pigeon_instanceArg, webViewArg, requestArg, errorArg)) {
       if (it is List<*>) {
         if (it.size > 1) {
-          callback(Result.failure(AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
+          callback(
+              Result.failure(
+                  AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
         } else {
           callback(Result.success(Unit))
         }
       } else {
         callback(Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
-      } 
+      }
     }
   }
 
   /**
-   * Give the host application a chance to take control when a URL is about to
-   * be loaded in the current WebView.
+   * Give the host application a chance to take control when a URL is about to be loaded in the
+   * current WebView.
    */
-  fun requestLoading(pigeon_instanceArg: android.webkit.WebViewClient, webViewArg: android.webkit.WebView, requestArg: android.webkit.WebResourceRequest, callback: (Result<Unit>) -> Unit)
-{
+  fun requestLoading(
+      pigeon_instanceArg: android.webkit.WebViewClient,
+      webViewArg: android.webkit.WebView,
+      requestArg: android.webkit.WebResourceRequest,
+      callback: (Result<Unit>) -> Unit
+  ) {
     if (pigeonRegistrar.ignoreCallsToDart) {
       callback(
           Result.failure(
               AndroidWebKitError("ignore-calls-error", "Calls to Dart are being ignored.", "")))
       return
-    }     else if (!pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
+    } else if (!pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
       callback(
           Result.failure(
-              AndroidWebKitError("missing-instance-error", "Callback to `WebViewClient.requestLoading` failed because native instance was not in the instance manager.", "")))
+              AndroidWebKitError(
+                  "missing-instance-error",
+                  "Callback to `WebViewClient.requestLoading` failed because native instance was not in the instance manager.",
+                  "")))
       return
     }
     val binaryMessenger = pigeonRegistrar.binaryMessenger
@@ -3059,31 +3511,40 @@ abstract class PigeonApiWebViewClient(open val pigeonRegistrar: AndroidWebkitLib
     channel.send(listOf(pigeon_instanceArg, webViewArg, requestArg)) {
       if (it is List<*>) {
         if (it.size > 1) {
-          callback(Result.failure(AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
+          callback(
+              Result.failure(
+                  AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
         } else {
           callback(Result.success(Unit))
         }
       } else {
         callback(Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
-      } 
+      }
     }
   }
 
   /**
-   * Give the host application a chance to take control when a URL is about to
-   * be loaded in the current WebView.
+   * Give the host application a chance to take control when a URL is about to be loaded in the
+   * current WebView.
    */
-  fun urlLoading(pigeon_instanceArg: android.webkit.WebViewClient, webViewArg: android.webkit.WebView, urlArg: String, callback: (Result<Unit>) -> Unit)
-{
+  fun urlLoading(
+      pigeon_instanceArg: android.webkit.WebViewClient,
+      webViewArg: android.webkit.WebView,
+      urlArg: String,
+      callback: (Result<Unit>) -> Unit
+  ) {
     if (pigeonRegistrar.ignoreCallsToDart) {
       callback(
           Result.failure(
               AndroidWebKitError("ignore-calls-error", "Calls to Dart are being ignored.", "")))
       return
-    }     else if (!pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
+    } else if (!pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
       callback(
           Result.failure(
-              AndroidWebKitError("missing-instance-error", "Callback to `WebViewClient.urlLoading` failed because native instance was not in the instance manager.", "")))
+              AndroidWebKitError(
+                  "missing-instance-error",
+                  "Callback to `WebViewClient.urlLoading` failed because native instance was not in the instance manager.",
+                  "")))
       return
     }
     val binaryMessenger = pigeonRegistrar.binaryMessenger
@@ -3093,31 +3554,36 @@ abstract class PigeonApiWebViewClient(open val pigeonRegistrar: AndroidWebkitLib
     channel.send(listOf(pigeon_instanceArg, webViewArg, urlArg)) {
       if (it is List<*>) {
         if (it.size > 1) {
-          callback(Result.failure(AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
+          callback(
+              Result.failure(
+                  AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
         } else {
           callback(Result.success(Unit))
         }
       } else {
         callback(Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
-      } 
+      }
     }
   }
 
-  /**
-   * Notifies the host that the page requested a new window
-   * (`target=_blank` / `window.open`).
-   */
-  fun onCreateWindow(pigeon_instanceArg: android.webkit.WebViewClient, urlArg: String, callback: (Result<Unit>) -> Unit)
-{
+  /** Notifies the host that the page requested a new window (`target=_blank` / `window.open`). */
+  fun onCreateWindow(
+      pigeon_instanceArg: android.webkit.WebViewClient,
+      urlArg: String,
+      callback: (Result<Unit>) -> Unit
+  ) {
     if (pigeonRegistrar.ignoreCallsToDart) {
       callback(
           Result.failure(
               AndroidWebKitError("ignore-calls-error", "Calls to Dart are being ignored.", "")))
       return
-    }     else if (!pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
+    } else if (!pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
       callback(
           Result.failure(
-              AndroidWebKitError("missing-instance-error", "Callback to `WebViewClient.onCreateWindow` failed because native instance was not in the instance manager.", "")))
+              AndroidWebKitError(
+                  "missing-instance-error",
+                  "Callback to `WebViewClient.onCreateWindow` failed because native instance was not in the instance manager.",
+                  "")))
       return
     }
     val binaryMessenger = pigeonRegistrar.binaryMessenger
@@ -3127,96 +3593,126 @@ abstract class PigeonApiWebViewClient(open val pigeonRegistrar: AndroidWebkitLib
     channel.send(listOf(pigeon_instanceArg, urlArg)) {
       if (it is List<*>) {
         if (it.size > 1) {
-          callback(Result.failure(AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
+          callback(
+              Result.failure(
+                  AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
         } else {
           callback(Result.success(Unit))
         }
       } else {
         callback(Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
-      } 
+      }
     }
   }
 
   /** Notify the host application to update its visited links database. */
-  fun doUpdateVisitedHistory(pigeon_instanceArg: android.webkit.WebViewClient, webViewArg: android.webkit.WebView, urlArg: String, isReloadArg: Boolean, callback: (Result<Unit>) -> Unit)
-{
+  fun doUpdateVisitedHistory(
+      pigeon_instanceArg: android.webkit.WebViewClient,
+      webViewArg: android.webkit.WebView,
+      urlArg: String,
+      isReloadArg: Boolean,
+      callback: (Result<Unit>) -> Unit
+  ) {
     if (pigeonRegistrar.ignoreCallsToDart) {
       callback(
           Result.failure(
               AndroidWebKitError("ignore-calls-error", "Calls to Dart are being ignored.", "")))
       return
-    }     else if (!pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
+    } else if (!pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
       callback(
           Result.failure(
-              AndroidWebKitError("missing-instance-error", "Callback to `WebViewClient.doUpdateVisitedHistory` failed because native instance was not in the instance manager.", "")))
+              AndroidWebKitError(
+                  "missing-instance-error",
+                  "Callback to `WebViewClient.doUpdateVisitedHistory` failed because native instance was not in the instance manager.",
+                  "")))
       return
     }
     val binaryMessenger = pigeonRegistrar.binaryMessenger
     val codec = pigeonRegistrar.codec
-    val channelName = "dev.flutter.pigeon.webview_flutter_android.WebViewClient.doUpdateVisitedHistory"
+    val channelName =
+        "dev.flutter.pigeon.webview_flutter_android.WebViewClient.doUpdateVisitedHistory"
     val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
     channel.send(listOf(pigeon_instanceArg, webViewArg, urlArg, isReloadArg)) {
       if (it is List<*>) {
         if (it.size > 1) {
-          callback(Result.failure(AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
+          callback(
+              Result.failure(
+                  AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
         } else {
           callback(Result.success(Unit))
         }
       } else {
         callback(Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
-      } 
+      }
     }
   }
 
-  /**
-   * Notifies the host application that the WebView received an HTTP
-   * authentication request.
-   */
-  fun onReceivedHttpAuthRequest(pigeon_instanceArg: android.webkit.WebViewClient, webViewArg: android.webkit.WebView, handlerArg: android.webkit.HttpAuthHandler, hostArg: String, realmArg: String, callback: (Result<Unit>) -> Unit)
-{
+  /** Notifies the host application that the WebView received an HTTP authentication request. */
+  fun onReceivedHttpAuthRequest(
+      pigeon_instanceArg: android.webkit.WebViewClient,
+      webViewArg: android.webkit.WebView,
+      handlerArg: android.webkit.HttpAuthHandler,
+      hostArg: String,
+      realmArg: String,
+      callback: (Result<Unit>) -> Unit
+  ) {
     if (pigeonRegistrar.ignoreCallsToDart) {
       callback(
           Result.failure(
               AndroidWebKitError("ignore-calls-error", "Calls to Dart are being ignored.", "")))
       return
-    }     else if (!pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
+    } else if (!pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
       callback(
           Result.failure(
-              AndroidWebKitError("missing-instance-error", "Callback to `WebViewClient.onReceivedHttpAuthRequest` failed because native instance was not in the instance manager.", "")))
+              AndroidWebKitError(
+                  "missing-instance-error",
+                  "Callback to `WebViewClient.onReceivedHttpAuthRequest` failed because native instance was not in the instance manager.",
+                  "")))
       return
     }
     val binaryMessenger = pigeonRegistrar.binaryMessenger
     val codec = pigeonRegistrar.codec
-    val channelName = "dev.flutter.pigeon.webview_flutter_android.WebViewClient.onReceivedHttpAuthRequest"
+    val channelName =
+        "dev.flutter.pigeon.webview_flutter_android.WebViewClient.onReceivedHttpAuthRequest"
     val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
     channel.send(listOf(pigeon_instanceArg, webViewArg, handlerArg, hostArg, realmArg)) {
       if (it is List<*>) {
         if (it.size > 1) {
-          callback(Result.failure(AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
+          callback(
+              Result.failure(
+                  AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
         } else {
           callback(Result.success(Unit))
         }
       } else {
         callback(Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
-      } 
+      }
     }
   }
 
   /**
-   * Ask the host application if the browser should resend data as the
-   * requested page was a result of a POST.
+   * Ask the host application if the browser should resend data as the requested page was a result
+   * of a POST.
    */
-  fun onFormResubmission(pigeon_instanceArg: android.webkit.WebViewClient, viewArg: android.webkit.WebView, dontResendArg: android.os.Message, resendArg: android.os.Message, callback: (Result<Unit>) -> Unit)
-{
+  fun onFormResubmission(
+      pigeon_instanceArg: android.webkit.WebViewClient,
+      viewArg: android.webkit.WebView,
+      dontResendArg: android.os.Message,
+      resendArg: android.os.Message,
+      callback: (Result<Unit>) -> Unit
+  ) {
     if (pigeonRegistrar.ignoreCallsToDart) {
       callback(
           Result.failure(
               AndroidWebKitError("ignore-calls-error", "Calls to Dart are being ignored.", "")))
       return
-    }     else if (!pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
+    } else if (!pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
       callback(
           Result.failure(
-              AndroidWebKitError("missing-instance-error", "Callback to `WebViewClient.onFormResubmission` failed because native instance was not in the instance manager.", "")))
+              AndroidWebKitError(
+                  "missing-instance-error",
+                  "Callback to `WebViewClient.onFormResubmission` failed because native instance was not in the instance manager.",
+                  "")))
       return
     }
     val binaryMessenger = pigeonRegistrar.binaryMessenger
@@ -3226,31 +3722,39 @@ abstract class PigeonApiWebViewClient(open val pigeonRegistrar: AndroidWebkitLib
     channel.send(listOf(pigeon_instanceArg, viewArg, dontResendArg, resendArg)) {
       if (it is List<*>) {
         if (it.size > 1) {
-          callback(Result.failure(AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
+          callback(
+              Result.failure(
+                  AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
         } else {
           callback(Result.success(Unit))
         }
       } else {
         callback(Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
-      } 
+      }
     }
   }
 
   /**
-   * Notify the host application that the WebView will load the resource
-   * specified by the given url.
+   * Notify the host application that the WebView will load the resource specified by the given url.
    */
-  fun onLoadResource(pigeon_instanceArg: android.webkit.WebViewClient, viewArg: android.webkit.WebView, urlArg: String, callback: (Result<Unit>) -> Unit)
-{
+  fun onLoadResource(
+      pigeon_instanceArg: android.webkit.WebViewClient,
+      viewArg: android.webkit.WebView,
+      urlArg: String,
+      callback: (Result<Unit>) -> Unit
+  ) {
     if (pigeonRegistrar.ignoreCallsToDart) {
       callback(
           Result.failure(
               AndroidWebKitError("ignore-calls-error", "Calls to Dart are being ignored.", "")))
       return
-    }     else if (!pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
+    } else if (!pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
       callback(
           Result.failure(
-              AndroidWebKitError("missing-instance-error", "Callback to `WebViewClient.onLoadResource` failed because native instance was not in the instance manager.", "")))
+              AndroidWebKitError(
+                  "missing-instance-error",
+                  "Callback to `WebViewClient.onLoadResource` failed because native instance was not in the instance manager.",
+                  "")))
       return
     }
     val binaryMessenger = pigeonRegistrar.binaryMessenger
@@ -3260,31 +3764,40 @@ abstract class PigeonApiWebViewClient(open val pigeonRegistrar: AndroidWebkitLib
     channel.send(listOf(pigeon_instanceArg, viewArg, urlArg)) {
       if (it is List<*>) {
         if (it.size > 1) {
-          callback(Result.failure(AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
+          callback(
+              Result.failure(
+                  AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
         } else {
           callback(Result.success(Unit))
         }
       } else {
         callback(Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
-      } 
+      }
     }
   }
 
   /**
-   * Notify the host application that WebView content left over from previous
-   * page navigations will no longer be drawn.
+   * Notify the host application that WebView content left over from previous page navigations will
+   * no longer be drawn.
    */
-  fun onPageCommitVisible(pigeon_instanceArg: android.webkit.WebViewClient, viewArg: android.webkit.WebView, urlArg: String, callback: (Result<Unit>) -> Unit)
-{
+  fun onPageCommitVisible(
+      pigeon_instanceArg: android.webkit.WebViewClient,
+      viewArg: android.webkit.WebView,
+      urlArg: String,
+      callback: (Result<Unit>) -> Unit
+  ) {
     if (pigeonRegistrar.ignoreCallsToDart) {
       callback(
           Result.failure(
               AndroidWebKitError("ignore-calls-error", "Calls to Dart are being ignored.", "")))
       return
-    }     else if (!pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
+    } else if (!pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
       callback(
           Result.failure(
-              AndroidWebKitError("missing-instance-error", "Callback to `WebViewClient.onPageCommitVisible` failed because native instance was not in the instance manager.", "")))
+              AndroidWebKitError(
+                  "missing-instance-error",
+                  "Callback to `WebViewClient.onPageCommitVisible` failed because native instance was not in the instance manager.",
+                  "")))
       return
     }
     val binaryMessenger = pigeonRegistrar.binaryMessenger
@@ -3294,96 +3807,124 @@ abstract class PigeonApiWebViewClient(open val pigeonRegistrar: AndroidWebkitLib
     channel.send(listOf(pigeon_instanceArg, viewArg, urlArg)) {
       if (it is List<*>) {
         if (it.size > 1) {
-          callback(Result.failure(AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
+          callback(
+              Result.failure(
+                  AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
         } else {
           callback(Result.success(Unit))
         }
       } else {
         callback(Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
-      } 
+      }
     }
   }
 
   /** Notify the host application to handle a SSL client certificate request. */
-  fun onReceivedClientCertRequest(pigeon_instanceArg: android.webkit.WebViewClient, viewArg: android.webkit.WebView, requestArg: android.webkit.ClientCertRequest, callback: (Result<Unit>) -> Unit)
-{
+  fun onReceivedClientCertRequest(
+      pigeon_instanceArg: android.webkit.WebViewClient,
+      viewArg: android.webkit.WebView,
+      requestArg: android.webkit.ClientCertRequest,
+      callback: (Result<Unit>) -> Unit
+  ) {
     if (pigeonRegistrar.ignoreCallsToDart) {
       callback(
           Result.failure(
               AndroidWebKitError("ignore-calls-error", "Calls to Dart are being ignored.", "")))
       return
-    }     else if (!pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
+    } else if (!pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
       callback(
           Result.failure(
-              AndroidWebKitError("missing-instance-error", "Callback to `WebViewClient.onReceivedClientCertRequest` failed because native instance was not in the instance manager.", "")))
+              AndroidWebKitError(
+                  "missing-instance-error",
+                  "Callback to `WebViewClient.onReceivedClientCertRequest` failed because native instance was not in the instance manager.",
+                  "")))
       return
     }
     val binaryMessenger = pigeonRegistrar.binaryMessenger
     val codec = pigeonRegistrar.codec
-    val channelName = "dev.flutter.pigeon.webview_flutter_android.WebViewClient.onReceivedClientCertRequest"
+    val channelName =
+        "dev.flutter.pigeon.webview_flutter_android.WebViewClient.onReceivedClientCertRequest"
     val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
     channel.send(listOf(pigeon_instanceArg, viewArg, requestArg)) {
       if (it is List<*>) {
         if (it.size > 1) {
-          callback(Result.failure(AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
+          callback(
+              Result.failure(
+                  AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
         } else {
           callback(Result.success(Unit))
         }
       } else {
         callback(Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
-      } 
+      }
     }
   }
 
   /**
-   * Notify the host application that a request to automatically log in the
-   * user has been processed.
+   * Notify the host application that a request to automatically log in the user has been processed.
    */
-  fun onReceivedLoginRequest(pigeon_instanceArg: android.webkit.WebViewClient, viewArg: android.webkit.WebView, realmArg: String, accountArg: String?, argsArg: String, callback: (Result<Unit>) -> Unit)
-{
+  fun onReceivedLoginRequest(
+      pigeon_instanceArg: android.webkit.WebViewClient,
+      viewArg: android.webkit.WebView,
+      realmArg: String,
+      accountArg: String?,
+      argsArg: String,
+      callback: (Result<Unit>) -> Unit
+  ) {
     if (pigeonRegistrar.ignoreCallsToDart) {
       callback(
           Result.failure(
               AndroidWebKitError("ignore-calls-error", "Calls to Dart are being ignored.", "")))
       return
-    }     else if (!pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
+    } else if (!pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
       callback(
           Result.failure(
-              AndroidWebKitError("missing-instance-error", "Callback to `WebViewClient.onReceivedLoginRequest` failed because native instance was not in the instance manager.", "")))
+              AndroidWebKitError(
+                  "missing-instance-error",
+                  "Callback to `WebViewClient.onReceivedLoginRequest` failed because native instance was not in the instance manager.",
+                  "")))
       return
     }
     val binaryMessenger = pigeonRegistrar.binaryMessenger
     val codec = pigeonRegistrar.codec
-    val channelName = "dev.flutter.pigeon.webview_flutter_android.WebViewClient.onReceivedLoginRequest"
+    val channelName =
+        "dev.flutter.pigeon.webview_flutter_android.WebViewClient.onReceivedLoginRequest"
     val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
     channel.send(listOf(pigeon_instanceArg, viewArg, realmArg, accountArg, argsArg)) {
       if (it is List<*>) {
         if (it.size > 1) {
-          callback(Result.failure(AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
+          callback(
+              Result.failure(
+                  AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
         } else {
           callback(Result.success(Unit))
         }
       } else {
         callback(Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
-      } 
+      }
     }
   }
 
-  /**
-   * Notifies the host application that an SSL error occurred while loading a
-   * resource.
-   */
-  fun onReceivedSslError(pigeon_instanceArg: android.webkit.WebViewClient, viewArg: android.webkit.WebView, handlerArg: android.webkit.SslErrorHandler, errorArg: android.net.http.SslError, callback: (Result<Unit>) -> Unit)
-{
+  /** Notifies the host application that an SSL error occurred while loading a resource. */
+  fun onReceivedSslError(
+      pigeon_instanceArg: android.webkit.WebViewClient,
+      viewArg: android.webkit.WebView,
+      handlerArg: android.webkit.SslErrorHandler,
+      errorArg: android.net.http.SslError,
+      callback: (Result<Unit>) -> Unit
+  ) {
     if (pigeonRegistrar.ignoreCallsToDart) {
       callback(
           Result.failure(
               AndroidWebKitError("ignore-calls-error", "Calls to Dart are being ignored.", "")))
       return
-    }     else if (!pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
+    } else if (!pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
       callback(
           Result.failure(
-              AndroidWebKitError("missing-instance-error", "Callback to `WebViewClient.onReceivedSslError` failed because native instance was not in the instance manager.", "")))
+              AndroidWebKitError(
+                  "missing-instance-error",
+                  "Callback to `WebViewClient.onReceivedSslError` failed because native instance was not in the instance manager.",
+                  "")))
       return
     }
     val binaryMessenger = pigeonRegistrar.binaryMessenger
@@ -3393,31 +3934,38 @@ abstract class PigeonApiWebViewClient(open val pigeonRegistrar: AndroidWebkitLib
     channel.send(listOf(pigeon_instanceArg, viewArg, handlerArg, errorArg)) {
       if (it is List<*>) {
         if (it.size > 1) {
-          callback(Result.failure(AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
+          callback(
+              Result.failure(
+                  AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
         } else {
           callback(Result.success(Unit))
         }
       } else {
         callback(Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
-      } 
+      }
     }
   }
 
-  /**
-   * Notify the host application that the scale applied to the WebView has
-   * changed.
-   */
-  fun onScaleChanged(pigeon_instanceArg: android.webkit.WebViewClient, viewArg: android.webkit.WebView, oldScaleArg: Double, newScaleArg: Double, callback: (Result<Unit>) -> Unit)
-{
+  /** Notify the host application that the scale applied to the WebView has changed. */
+  fun onScaleChanged(
+      pigeon_instanceArg: android.webkit.WebViewClient,
+      viewArg: android.webkit.WebView,
+      oldScaleArg: Double,
+      newScaleArg: Double,
+      callback: (Result<Unit>) -> Unit
+  ) {
     if (pigeonRegistrar.ignoreCallsToDart) {
       callback(
           Result.failure(
               AndroidWebKitError("ignore-calls-error", "Calls to Dart are being ignored.", "")))
       return
-    }     else if (!pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
+    } else if (!pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
       callback(
           Result.failure(
-              AndroidWebKitError("missing-instance-error", "Callback to `WebViewClient.onScaleChanged` failed because native instance was not in the instance manager.", "")))
+              AndroidWebKitError(
+                  "missing-instance-error",
+                  "Callback to `WebViewClient.onScaleChanged` failed because native instance was not in the instance manager.",
+                  "")))
       return
     }
     val binaryMessenger = pigeonRegistrar.binaryMessenger
@@ -3427,16 +3975,17 @@ abstract class PigeonApiWebViewClient(open val pigeonRegistrar: AndroidWebkitLib
     channel.send(listOf(pigeon_instanceArg, viewArg, oldScaleArg, newScaleArg)) {
       if (it is List<*>) {
         if (it.size > 1) {
-          callback(Result.failure(AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
+          callback(
+              Result.failure(
+                  AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
         } else {
           callback(Result.success(Unit))
         }
       } else {
         callback(Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
-      } 
+      }
     }
   }
-
 }
 /**
  * Handles notifications that a file should be downloaded.
@@ -3444,7 +3993,9 @@ abstract class PigeonApiWebViewClient(open val pigeonRegistrar: AndroidWebkitLib
  * See https://developer.android.com/reference/android/webkit/DownloadListener.
  */
 @Suppress("UNCHECKED_CAST")
-abstract class PigeonApiDownloadListener(open val pigeonRegistrar: AndroidWebkitLibraryPigeonProxyApiRegistrar) {
+abstract class PigeonApiDownloadListener(
+    open val pigeonRegistrar: AndroidWebkitLibraryPigeonProxyApiRegistrar
+) {
   abstract fun pigeon_defaultConstructor(): android.webkit.DownloadListener
 
   companion object {
@@ -3452,17 +4003,23 @@ abstract class PigeonApiDownloadListener(open val pigeonRegistrar: AndroidWebkit
     fun setUpMessageHandlers(binaryMessenger: BinaryMessenger, api: PigeonApiDownloadListener?) {
       val codec = api?.pigeonRegistrar?.codec ?: AndroidWebkitLibraryPigeonCodec()
       run {
-        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.DownloadListener.pigeon_defaultConstructor", codec)
+        val channel =
+            BasicMessageChannel<Any?>(
+                binaryMessenger,
+                "dev.flutter.pigeon.webview_flutter_android.DownloadListener.pigeon_defaultConstructor",
+                codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val pigeon_identifierArg = args[0] as Long
-            val wrapped: List<Any?> = try {
-              api.pigeonRegistrar.instanceManager.addDartCreatedInstance(api.pigeon_defaultConstructor(), pigeon_identifierArg)
-              listOf(null)
-            } catch (exception: Throwable) {
-              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-            }
+            val wrapped: List<Any?> =
+                try {
+                  api.pigeonRegistrar.instanceManager.addDartCreatedInstance(
+                      api.pigeon_defaultConstructor(), pigeon_identifierArg)
+                  listOf(null)
+                } catch (exception: Throwable) {
+                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+                }
             reply.reply(wrapped)
           }
         } else {
@@ -3474,166 +4031,209 @@ abstract class PigeonApiDownloadListener(open val pigeonRegistrar: AndroidWebkit
 
   @Suppress("LocalVariableName", "FunctionName")
   /** Creates a Dart instance of DownloadListener and attaches it to [pigeon_instanceArg]. */
-  fun pigeon_newInstance(pigeon_instanceArg: android.webkit.DownloadListener, callback: (Result<Unit>) -> Unit)
-{
+  fun pigeon_newInstance(
+      pigeon_instanceArg: android.webkit.DownloadListener,
+      callback: (Result<Unit>) -> Unit
+  ) {
     if (pigeonRegistrar.ignoreCallsToDart) {
       callback(
           Result.failure(
               AndroidWebKitError("ignore-calls-error", "Calls to Dart are being ignored.", "")))
-    }     else if (pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
+    } else if (pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
       callback(Result.success(Unit))
-    }     else {
+    } else {
       callback(
           Result.failure(
-              AndroidWebKitError("new-instance-error", "Attempting to create a new Dart instance of DownloadListener, but the class has a nonnull callback method.", "")))
+              AndroidWebKitError(
+                  "new-instance-error",
+                  "Attempting to create a new Dart instance of DownloadListener, but the class has a nonnull callback method.",
+                  "")))
     }
   }
 
   /** Notify the host application that a file should be downloaded. */
-  fun onDownloadStart(pigeon_instanceArg: android.webkit.DownloadListener, urlArg: String, userAgentArg: String, contentDispositionArg: String, mimetypeArg: String, contentLengthArg: Long, callback: (Result<Unit>) -> Unit)
-{
+  fun onDownloadStart(
+      pigeon_instanceArg: android.webkit.DownloadListener,
+      urlArg: String,
+      userAgentArg: String,
+      contentDispositionArg: String,
+      mimetypeArg: String,
+      contentLengthArg: Long,
+      callback: (Result<Unit>) -> Unit
+  ) {
     if (pigeonRegistrar.ignoreCallsToDart) {
       callback(
           Result.failure(
               AndroidWebKitError("ignore-calls-error", "Calls to Dart are being ignored.", "")))
       return
-    }     else if (!pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
+    } else if (!pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
       callback(
           Result.failure(
-              AndroidWebKitError("missing-instance-error", "Callback to `DownloadListener.onDownloadStart` failed because native instance was not in the instance manager.", "")))
+              AndroidWebKitError(
+                  "missing-instance-error",
+                  "Callback to `DownloadListener.onDownloadStart` failed because native instance was not in the instance manager.",
+                  "")))
       return
     }
     val binaryMessenger = pigeonRegistrar.binaryMessenger
     val codec = pigeonRegistrar.codec
     val channelName = "dev.flutter.pigeon.webview_flutter_android.DownloadListener.onDownloadStart"
     val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
-    channel.send(listOf(pigeon_instanceArg, urlArg, userAgentArg, contentDispositionArg, mimetypeArg, contentLengthArg)) {
-      if (it is List<*>) {
-        if (it.size > 1) {
-          callback(Result.failure(AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
-        } else {
-          callback(Result.success(Unit))
+    channel.send(
+        listOf(
+            pigeon_instanceArg,
+            urlArg,
+            userAgentArg,
+            contentDispositionArg,
+            mimetypeArg,
+            contentLengthArg)) {
+          if (it is List<*>) {
+            if (it.size > 1) {
+              callback(
+                  Result.failure(
+                      AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
+            } else {
+              callback(Result.success(Unit))
+            }
+          } else {
+            callback(
+                Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
+          }
         }
-      } else {
-        callback(Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
-      } 
-    }
   }
-
 }
 /**
- * Handles notification of JavaScript dialogs, favicons, titles, and the
- * progress.
+ * Handles notification of JavaScript dialogs, favicons, titles, and the progress.
  *
  * See https://developer.android.com/reference/android/webkit/WebChromeClient.
  */
 @Suppress("UNCHECKED_CAST")
-abstract class PigeonApiWebChromeClient(open val pigeonRegistrar: AndroidWebkitLibraryPigeonProxyApiRegistrar) {
-  abstract fun pigeon_defaultConstructor(): io.flutter.plugins.webviewflutter.WebChromeClientProxyApi.WebChromeClientImpl
+abstract class PigeonApiWebChromeClient(
+    open val pigeonRegistrar: AndroidWebkitLibraryPigeonProxyApiRegistrar
+) {
+  abstract fun pigeon_defaultConstructor():
+      io.flutter.plugins.webviewflutter.WebChromeClientProxyApi.WebChromeClientImpl
 
   /**
    * Sets the required synchronous return value for the Java method,
    * `WebChromeClient.onShowFileChooser(...)`.
    *
-   * The Java method, `WebChromeClient.onShowFileChooser(...)`, requires
-   * a boolean to be returned and this method sets the returned value for all
-   * calls to the Java method.
+   * The Java method, `WebChromeClient.onShowFileChooser(...)`, requires a boolean to be returned
+   * and this method sets the returned value for all calls to the Java method.
    *
-   * Setting this to true indicates that all file chooser requests should be
-   * handled by `onShowFileChooser` and the returned list of Strings will be
-   * returned to the WebView. Otherwise, the client will use the default
-   * handling and the returned value in `onShowFileChooser` will be ignored.
+   * Setting this to true indicates that all file chooser requests should be handled by
+   * `onShowFileChooser` and the returned list of Strings will be returned to the WebView.
+   * Otherwise, the client will use the default handling and the returned value in
+   * `onShowFileChooser` will be ignored.
    *
    * Requires `onShowFileChooser` to be nonnull.
    *
    * Defaults to false.
    */
-  abstract fun setSynchronousReturnValueForOnShowFileChooser(pigeon_instance: io.flutter.plugins.webviewflutter.WebChromeClientProxyApi.WebChromeClientImpl, value: Boolean)
+  abstract fun setSynchronousReturnValueForOnShowFileChooser(
+      pigeon_instance:
+          io.flutter.plugins.webviewflutter.WebChromeClientProxyApi.WebChromeClientImpl,
+      value: Boolean
+  )
 
   /**
    * Sets the required synchronous return value for the Java method,
    * `WebChromeClient.onConsoleMessage(...)`.
    *
-   * The Java method, `WebChromeClient.onConsoleMessage(...)`, requires
-   * a boolean to be returned and this method sets the returned value for all
-   * calls to the Java method.
+   * The Java method, `WebChromeClient.onConsoleMessage(...)`, requires a boolean to be returned and
+   * this method sets the returned value for all calls to the Java method.
    *
-   * Setting this to true indicates that the client is handling all console
-   * messages.
+   * Setting this to true indicates that the client is handling all console messages.
    *
    * Requires `onConsoleMessage` to be nonnull.
    *
    * Defaults to false.
    */
-  abstract fun setSynchronousReturnValueForOnConsoleMessage(pigeon_instance: io.flutter.plugins.webviewflutter.WebChromeClientProxyApi.WebChromeClientImpl, value: Boolean)
+  abstract fun setSynchronousReturnValueForOnConsoleMessage(
+      pigeon_instance:
+          io.flutter.plugins.webviewflutter.WebChromeClientProxyApi.WebChromeClientImpl,
+      value: Boolean
+  )
 
   /**
    * Sets the required synchronous return value for the Java method,
    * `WebChromeClient.onJsAlert(...)`.
    *
-   * The Java method, `WebChromeClient.onJsAlert(...)`, requires a boolean to
-   * be returned and this method sets the returned value for all calls to the
-   * Java method.
+   * The Java method, `WebChromeClient.onJsAlert(...)`, requires a boolean to be returned and this
+   * method sets the returned value for all calls to the Java method.
    *
-   * Setting this to true indicates that the client is handling all console
-   * messages.
+   * Setting this to true indicates that the client is handling all console messages.
    *
    * Requires `onJsAlert` to be nonnull.
    *
    * Defaults to false.
    */
-  abstract fun setSynchronousReturnValueForOnJsAlert(pigeon_instance: io.flutter.plugins.webviewflutter.WebChromeClientProxyApi.WebChromeClientImpl, value: Boolean)
+  abstract fun setSynchronousReturnValueForOnJsAlert(
+      pigeon_instance:
+          io.flutter.plugins.webviewflutter.WebChromeClientProxyApi.WebChromeClientImpl,
+      value: Boolean
+  )
 
   /**
    * Sets the required synchronous return value for the Java method,
    * `WebChromeClient.onJsConfirm(...)`.
    *
-   * The Java method, `WebChromeClient.onJsConfirm(...)`, requires a boolean to
-   * be returned and this method sets the returned value for all calls to the
-   * Java method.
+   * The Java method, `WebChromeClient.onJsConfirm(...)`, requires a boolean to be returned and this
+   * method sets the returned value for all calls to the Java method.
    *
-   * Setting this to true indicates that the client is handling all console
-   * messages.
+   * Setting this to true indicates that the client is handling all console messages.
    *
    * Requires `onJsConfirm` to be nonnull.
    *
    * Defaults to false.
    */
-  abstract fun setSynchronousReturnValueForOnJsConfirm(pigeon_instance: io.flutter.plugins.webviewflutter.WebChromeClientProxyApi.WebChromeClientImpl, value: Boolean)
+  abstract fun setSynchronousReturnValueForOnJsConfirm(
+      pigeon_instance:
+          io.flutter.plugins.webviewflutter.WebChromeClientProxyApi.WebChromeClientImpl,
+      value: Boolean
+  )
 
   /**
    * Sets the required synchronous return value for the Java method,
    * `WebChromeClient.onJsPrompt(...)`.
    *
-   * The Java method, `WebChromeClient.onJsPrompt(...)`, requires a boolean to
-   * be returned and this method sets the returned value for all calls to the
-   * Java method.
+   * The Java method, `WebChromeClient.onJsPrompt(...)`, requires a boolean to be returned and this
+   * method sets the returned value for all calls to the Java method.
    *
-   * Setting this to true indicates that the client is handling all console
-   * messages.
+   * Setting this to true indicates that the client is handling all console messages.
    *
    * Requires `onJsPrompt` to be nonnull.
    *
    * Defaults to false.
    */
-  abstract fun setSynchronousReturnValueForOnJsPrompt(pigeon_instance: io.flutter.plugins.webviewflutter.WebChromeClientProxyApi.WebChromeClientImpl, value: Boolean)
+  abstract fun setSynchronousReturnValueForOnJsPrompt(
+      pigeon_instance:
+          io.flutter.plugins.webviewflutter.WebChromeClientProxyApi.WebChromeClientImpl,
+      value: Boolean
+  )
 
   companion object {
     @Suppress("LocalVariableName")
     fun setUpMessageHandlers(binaryMessenger: BinaryMessenger, api: PigeonApiWebChromeClient?) {
       val codec = api?.pigeonRegistrar?.codec ?: AndroidWebkitLibraryPigeonCodec()
       run {
-        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.WebChromeClient.pigeon_defaultConstructor", codec)
+        val channel =
+            BasicMessageChannel<Any?>(
+                binaryMessenger,
+                "dev.flutter.pigeon.webview_flutter_android.WebChromeClient.pigeon_defaultConstructor",
+                codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val pigeon_identifierArg = args[0] as Long
-            val wrapped: List<Any?> = try {
-              api.pigeonRegistrar.instanceManager.addDartCreatedInstance(api.pigeon_defaultConstructor(), pigeon_identifierArg)
-              listOf(null)
-            } catch (exception: Throwable) {
-              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-            }
+            val wrapped: List<Any?> =
+                try {
+                  api.pigeonRegistrar.instanceManager.addDartCreatedInstance(
+                      api.pigeon_defaultConstructor(), pigeon_identifierArg)
+                  listOf(null)
+                } catch (exception: Throwable) {
+                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+                }
             reply.reply(wrapped)
           }
         } else {
@@ -3641,18 +4241,25 @@ abstract class PigeonApiWebChromeClient(open val pigeonRegistrar: AndroidWebkitL
         }
       }
       run {
-        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.WebChromeClient.setSynchronousReturnValueForOnShowFileChooser", codec)
+        val channel =
+            BasicMessageChannel<Any?>(
+                binaryMessenger,
+                "dev.flutter.pigeon.webview_flutter_android.WebChromeClient.setSynchronousReturnValueForOnShowFileChooser",
+                codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
-            val pigeon_instanceArg = args[0] as io.flutter.plugins.webviewflutter.WebChromeClientProxyApi.WebChromeClientImpl
+            val pigeon_instanceArg =
+                args[0]
+                    as io.flutter.plugins.webviewflutter.WebChromeClientProxyApi.WebChromeClientImpl
             val valueArg = args[1] as Boolean
-            val wrapped: List<Any?> = try {
-              api.setSynchronousReturnValueForOnShowFileChooser(pigeon_instanceArg, valueArg)
-              listOf(null)
-            } catch (exception: Throwable) {
-              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-            }
+            val wrapped: List<Any?> =
+                try {
+                  api.setSynchronousReturnValueForOnShowFileChooser(pigeon_instanceArg, valueArg)
+                  listOf(null)
+                } catch (exception: Throwable) {
+                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+                }
             reply.reply(wrapped)
           }
         } else {
@@ -3660,18 +4267,25 @@ abstract class PigeonApiWebChromeClient(open val pigeonRegistrar: AndroidWebkitL
         }
       }
       run {
-        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.WebChromeClient.setSynchronousReturnValueForOnConsoleMessage", codec)
+        val channel =
+            BasicMessageChannel<Any?>(
+                binaryMessenger,
+                "dev.flutter.pigeon.webview_flutter_android.WebChromeClient.setSynchronousReturnValueForOnConsoleMessage",
+                codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
-            val pigeon_instanceArg = args[0] as io.flutter.plugins.webviewflutter.WebChromeClientProxyApi.WebChromeClientImpl
+            val pigeon_instanceArg =
+                args[0]
+                    as io.flutter.plugins.webviewflutter.WebChromeClientProxyApi.WebChromeClientImpl
             val valueArg = args[1] as Boolean
-            val wrapped: List<Any?> = try {
-              api.setSynchronousReturnValueForOnConsoleMessage(pigeon_instanceArg, valueArg)
-              listOf(null)
-            } catch (exception: Throwable) {
-              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-            }
+            val wrapped: List<Any?> =
+                try {
+                  api.setSynchronousReturnValueForOnConsoleMessage(pigeon_instanceArg, valueArg)
+                  listOf(null)
+                } catch (exception: Throwable) {
+                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+                }
             reply.reply(wrapped)
           }
         } else {
@@ -3679,18 +4293,25 @@ abstract class PigeonApiWebChromeClient(open val pigeonRegistrar: AndroidWebkitL
         }
       }
       run {
-        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.WebChromeClient.setSynchronousReturnValueForOnJsAlert", codec)
+        val channel =
+            BasicMessageChannel<Any?>(
+                binaryMessenger,
+                "dev.flutter.pigeon.webview_flutter_android.WebChromeClient.setSynchronousReturnValueForOnJsAlert",
+                codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
-            val pigeon_instanceArg = args[0] as io.flutter.plugins.webviewflutter.WebChromeClientProxyApi.WebChromeClientImpl
+            val pigeon_instanceArg =
+                args[0]
+                    as io.flutter.plugins.webviewflutter.WebChromeClientProxyApi.WebChromeClientImpl
             val valueArg = args[1] as Boolean
-            val wrapped: List<Any?> = try {
-              api.setSynchronousReturnValueForOnJsAlert(pigeon_instanceArg, valueArg)
-              listOf(null)
-            } catch (exception: Throwable) {
-              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-            }
+            val wrapped: List<Any?> =
+                try {
+                  api.setSynchronousReturnValueForOnJsAlert(pigeon_instanceArg, valueArg)
+                  listOf(null)
+                } catch (exception: Throwable) {
+                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+                }
             reply.reply(wrapped)
           }
         } else {
@@ -3698,18 +4319,25 @@ abstract class PigeonApiWebChromeClient(open val pigeonRegistrar: AndroidWebkitL
         }
       }
       run {
-        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.WebChromeClient.setSynchronousReturnValueForOnJsConfirm", codec)
+        val channel =
+            BasicMessageChannel<Any?>(
+                binaryMessenger,
+                "dev.flutter.pigeon.webview_flutter_android.WebChromeClient.setSynchronousReturnValueForOnJsConfirm",
+                codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
-            val pigeon_instanceArg = args[0] as io.flutter.plugins.webviewflutter.WebChromeClientProxyApi.WebChromeClientImpl
+            val pigeon_instanceArg =
+                args[0]
+                    as io.flutter.plugins.webviewflutter.WebChromeClientProxyApi.WebChromeClientImpl
             val valueArg = args[1] as Boolean
-            val wrapped: List<Any?> = try {
-              api.setSynchronousReturnValueForOnJsConfirm(pigeon_instanceArg, valueArg)
-              listOf(null)
-            } catch (exception: Throwable) {
-              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-            }
+            val wrapped: List<Any?> =
+                try {
+                  api.setSynchronousReturnValueForOnJsConfirm(pigeon_instanceArg, valueArg)
+                  listOf(null)
+                } catch (exception: Throwable) {
+                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+                }
             reply.reply(wrapped)
           }
         } else {
@@ -3717,18 +4345,25 @@ abstract class PigeonApiWebChromeClient(open val pigeonRegistrar: AndroidWebkitL
         }
       }
       run {
-        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.WebChromeClient.setSynchronousReturnValueForOnJsPrompt", codec)
+        val channel =
+            BasicMessageChannel<Any?>(
+                binaryMessenger,
+                "dev.flutter.pigeon.webview_flutter_android.WebChromeClient.setSynchronousReturnValueForOnJsPrompt",
+                codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
-            val pigeon_instanceArg = args[0] as io.flutter.plugins.webviewflutter.WebChromeClientProxyApi.WebChromeClientImpl
+            val pigeon_instanceArg =
+                args[0]
+                    as io.flutter.plugins.webviewflutter.WebChromeClientProxyApi.WebChromeClientImpl
             val valueArg = args[1] as Boolean
-            val wrapped: List<Any?> = try {
-              api.setSynchronousReturnValueForOnJsPrompt(pigeon_instanceArg, valueArg)
-              listOf(null)
-            } catch (exception: Throwable) {
-              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-            }
+            val wrapped: List<Any?> =
+                try {
+                  api.setSynchronousReturnValueForOnJsPrompt(pigeon_instanceArg, valueArg)
+                  listOf(null)
+                } catch (exception: Throwable) {
+                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+                }
             reply.reply(wrapped)
           }
         } else {
@@ -3740,33 +4375,47 @@ abstract class PigeonApiWebChromeClient(open val pigeonRegistrar: AndroidWebkitL
 
   @Suppress("LocalVariableName", "FunctionName")
   /** Creates a Dart instance of WebChromeClient and attaches it to [pigeon_instanceArg]. */
-  fun pigeon_newInstance(pigeon_instanceArg: io.flutter.plugins.webviewflutter.WebChromeClientProxyApi.WebChromeClientImpl, callback: (Result<Unit>) -> Unit)
-{
+  fun pigeon_newInstance(
+      pigeon_instanceArg:
+          io.flutter.plugins.webviewflutter.WebChromeClientProxyApi.WebChromeClientImpl,
+      callback: (Result<Unit>) -> Unit
+  ) {
     if (pigeonRegistrar.ignoreCallsToDart) {
       callback(
           Result.failure(
               AndroidWebKitError("ignore-calls-error", "Calls to Dart are being ignored.", "")))
-    }     else if (pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
+    } else if (pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
       callback(Result.success(Unit))
-    }     else {
+    } else {
       callback(
           Result.failure(
-              AndroidWebKitError("new-instance-error", "Attempting to create a new Dart instance of WebChromeClient, but the class has a nonnull callback method.", "")))
+              AndroidWebKitError(
+                  "new-instance-error",
+                  "Attempting to create a new Dart instance of WebChromeClient, but the class has a nonnull callback method.",
+                  "")))
     }
   }
 
   /** Tell the host application the current progress of loading a page. */
-  fun onProgressChanged(pigeon_instanceArg: io.flutter.plugins.webviewflutter.WebChromeClientProxyApi.WebChromeClientImpl, webViewArg: android.webkit.WebView, progressArg: Long, callback: (Result<Unit>) -> Unit)
-{
+  fun onProgressChanged(
+      pigeon_instanceArg:
+          io.flutter.plugins.webviewflutter.WebChromeClientProxyApi.WebChromeClientImpl,
+      webViewArg: android.webkit.WebView,
+      progressArg: Long,
+      callback: (Result<Unit>) -> Unit
+  ) {
     if (pigeonRegistrar.ignoreCallsToDart) {
       callback(
           Result.failure(
               AndroidWebKitError("ignore-calls-error", "Calls to Dart are being ignored.", "")))
       return
-    }     else if (!pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
+    } else if (!pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
       callback(
           Result.failure(
-              AndroidWebKitError("missing-instance-error", "Callback to `WebChromeClient.onProgressChanged` failed because native instance was not in the instance manager.", "")))
+              AndroidWebKitError(
+                  "missing-instance-error",
+                  "Callback to `WebChromeClient.onProgressChanged` failed because native instance was not in the instance manager.",
+                  "")))
       return
     }
     val binaryMessenger = pigeonRegistrar.binaryMessenger
@@ -3776,28 +4425,38 @@ abstract class PigeonApiWebChromeClient(open val pigeonRegistrar: AndroidWebkitL
     channel.send(listOf(pigeon_instanceArg, webViewArg, progressArg)) {
       if (it is List<*>) {
         if (it.size > 1) {
-          callback(Result.failure(AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
+          callback(
+              Result.failure(
+                  AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
         } else {
           callback(Result.success(Unit))
         }
       } else {
         callback(Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
-      } 
+      }
     }
   }
 
   /** Tell the client to show a file chooser. */
-  fun onShowFileChooser(pigeon_instanceArg: io.flutter.plugins.webviewflutter.WebChromeClientProxyApi.WebChromeClientImpl, webViewArg: android.webkit.WebView, paramsArg: android.webkit.WebChromeClient.FileChooserParams, callback: (Result<List<String>>) -> Unit)
-{
+  fun onShowFileChooser(
+      pigeon_instanceArg:
+          io.flutter.plugins.webviewflutter.WebChromeClientProxyApi.WebChromeClientImpl,
+      webViewArg: android.webkit.WebView,
+      paramsArg: android.webkit.WebChromeClient.FileChooserParams,
+      callback: (Result<List<String>>) -> Unit
+  ) {
     if (pigeonRegistrar.ignoreCallsToDart) {
       callback(
           Result.failure(
               AndroidWebKitError("ignore-calls-error", "Calls to Dart are being ignored.", "")))
       return
-    }     else if (!pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
+    } else if (!pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
       callback(
           Result.failure(
-              AndroidWebKitError("missing-instance-error", "Callback to `WebChromeClient.onShowFileChooser` failed because native instance was not in the instance manager.", "")))
+              AndroidWebKitError(
+                  "missing-instance-error",
+                  "Callback to `WebChromeClient.onShowFileChooser` failed because native instance was not in the instance manager.",
+                  "")))
       return
     }
     val binaryMessenger = pigeonRegistrar.binaryMessenger
@@ -3807,66 +4466,90 @@ abstract class PigeonApiWebChromeClient(open val pigeonRegistrar: AndroidWebkitL
     channel.send(listOf(pigeon_instanceArg, webViewArg, paramsArg)) {
       if (it is List<*>) {
         if (it.size > 1) {
-          callback(Result.failure(AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
+          callback(
+              Result.failure(
+                  AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
         } else if (it[0] == null) {
-          callback(Result.failure(AndroidWebKitError("null-error", "Flutter api returned null value for non-null return value.", "")))
+          callback(
+              Result.failure(
+                  AndroidWebKitError(
+                      "null-error",
+                      "Flutter api returned null value for non-null return value.",
+                      "")))
         } else {
           val output = it[0] as List<String>
           callback(Result.success(output))
         }
       } else {
         callback(Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
-      } 
+      }
     }
   }
 
   /**
-   * Notify the host application that web content is requesting permission to
-   * access the specified resources and the permission currently isn't granted
-   * or denied.
+   * Notify the host application that web content is requesting permission to access the specified
+   * resources and the permission currently isn't granted or denied.
    */
-  fun onPermissionRequest(pigeon_instanceArg: io.flutter.plugins.webviewflutter.WebChromeClientProxyApi.WebChromeClientImpl, requestArg: android.webkit.PermissionRequest, callback: (Result<Unit>) -> Unit)
-{
+  fun onPermissionRequest(
+      pigeon_instanceArg:
+          io.flutter.plugins.webviewflutter.WebChromeClientProxyApi.WebChromeClientImpl,
+      requestArg: android.webkit.PermissionRequest,
+      callback: (Result<Unit>) -> Unit
+  ) {
     if (pigeonRegistrar.ignoreCallsToDart) {
       callback(
           Result.failure(
               AndroidWebKitError("ignore-calls-error", "Calls to Dart are being ignored.", "")))
       return
-    }     else if (!pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
+    } else if (!pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
       callback(
           Result.failure(
-              AndroidWebKitError("missing-instance-error", "Callback to `WebChromeClient.onPermissionRequest` failed because native instance was not in the instance manager.", "")))
+              AndroidWebKitError(
+                  "missing-instance-error",
+                  "Callback to `WebChromeClient.onPermissionRequest` failed because native instance was not in the instance manager.",
+                  "")))
       return
     }
     val binaryMessenger = pigeonRegistrar.binaryMessenger
     val codec = pigeonRegistrar.codec
-    val channelName = "dev.flutter.pigeon.webview_flutter_android.WebChromeClient.onPermissionRequest"
+    val channelName =
+        "dev.flutter.pigeon.webview_flutter_android.WebChromeClient.onPermissionRequest"
     val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
     channel.send(listOf(pigeon_instanceArg, requestArg)) {
       if (it is List<*>) {
         if (it.size > 1) {
-          callback(Result.failure(AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
+          callback(
+              Result.failure(
+                  AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
         } else {
           callback(Result.success(Unit))
         }
       } else {
         callback(Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
-      } 
+      }
     }
   }
 
   /** Callback to Dart function `WebChromeClient.onShowCustomView`. */
-  fun onShowCustomView(pigeon_instanceArg: io.flutter.plugins.webviewflutter.WebChromeClientProxyApi.WebChromeClientImpl, viewArg: android.view.View, callbackArg: android.webkit.WebChromeClient.CustomViewCallback, callback: (Result<Unit>) -> Unit)
-{
+  fun onShowCustomView(
+      pigeon_instanceArg:
+          io.flutter.plugins.webviewflutter.WebChromeClientProxyApi.WebChromeClientImpl,
+      viewArg: android.view.View,
+      callbackArg: android.webkit.WebChromeClient.CustomViewCallback,
+      callback: (Result<Unit>) -> Unit
+  ) {
     if (pigeonRegistrar.ignoreCallsToDart) {
       callback(
           Result.failure(
               AndroidWebKitError("ignore-calls-error", "Calls to Dart are being ignored.", "")))
       return
-    }     else if (!pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
+    } else if (!pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
       callback(
           Result.failure(
-              AndroidWebKitError("missing-instance-error", "Callback to `WebChromeClient.onShowCustomView` failed because native instance was not in the instance manager.", "")))
+              AndroidWebKitError(
+                  "missing-instance-error",
+                  "Callback to `WebChromeClient.onShowCustomView` failed because native instance was not in the instance manager.",
+                  "")))
       return
     }
     val binaryMessenger = pigeonRegistrar.binaryMessenger
@@ -3876,31 +4559,36 @@ abstract class PigeonApiWebChromeClient(open val pigeonRegistrar: AndroidWebkitL
     channel.send(listOf(pigeon_instanceArg, viewArg, callbackArg)) {
       if (it is List<*>) {
         if (it.size > 1) {
-          callback(Result.failure(AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
+          callback(
+              Result.failure(
+                  AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
         } else {
           callback(Result.success(Unit))
         }
       } else {
         callback(Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
-      } 
+      }
     }
   }
 
-  /**
-   * Notify the host application that the current page has entered full screen
-   * mode.
-   */
-  fun onHideCustomView(pigeon_instanceArg: io.flutter.plugins.webviewflutter.WebChromeClientProxyApi.WebChromeClientImpl, callback: (Result<Unit>) -> Unit)
-{
+  /** Notify the host application that the current page has entered full screen mode. */
+  fun onHideCustomView(
+      pigeon_instanceArg:
+          io.flutter.plugins.webviewflutter.WebChromeClientProxyApi.WebChromeClientImpl,
+      callback: (Result<Unit>) -> Unit
+  ) {
     if (pigeonRegistrar.ignoreCallsToDart) {
       callback(
           Result.failure(
               AndroidWebKitError("ignore-calls-error", "Calls to Dart are being ignored.", "")))
       return
-    }     else if (!pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
+    } else if (!pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
       callback(
           Result.failure(
-              AndroidWebKitError("missing-instance-error", "Callback to `WebChromeClient.onHideCustomView` failed because native instance was not in the instance manager.", "")))
+              AndroidWebKitError(
+                  "missing-instance-error",
+                  "Callback to `WebChromeClient.onHideCustomView` failed because native instance was not in the instance manager.",
+                  "")))
       return
     }
     val binaryMessenger = pigeonRegistrar.binaryMessenger
@@ -3910,98 +4598,125 @@ abstract class PigeonApiWebChromeClient(open val pigeonRegistrar: AndroidWebkitL
     channel.send(listOf(pigeon_instanceArg)) {
       if (it is List<*>) {
         if (it.size > 1) {
-          callback(Result.failure(AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
+          callback(
+              Result.failure(
+                  AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
         } else {
           callback(Result.success(Unit))
         }
       } else {
         callback(Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
-      } 
+      }
     }
   }
 
   /**
-   * Notify the host application that web content from the specified origin is
-   * attempting to use the Geolocation API, but no permission state is
-   * currently set for that origin.
+   * Notify the host application that web content from the specified origin is attempting to use the
+   * Geolocation API, but no permission state is currently set for that origin.
    */
-  fun onGeolocationPermissionsShowPrompt(pigeon_instanceArg: io.flutter.plugins.webviewflutter.WebChromeClientProxyApi.WebChromeClientImpl, originArg: String, callbackArg: android.webkit.GeolocationPermissions.Callback, callback: (Result<Unit>) -> Unit)
-{
+  fun onGeolocationPermissionsShowPrompt(
+      pigeon_instanceArg:
+          io.flutter.plugins.webviewflutter.WebChromeClientProxyApi.WebChromeClientImpl,
+      originArg: String,
+      callbackArg: android.webkit.GeolocationPermissions.Callback,
+      callback: (Result<Unit>) -> Unit
+  ) {
     if (pigeonRegistrar.ignoreCallsToDart) {
       callback(
           Result.failure(
               AndroidWebKitError("ignore-calls-error", "Calls to Dart are being ignored.", "")))
       return
-    }     else if (!pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
+    } else if (!pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
       callback(
           Result.failure(
-              AndroidWebKitError("missing-instance-error", "Callback to `WebChromeClient.onGeolocationPermissionsShowPrompt` failed because native instance was not in the instance manager.", "")))
+              AndroidWebKitError(
+                  "missing-instance-error",
+                  "Callback to `WebChromeClient.onGeolocationPermissionsShowPrompt` failed because native instance was not in the instance manager.",
+                  "")))
       return
     }
     val binaryMessenger = pigeonRegistrar.binaryMessenger
     val codec = pigeonRegistrar.codec
-    val channelName = "dev.flutter.pigeon.webview_flutter_android.WebChromeClient.onGeolocationPermissionsShowPrompt"
+    val channelName =
+        "dev.flutter.pigeon.webview_flutter_android.WebChromeClient.onGeolocationPermissionsShowPrompt"
     val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
     channel.send(listOf(pigeon_instanceArg, originArg, callbackArg)) {
       if (it is List<*>) {
         if (it.size > 1) {
-          callback(Result.failure(AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
+          callback(
+              Result.failure(
+                  AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
         } else {
           callback(Result.success(Unit))
         }
       } else {
         callback(Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
-      } 
+      }
     }
   }
 
   /**
-   * Notify the host application that a request for Geolocation permissions,
-   * made with a previous call to `onGeolocationPermissionsShowPrompt` has been
-   * canceled.
+   * Notify the host application that a request for Geolocation permissions, made with a previous
+   * call to `onGeolocationPermissionsShowPrompt` has been canceled.
    */
-  fun onGeolocationPermissionsHidePrompt(pigeon_instanceArg: io.flutter.plugins.webviewflutter.WebChromeClientProxyApi.WebChromeClientImpl, callback: (Result<Unit>) -> Unit)
-{
+  fun onGeolocationPermissionsHidePrompt(
+      pigeon_instanceArg:
+          io.flutter.plugins.webviewflutter.WebChromeClientProxyApi.WebChromeClientImpl,
+      callback: (Result<Unit>) -> Unit
+  ) {
     if (pigeonRegistrar.ignoreCallsToDart) {
       callback(
           Result.failure(
               AndroidWebKitError("ignore-calls-error", "Calls to Dart are being ignored.", "")))
       return
-    }     else if (!pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
+    } else if (!pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
       callback(
           Result.failure(
-              AndroidWebKitError("missing-instance-error", "Callback to `WebChromeClient.onGeolocationPermissionsHidePrompt` failed because native instance was not in the instance manager.", "")))
+              AndroidWebKitError(
+                  "missing-instance-error",
+                  "Callback to `WebChromeClient.onGeolocationPermissionsHidePrompt` failed because native instance was not in the instance manager.",
+                  "")))
       return
     }
     val binaryMessenger = pigeonRegistrar.binaryMessenger
     val codec = pigeonRegistrar.codec
-    val channelName = "dev.flutter.pigeon.webview_flutter_android.WebChromeClient.onGeolocationPermissionsHidePrompt"
+    val channelName =
+        "dev.flutter.pigeon.webview_flutter_android.WebChromeClient.onGeolocationPermissionsHidePrompt"
     val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
     channel.send(listOf(pigeon_instanceArg)) {
       if (it is List<*>) {
         if (it.size > 1) {
-          callback(Result.failure(AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
+          callback(
+              Result.failure(
+                  AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
         } else {
           callback(Result.success(Unit))
         }
       } else {
         callback(Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
-      } 
+      }
     }
   }
 
   /** Report a JavaScript console message to the host application. */
-  fun onConsoleMessage(pigeon_instanceArg: io.flutter.plugins.webviewflutter.WebChromeClientProxyApi.WebChromeClientImpl, messageArg: android.webkit.ConsoleMessage, callback: (Result<Unit>) -> Unit)
-{
+  fun onConsoleMessage(
+      pigeon_instanceArg:
+          io.flutter.plugins.webviewflutter.WebChromeClientProxyApi.WebChromeClientImpl,
+      messageArg: android.webkit.ConsoleMessage,
+      callback: (Result<Unit>) -> Unit
+  ) {
     if (pigeonRegistrar.ignoreCallsToDart) {
       callback(
           Result.failure(
               AndroidWebKitError("ignore-calls-error", "Calls to Dart are being ignored.", "")))
       return
-    }     else if (!pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
+    } else if (!pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
       callback(
           Result.failure(
-              AndroidWebKitError("missing-instance-error", "Callback to `WebChromeClient.onConsoleMessage` failed because native instance was not in the instance manager.", "")))
+              AndroidWebKitError(
+                  "missing-instance-error",
+                  "Callback to `WebChromeClient.onConsoleMessage` failed because native instance was not in the instance manager.",
+                  "")))
       return
     }
     val binaryMessenger = pigeonRegistrar.binaryMessenger
@@ -4011,31 +4726,41 @@ abstract class PigeonApiWebChromeClient(open val pigeonRegistrar: AndroidWebkitL
     channel.send(listOf(pigeon_instanceArg, messageArg)) {
       if (it is List<*>) {
         if (it.size > 1) {
-          callback(Result.failure(AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
+          callback(
+              Result.failure(
+                  AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
         } else {
           callback(Result.success(Unit))
         }
       } else {
         callback(Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
-      } 
+      }
     }
   }
 
   /**
-   * Notify the host application that the web page wants to display a
-   * JavaScript `alert()` dialog.
+   * Notify the host application that the web page wants to display a JavaScript `alert()` dialog.
    */
-  fun onJsAlert(pigeon_instanceArg: io.flutter.plugins.webviewflutter.WebChromeClientProxyApi.WebChromeClientImpl, webViewArg: android.webkit.WebView, urlArg: String, messageArg: String, callback: (Result<Unit>) -> Unit)
-{
+  fun onJsAlert(
+      pigeon_instanceArg:
+          io.flutter.plugins.webviewflutter.WebChromeClientProxyApi.WebChromeClientImpl,
+      webViewArg: android.webkit.WebView,
+      urlArg: String,
+      messageArg: String,
+      callback: (Result<Unit>) -> Unit
+  ) {
     if (pigeonRegistrar.ignoreCallsToDart) {
       callback(
           Result.failure(
               AndroidWebKitError("ignore-calls-error", "Calls to Dart are being ignored.", "")))
       return
-    }     else if (!pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
+    } else if (!pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
       callback(
           Result.failure(
-              AndroidWebKitError("missing-instance-error", "Callback to `WebChromeClient.onJsAlert` failed because native instance was not in the instance manager.", "")))
+              AndroidWebKitError(
+                  "missing-instance-error",
+                  "Callback to `WebChromeClient.onJsAlert` failed because native instance was not in the instance manager.",
+                  "")))
       return
     }
     val binaryMessenger = pigeonRegistrar.binaryMessenger
@@ -4045,31 +4770,41 @@ abstract class PigeonApiWebChromeClient(open val pigeonRegistrar: AndroidWebkitL
     channel.send(listOf(pigeon_instanceArg, webViewArg, urlArg, messageArg)) {
       if (it is List<*>) {
         if (it.size > 1) {
-          callback(Result.failure(AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
+          callback(
+              Result.failure(
+                  AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
         } else {
           callback(Result.success(Unit))
         }
       } else {
         callback(Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
-      } 
+      }
     }
   }
 
   /**
-   * Notify the host application that the web page wants to display a
-   * JavaScript `confirm()` dialog.
+   * Notify the host application that the web page wants to display a JavaScript `confirm()` dialog.
    */
-  fun onJsConfirm(pigeon_instanceArg: io.flutter.plugins.webviewflutter.WebChromeClientProxyApi.WebChromeClientImpl, webViewArg: android.webkit.WebView, urlArg: String, messageArg: String, callback: (Result<Boolean>) -> Unit)
-{
+  fun onJsConfirm(
+      pigeon_instanceArg:
+          io.flutter.plugins.webviewflutter.WebChromeClientProxyApi.WebChromeClientImpl,
+      webViewArg: android.webkit.WebView,
+      urlArg: String,
+      messageArg: String,
+      callback: (Result<Boolean>) -> Unit
+  ) {
     if (pigeonRegistrar.ignoreCallsToDart) {
       callback(
           Result.failure(
               AndroidWebKitError("ignore-calls-error", "Calls to Dart are being ignored.", "")))
       return
-    }     else if (!pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
+    } else if (!pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
       callback(
           Result.failure(
-              AndroidWebKitError("missing-instance-error", "Callback to `WebChromeClient.onJsConfirm` failed because native instance was not in the instance manager.", "")))
+              AndroidWebKitError(
+                  "missing-instance-error",
+                  "Callback to `WebChromeClient.onJsConfirm` failed because native instance was not in the instance manager.",
+                  "")))
       return
     }
     val binaryMessenger = pigeonRegistrar.binaryMessenger
@@ -4079,34 +4814,50 @@ abstract class PigeonApiWebChromeClient(open val pigeonRegistrar: AndroidWebkitL
     channel.send(listOf(pigeon_instanceArg, webViewArg, urlArg, messageArg)) {
       if (it is List<*>) {
         if (it.size > 1) {
-          callback(Result.failure(AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
+          callback(
+              Result.failure(
+                  AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
         } else if (it[0] == null) {
-          callback(Result.failure(AndroidWebKitError("null-error", "Flutter api returned null value for non-null return value.", "")))
+          callback(
+              Result.failure(
+                  AndroidWebKitError(
+                      "null-error",
+                      "Flutter api returned null value for non-null return value.",
+                      "")))
         } else {
           val output = it[0] as Boolean
           callback(Result.success(output))
         }
       } else {
         callback(Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
-      } 
+      }
     }
   }
 
   /**
-   * Notify the host application that the web page wants to display a
-   * JavaScript `prompt()` dialog.
+   * Notify the host application that the web page wants to display a JavaScript `prompt()` dialog.
    */
-  fun onJsPrompt(pigeon_instanceArg: io.flutter.plugins.webviewflutter.WebChromeClientProxyApi.WebChromeClientImpl, webViewArg: android.webkit.WebView, urlArg: String, messageArg: String, defaultValueArg: String, callback: (Result<String?>) -> Unit)
-{
+  fun onJsPrompt(
+      pigeon_instanceArg:
+          io.flutter.plugins.webviewflutter.WebChromeClientProxyApi.WebChromeClientImpl,
+      webViewArg: android.webkit.WebView,
+      urlArg: String,
+      messageArg: String,
+      defaultValueArg: String,
+      callback: (Result<String?>) -> Unit
+  ) {
     if (pigeonRegistrar.ignoreCallsToDart) {
       callback(
           Result.failure(
               AndroidWebKitError("ignore-calls-error", "Calls to Dart are being ignored.", "")))
       return
-    }     else if (!pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
+    } else if (!pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
       callback(
           Result.failure(
-              AndroidWebKitError("missing-instance-error", "Callback to `WebChromeClient.onJsPrompt` failed because native instance was not in the instance manager.", "")))
+              AndroidWebKitError(
+                  "missing-instance-error",
+                  "Callback to `WebChromeClient.onJsPrompt` failed because native instance was not in the instance manager.",
+                  "")))
       return
     }
     val binaryMessenger = pigeonRegistrar.binaryMessenger
@@ -4116,17 +4867,18 @@ abstract class PigeonApiWebChromeClient(open val pigeonRegistrar: AndroidWebkitL
     channel.send(listOf(pigeon_instanceArg, webViewArg, urlArg, messageArg, defaultValueArg)) {
       if (it is List<*>) {
         if (it.size > 1) {
-          callback(Result.failure(AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
+          callback(
+              Result.failure(
+                  AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
         } else {
           val output = it[0] as String?
           callback(Result.success(output))
         }
       } else {
         callback(Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
-      } 
+      }
     }
   }
-
 }
 /**
  * Provides access to the assets registered as part of the App bundle.
@@ -4134,7 +4886,9 @@ abstract class PigeonApiWebChromeClient(open val pigeonRegistrar: AndroidWebkitL
  * Convenience class for accessing Flutter asset resources.
  */
 @Suppress("UNCHECKED_CAST")
-abstract class PigeonApiFlutterAssetManager(open val pigeonRegistrar: AndroidWebkitLibraryPigeonProxyApiRegistrar) {
+abstract class PigeonApiFlutterAssetManager(
+    open val pigeonRegistrar: AndroidWebkitLibraryPigeonProxyApiRegistrar
+) {
   /** The global instance of the `FlutterAssetManager`. */
   abstract fun instance(): io.flutter.plugins.webviewflutter.FlutterAssetManager
 
@@ -4143,35 +4897,46 @@ abstract class PigeonApiFlutterAssetManager(open val pigeonRegistrar: AndroidWeb
    *
    * Throws an IOException in case I/O operations were interrupted.
    */
-  abstract fun list(pigeon_instance: io.flutter.plugins.webviewflutter.FlutterAssetManager, path: String): List<String>
+  abstract fun list(
+      pigeon_instance: io.flutter.plugins.webviewflutter.FlutterAssetManager,
+      path: String
+  ): List<String>
 
   /**
    * Gets the relative file path to the Flutter asset with the given name, including the file's
    * extension, e.g., "myImage.jpg".
    *
-   * The returned file path is relative to the Android app's standard asset's
-   * directory. Therefore, the returned path is appropriate to pass to
-   * Android's AssetManager, but the path is not appropriate to load as an
-   * absolute path.
+   * The returned file path is relative to the Android app's standard asset's directory. Therefore,
+   * the returned path is appropriate to pass to Android's AssetManager, but the path is not
+   * appropriate to load as an absolute path.
    */
-  abstract fun getAssetFilePathByName(pigeon_instance: io.flutter.plugins.webviewflutter.FlutterAssetManager, name: String): String
+  abstract fun getAssetFilePathByName(
+      pigeon_instance: io.flutter.plugins.webviewflutter.FlutterAssetManager,
+      name: String
+  ): String
 
   companion object {
     @Suppress("LocalVariableName")
     fun setUpMessageHandlers(binaryMessenger: BinaryMessenger, api: PigeonApiFlutterAssetManager?) {
       val codec = api?.pigeonRegistrar?.codec ?: AndroidWebkitLibraryPigeonCodec()
       run {
-        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.FlutterAssetManager.instance", codec)
+        val channel =
+            BasicMessageChannel<Any?>(
+                binaryMessenger,
+                "dev.flutter.pigeon.webview_flutter_android.FlutterAssetManager.instance",
+                codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val pigeon_identifierArg = args[0] as Long
-            val wrapped: List<Any?> = try {
-              api.pigeonRegistrar.instanceManager.addDartCreatedInstance(api.instance(), pigeon_identifierArg)
-              listOf(null)
-            } catch (exception: Throwable) {
-              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-            }
+            val wrapped: List<Any?> =
+                try {
+                  api.pigeonRegistrar.instanceManager.addDartCreatedInstance(
+                      api.instance(), pigeon_identifierArg)
+                  listOf(null)
+                } catch (exception: Throwable) {
+                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+                }
             reply.reply(wrapped)
           }
         } else {
@@ -4179,17 +4944,23 @@ abstract class PigeonApiFlutterAssetManager(open val pigeonRegistrar: AndroidWeb
         }
       }
       run {
-        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.FlutterAssetManager.list", codec)
+        val channel =
+            BasicMessageChannel<Any?>(
+                binaryMessenger,
+                "dev.flutter.pigeon.webview_flutter_android.FlutterAssetManager.list",
+                codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
-            val pigeon_instanceArg = args[0] as io.flutter.plugins.webviewflutter.FlutterAssetManager
+            val pigeon_instanceArg =
+                args[0] as io.flutter.plugins.webviewflutter.FlutterAssetManager
             val pathArg = args[1] as String
-            val wrapped: List<Any?> = try {
-              listOf(api.list(pigeon_instanceArg, pathArg))
-            } catch (exception: Throwable) {
-              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-            }
+            val wrapped: List<Any?> =
+                try {
+                  listOf(api.list(pigeon_instanceArg, pathArg))
+                } catch (exception: Throwable) {
+                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+                }
             reply.reply(wrapped)
           }
         } else {
@@ -4197,17 +4968,23 @@ abstract class PigeonApiFlutterAssetManager(open val pigeonRegistrar: AndroidWeb
         }
       }
       run {
-        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.FlutterAssetManager.getAssetFilePathByName", codec)
+        val channel =
+            BasicMessageChannel<Any?>(
+                binaryMessenger,
+                "dev.flutter.pigeon.webview_flutter_android.FlutterAssetManager.getAssetFilePathByName",
+                codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
-            val pigeon_instanceArg = args[0] as io.flutter.plugins.webviewflutter.FlutterAssetManager
+            val pigeon_instanceArg =
+                args[0] as io.flutter.plugins.webviewflutter.FlutterAssetManager
             val nameArg = args[1] as String
-            val wrapped: List<Any?> = try {
-              listOf(api.getAssetFilePathByName(pigeon_instanceArg, nameArg))
-            } catch (exception: Throwable) {
-              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-            }
+            val wrapped: List<Any?> =
+                try {
+                  listOf(api.getAssetFilePathByName(pigeon_instanceArg, nameArg))
+                } catch (exception: Throwable) {
+                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+                }
             reply.reply(wrapped)
           }
         } else {
@@ -4219,43 +4996,50 @@ abstract class PigeonApiFlutterAssetManager(open val pigeonRegistrar: AndroidWeb
 
   @Suppress("LocalVariableName", "FunctionName")
   /** Creates a Dart instance of FlutterAssetManager and attaches it to [pigeon_instanceArg]. */
-  fun pigeon_newInstance(pigeon_instanceArg: io.flutter.plugins.webviewflutter.FlutterAssetManager, callback: (Result<Unit>) -> Unit)
-{
+  fun pigeon_newInstance(
+      pigeon_instanceArg: io.flutter.plugins.webviewflutter.FlutterAssetManager,
+      callback: (Result<Unit>) -> Unit
+  ) {
     if (pigeonRegistrar.ignoreCallsToDart) {
       callback(
           Result.failure(
               AndroidWebKitError("ignore-calls-error", "Calls to Dart are being ignored.", "")))
-    }     else if (pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
+    } else if (pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
       callback(Result.success(Unit))
-    }     else {
-      val pigeon_identifierArg = pigeonRegistrar.instanceManager.addHostCreatedInstance(pigeon_instanceArg)
+    } else {
+      val pigeon_identifierArg =
+          pigeonRegistrar.instanceManager.addHostCreatedInstance(pigeon_instanceArg)
       val binaryMessenger = pigeonRegistrar.binaryMessenger
       val codec = pigeonRegistrar.codec
-      val channelName = "dev.flutter.pigeon.webview_flutter_android.FlutterAssetManager.pigeon_newInstance"
+      val channelName =
+          "dev.flutter.pigeon.webview_flutter_android.FlutterAssetManager.pigeon_newInstance"
       val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
       channel.send(listOf(pigeon_identifierArg)) {
         if (it is List<*>) {
           if (it.size > 1) {
-            callback(Result.failure(AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
+            callback(
+                Result.failure(
+                    AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
           } else {
             callback(Result.success(Unit))
           }
         } else {
-          callback(Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
-        } 
+          callback(
+              Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
+        }
       }
     }
   }
-
 }
 /**
- * This class is used to manage the JavaScript storage APIs provided by the
- * WebView.
+ * This class is used to manage the JavaScript storage APIs provided by the WebView.
  *
  * See https://developer.android.com/reference/android/webkit/WebStorage.
  */
 @Suppress("UNCHECKED_CAST")
-abstract class PigeonApiWebStorage(open val pigeonRegistrar: AndroidWebkitLibraryPigeonProxyApiRegistrar) {
+abstract class PigeonApiWebStorage(
+    open val pigeonRegistrar: AndroidWebkitLibraryPigeonProxyApiRegistrar
+) {
   abstract fun instance(): android.webkit.WebStorage
 
   /** Clears all storage currently being used by the JavaScript storage APIs. */
@@ -4266,17 +5050,23 @@ abstract class PigeonApiWebStorage(open val pigeonRegistrar: AndroidWebkitLibrar
     fun setUpMessageHandlers(binaryMessenger: BinaryMessenger, api: PigeonApiWebStorage?) {
       val codec = api?.pigeonRegistrar?.codec ?: AndroidWebkitLibraryPigeonCodec()
       run {
-        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.WebStorage.instance", codec)
+        val channel =
+            BasicMessageChannel<Any?>(
+                binaryMessenger,
+                "dev.flutter.pigeon.webview_flutter_android.WebStorage.instance",
+                codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val pigeon_identifierArg = args[0] as Long
-            val wrapped: List<Any?> = try {
-              api.pigeonRegistrar.instanceManager.addDartCreatedInstance(api.instance(), pigeon_identifierArg)
-              listOf(null)
-            } catch (exception: Throwable) {
-              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-            }
+            val wrapped: List<Any?> =
+                try {
+                  api.pigeonRegistrar.instanceManager.addDartCreatedInstance(
+                      api.instance(), pigeon_identifierArg)
+                  listOf(null)
+                } catch (exception: Throwable) {
+                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+                }
             reply.reply(wrapped)
           }
         } else {
@@ -4284,17 +5074,22 @@ abstract class PigeonApiWebStorage(open val pigeonRegistrar: AndroidWebkitLibrar
         }
       }
       run {
-        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.WebStorage.deleteAllData", codec)
+        val channel =
+            BasicMessageChannel<Any?>(
+                binaryMessenger,
+                "dev.flutter.pigeon.webview_flutter_android.WebStorage.deleteAllData",
+                codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val pigeon_instanceArg = args[0] as android.webkit.WebStorage
-            val wrapped: List<Any?> = try {
-              api.deleteAllData(pigeon_instanceArg)
-              listOf(null)
-            } catch (exception: Throwable) {
-              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-            }
+            val wrapped: List<Any?> =
+                try {
+                  api.deleteAllData(pigeon_instanceArg)
+                  listOf(null)
+                } catch (exception: Throwable) {
+                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+                }
             reply.reply(wrapped)
           }
         } else {
@@ -4306,16 +5101,19 @@ abstract class PigeonApiWebStorage(open val pigeonRegistrar: AndroidWebkitLibrar
 
   @Suppress("LocalVariableName", "FunctionName")
   /** Creates a Dart instance of WebStorage and attaches it to [pigeon_instanceArg]. */
-  fun pigeon_newInstance(pigeon_instanceArg: android.webkit.WebStorage, callback: (Result<Unit>) -> Unit)
-{
+  fun pigeon_newInstance(
+      pigeon_instanceArg: android.webkit.WebStorage,
+      callback: (Result<Unit>) -> Unit
+  ) {
     if (pigeonRegistrar.ignoreCallsToDart) {
       callback(
           Result.failure(
               AndroidWebKitError("ignore-calls-error", "Calls to Dart are being ignored.", "")))
-    }     else if (pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
+    } else if (pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
       callback(Result.success(Unit))
-    }     else {
-      val pigeon_identifierArg = pigeonRegistrar.instanceManager.addHostCreatedInstance(pigeon_instanceArg)
+    } else {
+      val pigeon_identifierArg =
+          pigeonRegistrar.instanceManager.addHostCreatedInstance(pigeon_instanceArg)
       val binaryMessenger = pigeonRegistrar.binaryMessenger
       val codec = pigeonRegistrar.codec
       val channelName = "dev.flutter.pigeon.webview_flutter_android.WebStorage.pigeon_newInstance"
@@ -4323,17 +5121,19 @@ abstract class PigeonApiWebStorage(open val pigeonRegistrar: AndroidWebkitLibrar
       channel.send(listOf(pigeon_identifierArg)) {
         if (it is List<*>) {
           if (it.size > 1) {
-            callback(Result.failure(AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
+            callback(
+                Result.failure(
+                    AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
           } else {
             callback(Result.success(Unit))
           }
         } else {
-          callback(Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
-        } 
+          callback(
+              Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
+        }
       }
     }
   }
-
 }
 /**
  * Parameters used in the `WebChromeClient.onShowFileChooser` method.
@@ -4341,68 +5141,90 @@ abstract class PigeonApiWebStorage(open val pigeonRegistrar: AndroidWebkitLibrar
  * See https://developer.android.com/reference/android/webkit/WebChromeClient.FileChooserParams.
  */
 @Suppress("UNCHECKED_CAST")
-abstract class PigeonApiFileChooserParams(open val pigeonRegistrar: AndroidWebkitLibraryPigeonProxyApiRegistrar) {
+abstract class PigeonApiFileChooserParams(
+    open val pigeonRegistrar: AndroidWebkitLibraryPigeonProxyApiRegistrar
+) {
   /** Preference for a live media captured value (e.g. Camera, Microphone). */
-  abstract fun isCaptureEnabled(pigeon_instance: android.webkit.WebChromeClient.FileChooserParams): Boolean
+  abstract fun isCaptureEnabled(
+      pigeon_instance: android.webkit.WebChromeClient.FileChooserParams
+  ): Boolean
 
   /** An array of acceptable MIME types. */
-  abstract fun acceptTypes(pigeon_instance: android.webkit.WebChromeClient.FileChooserParams): List<String>
+  abstract fun acceptTypes(
+      pigeon_instance: android.webkit.WebChromeClient.FileChooserParams
+  ): List<String>
 
   /** File chooser mode. */
-  abstract fun mode(pigeon_instance: android.webkit.WebChromeClient.FileChooserParams): FileChooserMode
+  abstract fun mode(
+      pigeon_instance: android.webkit.WebChromeClient.FileChooserParams
+  ): FileChooserMode
 
   /** File name of a default selection if specified, or null. */
-  abstract fun filenameHint(pigeon_instance: android.webkit.WebChromeClient.FileChooserParams): String?
+  abstract fun filenameHint(
+      pigeon_instance: android.webkit.WebChromeClient.FileChooserParams
+  ): String?
 
   @Suppress("LocalVariableName", "FunctionName")
   /** Creates a Dart instance of FileChooserParams and attaches it to [pigeon_instanceArg]. */
-  fun pigeon_newInstance(pigeon_instanceArg: android.webkit.WebChromeClient.FileChooserParams, callback: (Result<Unit>) -> Unit)
-{
+  fun pigeon_newInstance(
+      pigeon_instanceArg: android.webkit.WebChromeClient.FileChooserParams,
+      callback: (Result<Unit>) -> Unit
+  ) {
     if (pigeonRegistrar.ignoreCallsToDart) {
       callback(
           Result.failure(
               AndroidWebKitError("ignore-calls-error", "Calls to Dart are being ignored.", "")))
-    }     else if (pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
+    } else if (pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
       callback(Result.success(Unit))
-    }     else {
-      val pigeon_identifierArg = pigeonRegistrar.instanceManager.addHostCreatedInstance(pigeon_instanceArg)
+    } else {
+      val pigeon_identifierArg =
+          pigeonRegistrar.instanceManager.addHostCreatedInstance(pigeon_instanceArg)
       val isCaptureEnabledArg = isCaptureEnabled(pigeon_instanceArg)
       val acceptTypesArg = acceptTypes(pigeon_instanceArg)
       val modeArg = mode(pigeon_instanceArg)
       val filenameHintArg = filenameHint(pigeon_instanceArg)
       val binaryMessenger = pigeonRegistrar.binaryMessenger
       val codec = pigeonRegistrar.codec
-      val channelName = "dev.flutter.pigeon.webview_flutter_android.FileChooserParams.pigeon_newInstance"
+      val channelName =
+          "dev.flutter.pigeon.webview_flutter_android.FileChooserParams.pigeon_newInstance"
       val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
-      channel.send(listOf(pigeon_identifierArg, isCaptureEnabledArg, acceptTypesArg, modeArg, filenameHintArg)) {
-        if (it is List<*>) {
-          if (it.size > 1) {
-            callback(Result.failure(AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
-          } else {
-            callback(Result.success(Unit))
+      channel.send(
+          listOf(
+              pigeon_identifierArg,
+              isCaptureEnabledArg,
+              acceptTypesArg,
+              modeArg,
+              filenameHintArg)) {
+            if (it is List<*>) {
+              if (it.size > 1) {
+                callback(
+                    Result.failure(
+                        AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
+              } else {
+                callback(Result.success(Unit))
+              }
+            } else {
+              callback(
+                  Result.failure(
+                      AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
+            }
           }
-        } else {
-          callback(Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
-        } 
-      }
     }
   }
-
 }
 /**
- * This class defines a permission request and is used when web content
- * requests access to protected resources.
+ * This class defines a permission request and is used when web content requests access to protected
+ * resources.
  *
  * See https://developer.android.com/reference/android/webkit/PermissionRequest.
  */
 @Suppress("UNCHECKED_CAST")
-abstract class PigeonApiPermissionRequest(open val pigeonRegistrar: AndroidWebkitLibraryPigeonProxyApiRegistrar) {
+abstract class PigeonApiPermissionRequest(
+    open val pigeonRegistrar: AndroidWebkitLibraryPigeonProxyApiRegistrar
+) {
   abstract fun resources(pigeon_instance: android.webkit.PermissionRequest): List<String>
 
-  /**
-   * Call this method to grant origin the permission to access the given
-   * resources.
-   */
+  /** Call this method to grant origin the permission to access the given resources. */
   abstract fun grant(pigeon_instance: android.webkit.PermissionRequest, resources: List<String>)
 
   /** Call this method to deny the request. */
@@ -4413,18 +5235,23 @@ abstract class PigeonApiPermissionRequest(open val pigeonRegistrar: AndroidWebki
     fun setUpMessageHandlers(binaryMessenger: BinaryMessenger, api: PigeonApiPermissionRequest?) {
       val codec = api?.pigeonRegistrar?.codec ?: AndroidWebkitLibraryPigeonCodec()
       run {
-        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.PermissionRequest.grant", codec)
+        val channel =
+            BasicMessageChannel<Any?>(
+                binaryMessenger,
+                "dev.flutter.pigeon.webview_flutter_android.PermissionRequest.grant",
+                codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val pigeon_instanceArg = args[0] as android.webkit.PermissionRequest
             val resourcesArg = args[1] as List<String>
-            val wrapped: List<Any?> = try {
-              api.grant(pigeon_instanceArg, resourcesArg)
-              listOf(null)
-            } catch (exception: Throwable) {
-              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-            }
+            val wrapped: List<Any?> =
+                try {
+                  api.grant(pigeon_instanceArg, resourcesArg)
+                  listOf(null)
+                } catch (exception: Throwable) {
+                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+                }
             reply.reply(wrapped)
           }
         } else {
@@ -4432,17 +5259,22 @@ abstract class PigeonApiPermissionRequest(open val pigeonRegistrar: AndroidWebki
         }
       }
       run {
-        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.PermissionRequest.deny", codec)
+        val channel =
+            BasicMessageChannel<Any?>(
+                binaryMessenger,
+                "dev.flutter.pigeon.webview_flutter_android.PermissionRequest.deny",
+                codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val pigeon_instanceArg = args[0] as android.webkit.PermissionRequest
-            val wrapped: List<Any?> = try {
-              api.deny(pigeon_instanceArg)
-              listOf(null)
-            } catch (exception: Throwable) {
-              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-            }
+            val wrapped: List<Any?> =
+                try {
+                  api.deny(pigeon_instanceArg)
+                  listOf(null)
+                } catch (exception: Throwable) {
+                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+                }
             reply.reply(wrapped)
           }
         } else {
@@ -4454,63 +5286,78 @@ abstract class PigeonApiPermissionRequest(open val pigeonRegistrar: AndroidWebki
 
   @Suppress("LocalVariableName", "FunctionName")
   /** Creates a Dart instance of PermissionRequest and attaches it to [pigeon_instanceArg]. */
-  fun pigeon_newInstance(pigeon_instanceArg: android.webkit.PermissionRequest, callback: (Result<Unit>) -> Unit)
-{
+  fun pigeon_newInstance(
+      pigeon_instanceArg: android.webkit.PermissionRequest,
+      callback: (Result<Unit>) -> Unit
+  ) {
     if (pigeonRegistrar.ignoreCallsToDart) {
       callback(
           Result.failure(
               AndroidWebKitError("ignore-calls-error", "Calls to Dart are being ignored.", "")))
-    }     else if (pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
+    } else if (pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
       callback(Result.success(Unit))
-    }     else {
-      val pigeon_identifierArg = pigeonRegistrar.instanceManager.addHostCreatedInstance(pigeon_instanceArg)
+    } else {
+      val pigeon_identifierArg =
+          pigeonRegistrar.instanceManager.addHostCreatedInstance(pigeon_instanceArg)
       val resourcesArg = resources(pigeon_instanceArg)
       val binaryMessenger = pigeonRegistrar.binaryMessenger
       val codec = pigeonRegistrar.codec
-      val channelName = "dev.flutter.pigeon.webview_flutter_android.PermissionRequest.pigeon_newInstance"
+      val channelName =
+          "dev.flutter.pigeon.webview_flutter_android.PermissionRequest.pigeon_newInstance"
       val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
       channel.send(listOf(pigeon_identifierArg, resourcesArg)) {
         if (it is List<*>) {
           if (it.size > 1) {
-            callback(Result.failure(AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
+            callback(
+                Result.failure(
+                    AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
           } else {
             callback(Result.success(Unit))
           }
         } else {
-          callback(Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
-        } 
+          callback(
+              Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
+        }
       }
     }
   }
-
 }
 /**
- * A callback interface used by the host application to notify the current page
- * that its custom view has been dismissed.
+ * A callback interface used by the host application to notify the current page that its custom view
+ * has been dismissed.
  *
  * See https://developer.android.com/reference/android/webkit/WebChromeClient.CustomViewCallback.
  */
 @Suppress("UNCHECKED_CAST")
-abstract class PigeonApiCustomViewCallback(open val pigeonRegistrar: AndroidWebkitLibraryPigeonProxyApiRegistrar) {
+abstract class PigeonApiCustomViewCallback(
+    open val pigeonRegistrar: AndroidWebkitLibraryPigeonProxyApiRegistrar
+) {
   /** Invoked when the host application dismisses the custom view. */
-  abstract fun onCustomViewHidden(pigeon_instance: android.webkit.WebChromeClient.CustomViewCallback)
+  abstract fun onCustomViewHidden(
+      pigeon_instance: android.webkit.WebChromeClient.CustomViewCallback
+  )
 
   companion object {
     @Suppress("LocalVariableName")
     fun setUpMessageHandlers(binaryMessenger: BinaryMessenger, api: PigeonApiCustomViewCallback?) {
       val codec = api?.pigeonRegistrar?.codec ?: AndroidWebkitLibraryPigeonCodec()
       run {
-        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.CustomViewCallback.onCustomViewHidden", codec)
+        val channel =
+            BasicMessageChannel<Any?>(
+                binaryMessenger,
+                "dev.flutter.pigeon.webview_flutter_android.CustomViewCallback.onCustomViewHidden",
+                codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val pigeon_instanceArg = args[0] as android.webkit.WebChromeClient.CustomViewCallback
-            val wrapped: List<Any?> = try {
-              api.onCustomViewHidden(pigeon_instanceArg)
-              listOf(null)
-            } catch (exception: Throwable) {
-              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-            }
+            val wrapped: List<Any?> =
+                try {
+                  api.onCustomViewHidden(pigeon_instanceArg)
+                  listOf(null)
+                } catch (exception: Throwable) {
+                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+                }
             reply.reply(wrapped)
           }
         } else {
@@ -4522,43 +5369,50 @@ abstract class PigeonApiCustomViewCallback(open val pigeonRegistrar: AndroidWebk
 
   @Suppress("LocalVariableName", "FunctionName")
   /** Creates a Dart instance of CustomViewCallback and attaches it to [pigeon_instanceArg]. */
-  fun pigeon_newInstance(pigeon_instanceArg: android.webkit.WebChromeClient.CustomViewCallback, callback: (Result<Unit>) -> Unit)
-{
+  fun pigeon_newInstance(
+      pigeon_instanceArg: android.webkit.WebChromeClient.CustomViewCallback,
+      callback: (Result<Unit>) -> Unit
+  ) {
     if (pigeonRegistrar.ignoreCallsToDart) {
       callback(
           Result.failure(
               AndroidWebKitError("ignore-calls-error", "Calls to Dart are being ignored.", "")))
-    }     else if (pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
+    } else if (pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
       callback(Result.success(Unit))
-    }     else {
-      val pigeon_identifierArg = pigeonRegistrar.instanceManager.addHostCreatedInstance(pigeon_instanceArg)
+    } else {
+      val pigeon_identifierArg =
+          pigeonRegistrar.instanceManager.addHostCreatedInstance(pigeon_instanceArg)
       val binaryMessenger = pigeonRegistrar.binaryMessenger
       val codec = pigeonRegistrar.codec
-      val channelName = "dev.flutter.pigeon.webview_flutter_android.CustomViewCallback.pigeon_newInstance"
+      val channelName =
+          "dev.flutter.pigeon.webview_flutter_android.CustomViewCallback.pigeon_newInstance"
       val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
       channel.send(listOf(pigeon_identifierArg)) {
         if (it is List<*>) {
           if (it.size > 1) {
-            callback(Result.failure(AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
+            callback(
+                Result.failure(
+                    AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
           } else {
             callback(Result.success(Unit))
           }
         } else {
-          callback(Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
-        } 
+          callback(
+              Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
+        }
       }
     }
   }
-
 }
 /**
- * This class represents the basic building block for user interface
- * components.
+ * This class represents the basic building block for user interface components.
  *
  * See https://developer.android.com/reference/android/view/View.
  */
 @Suppress("UNCHECKED_CAST")
-abstract class PigeonApiView(open val pigeonRegistrar: AndroidWebkitLibraryPigeonProxyApiRegistrar) {
+abstract class PigeonApiView(
+    open val pigeonRegistrar: AndroidWebkitLibraryPigeonProxyApiRegistrar
+) {
   /** Set the scrolled position of your view. */
   abstract fun scrollTo(pigeon_instance: android.view.View, x: Long, y: Long)
 
@@ -4586,33 +5440,38 @@ abstract class PigeonApiView(open val pigeonRegistrar: AndroidWebkitLibraryPigeo
   abstract fun setOverScrollMode(pigeon_instance: android.view.View, mode: OverScrollMode)
 
   /**
-   * Sets the listener to the native method
-   * `ViewCompat.setOnApplyWindowInsetsListener` to mark the passed insets to
-   * zero.
+   * Sets the listener to the native method `ViewCompat.setOnApplyWindowInsetsListener` to mark the
+   * passed insets to zero.
    *
-   * This is a convenience method because `View.OnApplyWindowInsetsListener`
-   * requires implementing a callback that requires a synchronous return value.
+   * This is a convenience method because `View.OnApplyWindowInsetsListener` requires implementing a
+   * callback that requires a synchronous return value.
    */
-  abstract fun setInsetListenerToSetInsetsToZero(pigeon_instance: android.view.View, types: List<WindowInsetsType>)
+  abstract fun setInsetListenerToSetInsetsToZero(
+      pigeon_instance: android.view.View,
+      types: List<WindowInsetsType>
+  )
 
   companion object {
     @Suppress("LocalVariableName")
     fun setUpMessageHandlers(binaryMessenger: BinaryMessenger, api: PigeonApiView?) {
       val codec = api?.pigeonRegistrar?.codec ?: AndroidWebkitLibraryPigeonCodec()
       run {
-        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.View.scrollTo", codec)
+        val channel =
+            BasicMessageChannel<Any?>(
+                binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.View.scrollTo", codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val pigeon_instanceArg = args[0] as android.view.View
             val xArg = args[1] as Long
             val yArg = args[2] as Long
-            val wrapped: List<Any?> = try {
-              api.scrollTo(pigeon_instanceArg, xArg, yArg)
-              listOf(null)
-            } catch (exception: Throwable) {
-              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-            }
+            val wrapped: List<Any?> =
+                try {
+                  api.scrollTo(pigeon_instanceArg, xArg, yArg)
+                  listOf(null)
+                } catch (exception: Throwable) {
+                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+                }
             reply.reply(wrapped)
           }
         } else {
@@ -4620,19 +5479,22 @@ abstract class PigeonApiView(open val pigeonRegistrar: AndroidWebkitLibraryPigeo
         }
       }
       run {
-        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.View.scrollBy", codec)
+        val channel =
+            BasicMessageChannel<Any?>(
+                binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.View.scrollBy", codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val pigeon_instanceArg = args[0] as android.view.View
             val xArg = args[1] as Long
             val yArg = args[2] as Long
-            val wrapped: List<Any?> = try {
-              api.scrollBy(pigeon_instanceArg, xArg, yArg)
-              listOf(null)
-            } catch (exception: Throwable) {
-              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-            }
+            val wrapped: List<Any?> =
+                try {
+                  api.scrollBy(pigeon_instanceArg, xArg, yArg)
+                  listOf(null)
+                } catch (exception: Throwable) {
+                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+                }
             reply.reply(wrapped)
           }
         } else {
@@ -4640,16 +5502,21 @@ abstract class PigeonApiView(open val pigeonRegistrar: AndroidWebkitLibraryPigeo
         }
       }
       run {
-        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.View.getScrollPosition", codec)
+        val channel =
+            BasicMessageChannel<Any?>(
+                binaryMessenger,
+                "dev.flutter.pigeon.webview_flutter_android.View.getScrollPosition",
+                codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val pigeon_instanceArg = args[0] as android.view.View
-            val wrapped: List<Any?> = try {
-              listOf(api.getScrollPosition(pigeon_instanceArg))
-            } catch (exception: Throwable) {
-              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-            }
+            val wrapped: List<Any?> =
+                try {
+                  listOf(api.getScrollPosition(pigeon_instanceArg))
+                } catch (exception: Throwable) {
+                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+                }
             reply.reply(wrapped)
           }
         } else {
@@ -4657,37 +5524,23 @@ abstract class PigeonApiView(open val pigeonRegistrar: AndroidWebkitLibraryPigeo
         }
       }
       run {
-        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.View.setVerticalScrollBarEnabled", codec)
-        if (api != null) {
-          channel.setMessageHandler { message, reply ->
-            val args = message as List<Any?>
-            val pigeon_instanceArg = args[0] as android.view.View
-            val enabledArg = args[1] as Boolean
-            val wrapped: List<Any?> = try {
-              api.setVerticalScrollBarEnabled(pigeon_instanceArg, enabledArg)
-              listOf(null)
-            } catch (exception: Throwable) {
-              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-            }
-            reply.reply(wrapped)
-          }
-        } else {
-          channel.setMessageHandler(null)
-        }
-      }
-      run {
-        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.View.setHorizontalScrollBarEnabled", codec)
+        val channel =
+            BasicMessageChannel<Any?>(
+                binaryMessenger,
+                "dev.flutter.pigeon.webview_flutter_android.View.setVerticalScrollBarEnabled",
+                codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val pigeon_instanceArg = args[0] as android.view.View
             val enabledArg = args[1] as Boolean
-            val wrapped: List<Any?> = try {
-              api.setHorizontalScrollBarEnabled(pigeon_instanceArg, enabledArg)
-              listOf(null)
-            } catch (exception: Throwable) {
-              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-            }
+            val wrapped: List<Any?> =
+                try {
+                  api.setVerticalScrollBarEnabled(pigeon_instanceArg, enabledArg)
+                  listOf(null)
+                } catch (exception: Throwable) {
+                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+                }
             reply.reply(wrapped)
           }
         } else {
@@ -4695,18 +5548,47 @@ abstract class PigeonApiView(open val pigeonRegistrar: AndroidWebkitLibraryPigeo
         }
       }
       run {
-        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.View.setOverScrollMode", codec)
+        val channel =
+            BasicMessageChannel<Any?>(
+                binaryMessenger,
+                "dev.flutter.pigeon.webview_flutter_android.View.setHorizontalScrollBarEnabled",
+                codec)
+        if (api != null) {
+          channel.setMessageHandler { message, reply ->
+            val args = message as List<Any?>
+            val pigeon_instanceArg = args[0] as android.view.View
+            val enabledArg = args[1] as Boolean
+            val wrapped: List<Any?> =
+                try {
+                  api.setHorizontalScrollBarEnabled(pigeon_instanceArg, enabledArg)
+                  listOf(null)
+                } catch (exception: Throwable) {
+                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+                }
+            reply.reply(wrapped)
+          }
+        } else {
+          channel.setMessageHandler(null)
+        }
+      }
+      run {
+        val channel =
+            BasicMessageChannel<Any?>(
+                binaryMessenger,
+                "dev.flutter.pigeon.webview_flutter_android.View.setOverScrollMode",
+                codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val pigeon_instanceArg = args[0] as android.view.View
             val modeArg = args[1] as OverScrollMode
-            val wrapped: List<Any?> = try {
-              api.setOverScrollMode(pigeon_instanceArg, modeArg)
-              listOf(null)
-            } catch (exception: Throwable) {
-              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-            }
+            val wrapped: List<Any?> =
+                try {
+                  api.setOverScrollMode(pigeon_instanceArg, modeArg)
+                  listOf(null)
+                } catch (exception: Throwable) {
+                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+                }
             reply.reply(wrapped)
           }
         } else {
@@ -4714,18 +5596,23 @@ abstract class PigeonApiView(open val pigeonRegistrar: AndroidWebkitLibraryPigeo
         }
       }
       run {
-        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.View.setInsetListenerToSetInsetsToZero", codec)
+        val channel =
+            BasicMessageChannel<Any?>(
+                binaryMessenger,
+                "dev.flutter.pigeon.webview_flutter_android.View.setInsetListenerToSetInsetsToZero",
+                codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val pigeon_instanceArg = args[0] as android.view.View
             val typesArg = args[1] as List<WindowInsetsType>
-            val wrapped: List<Any?> = try {
-              api.setInsetListenerToSetInsetsToZero(pigeon_instanceArg, typesArg)
-              listOf(null)
-            } catch (exception: Throwable) {
-              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-            }
+            val wrapped: List<Any?> =
+                try {
+                  api.setInsetListenerToSetInsetsToZero(pigeon_instanceArg, typesArg)
+                  listOf(null)
+                } catch (exception: Throwable) {
+                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+                }
             reply.reply(wrapped)
           }
         } else {
@@ -4737,16 +5624,16 @@ abstract class PigeonApiView(open val pigeonRegistrar: AndroidWebkitLibraryPigeo
 
   @Suppress("LocalVariableName", "FunctionName")
   /** Creates a Dart instance of View and attaches it to [pigeon_instanceArg]. */
-  fun pigeon_newInstance(pigeon_instanceArg: android.view.View, callback: (Result<Unit>) -> Unit)
-{
+  fun pigeon_newInstance(pigeon_instanceArg: android.view.View, callback: (Result<Unit>) -> Unit) {
     if (pigeonRegistrar.ignoreCallsToDart) {
       callback(
           Result.failure(
               AndroidWebKitError("ignore-calls-error", "Calls to Dart are being ignored.", "")))
-    }     else if (pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
+    } else if (pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
       callback(Result.success(Unit))
-    }     else {
-      val pigeon_identifierArg = pigeonRegistrar.instanceManager.addHostCreatedInstance(pigeon_instanceArg)
+    } else {
+      val pigeon_identifierArg =
+          pigeonRegistrar.instanceManager.addHostCreatedInstance(pigeon_instanceArg)
       val binaryMessenger = pigeonRegistrar.binaryMessenger
       val codec = pigeonRegistrar.codec
       val channelName = "dev.flutter.pigeon.webview_flutter_android.View.pigeon_newInstance"
@@ -4754,35 +5641,51 @@ abstract class PigeonApiView(open val pigeonRegistrar: AndroidWebkitLibraryPigeo
       channel.send(listOf(pigeon_identifierArg)) {
         if (it is List<*>) {
           if (it.size > 1) {
-            callback(Result.failure(AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
+            callback(
+                Result.failure(
+                    AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
           } else {
             callback(Result.success(Unit))
           }
         } else {
-          callback(Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
-        } 
+          callback(
+              Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
+        }
       }
     }
   }
-
 }
 /**
- * A callback interface used by the host application to set the Geolocation
- * permission state for an origin.
+ * A callback interface used by the host application to set the Geolocation permission state for an
+ * origin.
  *
  * See https://developer.android.com/reference/android/webkit/GeolocationPermissions.Callback.
  */
 @Suppress("UNCHECKED_CAST")
-abstract class PigeonApiGeolocationPermissionsCallback(open val pigeonRegistrar: AndroidWebkitLibraryPigeonProxyApiRegistrar) {
+abstract class PigeonApiGeolocationPermissionsCallback(
+    open val pigeonRegistrar: AndroidWebkitLibraryPigeonProxyApiRegistrar
+) {
   /** Sets the Geolocation permission state for the supplied origin. */
-  abstract fun invoke(pigeon_instance: android.webkit.GeolocationPermissions.Callback, origin: String, allow: Boolean, retain: Boolean)
+  abstract fun invoke(
+      pigeon_instance: android.webkit.GeolocationPermissions.Callback,
+      origin: String,
+      allow: Boolean,
+      retain: Boolean
+  )
 
   companion object {
     @Suppress("LocalVariableName")
-    fun setUpMessageHandlers(binaryMessenger: BinaryMessenger, api: PigeonApiGeolocationPermissionsCallback?) {
+    fun setUpMessageHandlers(
+        binaryMessenger: BinaryMessenger,
+        api: PigeonApiGeolocationPermissionsCallback?
+    ) {
       val codec = api?.pigeonRegistrar?.codec ?: AndroidWebkitLibraryPigeonCodec()
       run {
-        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.GeolocationPermissionsCallback.invoke", codec)
+        val channel =
+            BasicMessageChannel<Any?>(
+                binaryMessenger,
+                "dev.flutter.pigeon.webview_flutter_android.GeolocationPermissionsCallback.invoke",
+                codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
@@ -4790,12 +5693,13 @@ abstract class PigeonApiGeolocationPermissionsCallback(open val pigeonRegistrar:
             val originArg = args[1] as String
             val allowArg = args[2] as Boolean
             val retainArg = args[3] as Boolean
-            val wrapped: List<Any?> = try {
-              api.invoke(pigeon_instanceArg, originArg, allowArg, retainArg)
-              listOf(null)
-            } catch (exception: Throwable) {
-              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-            }
+            val wrapped: List<Any?> =
+                try {
+                  api.invoke(pigeon_instanceArg, originArg, allowArg, retainArg)
+                  listOf(null)
+                } catch (exception: Throwable) {
+                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+                }
             reply.reply(wrapped)
           }
         } else {
@@ -4806,35 +5710,44 @@ abstract class PigeonApiGeolocationPermissionsCallback(open val pigeonRegistrar:
   }
 
   @Suppress("LocalVariableName", "FunctionName")
-  /** Creates a Dart instance of GeolocationPermissionsCallback and attaches it to [pigeon_instanceArg]. */
-  fun pigeon_newInstance(pigeon_instanceArg: android.webkit.GeolocationPermissions.Callback, callback: (Result<Unit>) -> Unit)
-{
+  /**
+   * Creates a Dart instance of GeolocationPermissionsCallback and attaches it to
+   * [pigeon_instanceArg].
+   */
+  fun pigeon_newInstance(
+      pigeon_instanceArg: android.webkit.GeolocationPermissions.Callback,
+      callback: (Result<Unit>) -> Unit
+  ) {
     if (pigeonRegistrar.ignoreCallsToDart) {
       callback(
           Result.failure(
               AndroidWebKitError("ignore-calls-error", "Calls to Dart are being ignored.", "")))
-    }     else if (pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
+    } else if (pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
       callback(Result.success(Unit))
-    }     else {
-      val pigeon_identifierArg = pigeonRegistrar.instanceManager.addHostCreatedInstance(pigeon_instanceArg)
+    } else {
+      val pigeon_identifierArg =
+          pigeonRegistrar.instanceManager.addHostCreatedInstance(pigeon_instanceArg)
       val binaryMessenger = pigeonRegistrar.binaryMessenger
       val codec = pigeonRegistrar.codec
-      val channelName = "dev.flutter.pigeon.webview_flutter_android.GeolocationPermissionsCallback.pigeon_newInstance"
+      val channelName =
+          "dev.flutter.pigeon.webview_flutter_android.GeolocationPermissionsCallback.pigeon_newInstance"
       val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
       channel.send(listOf(pigeon_identifierArg)) {
         if (it is List<*>) {
           if (it.size > 1) {
-            callback(Result.failure(AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
+            callback(
+                Result.failure(
+                    AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
           } else {
             callback(Result.success(Unit))
           }
         } else {
-          callback(Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
-        } 
+          callback(
+              Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
+        }
       }
     }
   }
-
 }
 /**
  * Represents a request for HTTP authentication.
@@ -4842,38 +5755,45 @@ abstract class PigeonApiGeolocationPermissionsCallback(open val pigeonRegistrar:
  * See https://developer.android.com/reference/android/webkit/HttpAuthHandler.
  */
 @Suppress("UNCHECKED_CAST")
-abstract class PigeonApiHttpAuthHandler(open val pigeonRegistrar: AndroidWebkitLibraryPigeonProxyApiRegistrar) {
+abstract class PigeonApiHttpAuthHandler(
+    open val pigeonRegistrar: AndroidWebkitLibraryPigeonProxyApiRegistrar
+) {
   /**
-   * Gets whether the credentials stored for the current host (i.e. the host
-   * for which `WebViewClient.onReceivedHttpAuthRequest` was called) are
-   * suitable for use.
+   * Gets whether the credentials stored for the current host (i.e. the host for which
+   * `WebViewClient.onReceivedHttpAuthRequest` was called) are suitable for use.
    */
   abstract fun useHttpAuthUsernamePassword(pigeon_instance: android.webkit.HttpAuthHandler): Boolean
 
   /** Instructs the WebView to cancel the authentication request.. */
   abstract fun cancel(pigeon_instance: android.webkit.HttpAuthHandler)
 
-  /**
-   * Instructs the WebView to proceed with the authentication with the given
-   * credentials.
-   */
-  abstract fun proceed(pigeon_instance: android.webkit.HttpAuthHandler, username: String, password: String)
+  /** Instructs the WebView to proceed with the authentication with the given credentials. */
+  abstract fun proceed(
+      pigeon_instance: android.webkit.HttpAuthHandler,
+      username: String,
+      password: String
+  )
 
   companion object {
     @Suppress("LocalVariableName")
     fun setUpMessageHandlers(binaryMessenger: BinaryMessenger, api: PigeonApiHttpAuthHandler?) {
       val codec = api?.pigeonRegistrar?.codec ?: AndroidWebkitLibraryPigeonCodec()
       run {
-        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.HttpAuthHandler.useHttpAuthUsernamePassword", codec)
+        val channel =
+            BasicMessageChannel<Any?>(
+                binaryMessenger,
+                "dev.flutter.pigeon.webview_flutter_android.HttpAuthHandler.useHttpAuthUsernamePassword",
+                codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val pigeon_instanceArg = args[0] as android.webkit.HttpAuthHandler
-            val wrapped: List<Any?> = try {
-              listOf(api.useHttpAuthUsernamePassword(pigeon_instanceArg))
-            } catch (exception: Throwable) {
-              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-            }
+            val wrapped: List<Any?> =
+                try {
+                  listOf(api.useHttpAuthUsernamePassword(pigeon_instanceArg))
+                } catch (exception: Throwable) {
+                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+                }
             reply.reply(wrapped)
           }
         } else {
@@ -4881,17 +5801,22 @@ abstract class PigeonApiHttpAuthHandler(open val pigeonRegistrar: AndroidWebkitL
         }
       }
       run {
-        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.HttpAuthHandler.cancel", codec)
+        val channel =
+            BasicMessageChannel<Any?>(
+                binaryMessenger,
+                "dev.flutter.pigeon.webview_flutter_android.HttpAuthHandler.cancel",
+                codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val pigeon_instanceArg = args[0] as android.webkit.HttpAuthHandler
-            val wrapped: List<Any?> = try {
-              api.cancel(pigeon_instanceArg)
-              listOf(null)
-            } catch (exception: Throwable) {
-              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-            }
+            val wrapped: List<Any?> =
+                try {
+                  api.cancel(pigeon_instanceArg)
+                  listOf(null)
+                } catch (exception: Throwable) {
+                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+                }
             reply.reply(wrapped)
           }
         } else {
@@ -4899,19 +5824,24 @@ abstract class PigeonApiHttpAuthHandler(open val pigeonRegistrar: AndroidWebkitL
         }
       }
       run {
-        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.HttpAuthHandler.proceed", codec)
+        val channel =
+            BasicMessageChannel<Any?>(
+                binaryMessenger,
+                "dev.flutter.pigeon.webview_flutter_android.HttpAuthHandler.proceed",
+                codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val pigeon_instanceArg = args[0] as android.webkit.HttpAuthHandler
             val usernameArg = args[1] as String
             val passwordArg = args[2] as String
-            val wrapped: List<Any?> = try {
-              api.proceed(pigeon_instanceArg, usernameArg, passwordArg)
-              listOf(null)
-            } catch (exception: Throwable) {
-              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-            }
+            val wrapped: List<Any?> =
+                try {
+                  api.proceed(pigeon_instanceArg, usernameArg, passwordArg)
+                  listOf(null)
+                } catch (exception: Throwable) {
+                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+                }
             reply.reply(wrapped)
           }
         } else {
@@ -4923,46 +5853,53 @@ abstract class PigeonApiHttpAuthHandler(open val pigeonRegistrar: AndroidWebkitL
 
   @Suppress("LocalVariableName", "FunctionName")
   /** Creates a Dart instance of HttpAuthHandler and attaches it to [pigeon_instanceArg]. */
-  fun pigeon_newInstance(pigeon_instanceArg: android.webkit.HttpAuthHandler, callback: (Result<Unit>) -> Unit)
-{
+  fun pigeon_newInstance(
+      pigeon_instanceArg: android.webkit.HttpAuthHandler,
+      callback: (Result<Unit>) -> Unit
+  ) {
     if (pigeonRegistrar.ignoreCallsToDart) {
       callback(
           Result.failure(
               AndroidWebKitError("ignore-calls-error", "Calls to Dart are being ignored.", "")))
-    }     else if (pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
+    } else if (pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
       callback(Result.success(Unit))
-    }     else {
-      val pigeon_identifierArg = pigeonRegistrar.instanceManager.addHostCreatedInstance(pigeon_instanceArg)
+    } else {
+      val pigeon_identifierArg =
+          pigeonRegistrar.instanceManager.addHostCreatedInstance(pigeon_instanceArg)
       val binaryMessenger = pigeonRegistrar.binaryMessenger
       val codec = pigeonRegistrar.codec
-      val channelName = "dev.flutter.pigeon.webview_flutter_android.HttpAuthHandler.pigeon_newInstance"
+      val channelName =
+          "dev.flutter.pigeon.webview_flutter_android.HttpAuthHandler.pigeon_newInstance"
       val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
       channel.send(listOf(pigeon_identifierArg)) {
         if (it is List<*>) {
           if (it.size > 1) {
-            callback(Result.failure(AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
+            callback(
+                Result.failure(
+                    AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
           } else {
             callback(Result.success(Unit))
           }
         } else {
-          callback(Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
-        } 
+          callback(
+              Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
+        }
       }
     }
   }
-
 }
 /**
- * Defines a message containing a description and arbitrary data object that
- * can be sent to a `Handler`.
+ * Defines a message containing a description and arbitrary data object that can be sent to a
+ * `Handler`.
  *
  * See https://developer.android.com/reference/android/os/Message.
  */
 @Suppress("UNCHECKED_CAST")
-abstract class PigeonApiAndroidMessage(open val pigeonRegistrar: AndroidWebkitLibraryPigeonProxyApiRegistrar) {
+abstract class PigeonApiAndroidMessage(
+    open val pigeonRegistrar: AndroidWebkitLibraryPigeonProxyApiRegistrar
+) {
   /**
-   * Sends this message to the Android native `Handler` specified by
-   * getTarget().
+   * Sends this message to the Android native `Handler` specified by getTarget().
    *
    * Throws a null pointer exception if this field has not been set.
    */
@@ -4973,17 +5910,22 @@ abstract class PigeonApiAndroidMessage(open val pigeonRegistrar: AndroidWebkitLi
     fun setUpMessageHandlers(binaryMessenger: BinaryMessenger, api: PigeonApiAndroidMessage?) {
       val codec = api?.pigeonRegistrar?.codec ?: AndroidWebkitLibraryPigeonCodec()
       run {
-        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.AndroidMessage.sendToTarget", codec)
+        val channel =
+            BasicMessageChannel<Any?>(
+                binaryMessenger,
+                "dev.flutter.pigeon.webview_flutter_android.AndroidMessage.sendToTarget",
+                codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val pigeon_instanceArg = args[0] as android.os.Message
-            val wrapped: List<Any?> = try {
-              api.sendToTarget(pigeon_instanceArg)
-              listOf(null)
-            } catch (exception: Throwable) {
-              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-            }
+            val wrapped: List<Any?> =
+                try {
+                  api.sendToTarget(pigeon_instanceArg)
+                  listOf(null)
+                } catch (exception: Throwable) {
+                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+                }
             reply.reply(wrapped)
           }
         } else {
@@ -4995,43 +5937,48 @@ abstract class PigeonApiAndroidMessage(open val pigeonRegistrar: AndroidWebkitLi
 
   @Suppress("LocalVariableName", "FunctionName")
   /** Creates a Dart instance of AndroidMessage and attaches it to [pigeon_instanceArg]. */
-  fun pigeon_newInstance(pigeon_instanceArg: android.os.Message, callback: (Result<Unit>) -> Unit)
-{
+  fun pigeon_newInstance(pigeon_instanceArg: android.os.Message, callback: (Result<Unit>) -> Unit) {
     if (pigeonRegistrar.ignoreCallsToDart) {
       callback(
           Result.failure(
               AndroidWebKitError("ignore-calls-error", "Calls to Dart are being ignored.", "")))
-    }     else if (pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
+    } else if (pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
       callback(Result.success(Unit))
-    }     else {
-      val pigeon_identifierArg = pigeonRegistrar.instanceManager.addHostCreatedInstance(pigeon_instanceArg)
+    } else {
+      val pigeon_identifierArg =
+          pigeonRegistrar.instanceManager.addHostCreatedInstance(pigeon_instanceArg)
       val binaryMessenger = pigeonRegistrar.binaryMessenger
       val codec = pigeonRegistrar.codec
-      val channelName = "dev.flutter.pigeon.webview_flutter_android.AndroidMessage.pigeon_newInstance"
+      val channelName =
+          "dev.flutter.pigeon.webview_flutter_android.AndroidMessage.pigeon_newInstance"
       val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
       channel.send(listOf(pigeon_identifierArg)) {
         if (it is List<*>) {
           if (it.size > 1) {
-            callback(Result.failure(AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
+            callback(
+                Result.failure(
+                    AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
           } else {
             callback(Result.success(Unit))
           }
         } else {
-          callback(Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
-        } 
+          callback(
+              Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
+        }
       }
     }
   }
-
 }
 /**
- * Defines a message containing a description and arbitrary data object that
- * can be sent to a `Handler`.
+ * Defines a message containing a description and arbitrary data object that can be sent to a
+ * `Handler`.
  *
  * See https://developer.android.com/reference/android/webkit/ClientCertRequest.
  */
 @Suppress("UNCHECKED_CAST")
-abstract class PigeonApiClientCertRequest(open val pigeonRegistrar: AndroidWebkitLibraryPigeonProxyApiRegistrar) {
+abstract class PigeonApiClientCertRequest(
+    open val pigeonRegistrar: AndroidWebkitLibraryPigeonProxyApiRegistrar
+) {
   /** Cancel this request. */
   abstract fun cancel(pigeon_instance: android.webkit.ClientCertRequest)
 
@@ -5039,24 +5986,33 @@ abstract class PigeonApiClientCertRequest(open val pigeonRegistrar: AndroidWebki
   abstract fun ignore(pigeon_instance: android.webkit.ClientCertRequest)
 
   /** Proceed with the specified private key and client certificate chain. */
-  abstract fun proceed(pigeon_instance: android.webkit.ClientCertRequest, privateKey: java.security.PrivateKey, chain: List<java.security.cert.X509Certificate>)
+  abstract fun proceed(
+      pigeon_instance: android.webkit.ClientCertRequest,
+      privateKey: java.security.PrivateKey,
+      chain: List<java.security.cert.X509Certificate>
+  )
 
   companion object {
     @Suppress("LocalVariableName")
     fun setUpMessageHandlers(binaryMessenger: BinaryMessenger, api: PigeonApiClientCertRequest?) {
       val codec = api?.pigeonRegistrar?.codec ?: AndroidWebkitLibraryPigeonCodec()
       run {
-        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.ClientCertRequest.cancel", codec)
+        val channel =
+            BasicMessageChannel<Any?>(
+                binaryMessenger,
+                "dev.flutter.pigeon.webview_flutter_android.ClientCertRequest.cancel",
+                codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val pigeon_instanceArg = args[0] as android.webkit.ClientCertRequest
-            val wrapped: List<Any?> = try {
-              api.cancel(pigeon_instanceArg)
-              listOf(null)
-            } catch (exception: Throwable) {
-              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-            }
+            val wrapped: List<Any?> =
+                try {
+                  api.cancel(pigeon_instanceArg)
+                  listOf(null)
+                } catch (exception: Throwable) {
+                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+                }
             reply.reply(wrapped)
           }
         } else {
@@ -5064,17 +6020,22 @@ abstract class PigeonApiClientCertRequest(open val pigeonRegistrar: AndroidWebki
         }
       }
       run {
-        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.ClientCertRequest.ignore", codec)
+        val channel =
+            BasicMessageChannel<Any?>(
+                binaryMessenger,
+                "dev.flutter.pigeon.webview_flutter_android.ClientCertRequest.ignore",
+                codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val pigeon_instanceArg = args[0] as android.webkit.ClientCertRequest
-            val wrapped: List<Any?> = try {
-              api.ignore(pigeon_instanceArg)
-              listOf(null)
-            } catch (exception: Throwable) {
-              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-            }
+            val wrapped: List<Any?> =
+                try {
+                  api.ignore(pigeon_instanceArg)
+                  listOf(null)
+                } catch (exception: Throwable) {
+                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+                }
             reply.reply(wrapped)
           }
         } else {
@@ -5082,19 +6043,24 @@ abstract class PigeonApiClientCertRequest(open val pigeonRegistrar: AndroidWebki
         }
       }
       run {
-        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.ClientCertRequest.proceed", codec)
+        val channel =
+            BasicMessageChannel<Any?>(
+                binaryMessenger,
+                "dev.flutter.pigeon.webview_flutter_android.ClientCertRequest.proceed",
+                codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val pigeon_instanceArg = args[0] as android.webkit.ClientCertRequest
             val privateKeyArg = args[1] as java.security.PrivateKey
             val chainArg = args[2] as List<java.security.cert.X509Certificate>
-            val wrapped: List<Any?> = try {
-              api.proceed(pigeon_instanceArg, privateKeyArg, chainArg)
-              listOf(null)
-            } catch (exception: Throwable) {
-              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-            }
+            val wrapped: List<Any?> =
+                try {
+                  api.proceed(pigeon_instanceArg, privateKeyArg, chainArg)
+                  listOf(null)
+                } catch (exception: Throwable) {
+                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+                }
             reply.reply(wrapped)
           }
         } else {
@@ -5106,57 +6072,68 @@ abstract class PigeonApiClientCertRequest(open val pigeonRegistrar: AndroidWebki
 
   @Suppress("LocalVariableName", "FunctionName")
   /** Creates a Dart instance of ClientCertRequest and attaches it to [pigeon_instanceArg]. */
-  fun pigeon_newInstance(pigeon_instanceArg: android.webkit.ClientCertRequest, callback: (Result<Unit>) -> Unit)
-{
+  fun pigeon_newInstance(
+      pigeon_instanceArg: android.webkit.ClientCertRequest,
+      callback: (Result<Unit>) -> Unit
+  ) {
     if (pigeonRegistrar.ignoreCallsToDart) {
       callback(
           Result.failure(
               AndroidWebKitError("ignore-calls-error", "Calls to Dart are being ignored.", "")))
-    }     else if (pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
+    } else if (pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
       callback(Result.success(Unit))
-    }     else {
-      val pigeon_identifierArg = pigeonRegistrar.instanceManager.addHostCreatedInstance(pigeon_instanceArg)
+    } else {
+      val pigeon_identifierArg =
+          pigeonRegistrar.instanceManager.addHostCreatedInstance(pigeon_instanceArg)
       val binaryMessenger = pigeonRegistrar.binaryMessenger
       val codec = pigeonRegistrar.codec
-      val channelName = "dev.flutter.pigeon.webview_flutter_android.ClientCertRequest.pigeon_newInstance"
+      val channelName =
+          "dev.flutter.pigeon.webview_flutter_android.ClientCertRequest.pigeon_newInstance"
       val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
       channel.send(listOf(pigeon_identifierArg)) {
         if (it is List<*>) {
           if (it.size > 1) {
-            callback(Result.failure(AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
+            callback(
+                Result.failure(
+                    AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
           } else {
             callback(Result.success(Unit))
           }
         } else {
-          callback(Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
-        } 
+          callback(
+              Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
+        }
       }
     }
   }
-
 }
 /**
  * A private key.
  *
- * The purpose of this interface is to group (and provide type safety for) all
- * private key interfaces.
+ * The purpose of this interface is to group (and provide type safety for) all private key
+ * interfaces.
  *
  * See https://developer.android.com/reference/java/security/PrivateKey.
  */
 @Suppress("UNCHECKED_CAST")
-open class PigeonApiPrivateKey(open val pigeonRegistrar: AndroidWebkitLibraryPigeonProxyApiRegistrar) {
+open class PigeonApiPrivateKey(
+    open val pigeonRegistrar: AndroidWebkitLibraryPigeonProxyApiRegistrar
+) {
   @Suppress("LocalVariableName", "FunctionName")
   /** Creates a Dart instance of PrivateKey and attaches it to [pigeon_instanceArg]. */
-  fun pigeon_newInstance(pigeon_instanceArg: java.security.PrivateKey, callback: (Result<Unit>) -> Unit)
-{
+  fun pigeon_newInstance(
+      pigeon_instanceArg: java.security.PrivateKey,
+      callback: (Result<Unit>) -> Unit
+  ) {
     if (pigeonRegistrar.ignoreCallsToDart) {
       callback(
           Result.failure(
               AndroidWebKitError("ignore-calls-error", "Calls to Dart are being ignored.", "")))
-    }     else if (pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
+    } else if (pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
       callback(Result.success(Unit))
-    }     else {
-      val pigeon_identifierArg = pigeonRegistrar.instanceManager.addHostCreatedInstance(pigeon_instanceArg)
+    } else {
+      val pigeon_identifierArg =
+          pigeonRegistrar.instanceManager.addHostCreatedInstance(pigeon_instanceArg)
       val binaryMessenger = pigeonRegistrar.binaryMessenger
       val codec = pigeonRegistrar.codec
       val channelName = "dev.flutter.pigeon.webview_flutter_android.PrivateKey.pigeon_newInstance"
@@ -5164,65 +6141,73 @@ open class PigeonApiPrivateKey(open val pigeonRegistrar: AndroidWebkitLibraryPig
       channel.send(listOf(pigeon_identifierArg)) {
         if (it is List<*>) {
           if (it.size > 1) {
-            callback(Result.failure(AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
+            callback(
+                Result.failure(
+                    AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
           } else {
             callback(Result.success(Unit))
           }
         } else {
-          callback(Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
-        } 
+          callback(
+              Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
+        }
       }
     }
   }
-
 }
 /**
  * Abstract class for X.509 certificates.
  *
- * This provides a standard way to access all the attributes of an X.509
- * certificate.
+ * This provides a standard way to access all the attributes of an X.509 certificate.
  *
  * See https://developer.android.com/reference/java/security/cert/X509Certificate.
  */
 @Suppress("UNCHECKED_CAST")
-open class PigeonApiX509Certificate(open val pigeonRegistrar: AndroidWebkitLibraryPigeonProxyApiRegistrar) {
+open class PigeonApiX509Certificate(
+    open val pigeonRegistrar: AndroidWebkitLibraryPigeonProxyApiRegistrar
+) {
   @Suppress("LocalVariableName", "FunctionName")
   /** Creates a Dart instance of X509Certificate and attaches it to [pigeon_instanceArg]. */
-  fun pigeon_newInstance(pigeon_instanceArg: java.security.cert.X509Certificate, callback: (Result<Unit>) -> Unit)
-{
+  fun pigeon_newInstance(
+      pigeon_instanceArg: java.security.cert.X509Certificate,
+      callback: (Result<Unit>) -> Unit
+  ) {
     if (pigeonRegistrar.ignoreCallsToDart) {
       callback(
           Result.failure(
               AndroidWebKitError("ignore-calls-error", "Calls to Dart are being ignored.", "")))
-    }     else if (pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
+    } else if (pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
       callback(Result.success(Unit))
-    }     else {
-      val pigeon_identifierArg = pigeonRegistrar.instanceManager.addHostCreatedInstance(pigeon_instanceArg)
+    } else {
+      val pigeon_identifierArg =
+          pigeonRegistrar.instanceManager.addHostCreatedInstance(pigeon_instanceArg)
       val binaryMessenger = pigeonRegistrar.binaryMessenger
       val codec = pigeonRegistrar.codec
-      val channelName = "dev.flutter.pigeon.webview_flutter_android.X509Certificate.pigeon_newInstance"
+      val channelName =
+          "dev.flutter.pigeon.webview_flutter_android.X509Certificate.pigeon_newInstance"
       val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
       channel.send(listOf(pigeon_identifierArg)) {
         if (it is List<*>) {
           if (it.size > 1) {
-            callback(Result.failure(AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
+            callback(
+                Result.failure(
+                    AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
           } else {
             callback(Result.success(Unit))
           }
         } else {
-          callback(Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
-        } 
+          callback(
+              Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
+        }
       }
     }
   }
 
   @Suppress("FunctionName")
   /** An implementation of [PigeonApiCertificate] used to access callback methods */
-  fun pigeon_getPigeonApiCertificate(): PigeonApiCertificate
-  {
+  fun pigeon_getPigeonApiCertificate(): PigeonApiCertificate {
     return pigeonRegistrar.getPigeonApiCertificate()
   }
-
 }
 /**
  * Represents a request for handling an SSL error.
@@ -5230,16 +6215,18 @@ open class PigeonApiX509Certificate(open val pigeonRegistrar: AndroidWebkitLibra
  * See https://developer.android.com/reference/android/webkit/SslErrorHandler.
  */
 @Suppress("UNCHECKED_CAST")
-abstract class PigeonApiSslErrorHandler(open val pigeonRegistrar: AndroidWebkitLibraryPigeonProxyApiRegistrar) {
+abstract class PigeonApiSslErrorHandler(
+    open val pigeonRegistrar: AndroidWebkitLibraryPigeonProxyApiRegistrar
+) {
   /**
-   * Instructs the WebView that encountered the SSL certificate error to
-   * terminate communication with the server.
+   * Instructs the WebView that encountered the SSL certificate error to terminate communication
+   * with the server.
    */
   abstract fun cancel(pigeon_instance: android.webkit.SslErrorHandler)
 
   /**
-   * Instructs the WebView that encountered the SSL certificate error to ignore
-   * the error and continue communicating with the server.
+   * Instructs the WebView that encountered the SSL certificate error to ignore the error and
+   * continue communicating with the server.
    */
   abstract fun proceed(pigeon_instance: android.webkit.SslErrorHandler)
 
@@ -5248,17 +6235,22 @@ abstract class PigeonApiSslErrorHandler(open val pigeonRegistrar: AndroidWebkitL
     fun setUpMessageHandlers(binaryMessenger: BinaryMessenger, api: PigeonApiSslErrorHandler?) {
       val codec = api?.pigeonRegistrar?.codec ?: AndroidWebkitLibraryPigeonCodec()
       run {
-        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.SslErrorHandler.cancel", codec)
+        val channel =
+            BasicMessageChannel<Any?>(
+                binaryMessenger,
+                "dev.flutter.pigeon.webview_flutter_android.SslErrorHandler.cancel",
+                codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val pigeon_instanceArg = args[0] as android.webkit.SslErrorHandler
-            val wrapped: List<Any?> = try {
-              api.cancel(pigeon_instanceArg)
-              listOf(null)
-            } catch (exception: Throwable) {
-              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-            }
+            val wrapped: List<Any?> =
+                try {
+                  api.cancel(pigeon_instanceArg)
+                  listOf(null)
+                } catch (exception: Throwable) {
+                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+                }
             reply.reply(wrapped)
           }
         } else {
@@ -5266,17 +6258,22 @@ abstract class PigeonApiSslErrorHandler(open val pigeonRegistrar: AndroidWebkitL
         }
       }
       run {
-        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.SslErrorHandler.proceed", codec)
+        val channel =
+            BasicMessageChannel<Any?>(
+                binaryMessenger,
+                "dev.flutter.pigeon.webview_flutter_android.SslErrorHandler.proceed",
+                codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val pigeon_instanceArg = args[0] as android.webkit.SslErrorHandler
-            val wrapped: List<Any?> = try {
-              api.proceed(pigeon_instanceArg)
-              listOf(null)
-            } catch (exception: Throwable) {
-              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-            }
+            val wrapped: List<Any?> =
+                try {
+                  api.proceed(pigeon_instanceArg)
+                  listOf(null)
+                } catch (exception: Throwable) {
+                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+                }
             reply.reply(wrapped)
           }
         } else {
@@ -5288,45 +6285,54 @@ abstract class PigeonApiSslErrorHandler(open val pigeonRegistrar: AndroidWebkitL
 
   @Suppress("LocalVariableName", "FunctionName")
   /** Creates a Dart instance of SslErrorHandler and attaches it to [pigeon_instanceArg]. */
-  fun pigeon_newInstance(pigeon_instanceArg: android.webkit.SslErrorHandler, callback: (Result<Unit>) -> Unit)
-{
+  fun pigeon_newInstance(
+      pigeon_instanceArg: android.webkit.SslErrorHandler,
+      callback: (Result<Unit>) -> Unit
+  ) {
     if (pigeonRegistrar.ignoreCallsToDart) {
       callback(
           Result.failure(
               AndroidWebKitError("ignore-calls-error", "Calls to Dart are being ignored.", "")))
-    }     else if (pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
+    } else if (pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
       callback(Result.success(Unit))
-    }     else {
-      val pigeon_identifierArg = pigeonRegistrar.instanceManager.addHostCreatedInstance(pigeon_instanceArg)
+    } else {
+      val pigeon_identifierArg =
+          pigeonRegistrar.instanceManager.addHostCreatedInstance(pigeon_instanceArg)
       val binaryMessenger = pigeonRegistrar.binaryMessenger
       val codec = pigeonRegistrar.codec
-      val channelName = "dev.flutter.pigeon.webview_flutter_android.SslErrorHandler.pigeon_newInstance"
+      val channelName =
+          "dev.flutter.pigeon.webview_flutter_android.SslErrorHandler.pigeon_newInstance"
       val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
       channel.send(listOf(pigeon_identifierArg)) {
         if (it is List<*>) {
           if (it.size > 1) {
-            callback(Result.failure(AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
+            callback(
+                Result.failure(
+                    AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
           } else {
             callback(Result.success(Unit))
           }
         } else {
-          callback(Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
-        } 
+          callback(
+              Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
+        }
       }
     }
   }
-
 }
 /**
- * This class represents a set of one or more SSL errors and the associated SSL
- * certificate.
+ * This class represents a set of one or more SSL errors and the associated SSL certificate.
  *
  * See https://developer.android.com/reference/android/net/http/SslError.
  */
 @Suppress("UNCHECKED_CAST")
-abstract class PigeonApiSslError(open val pigeonRegistrar: AndroidWebkitLibraryPigeonProxyApiRegistrar) {
+abstract class PigeonApiSslError(
+    open val pigeonRegistrar: AndroidWebkitLibraryPigeonProxyApiRegistrar
+) {
   /** Gets the SSL certificate associated with this object. */
-  abstract fun certificate(pigeon_instance: android.net.http.SslError): android.net.http.SslCertificate
+  abstract fun certificate(
+      pigeon_instance: android.net.http.SslError
+  ): android.net.http.SslCertificate
 
   /** Gets the URL associated with this object. */
   abstract fun url(pigeon_instance: android.net.http.SslError): String
@@ -5342,16 +6348,21 @@ abstract class PigeonApiSslError(open val pigeonRegistrar: AndroidWebkitLibraryP
     fun setUpMessageHandlers(binaryMessenger: BinaryMessenger, api: PigeonApiSslError?) {
       val codec = api?.pigeonRegistrar?.codec ?: AndroidWebkitLibraryPigeonCodec()
       run {
-        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.SslError.getPrimaryError", codec)
+        val channel =
+            BasicMessageChannel<Any?>(
+                binaryMessenger,
+                "dev.flutter.pigeon.webview_flutter_android.SslError.getPrimaryError",
+                codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val pigeon_instanceArg = args[0] as android.net.http.SslError
-            val wrapped: List<Any?> = try {
-              listOf(api.getPrimaryError(pigeon_instanceArg))
-            } catch (exception: Throwable) {
-              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-            }
+            val wrapped: List<Any?> =
+                try {
+                  listOf(api.getPrimaryError(pigeon_instanceArg))
+                } catch (exception: Throwable) {
+                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+                }
             reply.reply(wrapped)
           }
         } else {
@@ -5359,17 +6370,22 @@ abstract class PigeonApiSslError(open val pigeonRegistrar: AndroidWebkitLibraryP
         }
       }
       run {
-        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.SslError.hasError", codec)
+        val channel =
+            BasicMessageChannel<Any?>(
+                binaryMessenger,
+                "dev.flutter.pigeon.webview_flutter_android.SslError.hasError",
+                codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val pigeon_instanceArg = args[0] as android.net.http.SslError
             val errorArg = args[1] as SslErrorType
-            val wrapped: List<Any?> = try {
-              listOf(api.hasError(pigeon_instanceArg, errorArg))
-            } catch (exception: Throwable) {
-              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-            }
+            val wrapped: List<Any?> =
+                try {
+                  listOf(api.hasError(pigeon_instanceArg, errorArg))
+                } catch (exception: Throwable) {
+                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+                }
             reply.reply(wrapped)
           }
         } else {
@@ -5381,16 +6397,19 @@ abstract class PigeonApiSslError(open val pigeonRegistrar: AndroidWebkitLibraryP
 
   @Suppress("LocalVariableName", "FunctionName")
   /** Creates a Dart instance of SslError and attaches it to [pigeon_instanceArg]. */
-  fun pigeon_newInstance(pigeon_instanceArg: android.net.http.SslError, callback: (Result<Unit>) -> Unit)
-{
+  fun pigeon_newInstance(
+      pigeon_instanceArg: android.net.http.SslError,
+      callback: (Result<Unit>) -> Unit
+  ) {
     if (pigeonRegistrar.ignoreCallsToDart) {
       callback(
           Result.failure(
               AndroidWebKitError("ignore-calls-error", "Calls to Dart are being ignored.", "")))
-    }     else if (pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
+    } else if (pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
       callback(Result.success(Unit))
-    }     else {
-      val pigeon_identifierArg = pigeonRegistrar.instanceManager.addHostCreatedInstance(pigeon_instanceArg)
+    } else {
+      val pigeon_identifierArg =
+          pigeonRegistrar.instanceManager.addHostCreatedInstance(pigeon_instanceArg)
       val certificateArg = certificate(pigeon_instanceArg)
       val urlArg = url(pigeon_instanceArg)
       val binaryMessenger = pigeonRegistrar.binaryMessenger
@@ -5400,28 +6419,30 @@ abstract class PigeonApiSslError(open val pigeonRegistrar: AndroidWebkitLibraryP
       channel.send(listOf(pigeon_identifierArg, certificateArg, urlArg)) {
         if (it is List<*>) {
           if (it.size > 1) {
-            callback(Result.failure(AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
+            callback(
+                Result.failure(
+                    AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
           } else {
             callback(Result.success(Unit))
           }
         } else {
-          callback(Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
-        } 
+          callback(
+              Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
+        }
       }
     }
   }
-
 }
 /**
  * A distinguished name helper class.
  *
- * A 3-tuple of:
- * the most specific common name (CN)
- * the most specific organization (O)
- * the most specific organizational unit (OU)
+ * A 3-tuple of: the most specific common name (CN) the most specific organization (O) the most
+ * specific organizational unit (OU)
  */
 @Suppress("UNCHECKED_CAST")
-abstract class PigeonApiSslCertificateDName(open val pigeonRegistrar: AndroidWebkitLibraryPigeonProxyApiRegistrar) {
+abstract class PigeonApiSslCertificateDName(
+    open val pigeonRegistrar: AndroidWebkitLibraryPigeonProxyApiRegistrar
+) {
   /** The most specific Common-name (CN) component of this name. */
   abstract fun getCName(pigeon_instance: android.net.http.SslCertificate.DName): String
 
@@ -5439,16 +6460,21 @@ abstract class PigeonApiSslCertificateDName(open val pigeonRegistrar: AndroidWeb
     fun setUpMessageHandlers(binaryMessenger: BinaryMessenger, api: PigeonApiSslCertificateDName?) {
       val codec = api?.pigeonRegistrar?.codec ?: AndroidWebkitLibraryPigeonCodec()
       run {
-        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.SslCertificateDName.getCName", codec)
+        val channel =
+            BasicMessageChannel<Any?>(
+                binaryMessenger,
+                "dev.flutter.pigeon.webview_flutter_android.SslCertificateDName.getCName",
+                codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val pigeon_instanceArg = args[0] as android.net.http.SslCertificate.DName
-            val wrapped: List<Any?> = try {
-              listOf(api.getCName(pigeon_instanceArg))
-            } catch (exception: Throwable) {
-              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-            }
+            val wrapped: List<Any?> =
+                try {
+                  listOf(api.getCName(pigeon_instanceArg))
+                } catch (exception: Throwable) {
+                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+                }
             reply.reply(wrapped)
           }
         } else {
@@ -5456,16 +6482,21 @@ abstract class PigeonApiSslCertificateDName(open val pigeonRegistrar: AndroidWeb
         }
       }
       run {
-        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.SslCertificateDName.getDName", codec)
+        val channel =
+            BasicMessageChannel<Any?>(
+                binaryMessenger,
+                "dev.flutter.pigeon.webview_flutter_android.SslCertificateDName.getDName",
+                codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val pigeon_instanceArg = args[0] as android.net.http.SslCertificate.DName
-            val wrapped: List<Any?> = try {
-              listOf(api.getDName(pigeon_instanceArg))
-            } catch (exception: Throwable) {
-              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-            }
+            val wrapped: List<Any?> =
+                try {
+                  listOf(api.getDName(pigeon_instanceArg))
+                } catch (exception: Throwable) {
+                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+                }
             reply.reply(wrapped)
           }
         } else {
@@ -5473,16 +6504,21 @@ abstract class PigeonApiSslCertificateDName(open val pigeonRegistrar: AndroidWeb
         }
       }
       run {
-        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.SslCertificateDName.getOName", codec)
+        val channel =
+            BasicMessageChannel<Any?>(
+                binaryMessenger,
+                "dev.flutter.pigeon.webview_flutter_android.SslCertificateDName.getOName",
+                codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val pigeon_instanceArg = args[0] as android.net.http.SslCertificate.DName
-            val wrapped: List<Any?> = try {
-              listOf(api.getOName(pigeon_instanceArg))
-            } catch (exception: Throwable) {
-              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-            }
+            val wrapped: List<Any?> =
+                try {
+                  listOf(api.getOName(pigeon_instanceArg))
+                } catch (exception: Throwable) {
+                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+                }
             reply.reply(wrapped)
           }
         } else {
@@ -5490,16 +6526,21 @@ abstract class PigeonApiSslCertificateDName(open val pigeonRegistrar: AndroidWeb
         }
       }
       run {
-        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.SslCertificateDName.getUName", codec)
+        val channel =
+            BasicMessageChannel<Any?>(
+                binaryMessenger,
+                "dev.flutter.pigeon.webview_flutter_android.SslCertificateDName.getUName",
+                codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val pigeon_instanceArg = args[0] as android.net.http.SslCertificate.DName
-            val wrapped: List<Any?> = try {
-              listOf(api.getUName(pigeon_instanceArg))
-            } catch (exception: Throwable) {
-              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-            }
+            val wrapped: List<Any?> =
+                try {
+                  listOf(api.getUName(pigeon_instanceArg))
+                } catch (exception: Throwable) {
+                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+                }
             reply.reply(wrapped)
           }
         } else {
@@ -5511,34 +6552,40 @@ abstract class PigeonApiSslCertificateDName(open val pigeonRegistrar: AndroidWeb
 
   @Suppress("LocalVariableName", "FunctionName")
   /** Creates a Dart instance of SslCertificateDName and attaches it to [pigeon_instanceArg]. */
-  fun pigeon_newInstance(pigeon_instanceArg: android.net.http.SslCertificate.DName, callback: (Result<Unit>) -> Unit)
-{
+  fun pigeon_newInstance(
+      pigeon_instanceArg: android.net.http.SslCertificate.DName,
+      callback: (Result<Unit>) -> Unit
+  ) {
     if (pigeonRegistrar.ignoreCallsToDart) {
       callback(
           Result.failure(
               AndroidWebKitError("ignore-calls-error", "Calls to Dart are being ignored.", "")))
-    }     else if (pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
+    } else if (pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
       callback(Result.success(Unit))
-    }     else {
-      val pigeon_identifierArg = pigeonRegistrar.instanceManager.addHostCreatedInstance(pigeon_instanceArg)
+    } else {
+      val pigeon_identifierArg =
+          pigeonRegistrar.instanceManager.addHostCreatedInstance(pigeon_instanceArg)
       val binaryMessenger = pigeonRegistrar.binaryMessenger
       val codec = pigeonRegistrar.codec
-      val channelName = "dev.flutter.pigeon.webview_flutter_android.SslCertificateDName.pigeon_newInstance"
+      val channelName =
+          "dev.flutter.pigeon.webview_flutter_android.SslCertificateDName.pigeon_newInstance"
       val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
       channel.send(listOf(pigeon_identifierArg)) {
         if (it is List<*>) {
           if (it.size > 1) {
-            callback(Result.failure(AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
+            callback(
+                Result.failure(
+                    AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
           } else {
             callback(Result.success(Unit))
           }
         } else {
-          callback(Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
-        } 
+          callback(
+              Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
+        }
       }
     }
   }
-
 }
 /**
  * SSL certificate info (certificate details) class.
@@ -5546,48 +6593,56 @@ abstract class PigeonApiSslCertificateDName(open val pigeonRegistrar: AndroidWeb
  * See https://developer.android.com/reference/android/net/http/SslCertificate.
  */
 @Suppress("UNCHECKED_CAST")
-abstract class PigeonApiSslCertificate(open val pigeonRegistrar: AndroidWebkitLibraryPigeonProxyApiRegistrar) {
+abstract class PigeonApiSslCertificate(
+    open val pigeonRegistrar: AndroidWebkitLibraryPigeonProxyApiRegistrar
+) {
   /** Issued-by distinguished name or null if none has been set. */
-  abstract fun getIssuedBy(pigeon_instance: android.net.http.SslCertificate): android.net.http.SslCertificate.DName?
+  abstract fun getIssuedBy(
+      pigeon_instance: android.net.http.SslCertificate
+  ): android.net.http.SslCertificate.DName?
 
   /** Issued-to distinguished name or null if none has been set. */
-  abstract fun getIssuedTo(pigeon_instance: android.net.http.SslCertificate): android.net.http.SslCertificate.DName?
+  abstract fun getIssuedTo(
+      pigeon_instance: android.net.http.SslCertificate
+  ): android.net.http.SslCertificate.DName?
 
-  /**
-   * Not-after date from the certificate validity period or null if none has been
-   * set.
-   */
+  /** Not-after date from the certificate validity period or null if none has been set. */
   abstract fun getValidNotAfterMsSinceEpoch(pigeon_instance: android.net.http.SslCertificate): Long?
 
-  /**
-   * Not-before date from the certificate validity period or null if none has
-   * been set.
-   */
-  abstract fun getValidNotBeforeMsSinceEpoch(pigeon_instance: android.net.http.SslCertificate): Long?
+  /** Not-before date from the certificate validity period or null if none has been set. */
+  abstract fun getValidNotBeforeMsSinceEpoch(
+      pigeon_instance: android.net.http.SslCertificate
+  ): Long?
 
   /**
-   * The X509Certificate used to create this SslCertificate or null if no
-   * certificate was provided.
+   * The X509Certificate used to create this SslCertificate or null if no certificate was provided.
    *
    * Always returns null on Android versions below Q.
    */
-  abstract fun getX509Certificate(pigeon_instance: android.net.http.SslCertificate): java.security.cert.X509Certificate?
+  abstract fun getX509Certificate(
+      pigeon_instance: android.net.http.SslCertificate
+  ): java.security.cert.X509Certificate?
 
   companion object {
     @Suppress("LocalVariableName")
     fun setUpMessageHandlers(binaryMessenger: BinaryMessenger, api: PigeonApiSslCertificate?) {
       val codec = api?.pigeonRegistrar?.codec ?: AndroidWebkitLibraryPigeonCodec()
       run {
-        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.SslCertificate.getIssuedBy", codec)
+        val channel =
+            BasicMessageChannel<Any?>(
+                binaryMessenger,
+                "dev.flutter.pigeon.webview_flutter_android.SslCertificate.getIssuedBy",
+                codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val pigeon_instanceArg = args[0] as android.net.http.SslCertificate
-            val wrapped: List<Any?> = try {
-              listOf(api.getIssuedBy(pigeon_instanceArg))
-            } catch (exception: Throwable) {
-              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-            }
+            val wrapped: List<Any?> =
+                try {
+                  listOf(api.getIssuedBy(pigeon_instanceArg))
+                } catch (exception: Throwable) {
+                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+                }
             reply.reply(wrapped)
           }
         } else {
@@ -5595,16 +6650,21 @@ abstract class PigeonApiSslCertificate(open val pigeonRegistrar: AndroidWebkitLi
         }
       }
       run {
-        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.SslCertificate.getIssuedTo", codec)
+        val channel =
+            BasicMessageChannel<Any?>(
+                binaryMessenger,
+                "dev.flutter.pigeon.webview_flutter_android.SslCertificate.getIssuedTo",
+                codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val pigeon_instanceArg = args[0] as android.net.http.SslCertificate
-            val wrapped: List<Any?> = try {
-              listOf(api.getIssuedTo(pigeon_instanceArg))
-            } catch (exception: Throwable) {
-              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-            }
+            val wrapped: List<Any?> =
+                try {
+                  listOf(api.getIssuedTo(pigeon_instanceArg))
+                } catch (exception: Throwable) {
+                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+                }
             reply.reply(wrapped)
           }
         } else {
@@ -5612,16 +6672,21 @@ abstract class PigeonApiSslCertificate(open val pigeonRegistrar: AndroidWebkitLi
         }
       }
       run {
-        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.SslCertificate.getValidNotAfterMsSinceEpoch", codec)
+        val channel =
+            BasicMessageChannel<Any?>(
+                binaryMessenger,
+                "dev.flutter.pigeon.webview_flutter_android.SslCertificate.getValidNotAfterMsSinceEpoch",
+                codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val pigeon_instanceArg = args[0] as android.net.http.SslCertificate
-            val wrapped: List<Any?> = try {
-              listOf(api.getValidNotAfterMsSinceEpoch(pigeon_instanceArg))
-            } catch (exception: Throwable) {
-              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-            }
+            val wrapped: List<Any?> =
+                try {
+                  listOf(api.getValidNotAfterMsSinceEpoch(pigeon_instanceArg))
+                } catch (exception: Throwable) {
+                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+                }
             reply.reply(wrapped)
           }
         } else {
@@ -5629,16 +6694,21 @@ abstract class PigeonApiSslCertificate(open val pigeonRegistrar: AndroidWebkitLi
         }
       }
       run {
-        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.SslCertificate.getValidNotBeforeMsSinceEpoch", codec)
+        val channel =
+            BasicMessageChannel<Any?>(
+                binaryMessenger,
+                "dev.flutter.pigeon.webview_flutter_android.SslCertificate.getValidNotBeforeMsSinceEpoch",
+                codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val pigeon_instanceArg = args[0] as android.net.http.SslCertificate
-            val wrapped: List<Any?> = try {
-              listOf(api.getValidNotBeforeMsSinceEpoch(pigeon_instanceArg))
-            } catch (exception: Throwable) {
-              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-            }
+            val wrapped: List<Any?> =
+                try {
+                  listOf(api.getValidNotBeforeMsSinceEpoch(pigeon_instanceArg))
+                } catch (exception: Throwable) {
+                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+                }
             reply.reply(wrapped)
           }
         } else {
@@ -5646,16 +6716,21 @@ abstract class PigeonApiSslCertificate(open val pigeonRegistrar: AndroidWebkitLi
         }
       }
       run {
-        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.SslCertificate.getX509Certificate", codec)
+        val channel =
+            BasicMessageChannel<Any?>(
+                binaryMessenger,
+                "dev.flutter.pigeon.webview_flutter_android.SslCertificate.getX509Certificate",
+                codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val pigeon_instanceArg = args[0] as android.net.http.SslCertificate
-            val wrapped: List<Any?> = try {
-              listOf(api.getX509Certificate(pigeon_instanceArg))
-            } catch (exception: Throwable) {
-              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-            }
+            val wrapped: List<Any?> =
+                try {
+                  listOf(api.getX509Certificate(pigeon_instanceArg))
+                } catch (exception: Throwable) {
+                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+                }
             reply.reply(wrapped)
           }
         } else {
@@ -5667,34 +6742,40 @@ abstract class PigeonApiSslCertificate(open val pigeonRegistrar: AndroidWebkitLi
 
   @Suppress("LocalVariableName", "FunctionName")
   /** Creates a Dart instance of SslCertificate and attaches it to [pigeon_instanceArg]. */
-  fun pigeon_newInstance(pigeon_instanceArg: android.net.http.SslCertificate, callback: (Result<Unit>) -> Unit)
-{
+  fun pigeon_newInstance(
+      pigeon_instanceArg: android.net.http.SslCertificate,
+      callback: (Result<Unit>) -> Unit
+  ) {
     if (pigeonRegistrar.ignoreCallsToDart) {
       callback(
           Result.failure(
               AndroidWebKitError("ignore-calls-error", "Calls to Dart are being ignored.", "")))
-    }     else if (pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
+    } else if (pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
       callback(Result.success(Unit))
-    }     else {
-      val pigeon_identifierArg = pigeonRegistrar.instanceManager.addHostCreatedInstance(pigeon_instanceArg)
+    } else {
+      val pigeon_identifierArg =
+          pigeonRegistrar.instanceManager.addHostCreatedInstance(pigeon_instanceArg)
       val binaryMessenger = pigeonRegistrar.binaryMessenger
       val codec = pigeonRegistrar.codec
-      val channelName = "dev.flutter.pigeon.webview_flutter_android.SslCertificate.pigeon_newInstance"
+      val channelName =
+          "dev.flutter.pigeon.webview_flutter_android.SslCertificate.pigeon_newInstance"
       val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
       channel.send(listOf(pigeon_identifierArg)) {
         if (it is List<*>) {
           if (it.size > 1) {
-            callback(Result.failure(AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
+            callback(
+                Result.failure(
+                    AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
           } else {
             callback(Result.success(Unit))
           }
         } else {
-          callback(Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
-        } 
+          callback(
+              Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
+        }
       }
     }
   }
-
 }
 /**
  * Abstract class for managing a variety of identity certificates.
@@ -5702,7 +6783,9 @@ abstract class PigeonApiSslCertificate(open val pigeonRegistrar: AndroidWebkitLi
  * See https://developer.android.com/reference/java/security/cert/Certificate.
  */
 @Suppress("UNCHECKED_CAST")
-abstract class PigeonApiCertificate(open val pigeonRegistrar: AndroidWebkitLibraryPigeonProxyApiRegistrar) {
+abstract class PigeonApiCertificate(
+    open val pigeonRegistrar: AndroidWebkitLibraryPigeonProxyApiRegistrar
+) {
   /** The encoded form of this certificate. */
   abstract fun getEncoded(pigeon_instance: java.security.cert.Certificate): ByteArray
 
@@ -5711,16 +6794,21 @@ abstract class PigeonApiCertificate(open val pigeonRegistrar: AndroidWebkitLibra
     fun setUpMessageHandlers(binaryMessenger: BinaryMessenger, api: PigeonApiCertificate?) {
       val codec = api?.pigeonRegistrar?.codec ?: AndroidWebkitLibraryPigeonCodec()
       run {
-        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.Certificate.getEncoded", codec)
+        val channel =
+            BasicMessageChannel<Any?>(
+                binaryMessenger,
+                "dev.flutter.pigeon.webview_flutter_android.Certificate.getEncoded",
+                codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val pigeon_instanceArg = args[0] as java.security.cert.Certificate
-            val wrapped: List<Any?> = try {
-              listOf(api.getEncoded(pigeon_instanceArg))
-            } catch (exception: Throwable) {
-              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-            }
+            val wrapped: List<Any?> =
+                try {
+                  listOf(api.getEncoded(pigeon_instanceArg))
+                } catch (exception: Throwable) {
+                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+                }
             reply.reply(wrapped)
           }
         } else {
@@ -5732,16 +6820,19 @@ abstract class PigeonApiCertificate(open val pigeonRegistrar: AndroidWebkitLibra
 
   @Suppress("LocalVariableName", "FunctionName")
   /** Creates a Dart instance of Certificate and attaches it to [pigeon_instanceArg]. */
-  fun pigeon_newInstance(pigeon_instanceArg: java.security.cert.Certificate, callback: (Result<Unit>) -> Unit)
-{
+  fun pigeon_newInstance(
+      pigeon_instanceArg: java.security.cert.Certificate,
+      callback: (Result<Unit>) -> Unit
+  ) {
     if (pigeonRegistrar.ignoreCallsToDart) {
       callback(
           Result.failure(
               AndroidWebKitError("ignore-calls-error", "Calls to Dart are being ignored.", "")))
-    }     else if (pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
+    } else if (pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
       callback(Result.success(Unit))
-    }     else {
-      val pigeon_identifierArg = pigeonRegistrar.instanceManager.addHostCreatedInstance(pigeon_instanceArg)
+    } else {
+      val pigeon_identifierArg =
+          pigeonRegistrar.instanceManager.addHostCreatedInstance(pigeon_instanceArg)
       val binaryMessenger = pigeonRegistrar.binaryMessenger
       val codec = pigeonRegistrar.codec
       val channelName = "dev.flutter.pigeon.webview_flutter_android.Certificate.pigeon_newInstance"
@@ -5749,17 +6840,19 @@ abstract class PigeonApiCertificate(open val pigeonRegistrar: AndroidWebkitLibra
       channel.send(listOf(pigeon_identifierArg)) {
         if (it is List<*>) {
           if (it.size > 1) {
-            callback(Result.failure(AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
+            callback(
+                Result.failure(
+                    AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
           } else {
             callback(Result.success(Unit))
           }
         } else {
-          callback(Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
-        } 
+          callback(
+              Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
+        }
       }
     }
   }
-
 }
 /**
  * Compatibility version of `WebSettings`.
@@ -5767,7 +6860,9 @@ abstract class PigeonApiCertificate(open val pigeonRegistrar: AndroidWebkitLibra
  * See https://developer.android.com/reference/kotlin/androidx/webkit/WebSettingsCompat.
  */
 @Suppress("UNCHECKED_CAST")
-abstract class PigeonApiWebSettingsCompat(open val pigeonRegistrar: AndroidWebkitLibraryPigeonProxyApiRegistrar) {
+abstract class PigeonApiWebSettingsCompat(
+    open val pigeonRegistrar: AndroidWebkitLibraryPigeonProxyApiRegistrar
+) {
   abstract fun setPaymentRequestEnabled(webSettings: android.webkit.WebSettings, enabled: Boolean)
 
   companion object {
@@ -5775,18 +6870,23 @@ abstract class PigeonApiWebSettingsCompat(open val pigeonRegistrar: AndroidWebki
     fun setUpMessageHandlers(binaryMessenger: BinaryMessenger, api: PigeonApiWebSettingsCompat?) {
       val codec = api?.pigeonRegistrar?.codec ?: AndroidWebkitLibraryPigeonCodec()
       run {
-        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.WebSettingsCompat.setPaymentRequestEnabled", codec)
+        val channel =
+            BasicMessageChannel<Any?>(
+                binaryMessenger,
+                "dev.flutter.pigeon.webview_flutter_android.WebSettingsCompat.setPaymentRequestEnabled",
+                codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val webSettingsArg = args[0] as android.webkit.WebSettings
             val enabledArg = args[1] as Boolean
-            val wrapped: List<Any?> = try {
-              api.setPaymentRequestEnabled(webSettingsArg, enabledArg)
-              listOf(null)
-            } catch (exception: Throwable) {
-              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-            }
+            val wrapped: List<Any?> =
+                try {
+                  api.setPaymentRequestEnabled(webSettingsArg, enabledArg)
+                  listOf(null)
+                } catch (exception: Throwable) {
+                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+                }
             reply.reply(wrapped)
           }
         } else {
@@ -5798,34 +6898,40 @@ abstract class PigeonApiWebSettingsCompat(open val pigeonRegistrar: AndroidWebki
 
   @Suppress("LocalVariableName", "FunctionName")
   /** Creates a Dart instance of WebSettingsCompat and attaches it to [pigeon_instanceArg]. */
-  fun pigeon_newInstance(pigeon_instanceArg: androidx.webkit.WebSettingsCompat, callback: (Result<Unit>) -> Unit)
-{
+  fun pigeon_newInstance(
+      pigeon_instanceArg: androidx.webkit.WebSettingsCompat,
+      callback: (Result<Unit>) -> Unit
+  ) {
     if (pigeonRegistrar.ignoreCallsToDart) {
       callback(
           Result.failure(
               AndroidWebKitError("ignore-calls-error", "Calls to Dart are being ignored.", "")))
-    }     else if (pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
+    } else if (pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
       callback(Result.success(Unit))
-    }     else {
-      val pigeon_identifierArg = pigeonRegistrar.instanceManager.addHostCreatedInstance(pigeon_instanceArg)
+    } else {
+      val pigeon_identifierArg =
+          pigeonRegistrar.instanceManager.addHostCreatedInstance(pigeon_instanceArg)
       val binaryMessenger = pigeonRegistrar.binaryMessenger
       val codec = pigeonRegistrar.codec
-      val channelName = "dev.flutter.pigeon.webview_flutter_android.WebSettingsCompat.pigeon_newInstance"
+      val channelName =
+          "dev.flutter.pigeon.webview_flutter_android.WebSettingsCompat.pigeon_newInstance"
       val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
       channel.send(listOf(pigeon_identifierArg)) {
         if (it is List<*>) {
           if (it.size > 1) {
-            callback(Result.failure(AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
+            callback(
+                Result.failure(
+                    AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
           } else {
             callback(Result.success(Unit))
           }
         } else {
-          callback(Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
-        } 
+          callback(
+              Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
+        }
       }
     }
   }
-
 }
 /**
  * Utility class for checking which WebView Support Library features are supported on the device.
@@ -5833,7 +6939,9 @@ abstract class PigeonApiWebSettingsCompat(open val pigeonRegistrar: AndroidWebki
  * See https://developer.android.com/reference/kotlin/androidx/webkit/WebViewFeature.
  */
 @Suppress("UNCHECKED_CAST")
-abstract class PigeonApiWebViewFeature(open val pigeonRegistrar: AndroidWebkitLibraryPigeonProxyApiRegistrar) {
+abstract class PigeonApiWebViewFeature(
+    open val pigeonRegistrar: AndroidWebkitLibraryPigeonProxyApiRegistrar
+) {
   abstract fun isFeatureSupported(feature: String): Boolean
 
   companion object {
@@ -5841,16 +6949,21 @@ abstract class PigeonApiWebViewFeature(open val pigeonRegistrar: AndroidWebkitLi
     fun setUpMessageHandlers(binaryMessenger: BinaryMessenger, api: PigeonApiWebViewFeature?) {
       val codec = api?.pigeonRegistrar?.codec ?: AndroidWebkitLibraryPigeonCodec()
       run {
-        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.webview_flutter_android.WebViewFeature.isFeatureSupported", codec)
+        val channel =
+            BasicMessageChannel<Any?>(
+                binaryMessenger,
+                "dev.flutter.pigeon.webview_flutter_android.WebViewFeature.isFeatureSupported",
+                codec)
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
             val featureArg = args[0] as String
-            val wrapped: List<Any?> = try {
-              listOf(api.isFeatureSupported(featureArg))
-            } catch (exception: Throwable) {
-              AndroidWebkitLibraryPigeonUtils.wrapError(exception)
-            }
+            val wrapped: List<Any?> =
+                try {
+                  listOf(api.isFeatureSupported(featureArg))
+                } catch (exception: Throwable) {
+                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+                }
             reply.reply(wrapped)
           }
         } else {
@@ -5862,32 +6975,38 @@ abstract class PigeonApiWebViewFeature(open val pigeonRegistrar: AndroidWebkitLi
 
   @Suppress("LocalVariableName", "FunctionName")
   /** Creates a Dart instance of WebViewFeature and attaches it to [pigeon_instanceArg]. */
-  fun pigeon_newInstance(pigeon_instanceArg: androidx.webkit.WebViewFeature, callback: (Result<Unit>) -> Unit)
-{
+  fun pigeon_newInstance(
+      pigeon_instanceArg: androidx.webkit.WebViewFeature,
+      callback: (Result<Unit>) -> Unit
+  ) {
     if (pigeonRegistrar.ignoreCallsToDart) {
       callback(
           Result.failure(
               AndroidWebKitError("ignore-calls-error", "Calls to Dart are being ignored.", "")))
-    }     else if (pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
+    } else if (pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
       callback(Result.success(Unit))
-    }     else {
-      val pigeon_identifierArg = pigeonRegistrar.instanceManager.addHostCreatedInstance(pigeon_instanceArg)
+    } else {
+      val pigeon_identifierArg =
+          pigeonRegistrar.instanceManager.addHostCreatedInstance(pigeon_instanceArg)
       val binaryMessenger = pigeonRegistrar.binaryMessenger
       val codec = pigeonRegistrar.codec
-      val channelName = "dev.flutter.pigeon.webview_flutter_android.WebViewFeature.pigeon_newInstance"
+      val channelName =
+          "dev.flutter.pigeon.webview_flutter_android.WebViewFeature.pigeon_newInstance"
       val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
       channel.send(listOf(pigeon_identifierArg)) {
         if (it is List<*>) {
           if (it.size > 1) {
-            callback(Result.failure(AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
+            callback(
+                Result.failure(
+                    AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
           } else {
             callback(Result.success(Unit))
           }
         } else {
-          callback(Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
-        } 
+          callback(
+              Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
+        }
       }
     }
   }
-
 }

--- a/packages/webview_flutter/webview_flutter_android/android/src/main/java/io/flutter/plugins/webviewflutter/WebChromeClientProxyApi.java
+++ b/packages/webview_flutter/webview_flutter_android/android/src/main/java/io/flutter/plugins/webviewflutter/WebChromeClientProxyApi.java
@@ -274,13 +274,18 @@ public class WebChromeClientProxyApi extends PigeonApiWebChromeClient {
         return false;
       }
 
+      // Forward new-window navigations (`target=_blank` / `window.open`) to Dart
+      // via onCreateWindow — same role as WebChromeClient.onCreateWindow.
       final WebViewClient windowWebViewClient =
           new WebViewClient() {
             @Override
             public boolean shouldOverrideUrlLoading(
                 @NonNull WebView windowWebView, @NonNull WebResourceRequest request) {
-              if (!webViewClient.shouldOverrideUrlLoading(view, request)) {
-                view.loadUrl(request.getUrl().toString());
+              final String url = request.getUrl().toString();
+              if (webViewClient instanceof WebViewClientProxyApi.WebViewClientImpl) {
+                ((WebViewClientProxyApi.WebViewClientImpl) webViewClient).notifyCreateWindow(url);
+              } else if (!webViewClient.shouldOverrideUrlLoading(view, request)) {
+                view.loadUrl(url);
               }
               return true;
             }

--- a/packages/webview_flutter/webview_flutter_android/android/src/main/java/io/flutter/plugins/webviewflutter/WebViewClientProxyApi.java
+++ b/packages/webview_flutter/webview_flutter_android/android/src/main/java/io/flutter/plugins/webviewflutter/WebViewClientProxyApi.java
@@ -35,6 +35,15 @@ public class WebViewClientProxyApi extends PigeonApiWebViewClient {
       this.api = api;
     }
 
+    /**
+     * Notifies Dart that the page requested a new window (`target=_blank` /
+     * `window.open`).
+     */
+    public void notifyCreateWindow(@NonNull String url) {
+      api.getPigeonRegistrar()
+          .runOnMainThread(() -> api.onCreateWindow(this, url, reply -> null));
+    }
+
     @Override
     public void onPageStarted(@NonNull WebView view, @NonNull String url, @NonNull Bitmap favicon) {
       api.getPigeonRegistrar()

--- a/packages/webview_flutter/webview_flutter_android/android/src/main/java/io/flutter/plugins/webviewflutter/WebViewClientProxyApi.java
+++ b/packages/webview_flutter/webview_flutter_android/android/src/main/java/io/flutter/plugins/webviewflutter/WebViewClientProxyApi.java
@@ -35,13 +35,9 @@ public class WebViewClientProxyApi extends PigeonApiWebViewClient {
       this.api = api;
     }
 
-    /**
-     * Notifies Dart that the page requested a new window (`target=_blank` /
-     * `window.open`).
-     */
+    /** Notifies Dart that the page requested a new window (`target=_blank` / `window.open`). */
     public void notifyCreateWindow(@NonNull String url) {
-      api.getPigeonRegistrar()
-          .runOnMainThread(() -> api.onCreateWindow(this, url, reply -> null));
+      api.getPigeonRegistrar().runOnMainThread(() -> api.onCreateWindow(this, url, reply -> null));
     }
 
     @Override

--- a/packages/webview_flutter/webview_flutter_android/android/src/test/java/io/flutter/plugins/webviewflutter/WebChromeClientTest.java
+++ b/packages/webview_flutter/webview_flutter_android/android/src/test/java/io/flutter/plugins/webviewflutter/WebChromeClientTest.java
@@ -90,6 +90,42 @@ public class WebChromeClientTest {
   }
 
   @Test
+  public void onCreateWindowWithWebViewClientImplNotifiesDart() {
+    final WebViewClientProxyApi mockWebViewClientApi = mock(WebViewClientProxyApi.class);
+    when(mockWebViewClientApi.getPigeonRegistrar()).thenReturn(new TestProxyApiRegistrar());
+    final WebViewClientProxyApi.WebViewClientImpl webViewClient =
+        new WebViewClientProxyApi.WebViewClientImpl(mockWebViewClientApi);
+
+    final WebView mockOnCreateWindowWebView = mock(WebView.class);
+    final Message message = new Message();
+    message.obj = mock(WebViewTransport.class);
+
+    final WebChromeClientProxyApi mockApi = mock(WebChromeClientProxyApi.class);
+    final WebChromeClientImpl instance = new WebChromeClientImpl(mockApi);
+
+    final WebView mockWebView = mock(WebView.class);
+    instance.setWebViewClient(webViewClient);
+    assertTrue(instance.onCreateWindow(mockWebView, message, mockOnCreateWindowWebView));
+
+    final ArgumentCaptor<WebViewClient> webViewClientCaptor =
+        ArgumentCaptor.forClass(WebViewClient.class);
+    verify(mockOnCreateWindowWebView).setWebViewClient(webViewClientCaptor.capture());
+    final WebViewClient onCreateWindowWebViewClient = webViewClientCaptor.getValue();
+    assertNotNull(onCreateWindowWebViewClient);
+
+    final WebResourceRequest mockRequest = mock(WebResourceRequest.class);
+    when(mockRequest.getUrl()).thenReturn(mock(Uri.class));
+    when(mockRequest.getUrl().toString()).thenReturn("https://www.google.com");
+
+    assertTrue(
+        onCreateWindowWebViewClient.shouldOverrideUrlLoading(
+            mockOnCreateWindowWebView, mockRequest));
+    verify(mockWebViewClientApi)
+        .onCreateWindow(eq(webViewClient), eq("https://www.google.com"), any());
+    verify(mockWebView, never()).loadUrl(any());
+  }
+
+  @Test
   public void onPermissionRequest() {
     final WebChromeClientProxyApi mockApi = mock(WebChromeClientProxyApi.class);
     when(mockApi.getPigeonRegistrar()).thenReturn(new TestProxyApiRegistrar());

--- a/packages/webview_flutter/webview_flutter_android/android/src/test/java/io/flutter/plugins/webviewflutter/WebViewClientTest.java
+++ b/packages/webview_flutter/webview_flutter_android/android/src/test/java/io/flutter/plugins/webviewflutter/WebViewClientTest.java
@@ -38,6 +38,18 @@ public class WebViewClientTest {
   }
 
   @Test
+  public void onCreateWindow() {
+    final WebViewClientProxyApi mockApi = mock(WebViewClientProxyApi.class);
+    when(mockApi.getPigeonRegistrar()).thenReturn(new TestProxyApiRegistrar());
+
+    final WebViewClientImpl instance = new WebViewClientImpl(mockApi);
+    final String url = "https://www.google.com";
+    instance.notifyCreateWindow(url);
+
+    verify(mockApi).onCreateWindow(eq(instance), eq(url), any());
+  }
+
+  @Test
   public void onReceivedError() {
     final WebViewClientProxyApi mockApi = mock(WebViewClientProxyApi.class);
     when(mockApi.getPigeonRegistrar()).thenReturn(new TestProxyApiRegistrar());

--- a/packages/webview_flutter/webview_flutter_android/example/integration_test/webview_flutter_test_legacy.dart
+++ b/packages/webview_flutter/webview_flutter_android/example/integration_test/webview_flutter_test_legacy.dart
@@ -101,26 +101,28 @@ Future<void> main() async {
     );
   });
 
-  testWidgets('withWeakRefenceTo allows encapsulating class to be garbage collected', (
-    WidgetTester tester,
-  ) async {
-    final gcCompleter = Completer<int>();
-    final instanceManager = android.PigeonInstanceManager(
-      onWeakReferenceRemoved: gcCompleter.complete,
-    );
+  testWidgets(
+    'withWeakRefenceTo allows encapsulating class to be garbage collected',
+    (WidgetTester tester) async {
+      final gcCompleter = Completer<int>();
+      final instanceManager = android.PigeonInstanceManager(
+        onWeakReferenceRemoved: gcCompleter.complete,
+      );
 
-    ClassWithCallbackClass? instance = ClassWithCallbackClass();
-    instanceManager.addHostCreatedInstance(instance.callbackClass, 0);
-    instance = null;
+      ClassWithCallbackClass? instance = ClassWithCallbackClass();
+      instanceManager.addHostCreatedInstance(instance.callbackClass, 0);
+      instance = null;
 
-    // Force garbage collection.
-    await IntegrationTestWidgetsFlutterBinding.instance.watchPerformance(() async {
-      await tester.pumpAndSettle();
-    });
+      // Force garbage collection.
+      await IntegrationTestWidgetsFlutterBinding.instance.watchPerformance(() async {
+        await tester.pumpAndSettle();
+      });
 
-    final int gcIdentifier = await gcCompleter.future;
-    expect(gcIdentifier, 0);
-  }, timeout: const Timeout(Duration(seconds: 10)));
+      final int gcIdentifier = await gcCompleter.future;
+      expect(gcIdentifier, 0);
+    },
+    timeout: const Timeout(Duration(seconds: 10)),
+  );
 
   // TODO(bparrishMines): This test is skipped because of
   // https://github.com/flutter/flutter/issues/123327

--- a/packages/webview_flutter/webview_flutter_android/example/pubspec.yaml
+++ b/packages/webview_flutter/webview_flutter_android/example/pubspec.yaml
@@ -33,3 +33,7 @@ flutter:
     - assets/sample_video.mp4
     - assets/www/index.html
     - assets/www/styles/style.css
+# FOR TESTING AND INITIAL REVIEW ONLY. DO NOT MERGE.
+# See https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changing-federated-plugins
+dependency_overrides:
+  webview_flutter_platform_interface: {path: ../../../../packages/webview_flutter/webview_flutter_platform_interface}

--- a/packages/webview_flutter/webview_flutter_android/lib/src/android_webkit.g.dart
+++ b/packages/webview_flutter/webview_flutter_android/lib/src/android_webkit.g.dart
@@ -15,9 +15,9 @@ import 'package:flutter/widgets.dart' show WidgetsFlutterBinding;
 import 'package:meta/meta.dart' show immutable, protected, visibleForTesting;
 
 Object? _extractReplyValueOrThrow(
-  List<Object?>? replyList,
-  String channelName, {
-  required bool isNullValid,
+    List<Object?>? replyList,
+    String channelName, {
+    required bool isNullValid,
 }) {
   if (replyList == null) {
     throw PlatformException(
@@ -39,6 +39,7 @@ Object? _extractReplyValueOrThrow(
   return replyList.firstOrNull;
 }
 
+
 List<Object?> wrapResponse({Object? result, PlatformException? error, bool empty = false}) {
   if (empty) {
     return <Object?>[];
@@ -48,7 +49,6 @@ List<Object?> wrapResponse({Object? result, PlatformException? error, bool empty
   }
   return <Object?>[error.code, error.message, error.details];
 }
-
 /// Provides overrides for the constructors and static members of each
 /// Dart proxy class.
 ///
@@ -59,102 +59,133 @@ List<Object?> wrapResponse({Object? result, PlatformException? error, bool empty
 @visibleForTesting
 class PigeonOverrides {
   /// Overrides [WebView.new].
-  static WebView Function({
-    void Function(WebView pigeon_instance, int left, int top, int oldLeft, int oldTop)?
-    onScrollChanged,
-  })?
-  webView_new;
+  static WebView Function(
+      {void Function(
+        WebView pigeon_instance,
+        int left,
+        int top,
+        int oldLeft,
+        int oldTop,
+      )? onScrollChanged})? webView_new;
 
   /// Overrides [JavaScriptChannel.new].
   static JavaScriptChannel Function({
     required String channelName,
-    required void Function(JavaScriptChannel pigeon_instance, String message) postMessage,
-  })?
-  javaScriptChannel_new;
+    required void Function(
+      JavaScriptChannel pigeon_instance,
+      String message,
+    ) postMessage,
+  })? javaScriptChannel_new;
 
   /// Overrides [WebViewClient.new].
   static WebViewClient Function({
-    void Function(WebViewClient pigeon_instance, WebView webView, String url)? onPageStarted,
-    void Function(WebViewClient pigeon_instance, WebView webView, String url)? onPageFinished,
+    void Function(
+      WebViewClient pigeon_instance,
+      WebView webView,
+      String url,
+    )? onPageStarted,
+    void Function(
+      WebViewClient pigeon_instance,
+      WebView webView,
+      String url,
+    )? onPageFinished,
     void Function(
       WebViewClient pigeon_instance,
       WebView webView,
       WebResourceRequest request,
       WebResourceResponse response,
-    )?
-    onReceivedHttpError,
+    )? onReceivedHttpError,
     void Function(
       WebViewClient pigeon_instance,
       WebView webView,
       WebResourceRequest request,
       WebResourceError error,
-    )?
-    onReceivedRequestError,
+    )? onReceivedRequestError,
     void Function(
       WebViewClient pigeon_instance,
       WebView webView,
       WebResourceRequest request,
       WebResourceErrorCompat error,
-    )?
-    onReceivedRequestErrorCompat,
-    void Function(WebViewClient pigeon_instance, WebView webView, WebResourceRequest request)?
-    requestLoading,
-    void Function(WebViewClient pigeon_instance, String url)? onCreateWindow,
-    void Function(WebViewClient pigeon_instance, WebView webView, String url)? urlLoading,
-    void Function(WebViewClient pigeon_instance, WebView webView, String url, bool isReload)?
-    doUpdateVisitedHistory,
+    )? onReceivedRequestErrorCompat,
+    void Function(
+      WebViewClient pigeon_instance,
+      WebView webView,
+      WebResourceRequest request,
+    )? requestLoading,
+    void Function(
+      WebViewClient pigeon_instance,
+      WebView webView,
+      String url,
+    )? urlLoading,
+    void Function(
+      WebViewClient pigeon_instance,
+      String url,
+    )? onCreateWindow,
+    void Function(
+      WebViewClient pigeon_instance,
+      WebView webView,
+      String url,
+      bool isReload,
+    )? doUpdateVisitedHistory,
     void Function(
       WebViewClient pigeon_instance,
       WebView webView,
       HttpAuthHandler handler,
       String host,
       String realm,
-    )?
-    onReceivedHttpAuthRequest,
+    )? onReceivedHttpAuthRequest,
     void Function(
       WebViewClient pigeon_instance,
       WebView view,
       AndroidMessage dontResend,
       AndroidMessage resend,
-    )?
-    onFormResubmission,
-    void Function(WebViewClient pigeon_instance, WebView view, String url)? onLoadResource,
-    void Function(WebViewClient pigeon_instance, WebView view, String url)? onPageCommitVisible,
-    void Function(WebViewClient pigeon_instance, WebView view, ClientCertRequest request)?
-    onReceivedClientCertRequest,
+    )? onFormResubmission,
+    void Function(
+      WebViewClient pigeon_instance,
+      WebView view,
+      String url,
+    )? onLoadResource,
+    void Function(
+      WebViewClient pigeon_instance,
+      WebView view,
+      String url,
+    )? onPageCommitVisible,
+    void Function(
+      WebViewClient pigeon_instance,
+      WebView view,
+      ClientCertRequest request,
+    )? onReceivedClientCertRequest,
     void Function(
       WebViewClient pigeon_instance,
       WebView view,
       String realm,
       String? account,
       String args,
-    )?
-    onReceivedLoginRequest,
+    )? onReceivedLoginRequest,
     void Function(
       WebViewClient pigeon_instance,
       WebView view,
       SslErrorHandler handler,
       SslError error,
-    )?
-    onReceivedSslError,
-    void Function(WebViewClient pigeon_instance, WebView view, double oldScale, double newScale)?
-    onScaleChanged,
-  })?
-  webViewClient_new;
+    )? onReceivedSslError,
+    void Function(
+      WebViewClient pigeon_instance,
+      WebView view,
+      double oldScale,
+      double newScale,
+    )? onScaleChanged,
+  })? webViewClient_new;
 
   /// Overrides [DownloadListener.new].
-  static DownloadListener Function({
-    required void Function(
-      DownloadListener pigeon_instance,
-      String url,
-      String userAgent,
-      String contentDisposition,
-      String mimetype,
-      int contentLength,
-    )
-    onDownloadStart,
-  })?
-  downloadListener_new;
+  static DownloadListener Function(
+      {required void Function(
+        DownloadListener pigeon_instance,
+        String url,
+        String userAgent,
+        String contentDisposition,
+        String mimetype,
+        int contentLength,
+      ) onDownloadStart})? downloadListener_new;
 
   /// Overrides [WebChromeClient.new].
   static WebChromeClient Function({
@@ -162,46 +193,53 @@ class PigeonOverrides {
       WebChromeClient pigeon_instance,
       WebView webView,
       FileChooserParams params,
-    )
-    onShowFileChooser,
+    ) onShowFileChooser,
     required Future<bool> Function(
       WebChromeClient pigeon_instance,
       WebView webView,
       String url,
       String message,
-    )
-    onJsConfirm,
-    void Function(WebChromeClient pigeon_instance, WebView webView, int progress)?
-    onProgressChanged,
-    void Function(WebChromeClient pigeon_instance, PermissionRequest request)? onPermissionRequest,
-    void Function(WebChromeClient pigeon_instance, View view, CustomViewCallback callback)?
-    onShowCustomView,
+    ) onJsConfirm,
+    void Function(
+      WebChromeClient pigeon_instance,
+      WebView webView,
+      int progress,
+    )? onProgressChanged,
+    void Function(
+      WebChromeClient pigeon_instance,
+      PermissionRequest request,
+    )? onPermissionRequest,
+    void Function(
+      WebChromeClient pigeon_instance,
+      View view,
+      CustomViewCallback callback,
+    )? onShowCustomView,
     void Function(WebChromeClient pigeon_instance)? onHideCustomView,
     void Function(
       WebChromeClient pigeon_instance,
       String origin,
       GeolocationPermissionsCallback callback,
-    )?
-    onGeolocationPermissionsShowPrompt,
-    void Function(WebChromeClient pigeon_instance)? onGeolocationPermissionsHidePrompt,
-    void Function(WebChromeClient pigeon_instance, ConsoleMessage message)? onConsoleMessage,
+    )? onGeolocationPermissionsShowPrompt,
+    void Function(WebChromeClient pigeon_instance)?
+        onGeolocationPermissionsHidePrompt,
+    void Function(
+      WebChromeClient pigeon_instance,
+      ConsoleMessage message,
+    )? onConsoleMessage,
     Future<void> Function(
       WebChromeClient pigeon_instance,
       WebView webView,
       String url,
       String message,
-    )?
-    onJsAlert,
+    )? onJsAlert,
     Future<String?> Function(
       WebChromeClient pigeon_instance,
       WebView webView,
       String url,
       String message,
       String defaultValue,
-    )?
-    onJsPrompt,
-  })?
-  webChromeClient_new;
+    )? onJsPrompt,
+  })? webChromeClient_new;
 
   /// Overrides [CookieManager.instance].
   static CookieManager? cookieManager_instance;
@@ -216,7 +254,10 @@ class PigeonOverrides {
   static Future<void> Function(bool)? webView_setWebContentsDebuggingEnabled;
 
   /// Overrides [WebSettingsCompat.setPaymentRequestEnabled].
-  static Future<void> Function(WebSettings, bool)? webSettingsCompat_setPaymentRequestEnabled;
+  static Future<void> Function(
+    WebSettings,
+    bool,
+  )? webSettingsCompat_setPaymentRequestEnabled;
 
   /// Overrides [WebViewFeature.isFeatureSupported].
   static Future<bool> Function(String)? webViewFeature_isFeatureSupported;
@@ -248,7 +289,8 @@ abstract class PigeonInternalProxyApiBaseClass {
   PigeonInternalProxyApiBaseClass({
     this.pigeon_binaryMessenger,
     PigeonInstanceManager? pigeon_instanceManager,
-  }) : pigeon_instanceManager = pigeon_instanceManager ?? PigeonInstanceManager.instance;
+  }) : pigeon_instanceManager =
+            pigeon_instanceManager ?? PigeonInstanceManager.instance;
 
   /// Sends and receives binary data across the Flutter platform barrier.
   ///
@@ -320,8 +362,7 @@ class PigeonInstanceManager {
   final Expando<int> _identifiers = Expando<int>();
   final Map<int, WeakReference<PigeonInternalProxyApiBaseClass>> _weakInstances =
       <int, WeakReference<PigeonInternalProxyApiBaseClass>>{};
-  final Map<int, PigeonInternalProxyApiBaseClass> _strongInstances =
-      <int, PigeonInternalProxyApiBaseClass>{};
+  final Map<int, PigeonInternalProxyApiBaseClass> _strongInstances = <int, PigeonInternalProxyApiBaseClass>{};
   late final Finalizer<int> _finalizer;
   int _nextIdentifier = 0;
 
@@ -362,9 +403,7 @@ class PigeonInstanceManager {
     PermissionRequest.pigeon_setUpMessageHandlers(pigeon_instanceManager: instanceManager);
     CustomViewCallback.pigeon_setUpMessageHandlers(pigeon_instanceManager: instanceManager);
     View.pigeon_setUpMessageHandlers(pigeon_instanceManager: instanceManager);
-    GeolocationPermissionsCallback.pigeon_setUpMessageHandlers(
-      pigeon_instanceManager: instanceManager,
-    );
+    GeolocationPermissionsCallback.pigeon_setUpMessageHandlers(pigeon_instanceManager: instanceManager);
     HttpAuthHandler.pigeon_setUpMessageHandlers(pigeon_instanceManager: instanceManager);
     AndroidMessage.pigeon_setUpMessageHandlers(pigeon_instanceManager: instanceManager);
     ClientCertRequest.pigeon_setUpMessageHandlers(pigeon_instanceManager: instanceManager);
@@ -393,7 +432,8 @@ class PigeonInstanceManager {
 
     final int identifier = _nextUniqueIdentifier();
     _identifiers[instance] = identifier;
-    _weakInstances[identifier] = WeakReference<PigeonInternalProxyApiBaseClass>(instance);
+    _weakInstances[identifier] =
+        WeakReference<PigeonInternalProxyApiBaseClass>(instance);
     _finalizer.attach(instance, identifier, detach: instance);
 
     final PigeonInternalProxyApiBaseClass copy = instance.pigeon_copy();
@@ -495,7 +535,8 @@ class PigeonInstanceManager {
 
   /// Whether this manager contains the given [identifier].
   bool containsIdentifier(int identifier) {
-    return _weakInstances.containsKey(identifier) || _strongInstances.containsKey(identifier);
+    return _weakInstances.containsKey(identifier) ||
+        _strongInstances.containsKey(identifier);
   }
 
   int _nextUniqueIdentifier() {
@@ -512,7 +553,7 @@ class PigeonInstanceManager {
 class _PigeonInternalInstanceManagerApi {
   /// Constructor for [_PigeonInternalInstanceManagerApi].
   _PigeonInternalInstanceManagerApi({BinaryMessenger? binaryMessenger})
-    : pigeonVar_binaryMessenger = binaryMessenger;
+      : pigeonVar_binaryMessenger = binaryMessenger;
 
   final BinaryMessenger? pigeonVar_binaryMessenger;
 
@@ -525,10 +566,9 @@ class _PigeonInternalInstanceManagerApi {
   }) {
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-        'dev.flutter.pigeon.webview_flutter_android.PigeonInternalInstanceManager.removeStrongReference',
-        pigeonChannelCodec,
-        binaryMessenger: binaryMessenger,
-      );
+          'dev.flutter.pigeon.webview_flutter_android.PigeonInternalInstanceManager.removeStrongReference',
+          pigeonChannelCodec,
+          binaryMessenger: binaryMessenger);
       if (pigeon_clearHandlers) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
@@ -536,14 +576,14 @@ class _PigeonInternalInstanceManagerApi {
           final List<Object?> args = message! as List<Object?>;
           final int arg_identifier = args[0]! as int;
           try {
-            (instanceManager ?? PigeonInstanceManager.instance).remove(arg_identifier);
+            (instanceManager ?? PigeonInstanceManager.instance)
+                .remove(arg_identifier);
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
           } catch (e) {
             return wrapResponse(
-              error: PlatformException(code: 'error', message: e.toString()),
-            );
+                error: PlatformException(code: 'error', message: e.toString()));
           }
         });
       }
@@ -558,10 +598,15 @@ class _PigeonInternalInstanceManagerApi {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[identifier]);
+    final Future<Object?> pigeonVar_sendFuture =
+        pigeonVar_channel.send(<Object?>[identifier]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
-    _extractReplyValueOrThrow(pigeonVar_replyList, pigeonVar_channelName, isNullValid: true);
+    _extractReplyValueOrThrow(
+      pigeonVar_replyList,
+      pigeonVar_channelName,
+      isNullValid: true,
+    );
   }
 
   /// Clear the native `PigeonInstanceManager`.
@@ -578,33 +623,38 @@ class _PigeonInternalInstanceManagerApi {
     final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(null);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
-    _extractReplyValueOrThrow(pigeonVar_replyList, pigeonVar_channelName, isNullValid: true);
+    _extractReplyValueOrThrow(
+      pigeonVar_replyList,
+      pigeonVar_channelName,
+      isNullValid: true,
+    );
   }
 }
 
 class _PigeonInternalProxyApiBaseCodec extends _PigeonCodec {
-  const _PigeonInternalProxyApiBaseCodec(this.instanceManager);
-  final PigeonInstanceManager instanceManager;
-  @override
-  void writeValue(WriteBuffer buffer, Object? value) {
-    if (value is PigeonInternalProxyApiBaseClass) {
-      buffer.putUint8(128);
-      writeValue(buffer, instanceManager.getIdentifier(value));
-    } else {
-      super.writeValue(buffer, value);
-    }
-  }
-
-  @override
-  Object? readValueOfType(int type, ReadBuffer buffer) {
-    switch (type) {
-      case 128:
-        return instanceManager.getInstanceWithWeakReference(readValue(buffer)! as int);
-      default:
-        return super.readValueOfType(type, buffer);
-    }
-  }
+ const _PigeonInternalProxyApiBaseCodec(this.instanceManager);
+ final PigeonInstanceManager instanceManager;
+ @override
+ void writeValue(WriteBuffer buffer, Object? value) {
+   if (value is PigeonInternalProxyApiBaseClass) {
+     buffer.putUint8(128);
+     writeValue(buffer, instanceManager.getIdentifier(value));
+   } else {
+     super.writeValue(buffer, value);
+   }
+ }
+ @override
+ Object? readValueOfType(int type, ReadBuffer buffer) {
+   switch (type) {
+     case 128:
+       return instanceManager
+           .getInstanceWithWeakReference(readValue(buffer)! as int);
+     default:
+       return super.readValueOfType(type, buffer);
+   }
+ }
 }
+
 
 /// Mode of how to select files for a file chooser.
 ///
@@ -615,17 +665,14 @@ enum FileChooserMode {
   ///
   /// See https://developer.android.com/reference/android/webkit/WebChromeClient.FileChooserParams#MODE_OPEN.
   open,
-
   /// Similar to [open] but allows multiple files to be selected.
   ///
   /// See https://developer.android.com/reference/android/webkit/WebChromeClient.FileChooserParams#MODE_OPEN_MULTIPLE.
   openMultiple,
-
   /// Allows picking a nonexistent file and saving it.
   ///
   /// See https://developer.android.com/reference/android/webkit/WebChromeClient.FileChooserParams#MODE_SAVE.
   save,
-
   /// Indicates a `FileChooserMode` with an unknown mode.
   ///
   /// This does not represent an actual value provided by the platform and only
@@ -641,27 +688,22 @@ enum ConsoleMessageLevel {
   ///
   /// See https://developer.android.com/reference/android/webkit/ConsoleMessage.MessageLevel#DEBUG.
   debug,
-
   /// Indicates a message is provided as an error.
   ///
   /// See https://developer.android.com/reference/android/webkit/ConsoleMessage.MessageLevel#ERROR.
   error,
-
   /// Indicates a message is provided as a basic log message.
   ///
   /// See https://developer.android.com/reference/android/webkit/ConsoleMessage.MessageLevel#LOG.
   log,
-
   /// Indicates a message is provided as a tip.
   ///
   /// See https://developer.android.com/reference/android/webkit/ConsoleMessage.MessageLevel#TIP.
   tip,
-
   /// Indicates a message is provided as a warning.
   ///
   /// See https://developer.android.com/reference/android/webkit/ConsoleMessage.MessageLevel#WARNING.
   warning,
-
   /// Indicates a message with an unknown level.
   ///
   /// This does not represent an actual value provided by the platform and only
@@ -676,14 +718,11 @@ enum OverScrollMode {
   /// Always allow a user to over-scroll this view, provided it is a view that
   /// can scroll.
   always,
-
   /// Allow a user to over-scroll this view only if the content is large enough
   /// to meaningfully scroll, provided it is a view that can scroll.
   ifContentScrolls,
-
   /// Never allow a user to over-scroll this view.
   never,
-
   /// The type is not recognized by this wrapper.
   unknown,
 }
@@ -694,22 +733,16 @@ enum OverScrollMode {
 enum SslErrorType {
   /// The date of the certificate is invalid.
   dateInvalid,
-
   /// The certificate has expired.
   expired,
-
   /// Hostname mismatch.
   idMismatch,
-
   /// A generic error occurred.
   invalid,
-
   /// The certificate is not yet valid.
   notYetValid,
-
   /// The certificate authority is not trusted.
   untrusted,
-
   /// The type is not recognized by this wrapper.
   unknown,
 }
@@ -721,11 +754,9 @@ enum MixedContentMode {
   /// The WebView will allow a secure origin to load content from any other
   /// origin, even if that origin is insecure.
   alwaysAllow,
-
   /// The WebView will attempt to be compatible with the approach of a modern
   /// web browser with regard to mixed content.
   compatibilityMode,
-
   /// The WebView will not allow a secure origin to load content from an
   /// insecure origin.
   neverAllow,
@@ -740,23 +771,17 @@ enum WindowInsetsType {
   /// Includes statusBars(), captionBar() as well as navigationBars(),
   /// systemOverlays(), but not ime().
   systemBars,
-
   /// An inset type representing the area that used by DisplayCutout.
   displayCutout,
-
   /// An insets type representing the window of a caption bar.
   captionBar,
-
   /// An insets type representing the window of an InputMethod.
   ime,
   mandatorySystemGestures,
-
   /// An insets type representing any system bars for navigation.
   navigationBars,
-
   /// An insets type representing any system bars for displaying status.
   statusBars,
-
   /// An insets type representing the system gesture insets.
   ///
   /// The system gesture insets represent the area of a window where system
@@ -767,6 +792,7 @@ enum WindowInsetsType {
   tappableElement,
 }
 
+
 class _PigeonCodec extends StandardMessageCodec {
   const _PigeonCodec();
   @override
@@ -774,22 +800,22 @@ class _PigeonCodec extends StandardMessageCodec {
     if (value is int) {
       buffer.putUint8(4);
       buffer.putInt64(value);
-    } else if (value is FileChooserMode) {
+    }    else if (value is FileChooserMode) {
       buffer.putUint8(129);
       writeValue(buffer, value.index);
-    } else if (value is ConsoleMessageLevel) {
+    }    else if (value is ConsoleMessageLevel) {
       buffer.putUint8(130);
       writeValue(buffer, value.index);
-    } else if (value is OverScrollMode) {
+    }    else if (value is OverScrollMode) {
       buffer.putUint8(131);
       writeValue(buffer, value.index);
-    } else if (value is SslErrorType) {
+    }    else if (value is SslErrorType) {
       buffer.putUint8(132);
       writeValue(buffer, value.index);
-    } else if (value is MixedContentMode) {
+    }    else if (value is MixedContentMode) {
       buffer.putUint8(133);
       writeValue(buffer, value.index);
-    } else if (value is WindowInsetsType) {
+    }    else if (value is WindowInsetsType) {
       buffer.putUint8(134);
       writeValue(buffer, value.index);
     } else {
@@ -823,7 +849,6 @@ class _PigeonCodec extends StandardMessageCodec {
     }
   }
 }
-
 /// Encompasses parameters to the `WebViewClient.shouldInterceptRequest` method.
 ///
 /// See https://developer.android.com/reference/android/webkit/WebResourceRequest.
@@ -873,19 +898,17 @@ class WebResourceRequest extends PigeonInternalProxyApiBaseClass {
       bool hasGesture,
       String method,
       Map<String, String>? requestHeaders,
-    )?
-    pigeon_newInstance,
+    )? pigeon_newInstance,
   }) {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _PigeonInternalProxyApiBaseCodec(
-      pigeon_instanceManager ?? PigeonInstanceManager.instance,
-    );
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
+        _PigeonInternalProxyApiBaseCodec(
+            pigeon_instanceManager ?? PigeonInstanceManager.instance);
     final BinaryMessenger? binaryMessenger = pigeon_binaryMessenger;
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-        'dev.flutter.pigeon.webview_flutter_android.WebResourceRequest.pigeon_newInstance',
-        pigeonChannelCodec,
-        binaryMessenger: binaryMessenger,
-      );
+          'dev.flutter.pigeon.webview_flutter_android.WebResourceRequest.pigeon_newInstance',
+          pigeonChannelCodec,
+          binaryMessenger: binaryMessenger);
       if (pigeon_clearHandlers) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
@@ -897,18 +920,18 @@ class WebResourceRequest extends PigeonInternalProxyApiBaseClass {
           final bool arg_isRedirect = args[3]! as bool;
           final bool arg_hasGesture = args[4]! as bool;
           final String arg_method = args[5]! as String;
-          final Map<String, String>? arg_requestHeaders = (args[6] as Map<Object?, Object?>?)
-              ?.cast<String, String>();
+          final Map<String, String>? arg_requestHeaders =
+              (args[6] as Map<Object?, Object?>?)?.cast<String, String>();
           try {
-            (pigeon_instanceManager ?? PigeonInstanceManager.instance).addHostCreatedInstance(
+            (pigeon_instanceManager ?? PigeonInstanceManager.instance)
+                .addHostCreatedInstance(
               pigeon_newInstance?.call(
-                    arg_url,
-                    arg_isForMainFrame,
-                    arg_isRedirect,
-                    arg_hasGesture,
-                    arg_method,
-                    arg_requestHeaders,
-                  ) ??
+                      arg_url,
+                      arg_isForMainFrame,
+                      arg_isRedirect,
+                      arg_hasGesture,
+                      arg_method,
+                      arg_requestHeaders) ??
                   WebResourceRequest.pigeon_detached(
                     pigeon_binaryMessenger: pigeon_binaryMessenger,
                     pigeon_instanceManager: pigeon_instanceManager,
@@ -926,8 +949,7 @@ class WebResourceRequest extends PigeonInternalProxyApiBaseClass {
             return wrapResponse(error: e);
           } catch (e) {
             return wrapResponse(
-              error: PlatformException(code: 'error', message: e.toString()),
-            );
+                error: PlatformException(code: 'error', message: e.toString()));
           }
         });
       }
@@ -973,16 +995,15 @@ class WebResourceResponse extends PigeonInternalProxyApiBaseClass {
     PigeonInstanceManager? pigeon_instanceManager,
     WebResourceResponse Function(int statusCode)? pigeon_newInstance,
   }) {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _PigeonInternalProxyApiBaseCodec(
-      pigeon_instanceManager ?? PigeonInstanceManager.instance,
-    );
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
+        _PigeonInternalProxyApiBaseCodec(
+            pigeon_instanceManager ?? PigeonInstanceManager.instance);
     final BinaryMessenger? binaryMessenger = pigeon_binaryMessenger;
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-        'dev.flutter.pigeon.webview_flutter_android.WebResourceResponse.pigeon_newInstance',
-        pigeonChannelCodec,
-        binaryMessenger: binaryMessenger,
-      );
+          'dev.flutter.pigeon.webview_flutter_android.WebResourceResponse.pigeon_newInstance',
+          pigeonChannelCodec,
+          binaryMessenger: binaryMessenger);
       if (pigeon_clearHandlers) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
@@ -991,7 +1012,8 @@ class WebResourceResponse extends PigeonInternalProxyApiBaseClass {
           final int arg_pigeon_instanceIdentifier = args[0]! as int;
           final int arg_statusCode = args[1]! as int;
           try {
-            (pigeon_instanceManager ?? PigeonInstanceManager.instance).addHostCreatedInstance(
+            (pigeon_instanceManager ?? PigeonInstanceManager.instance)
+                .addHostCreatedInstance(
               pigeon_newInstance?.call(arg_statusCode) ??
                   WebResourceResponse.pigeon_detached(
                     pigeon_binaryMessenger: pigeon_binaryMessenger,
@@ -1005,8 +1027,7 @@ class WebResourceResponse extends PigeonInternalProxyApiBaseClass {
             return wrapResponse(error: e);
           } catch (e) {
             return wrapResponse(
-              error: PlatformException(code: 'error', message: e.toString()),
-            );
+                error: PlatformException(code: 'error', message: e.toString()));
           }
         });
       }
@@ -1050,18 +1071,20 @@ class WebResourceError extends PigeonInternalProxyApiBaseClass {
     bool pigeon_clearHandlers = false,
     BinaryMessenger? pigeon_binaryMessenger,
     PigeonInstanceManager? pigeon_instanceManager,
-    WebResourceError Function(int errorCode, String description)? pigeon_newInstance,
+    WebResourceError Function(
+      int errorCode,
+      String description,
+    )? pigeon_newInstance,
   }) {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _PigeonInternalProxyApiBaseCodec(
-      pigeon_instanceManager ?? PigeonInstanceManager.instance,
-    );
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
+        _PigeonInternalProxyApiBaseCodec(
+            pigeon_instanceManager ?? PigeonInstanceManager.instance);
     final BinaryMessenger? binaryMessenger = pigeon_binaryMessenger;
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-        'dev.flutter.pigeon.webview_flutter_android.WebResourceError.pigeon_newInstance',
-        pigeonChannelCodec,
-        binaryMessenger: binaryMessenger,
-      );
+          'dev.flutter.pigeon.webview_flutter_android.WebResourceError.pigeon_newInstance',
+          pigeonChannelCodec,
+          binaryMessenger: binaryMessenger);
       if (pigeon_clearHandlers) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
@@ -1071,7 +1094,8 @@ class WebResourceError extends PigeonInternalProxyApiBaseClass {
           final int arg_errorCode = args[1]! as int;
           final String arg_description = args[2]! as String;
           try {
-            (pigeon_instanceManager ?? PigeonInstanceManager.instance).addHostCreatedInstance(
+            (pigeon_instanceManager ?? PigeonInstanceManager.instance)
+                .addHostCreatedInstance(
               pigeon_newInstance?.call(arg_errorCode, arg_description) ??
                   WebResourceError.pigeon_detached(
                     pigeon_binaryMessenger: pigeon_binaryMessenger,
@@ -1086,8 +1110,7 @@ class WebResourceError extends PigeonInternalProxyApiBaseClass {
             return wrapResponse(error: e);
           } catch (e) {
             return wrapResponse(
-              error: PlatformException(code: 'error', message: e.toString()),
-            );
+                error: PlatformException(code: 'error', message: e.toString()));
           }
         });
       }
@@ -1132,18 +1155,20 @@ class WebResourceErrorCompat extends PigeonInternalProxyApiBaseClass {
     bool pigeon_clearHandlers = false,
     BinaryMessenger? pigeon_binaryMessenger,
     PigeonInstanceManager? pigeon_instanceManager,
-    WebResourceErrorCompat Function(int errorCode, String description)? pigeon_newInstance,
+    WebResourceErrorCompat Function(
+      int errorCode,
+      String description,
+    )? pigeon_newInstance,
   }) {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _PigeonInternalProxyApiBaseCodec(
-      pigeon_instanceManager ?? PigeonInstanceManager.instance,
-    );
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
+        _PigeonInternalProxyApiBaseCodec(
+            pigeon_instanceManager ?? PigeonInstanceManager.instance);
     final BinaryMessenger? binaryMessenger = pigeon_binaryMessenger;
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-        'dev.flutter.pigeon.webview_flutter_android.WebResourceErrorCompat.pigeon_newInstance',
-        pigeonChannelCodec,
-        binaryMessenger: binaryMessenger,
-      );
+          'dev.flutter.pigeon.webview_flutter_android.WebResourceErrorCompat.pigeon_newInstance',
+          pigeonChannelCodec,
+          binaryMessenger: binaryMessenger);
       if (pigeon_clearHandlers) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
@@ -1153,7 +1178,8 @@ class WebResourceErrorCompat extends PigeonInternalProxyApiBaseClass {
           final int arg_errorCode = args[1]! as int;
           final String arg_description = args[2]! as String;
           try {
-            (pigeon_instanceManager ?? PigeonInstanceManager.instance).addHostCreatedInstance(
+            (pigeon_instanceManager ?? PigeonInstanceManager.instance)
+                .addHostCreatedInstance(
               pigeon_newInstance?.call(arg_errorCode, arg_description) ??
                   WebResourceErrorCompat.pigeon_detached(
                     pigeon_binaryMessenger: pigeon_binaryMessenger,
@@ -1168,8 +1194,7 @@ class WebResourceErrorCompat extends PigeonInternalProxyApiBaseClass {
             return wrapResponse(error: e);
           } catch (e) {
             return wrapResponse(
-              error: PlatformException(code: 'error', message: e.toString()),
-            );
+                error: PlatformException(code: 'error', message: e.toString()));
           }
         });
       }
@@ -1211,18 +1236,20 @@ class WebViewPoint extends PigeonInternalProxyApiBaseClass {
     bool pigeon_clearHandlers = false,
     BinaryMessenger? pigeon_binaryMessenger,
     PigeonInstanceManager? pigeon_instanceManager,
-    WebViewPoint Function(int x, int y)? pigeon_newInstance,
+    WebViewPoint Function(
+      int x,
+      int y,
+    )? pigeon_newInstance,
   }) {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _PigeonInternalProxyApiBaseCodec(
-      pigeon_instanceManager ?? PigeonInstanceManager.instance,
-    );
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
+        _PigeonInternalProxyApiBaseCodec(
+            pigeon_instanceManager ?? PigeonInstanceManager.instance);
     final BinaryMessenger? binaryMessenger = pigeon_binaryMessenger;
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-        'dev.flutter.pigeon.webview_flutter_android.WebViewPoint.pigeon_newInstance',
-        pigeonChannelCodec,
-        binaryMessenger: binaryMessenger,
-      );
+          'dev.flutter.pigeon.webview_flutter_android.WebViewPoint.pigeon_newInstance',
+          pigeonChannelCodec,
+          binaryMessenger: binaryMessenger);
       if (pigeon_clearHandlers) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
@@ -1232,7 +1259,8 @@ class WebViewPoint extends PigeonInternalProxyApiBaseClass {
           final int arg_x = args[1]! as int;
           final int arg_y = args[2]! as int;
           try {
-            (pigeon_instanceManager ?? PigeonInstanceManager.instance).addHostCreatedInstance(
+            (pigeon_instanceManager ?? PigeonInstanceManager.instance)
+                .addHostCreatedInstance(
               pigeon_newInstance?.call(arg_x, arg_y) ??
                   WebViewPoint.pigeon_detached(
                     pigeon_binaryMessenger: pigeon_binaryMessenger,
@@ -1247,8 +1275,7 @@ class WebViewPoint extends PigeonInternalProxyApiBaseClass {
             return wrapResponse(error: e);
           } catch (e) {
             return wrapResponse(
-              error: PlatformException(code: 'error', message: e.toString()),
-            );
+                error: PlatformException(code: 'error', message: e.toString()));
           }
         });
       }
@@ -1301,19 +1328,17 @@ class ConsoleMessage extends PigeonInternalProxyApiBaseClass {
       String message,
       ConsoleMessageLevel level,
       String sourceId,
-    )?
-    pigeon_newInstance,
+    )? pigeon_newInstance,
   }) {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _PigeonInternalProxyApiBaseCodec(
-      pigeon_instanceManager ?? PigeonInstanceManager.instance,
-    );
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
+        _PigeonInternalProxyApiBaseCodec(
+            pigeon_instanceManager ?? PigeonInstanceManager.instance);
     final BinaryMessenger? binaryMessenger = pigeon_binaryMessenger;
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-        'dev.flutter.pigeon.webview_flutter_android.ConsoleMessage.pigeon_newInstance',
-        pigeonChannelCodec,
-        binaryMessenger: binaryMessenger,
-      );
+          'dev.flutter.pigeon.webview_flutter_android.ConsoleMessage.pigeon_newInstance',
+          pigeonChannelCodec,
+          binaryMessenger: binaryMessenger);
       if (pigeon_clearHandlers) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
@@ -1325,8 +1350,10 @@ class ConsoleMessage extends PigeonInternalProxyApiBaseClass {
           final ConsoleMessageLevel arg_level = args[3]! as ConsoleMessageLevel;
           final String arg_sourceId = args[4]! as String;
           try {
-            (pigeon_instanceManager ?? PigeonInstanceManager.instance).addHostCreatedInstance(
-              pigeon_newInstance?.call(arg_lineNumber, arg_message, arg_level, arg_sourceId) ??
+            (pigeon_instanceManager ?? PigeonInstanceManager.instance)
+                .addHostCreatedInstance(
+              pigeon_newInstance?.call(
+                      arg_lineNumber, arg_message, arg_level, arg_sourceId) ??
                   ConsoleMessage.pigeon_detached(
                     pigeon_binaryMessenger: pigeon_binaryMessenger,
                     pigeon_instanceManager: pigeon_instanceManager,
@@ -1342,8 +1369,7 @@ class ConsoleMessage extends PigeonInternalProxyApiBaseClass {
             return wrapResponse(error: e);
           } catch (e) {
             return wrapResponse(
-              error: PlatformException(code: 'error', message: e.toString()),
-            );
+                error: PlatformException(code: 'error', message: e.toString()));
           }
         });
       }
@@ -1372,14 +1398,18 @@ class CookieManager extends PigeonInternalProxyApiBaseClass {
   /// This should only be used by subclasses created by this library or to
   /// create copies for an [PigeonInstanceManager].
   @protected
-  CookieManager.pigeon_detached({super.pigeon_binaryMessenger, super.pigeon_instanceManager});
+  CookieManager.pigeon_detached({
+    super.pigeon_binaryMessenger,
+    super.pigeon_instanceManager,
+  });
 
   late final _PigeonInternalProxyApiBaseCodec _pigeonVar_codecCookieManager =
       _PigeonInternalProxyApiBaseCodec(pigeon_instanceManager);
 
   static final CookieManager _instance = pigeonVar_instance();
 
-  static CookieManager get instance => PigeonOverrides.cookieManager_instance ?? _instance;
+  static CookieManager get instance =>
+      PigeonOverrides.cookieManager_instance ?? _instance;
 
   static void pigeon_setUpMessageHandlers({
     bool pigeon_clearHandlers = false,
@@ -1387,16 +1417,15 @@ class CookieManager extends PigeonInternalProxyApiBaseClass {
     PigeonInstanceManager? pigeon_instanceManager,
     CookieManager Function()? pigeon_newInstance,
   }) {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _PigeonInternalProxyApiBaseCodec(
-      pigeon_instanceManager ?? PigeonInstanceManager.instance,
-    );
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
+        _PigeonInternalProxyApiBaseCodec(
+            pigeon_instanceManager ?? PigeonInstanceManager.instance);
     final BinaryMessenger? binaryMessenger = pigeon_binaryMessenger;
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-        'dev.flutter.pigeon.webview_flutter_android.CookieManager.pigeon_newInstance',
-        pigeonChannelCodec,
-        binaryMessenger: binaryMessenger,
-      );
+          'dev.flutter.pigeon.webview_flutter_android.CookieManager.pigeon_newInstance',
+          pigeonChannelCodec,
+          binaryMessenger: binaryMessenger);
       if (pigeon_clearHandlers) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
@@ -1404,7 +1433,8 @@ class CookieManager extends PigeonInternalProxyApiBaseClass {
           final List<Object?> args = message! as List<Object?>;
           final int arg_pigeon_instanceIdentifier = args[0]! as int;
           try {
-            (pigeon_instanceManager ?? PigeonInstanceManager.instance).addHostCreatedInstance(
+            (pigeon_instanceManager ?? PigeonInstanceManager.instance)
+                .addHostCreatedInstance(
               pigeon_newInstance?.call() ??
                   CookieManager.pigeon_detached(
                     pigeon_binaryMessenger: pigeon_binaryMessenger,
@@ -1417,8 +1447,7 @@ class CookieManager extends PigeonInternalProxyApiBaseClass {
             return wrapResponse(error: e);
           } catch (e) {
             return wrapResponse(
-              error: PlatformException(code: 'error', message: e.toString()),
-            );
+                error: PlatformException(code: 'error', message: e.toString()));
           }
         });
       }
@@ -1427,14 +1456,12 @@ class CookieManager extends PigeonInternalProxyApiBaseClass {
 
   static CookieManager pigeonVar_instance() {
     final CookieManager pigeonVar_instance = CookieManager.pigeon_detached();
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _PigeonInternalProxyApiBaseCodec(
-      PigeonInstanceManager.instance,
-    );
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
+        _PigeonInternalProxyApiBaseCodec(PigeonInstanceManager.instance);
     final BinaryMessenger pigeonVar_binaryMessenger =
         ServicesBinding.instance.defaultBinaryMessenger;
-    final int pigeonVar_instanceIdentifier = PigeonInstanceManager.instance.addDartCreatedInstance(
-      pigeonVar_instance,
-    );
+    final int pigeonVar_instanceIdentifier = PigeonInstanceManager.instance
+        .addDartCreatedInstance(pigeonVar_instance);
     () async {
       const pigeonVar_channelName =
           'dev.flutter.pigeon.webview_flutter_android.CookieManager.instance';
@@ -1443,19 +1470,26 @@ class CookieManager extends PigeonInternalProxyApiBaseClass {
         pigeonChannelCodec,
         binaryMessenger: pigeonVar_binaryMessenger,
       );
-      final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[
-        pigeonVar_instanceIdentifier,
-      ]);
+      final Future<Object?> pigeonVar_sendFuture =
+          pigeonVar_channel.send(<Object?>[pigeonVar_instanceIdentifier]);
       final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
-      _extractReplyValueOrThrow(pigeonVar_replyList, pigeonVar_channelName, isNullValid: true);
+      _extractReplyValueOrThrow(
+        pigeonVar_replyList,
+        pigeonVar_channelName,
+        isNullValid: true,
+      );
     }();
     return pigeonVar_instance;
   }
 
   /// Sets a single cookie (key-value pair) for the given URL.
-  Future<void> setCookie(String url, String value) async {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecCookieManager;
+  Future<void> setCookie(
+    String url,
+    String value,
+  ) async {
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
+        _pigeonVar_codecCookieManager;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
     const pigeonVar_channelName =
         'dev.flutter.pigeon.webview_flutter_android.CookieManager.setCookie';
@@ -1464,19 +1498,21 @@ class CookieManager extends PigeonInternalProxyApiBaseClass {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[
-      this,
-      url,
-      value,
-    ]);
+    final Future<Object?> pigeonVar_sendFuture =
+        pigeonVar_channel.send(<Object?>[this, url, value]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
-    _extractReplyValueOrThrow(pigeonVar_replyList, pigeonVar_channelName, isNullValid: true);
+    _extractReplyValueOrThrow(
+      pigeonVar_replyList,
+      pigeonVar_channelName,
+      isNullValid: true,
+    );
   }
 
   /// Removes all cookies.
   Future<bool> removeAllCookies() async {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecCookieManager;
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
+        _pigeonVar_codecCookieManager;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
     const pigeonVar_channelName =
         'dev.flutter.pigeon.webview_flutter_android.CookieManager.removeAllCookies';
@@ -1485,7 +1521,8 @@ class CookieManager extends PigeonInternalProxyApiBaseClass {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[this]);
+    final Future<Object?> pigeonVar_sendFuture =
+        pigeonVar_channel.send(<Object?>[this]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
@@ -1497,8 +1534,12 @@ class CookieManager extends PigeonInternalProxyApiBaseClass {
   }
 
   /// Sets whether the `WebView` should allow third party cookies to be set.
-  Future<void> setAcceptThirdPartyCookies(WebView webView, bool accept) async {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecCookieManager;
+  Future<void> setAcceptThirdPartyCookies(
+    WebView webView,
+    bool accept,
+  ) async {
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
+        _pigeonVar_codecCookieManager;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
     const pigeonVar_channelName =
         'dev.flutter.pigeon.webview_flutter_android.CookieManager.setAcceptThirdPartyCookies';
@@ -1507,14 +1548,15 @@ class CookieManager extends PigeonInternalProxyApiBaseClass {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[
-      this,
-      webView,
-      accept,
-    ]);
+    final Future<Object?> pigeonVar_sendFuture =
+        pigeonVar_channel.send(<Object?>[this, webView, accept]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
-    _extractReplyValueOrThrow(pigeonVar_replyList, pigeonVar_channelName, isNullValid: true);
+    _extractReplyValueOrThrow(
+      pigeonVar_replyList,
+      pigeonVar_channelName,
+      isNullValid: true,
+    );
   }
 
   /// Gets all the cookies for the given URL.
@@ -1525,7 +1567,8 @@ class CookieManager extends PigeonInternalProxyApiBaseClass {
   ///
   /// Note: Any cookies set with the "Partitioned" attribute will only be returned for the top-level partition of url.
   Future<String?> getCookies(String url) async {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecCookieManager;
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
+        _pigeonVar_codecCookieManager;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
     const pigeonVar_channelName =
         'dev.flutter.pigeon.webview_flutter_android.CookieManager.getCookies';
@@ -1534,7 +1577,8 @@ class CookieManager extends PigeonInternalProxyApiBaseClass {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[this, url]);
+    final Future<Object?> pigeonVar_sendFuture =
+        pigeonVar_channel.send(<Object?>[this, url]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
@@ -1561,8 +1605,13 @@ class WebView extends View {
   factory WebView({
     BinaryMessenger? pigeon_binaryMessenger,
     PigeonInstanceManager? pigeon_instanceManager,
-    void Function(WebView pigeon_instance, int left, int top, int oldLeft, int oldTop)?
-    onScrollChanged,
+    void Function(
+      WebView pigeon_instance,
+      int left,
+      int top,
+      int oldLeft,
+      int oldTop,
+    )? onScrollChanged,
   }) {
     if (PigeonOverrides.webView_new != null) {
       return PigeonOverrides.webView_new!(onScrollChanged: onScrollChanged);
@@ -1580,8 +1629,10 @@ class WebView extends View {
     super.pigeon_instanceManager,
     this.onScrollChanged,
   }) : super.pigeon_detached() {
-    final int pigeonVar_instanceIdentifier = pigeon_instanceManager.addDartCreatedInstance(this);
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecWebView;
+    final int pigeonVar_instanceIdentifier =
+        pigeon_instanceManager.addDartCreatedInstance(this);
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
+        _pigeonVar_codecWebView;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
     const pigeonVar_channelName =
         'dev.flutter.pigeon.webview_flutter_android.WebView.pigeon_defaultConstructor';
@@ -1590,13 +1641,16 @@ class WebView extends View {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[
-      pigeonVar_instanceIdentifier,
-    ]);
+    final Future<Object?> pigeonVar_sendFuture =
+        pigeonVar_channel.send(<Object?>[pigeonVar_instanceIdentifier]);
     () async {
       final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
-      _extractReplyValueOrThrow(pigeonVar_replyList, pigeonVar_channelName, isNullValid: true);
+      _extractReplyValueOrThrow(
+        pigeonVar_replyList,
+        pigeonVar_channelName,
+        isNullValid: true,
+      );
     }();
   }
 
@@ -1634,8 +1688,13 @@ class WebView extends View {
   ///
   /// Alternatively, [PigeonInstanceManager.removeWeakReference] can be used to
   /// release the associated Native object manually.
-  final void Function(WebView pigeon_instance, int left, int top, int oldLeft, int oldTop)?
-  onScrollChanged;
+  final void Function(
+    WebView pigeon_instance,
+    int left,
+    int top,
+    int oldLeft,
+    int oldTop,
+  )? onScrollChanged;
 
   /// The WebSettings object used to control the settings for this WebView.
   late final WebSettings settings = pigeonVar_settings();
@@ -1645,19 +1704,23 @@ class WebView extends View {
     BinaryMessenger? pigeon_binaryMessenger,
     PigeonInstanceManager? pigeon_instanceManager,
     WebView Function()? pigeon_newInstance,
-    void Function(WebView pigeon_instance, int left, int top, int oldLeft, int oldTop)?
-    onScrollChanged,
+    void Function(
+      WebView pigeon_instance,
+      int left,
+      int top,
+      int oldLeft,
+      int oldTop,
+    )? onScrollChanged,
   }) {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _PigeonInternalProxyApiBaseCodec(
-      pigeon_instanceManager ?? PigeonInstanceManager.instance,
-    );
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
+        _PigeonInternalProxyApiBaseCodec(
+            pigeon_instanceManager ?? PigeonInstanceManager.instance);
     final BinaryMessenger? binaryMessenger = pigeon_binaryMessenger;
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-        'dev.flutter.pigeon.webview_flutter_android.WebView.pigeon_newInstance',
-        pigeonChannelCodec,
-        binaryMessenger: binaryMessenger,
-      );
+          'dev.flutter.pigeon.webview_flutter_android.WebView.pigeon_newInstance',
+          pigeonChannelCodec,
+          binaryMessenger: binaryMessenger);
       if (pigeon_clearHandlers) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
@@ -1665,7 +1728,8 @@ class WebView extends View {
           final List<Object?> args = message! as List<Object?>;
           final int arg_pigeon_instanceIdentifier = args[0]! as int;
           try {
-            (pigeon_instanceManager ?? PigeonInstanceManager.instance).addHostCreatedInstance(
+            (pigeon_instanceManager ?? PigeonInstanceManager.instance)
+                .addHostCreatedInstance(
               pigeon_newInstance?.call() ??
                   WebView.pigeon_detached(
                     pigeon_binaryMessenger: pigeon_binaryMessenger,
@@ -1678,8 +1742,7 @@ class WebView extends View {
             return wrapResponse(error: e);
           } catch (e) {
             return wrapResponse(
-              error: PlatformException(code: 'error', message: e.toString()),
-            );
+                error: PlatformException(code: 'error', message: e.toString()));
           }
         });
       }
@@ -1687,10 +1750,9 @@ class WebView extends View {
 
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-        'dev.flutter.pigeon.webview_flutter_android.WebView.onScrollChanged',
-        pigeonChannelCodec,
-        binaryMessenger: binaryMessenger,
-      );
+          'dev.flutter.pigeon.webview_flutter_android.WebView.onScrollChanged',
+          pigeonChannelCodec,
+          binaryMessenger: binaryMessenger);
       if (pigeon_clearHandlers) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
@@ -1703,19 +1765,17 @@ class WebView extends View {
           final int arg_oldTop = args[4]! as int;
           try {
             (onScrollChanged ?? arg_pigeon_instance.onScrollChanged)?.call(
-              arg_pigeon_instance,
-              arg_left,
-              arg_top,
-              arg_oldLeft,
-              arg_oldTop,
-            );
+                arg_pigeon_instance,
+                arg_left,
+                arg_top,
+                arg_oldLeft,
+                arg_oldTop);
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
           } catch (e) {
             return wrapResponse(
-              error: PlatformException(code: 'error', message: e.toString()),
-            );
+                error: PlatformException(code: 'error', message: e.toString()));
           }
         });
       }
@@ -1727,48 +1787,57 @@ class WebView extends View {
       pigeon_binaryMessenger: pigeon_binaryMessenger,
       pigeon_instanceManager: pigeon_instanceManager,
     );
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecWebView;
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
+        _pigeonVar_codecWebView;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
-    final int pigeonVar_instanceIdentifier = pigeon_instanceManager.addDartCreatedInstance(
-      pigeonVar_instance,
-    );
+    final int pigeonVar_instanceIdentifier =
+        pigeon_instanceManager.addDartCreatedInstance(pigeonVar_instance);
     () async {
-      const pigeonVar_channelName = 'dev.flutter.pigeon.webview_flutter_android.WebView.settings';
+      const pigeonVar_channelName =
+          'dev.flutter.pigeon.webview_flutter_android.WebView.settings';
       final pigeonVar_channel = BasicMessageChannel<Object?>(
         pigeonVar_channelName,
         pigeonChannelCodec,
         binaryMessenger: pigeonVar_binaryMessenger,
       );
-      final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[
-        this,
-        pigeonVar_instanceIdentifier,
-      ]);
+      final Future<Object?> pigeonVar_sendFuture =
+          pigeonVar_channel.send(<Object?>[this, pigeonVar_instanceIdentifier]);
       final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
-      _extractReplyValueOrThrow(pigeonVar_replyList, pigeonVar_channelName, isNullValid: true);
+      _extractReplyValueOrThrow(
+        pigeonVar_replyList,
+        pigeonVar_channelName,
+        isNullValid: true,
+      );
     }();
     return pigeonVar_instance;
   }
 
   /// Loads the given data into this WebView using a 'data' scheme URL.
-  Future<void> loadData(String data, String? mimeType, String? encoding) async {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecWebView;
+  Future<void> loadData(
+    String data,
+    String? mimeType,
+    String? encoding,
+  ) async {
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
+        _pigeonVar_codecWebView;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
-    const pigeonVar_channelName = 'dev.flutter.pigeon.webview_flutter_android.WebView.loadData';
+    const pigeonVar_channelName =
+        'dev.flutter.pigeon.webview_flutter_android.WebView.loadData';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[
-      this,
-      data,
-      mimeType,
-      encoding,
-    ]);
+    final Future<Object?> pigeonVar_sendFuture =
+        pigeonVar_channel.send(<Object?>[this, data, mimeType, encoding]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
-    _extractReplyValueOrThrow(pigeonVar_replyList, pigeonVar_channelName, isNullValid: true);
+    _extractReplyValueOrThrow(
+      pigeonVar_replyList,
+      pigeonVar_channelName,
+      isNullValid: true,
+    );
   }
 
   /// Loads the given data into this WebView, using baseUrl as the base URL for
@@ -1780,7 +1849,8 @@ class WebView extends View {
     String? encoding,
     String? historyUrl,
   ) async {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecWebView;
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
+        _pigeonVar_codecWebView;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
     const pigeonVar_channelName =
         'dev.flutter.pigeon.webview_flutter_android.WebView.loadDataWithBaseUrl';
@@ -1789,66 +1859,83 @@ class WebView extends View {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[
-      this,
-      baseUrl,
-      data,
-      mimeType,
-      encoding,
-      historyUrl,
-    ]);
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel
+        .send(<Object?>[this, baseUrl, data, mimeType, encoding, historyUrl]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
-    _extractReplyValueOrThrow(pigeonVar_replyList, pigeonVar_channelName, isNullValid: true);
+    _extractReplyValueOrThrow(
+      pigeonVar_replyList,
+      pigeonVar_channelName,
+      isNullValid: true,
+    );
   }
 
   /// Loads the given URL.
-  Future<void> loadUrl(String url, Map<String, String> headers) async {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecWebView;
+  Future<void> loadUrl(
+    String url,
+    Map<String, String> headers,
+  ) async {
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
+        _pigeonVar_codecWebView;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
-    const pigeonVar_channelName = 'dev.flutter.pigeon.webview_flutter_android.WebView.loadUrl';
+    const pigeonVar_channelName =
+        'dev.flutter.pigeon.webview_flutter_android.WebView.loadUrl';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[
-      this,
-      url,
-      headers,
-    ]);
+    final Future<Object?> pigeonVar_sendFuture =
+        pigeonVar_channel.send(<Object?>[this, url, headers]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
-    _extractReplyValueOrThrow(pigeonVar_replyList, pigeonVar_channelName, isNullValid: true);
+    _extractReplyValueOrThrow(
+      pigeonVar_replyList,
+      pigeonVar_channelName,
+      isNullValid: true,
+    );
   }
 
   /// Loads the URL with postData using "POST" method into this WebView.
-  Future<void> postUrl(String url, Uint8List data) async {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecWebView;
+  Future<void> postUrl(
+    String url,
+    Uint8List data,
+  ) async {
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
+        _pigeonVar_codecWebView;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
-    const pigeonVar_channelName = 'dev.flutter.pigeon.webview_flutter_android.WebView.postUrl';
+    const pigeonVar_channelName =
+        'dev.flutter.pigeon.webview_flutter_android.WebView.postUrl';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[this, url, data]);
+    final Future<Object?> pigeonVar_sendFuture =
+        pigeonVar_channel.send(<Object?>[this, url, data]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
-    _extractReplyValueOrThrow(pigeonVar_replyList, pigeonVar_channelName, isNullValid: true);
+    _extractReplyValueOrThrow(
+      pigeonVar_replyList,
+      pigeonVar_channelName,
+      isNullValid: true,
+    );
   }
 
   /// Gets the URL for the current page.
   Future<String?> getUrl() async {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecWebView;
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
+        _pigeonVar_codecWebView;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
-    const pigeonVar_channelName = 'dev.flutter.pigeon.webview_flutter_android.WebView.getUrl';
+    const pigeonVar_channelName =
+        'dev.flutter.pigeon.webview_flutter_android.WebView.getUrl';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[this]);
+    final Future<Object?> pigeonVar_sendFuture =
+        pigeonVar_channel.send(<Object?>[this]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
@@ -1861,15 +1948,18 @@ class WebView extends View {
 
   /// Gets whether this WebView has a back history item.
   Future<bool> canGoBack() async {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecWebView;
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
+        _pigeonVar_codecWebView;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
-    const pigeonVar_channelName = 'dev.flutter.pigeon.webview_flutter_android.WebView.canGoBack';
+    const pigeonVar_channelName =
+        'dev.flutter.pigeon.webview_flutter_android.WebView.canGoBack';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[this]);
+    final Future<Object?> pigeonVar_sendFuture =
+        pigeonVar_channel.send(<Object?>[this]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
@@ -1882,15 +1972,18 @@ class WebView extends View {
 
   /// Gets whether this WebView has a forward history item.
   Future<bool> canGoForward() async {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecWebView;
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
+        _pigeonVar_codecWebView;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
-    const pigeonVar_channelName = 'dev.flutter.pigeon.webview_flutter_android.WebView.canGoForward';
+    const pigeonVar_channelName =
+        'dev.flutter.pigeon.webview_flutter_android.WebView.canGoForward';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[this]);
+    final Future<Object?> pigeonVar_sendFuture =
+        pigeonVar_channel.send(<Object?>[this]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
@@ -1903,75 +1996,101 @@ class WebView extends View {
 
   /// Goes back in the history of this WebView.
   Future<void> goBack() async {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecWebView;
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
+        _pigeonVar_codecWebView;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
-    const pigeonVar_channelName = 'dev.flutter.pigeon.webview_flutter_android.WebView.goBack';
+    const pigeonVar_channelName =
+        'dev.flutter.pigeon.webview_flutter_android.WebView.goBack';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[this]);
+    final Future<Object?> pigeonVar_sendFuture =
+        pigeonVar_channel.send(<Object?>[this]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
-    _extractReplyValueOrThrow(pigeonVar_replyList, pigeonVar_channelName, isNullValid: true);
+    _extractReplyValueOrThrow(
+      pigeonVar_replyList,
+      pigeonVar_channelName,
+      isNullValid: true,
+    );
   }
 
   /// Goes forward in the history of this WebView.
   Future<void> goForward() async {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecWebView;
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
+        _pigeonVar_codecWebView;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
-    const pigeonVar_channelName = 'dev.flutter.pigeon.webview_flutter_android.WebView.goForward';
+    const pigeonVar_channelName =
+        'dev.flutter.pigeon.webview_flutter_android.WebView.goForward';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[this]);
+    final Future<Object?> pigeonVar_sendFuture =
+        pigeonVar_channel.send(<Object?>[this]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
-    _extractReplyValueOrThrow(pigeonVar_replyList, pigeonVar_channelName, isNullValid: true);
+    _extractReplyValueOrThrow(
+      pigeonVar_replyList,
+      pigeonVar_channelName,
+      isNullValid: true,
+    );
   }
 
   /// Reloads the current URL.
   Future<void> reload() async {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecWebView;
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
+        _pigeonVar_codecWebView;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
-    const pigeonVar_channelName = 'dev.flutter.pigeon.webview_flutter_android.WebView.reload';
+    const pigeonVar_channelName =
+        'dev.flutter.pigeon.webview_flutter_android.WebView.reload';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[this]);
+    final Future<Object?> pigeonVar_sendFuture =
+        pigeonVar_channel.send(<Object?>[this]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
-    _extractReplyValueOrThrow(pigeonVar_replyList, pigeonVar_channelName, isNullValid: true);
+    _extractReplyValueOrThrow(
+      pigeonVar_replyList,
+      pigeonVar_channelName,
+      isNullValid: true,
+    );
   }
 
   /// Clears the resource cache.
   Future<void> clearCache(bool includeDiskFiles) async {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecWebView;
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
+        _pigeonVar_codecWebView;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
-    const pigeonVar_channelName = 'dev.flutter.pigeon.webview_flutter_android.WebView.clearCache';
+    const pigeonVar_channelName =
+        'dev.flutter.pigeon.webview_flutter_android.WebView.clearCache';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[
-      this,
-      includeDiskFiles,
-    ]);
+    final Future<Object?> pigeonVar_sendFuture =
+        pigeonVar_channel.send(<Object?>[this, includeDiskFiles]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
-    _extractReplyValueOrThrow(pigeonVar_replyList, pigeonVar_channelName, isNullValid: true);
+    _extractReplyValueOrThrow(
+      pigeonVar_replyList,
+      pigeonVar_channelName,
+      isNullValid: true,
+    );
   }
 
   /// Asynchronously evaluates JavaScript in the context of the currently
   /// displayed page.
   Future<String?> evaluateJavascript(String javascriptString) async {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecWebView;
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
+        _pigeonVar_codecWebView;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
     const pigeonVar_channelName =
         'dev.flutter.pigeon.webview_flutter_android.WebView.evaluateJavascript';
@@ -1980,10 +2099,8 @@ class WebView extends View {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[
-      this,
-      javascriptString,
-    ]);
+    final Future<Object?> pigeonVar_sendFuture =
+        pigeonVar_channel.send(<Object?>[this, javascriptString]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
@@ -1996,15 +2113,18 @@ class WebView extends View {
 
   /// Gets the title for the current page.
   Future<String?> getTitle() async {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecWebView;
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
+        _pigeonVar_codecWebView;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
-    const pigeonVar_channelName = 'dev.flutter.pigeon.webview_flutter_android.WebView.getTitle';
+    const pigeonVar_channelName =
+        'dev.flutter.pigeon.webview_flutter_android.WebView.getTitle';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[this]);
+    final Future<Object?> pigeonVar_sendFuture =
+        pigeonVar_channel.send(<Object?>[this]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
@@ -2025,9 +2145,9 @@ class WebView extends View {
     if (PigeonOverrides.webView_setWebContentsDebuggingEnabled != null) {
       return PigeonOverrides.webView_setWebContentsDebuggingEnabled!(enabled);
     }
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _PigeonInternalProxyApiBaseCodec(
-      pigeon_instanceManager ?? PigeonInstanceManager.instance,
-    );
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
+        _PigeonInternalProxyApiBaseCodec(
+            pigeon_instanceManager ?? PigeonInstanceManager.instance);
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
     const pigeonVar_channelName =
         'dev.flutter.pigeon.webview_flutter_android.WebView.setWebContentsDebuggingEnabled';
@@ -2036,16 +2156,22 @@ class WebView extends View {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[enabled]);
+    final Future<Object?> pigeonVar_sendFuture =
+        pigeonVar_channel.send(<Object?>[enabled]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
-    _extractReplyValueOrThrow(pigeonVar_replyList, pigeonVar_channelName, isNullValid: true);
+    _extractReplyValueOrThrow(
+      pigeonVar_replyList,
+      pigeonVar_channelName,
+      isNullValid: true,
+    );
   }
 
   /// Sets the WebViewClient that will receive various notifications and
   /// requests.
   Future<void> setWebViewClient(WebViewClient? client) async {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecWebView;
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
+        _pigeonVar_codecWebView;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
     const pigeonVar_channelName =
         'dev.flutter.pigeon.webview_flutter_android.WebView.setWebViewClient';
@@ -2054,15 +2180,21 @@ class WebView extends View {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[this, client]);
+    final Future<Object?> pigeonVar_sendFuture =
+        pigeonVar_channel.send(<Object?>[this, client]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
-    _extractReplyValueOrThrow(pigeonVar_replyList, pigeonVar_channelName, isNullValid: true);
+    _extractReplyValueOrThrow(
+      pigeonVar_replyList,
+      pigeonVar_channelName,
+      isNullValid: true,
+    );
   }
 
   /// Injects the supplied Java object into this WebView.
   Future<void> addJavaScriptChannel(JavaScriptChannel channel) async {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecWebView;
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
+        _pigeonVar_codecWebView;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
     const pigeonVar_channelName =
         'dev.flutter.pigeon.webview_flutter_android.WebView.addJavaScriptChannel';
@@ -2071,15 +2203,21 @@ class WebView extends View {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[this, channel]);
+    final Future<Object?> pigeonVar_sendFuture =
+        pigeonVar_channel.send(<Object?>[this, channel]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
-    _extractReplyValueOrThrow(pigeonVar_replyList, pigeonVar_channelName, isNullValid: true);
+    _extractReplyValueOrThrow(
+      pigeonVar_replyList,
+      pigeonVar_channelName,
+      isNullValid: true,
+    );
   }
 
   /// Removes a previously injected Java object from this WebView.
   Future<void> removeJavaScriptChannel(String name) async {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecWebView;
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
+        _pigeonVar_codecWebView;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
     const pigeonVar_channelName =
         'dev.flutter.pigeon.webview_flutter_android.WebView.removeJavaScriptChannel';
@@ -2088,16 +2226,22 @@ class WebView extends View {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[this, name]);
+    final Future<Object?> pigeonVar_sendFuture =
+        pigeonVar_channel.send(<Object?>[this, name]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
-    _extractReplyValueOrThrow(pigeonVar_replyList, pigeonVar_channelName, isNullValid: true);
+    _extractReplyValueOrThrow(
+      pigeonVar_replyList,
+      pigeonVar_channelName,
+      isNullValid: true,
+    );
   }
 
   /// Registers the interface to be used when content can not be handled by the
   /// rendering engine, and should be downloaded instead.
   Future<void> setDownloadListener(DownloadListener? listener) async {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecWebView;
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
+        _pigeonVar_codecWebView;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
     const pigeonVar_channelName =
         'dev.flutter.pigeon.webview_flutter_android.WebView.setDownloadListener';
@@ -2106,15 +2250,21 @@ class WebView extends View {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[this, listener]);
+    final Future<Object?> pigeonVar_sendFuture =
+        pigeonVar_channel.send(<Object?>[this, listener]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
-    _extractReplyValueOrThrow(pigeonVar_replyList, pigeonVar_channelName, isNullValid: true);
+    _extractReplyValueOrThrow(
+      pigeonVar_replyList,
+      pigeonVar_channelName,
+      isNullValid: true,
+    );
   }
 
   /// Sets the chrome handler.
   Future<void> setWebChromeClient(WebChromeClient? client) async {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecWebView;
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
+        _pigeonVar_codecWebView;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
     const pigeonVar_channelName =
         'dev.flutter.pigeon.webview_flutter_android.WebView.setWebChromeClient';
@@ -2123,15 +2273,21 @@ class WebView extends View {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[this, client]);
+    final Future<Object?> pigeonVar_sendFuture =
+        pigeonVar_channel.send(<Object?>[this, client]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
-    _extractReplyValueOrThrow(pigeonVar_replyList, pigeonVar_channelName, isNullValid: true);
+    _extractReplyValueOrThrow(
+      pigeonVar_replyList,
+      pigeonVar_channelName,
+      isNullValid: true,
+    );
   }
 
   /// Sets the background color for this view.
   Future<void> setBackgroundColor(int color) async {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecWebView;
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
+        _pigeonVar_codecWebView;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
     const pigeonVar_channelName =
         'dev.flutter.pigeon.webview_flutter_android.WebView.setBackgroundColor';
@@ -2140,26 +2296,38 @@ class WebView extends View {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[this, color]);
+    final Future<Object?> pigeonVar_sendFuture =
+        pigeonVar_channel.send(<Object?>[this, color]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
-    _extractReplyValueOrThrow(pigeonVar_replyList, pigeonVar_channelName, isNullValid: true);
+    _extractReplyValueOrThrow(
+      pigeonVar_replyList,
+      pigeonVar_channelName,
+      isNullValid: true,
+    );
   }
 
   /// Destroys the internal state of this WebView.
   Future<void> destroy() async {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecWebView;
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
+        _pigeonVar_codecWebView;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
-    const pigeonVar_channelName = 'dev.flutter.pigeon.webview_flutter_android.WebView.destroy';
+    const pigeonVar_channelName =
+        'dev.flutter.pigeon.webview_flutter_android.WebView.destroy';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[this]);
+    final Future<Object?> pigeonVar_sendFuture =
+        pigeonVar_channel.send(<Object?>[this]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
-    _extractReplyValueOrThrow(pigeonVar_replyList, pigeonVar_channelName, isNullValid: true);
+    _extractReplyValueOrThrow(
+      pigeonVar_replyList,
+      pigeonVar_channelName,
+      isNullValid: true,
+    );
   }
 
   @override
@@ -2181,7 +2349,10 @@ class WebSettings extends PigeonInternalProxyApiBaseClass {
   /// This should only be used by subclasses created by this library or to
   /// create copies for an [PigeonInstanceManager].
   @protected
-  WebSettings.pigeon_detached({super.pigeon_binaryMessenger, super.pigeon_instanceManager});
+  WebSettings.pigeon_detached({
+    super.pigeon_binaryMessenger,
+    super.pigeon_instanceManager,
+  });
 
   late final _PigeonInternalProxyApiBaseCodec _pigeonVar_codecWebSettings =
       _PigeonInternalProxyApiBaseCodec(pigeon_instanceManager);
@@ -2192,16 +2363,15 @@ class WebSettings extends PigeonInternalProxyApiBaseClass {
     PigeonInstanceManager? pigeon_instanceManager,
     WebSettings Function()? pigeon_newInstance,
   }) {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _PigeonInternalProxyApiBaseCodec(
-      pigeon_instanceManager ?? PigeonInstanceManager.instance,
-    );
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
+        _PigeonInternalProxyApiBaseCodec(
+            pigeon_instanceManager ?? PigeonInstanceManager.instance);
     final BinaryMessenger? binaryMessenger = pigeon_binaryMessenger;
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-        'dev.flutter.pigeon.webview_flutter_android.WebSettings.pigeon_newInstance',
-        pigeonChannelCodec,
-        binaryMessenger: binaryMessenger,
-      );
+          'dev.flutter.pigeon.webview_flutter_android.WebSettings.pigeon_newInstance',
+          pigeonChannelCodec,
+          binaryMessenger: binaryMessenger);
       if (pigeon_clearHandlers) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
@@ -2209,7 +2379,8 @@ class WebSettings extends PigeonInternalProxyApiBaseClass {
           final List<Object?> args = message! as List<Object?>;
           final int arg_pigeon_instanceIdentifier = args[0]! as int;
           try {
-            (pigeon_instanceManager ?? PigeonInstanceManager.instance).addHostCreatedInstance(
+            (pigeon_instanceManager ?? PigeonInstanceManager.instance)
+                .addHostCreatedInstance(
               pigeon_newInstance?.call() ??
                   WebSettings.pigeon_detached(
                     pigeon_binaryMessenger: pigeon_binaryMessenger,
@@ -2222,8 +2393,7 @@ class WebSettings extends PigeonInternalProxyApiBaseClass {
             return wrapResponse(error: e);
           } catch (e) {
             return wrapResponse(
-              error: PlatformException(code: 'error', message: e.toString()),
-            );
+                error: PlatformException(code: 'error', message: e.toString()));
           }
         });
       }
@@ -2232,7 +2402,8 @@ class WebSettings extends PigeonInternalProxyApiBaseClass {
 
   /// Sets whether the DOM storage API is enabled.
   Future<void> setDomStorageEnabled(bool flag) async {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecWebSettings;
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
+        _pigeonVar_codecWebSettings;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
     const pigeonVar_channelName =
         'dev.flutter.pigeon.webview_flutter_android.WebSettings.setDomStorageEnabled';
@@ -2241,15 +2412,21 @@ class WebSettings extends PigeonInternalProxyApiBaseClass {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[this, flag]);
+    final Future<Object?> pigeonVar_sendFuture =
+        pigeonVar_channel.send(<Object?>[this, flag]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
-    _extractReplyValueOrThrow(pigeonVar_replyList, pigeonVar_channelName, isNullValid: true);
+    _extractReplyValueOrThrow(
+      pigeonVar_replyList,
+      pigeonVar_channelName,
+      isNullValid: true,
+    );
   }
 
   /// Tells JavaScript to open windows automatically.
   Future<void> setJavaScriptCanOpenWindowsAutomatically(bool flag) async {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecWebSettings;
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
+        _pigeonVar_codecWebSettings;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
     const pigeonVar_channelName =
         'dev.flutter.pigeon.webview_flutter_android.WebSettings.setJavaScriptCanOpenWindowsAutomatically';
@@ -2258,15 +2435,21 @@ class WebSettings extends PigeonInternalProxyApiBaseClass {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[this, flag]);
+    final Future<Object?> pigeonVar_sendFuture =
+        pigeonVar_channel.send(<Object?>[this, flag]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
-    _extractReplyValueOrThrow(pigeonVar_replyList, pigeonVar_channelName, isNullValid: true);
+    _extractReplyValueOrThrow(
+      pigeonVar_replyList,
+      pigeonVar_channelName,
+      isNullValid: true,
+    );
   }
 
   /// Sets whether the WebView whether supports multiple windows.
   Future<void> setSupportMultipleWindows(bool support) async {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecWebSettings;
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
+        _pigeonVar_codecWebSettings;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
     const pigeonVar_channelName =
         'dev.flutter.pigeon.webview_flutter_android.WebSettings.setSupportMultipleWindows';
@@ -2275,15 +2458,21 @@ class WebSettings extends PigeonInternalProxyApiBaseClass {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[this, support]);
+    final Future<Object?> pigeonVar_sendFuture =
+        pigeonVar_channel.send(<Object?>[this, support]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
-    _extractReplyValueOrThrow(pigeonVar_replyList, pigeonVar_channelName, isNullValid: true);
+    _extractReplyValueOrThrow(
+      pigeonVar_replyList,
+      pigeonVar_channelName,
+      isNullValid: true,
+    );
   }
 
   /// Tells the WebView to enable JavaScript execution.
   Future<void> setJavaScriptEnabled(bool flag) async {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecWebSettings;
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
+        _pigeonVar_codecWebSettings;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
     const pigeonVar_channelName =
         'dev.flutter.pigeon.webview_flutter_android.WebSettings.setJavaScriptEnabled';
@@ -2292,15 +2481,21 @@ class WebSettings extends PigeonInternalProxyApiBaseClass {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[this, flag]);
+    final Future<Object?> pigeonVar_sendFuture =
+        pigeonVar_channel.send(<Object?>[this, flag]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
-    _extractReplyValueOrThrow(pigeonVar_replyList, pigeonVar_channelName, isNullValid: true);
+    _extractReplyValueOrThrow(
+      pigeonVar_replyList,
+      pigeonVar_channelName,
+      isNullValid: true,
+    );
   }
 
   /// Sets the WebView's user-agent string.
   Future<void> setUserAgentString(String? userAgentString) async {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecWebSettings;
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
+        _pigeonVar_codecWebSettings;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
     const pigeonVar_channelName =
         'dev.flutter.pigeon.webview_flutter_android.WebSettings.setUserAgentString';
@@ -2309,18 +2504,21 @@ class WebSettings extends PigeonInternalProxyApiBaseClass {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[
-      this,
-      userAgentString,
-    ]);
+    final Future<Object?> pigeonVar_sendFuture =
+        pigeonVar_channel.send(<Object?>[this, userAgentString]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
-    _extractReplyValueOrThrow(pigeonVar_replyList, pigeonVar_channelName, isNullValid: true);
+    _extractReplyValueOrThrow(
+      pigeonVar_replyList,
+      pigeonVar_channelName,
+      isNullValid: true,
+    );
   }
 
   /// Sets whether the WebView requires a user gesture to play media.
   Future<void> setMediaPlaybackRequiresUserGesture(bool require) async {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecWebSettings;
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
+        _pigeonVar_codecWebSettings;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
     const pigeonVar_channelName =
         'dev.flutter.pigeon.webview_flutter_android.WebSettings.setMediaPlaybackRequiresUserGesture';
@@ -2329,16 +2527,22 @@ class WebSettings extends PigeonInternalProxyApiBaseClass {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[this, require]);
+    final Future<Object?> pigeonVar_sendFuture =
+        pigeonVar_channel.send(<Object?>[this, require]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
-    _extractReplyValueOrThrow(pigeonVar_replyList, pigeonVar_channelName, isNullValid: true);
+    _extractReplyValueOrThrow(
+      pigeonVar_replyList,
+      pigeonVar_channelName,
+      isNullValid: true,
+    );
   }
 
   /// Sets whether the WebView should support zooming using its on-screen zoom
   /// controls and gestures.
   Future<void> setSupportZoom(bool support) async {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecWebSettings;
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
+        _pigeonVar_codecWebSettings;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
     const pigeonVar_channelName =
         'dev.flutter.pigeon.webview_flutter_android.WebSettings.setSupportZoom';
@@ -2347,16 +2551,22 @@ class WebSettings extends PigeonInternalProxyApiBaseClass {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[this, support]);
+    final Future<Object?> pigeonVar_sendFuture =
+        pigeonVar_channel.send(<Object?>[this, support]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
-    _extractReplyValueOrThrow(pigeonVar_replyList, pigeonVar_channelName, isNullValid: true);
+    _extractReplyValueOrThrow(
+      pigeonVar_replyList,
+      pigeonVar_channelName,
+      isNullValid: true,
+    );
   }
 
   /// Sets whether the WebView loads pages in overview mode, that is, zooms out
   /// the content to fit on screen by width.
   Future<void> setLoadWithOverviewMode(bool overview) async {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecWebSettings;
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
+        _pigeonVar_codecWebSettings;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
     const pigeonVar_channelName =
         'dev.flutter.pigeon.webview_flutter_android.WebSettings.setLoadWithOverviewMode';
@@ -2365,16 +2575,22 @@ class WebSettings extends PigeonInternalProxyApiBaseClass {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[this, overview]);
+    final Future<Object?> pigeonVar_sendFuture =
+        pigeonVar_channel.send(<Object?>[this, overview]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
-    _extractReplyValueOrThrow(pigeonVar_replyList, pigeonVar_channelName, isNullValid: true);
+    _extractReplyValueOrThrow(
+      pigeonVar_replyList,
+      pigeonVar_channelName,
+      isNullValid: true,
+    );
   }
 
   /// Sets whether the WebView should enable support for the "viewport" HTML
   /// meta tag or should use a wide viewport.
   Future<void> setUseWideViewPort(bool use) async {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecWebSettings;
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
+        _pigeonVar_codecWebSettings;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
     const pigeonVar_channelName =
         'dev.flutter.pigeon.webview_flutter_android.WebSettings.setUseWideViewPort';
@@ -2383,16 +2599,22 @@ class WebSettings extends PigeonInternalProxyApiBaseClass {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[this, use]);
+    final Future<Object?> pigeonVar_sendFuture =
+        pigeonVar_channel.send(<Object?>[this, use]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
-    _extractReplyValueOrThrow(pigeonVar_replyList, pigeonVar_channelName, isNullValid: true);
+    _extractReplyValueOrThrow(
+      pigeonVar_replyList,
+      pigeonVar_channelName,
+      isNullValid: true,
+    );
   }
 
   /// Sets whether the WebView should display on-screen zoom controls when using
   /// the built-in zoom mechanisms.
   Future<void> setDisplayZoomControls(bool enabled) async {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecWebSettings;
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
+        _pigeonVar_codecWebSettings;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
     const pigeonVar_channelName =
         'dev.flutter.pigeon.webview_flutter_android.WebSettings.setDisplayZoomControls';
@@ -2401,16 +2623,22 @@ class WebSettings extends PigeonInternalProxyApiBaseClass {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[this, enabled]);
+    final Future<Object?> pigeonVar_sendFuture =
+        pigeonVar_channel.send(<Object?>[this, enabled]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
-    _extractReplyValueOrThrow(pigeonVar_replyList, pigeonVar_channelName, isNullValid: true);
+    _extractReplyValueOrThrow(
+      pigeonVar_replyList,
+      pigeonVar_channelName,
+      isNullValid: true,
+    );
   }
 
   /// Sets whether the WebView should display on-screen zoom controls when using
   /// the built-in zoom mechanisms.
   Future<void> setBuiltInZoomControls(bool enabled) async {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecWebSettings;
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
+        _pigeonVar_codecWebSettings;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
     const pigeonVar_channelName =
         'dev.flutter.pigeon.webview_flutter_android.WebSettings.setBuiltInZoomControls';
@@ -2419,15 +2647,21 @@ class WebSettings extends PigeonInternalProxyApiBaseClass {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[this, enabled]);
+    final Future<Object?> pigeonVar_sendFuture =
+        pigeonVar_channel.send(<Object?>[this, enabled]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
-    _extractReplyValueOrThrow(pigeonVar_replyList, pigeonVar_channelName, isNullValid: true);
+    _extractReplyValueOrThrow(
+      pigeonVar_replyList,
+      pigeonVar_channelName,
+      isNullValid: true,
+    );
   }
 
   /// Enables or disables file access within WebView.
   Future<void> setAllowFileAccess(bool enabled) async {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecWebSettings;
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
+        _pigeonVar_codecWebSettings;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
     const pigeonVar_channelName =
         'dev.flutter.pigeon.webview_flutter_android.WebSettings.setAllowFileAccess';
@@ -2436,15 +2670,21 @@ class WebSettings extends PigeonInternalProxyApiBaseClass {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[this, enabled]);
+    final Future<Object?> pigeonVar_sendFuture =
+        pigeonVar_channel.send(<Object?>[this, enabled]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
-    _extractReplyValueOrThrow(pigeonVar_replyList, pigeonVar_channelName, isNullValid: true);
+    _extractReplyValueOrThrow(
+      pigeonVar_replyList,
+      pigeonVar_channelName,
+      isNullValid: true,
+    );
   }
 
   /// Enables or disables content URL access within WebView.
   Future<void> setAllowContentAccess(bool enabled) async {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecWebSettings;
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
+        _pigeonVar_codecWebSettings;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
     const pigeonVar_channelName =
         'dev.flutter.pigeon.webview_flutter_android.WebSettings.setAllowContentAccess';
@@ -2453,15 +2693,21 @@ class WebSettings extends PigeonInternalProxyApiBaseClass {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[this, enabled]);
+    final Future<Object?> pigeonVar_sendFuture =
+        pigeonVar_channel.send(<Object?>[this, enabled]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
-    _extractReplyValueOrThrow(pigeonVar_replyList, pigeonVar_channelName, isNullValid: true);
+    _extractReplyValueOrThrow(
+      pigeonVar_replyList,
+      pigeonVar_channelName,
+      isNullValid: true,
+    );
   }
 
   /// Sets whether Geolocation is enabled within WebView.
   Future<void> setGeolocationEnabled(bool enabled) async {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecWebSettings;
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
+        _pigeonVar_codecWebSettings;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
     const pigeonVar_channelName =
         'dev.flutter.pigeon.webview_flutter_android.WebSettings.setGeolocationEnabled';
@@ -2470,15 +2716,21 @@ class WebSettings extends PigeonInternalProxyApiBaseClass {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[this, enabled]);
+    final Future<Object?> pigeonVar_sendFuture =
+        pigeonVar_channel.send(<Object?>[this, enabled]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
-    _extractReplyValueOrThrow(pigeonVar_replyList, pigeonVar_channelName, isNullValid: true);
+    _extractReplyValueOrThrow(
+      pigeonVar_replyList,
+      pigeonVar_channelName,
+      isNullValid: true,
+    );
   }
 
   /// Sets the text zoom of the page in percent.
   Future<void> setTextZoom(int textZoom) async {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecWebSettings;
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
+        _pigeonVar_codecWebSettings;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
     const pigeonVar_channelName =
         'dev.flutter.pigeon.webview_flutter_android.WebSettings.setTextZoom';
@@ -2487,15 +2739,21 @@ class WebSettings extends PigeonInternalProxyApiBaseClass {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[this, textZoom]);
+    final Future<Object?> pigeonVar_sendFuture =
+        pigeonVar_channel.send(<Object?>[this, textZoom]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
-    _extractReplyValueOrThrow(pigeonVar_replyList, pigeonVar_channelName, isNullValid: true);
+    _extractReplyValueOrThrow(
+      pigeonVar_replyList,
+      pigeonVar_channelName,
+      isNullValid: true,
+    );
   }
 
   /// Gets the WebView's user-agent string.
   Future<String> getUserAgentString() async {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecWebSettings;
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
+        _pigeonVar_codecWebSettings;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
     const pigeonVar_channelName =
         'dev.flutter.pigeon.webview_flutter_android.WebSettings.getUserAgentString';
@@ -2504,7 +2762,8 @@ class WebSettings extends PigeonInternalProxyApiBaseClass {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[this]);
+    final Future<Object?> pigeonVar_sendFuture =
+        pigeonVar_channel.send(<Object?>[this]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
@@ -2517,7 +2776,8 @@ class WebSettings extends PigeonInternalProxyApiBaseClass {
 
   /// Configures the WebView's behavior when handling mixed content.
   Future<void> setMixedContentMode(MixedContentMode mode) async {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecWebSettings;
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
+        _pigeonVar_codecWebSettings;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
     const pigeonVar_channelName =
         'dev.flutter.pigeon.webview_flutter_android.WebSettings.setMixedContentMode';
@@ -2526,10 +2786,15 @@ class WebSettings extends PigeonInternalProxyApiBaseClass {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[this, mode]);
+    final Future<Object?> pigeonVar_sendFuture =
+        pigeonVar_channel.send(<Object?>[this, mode]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
-    _extractReplyValueOrThrow(pigeonVar_replyList, pigeonVar_channelName, isNullValid: true);
+    _extractReplyValueOrThrow(
+      pigeonVar_replyList,
+      pigeonVar_channelName,
+      isNullValid: true,
+    );
   }
 
   @override
@@ -2550,7 +2815,10 @@ class JavaScriptChannel extends PigeonInternalProxyApiBaseClass {
     BinaryMessenger? pigeon_binaryMessenger,
     PigeonInstanceManager? pigeon_instanceManager,
     required String channelName,
-    required void Function(JavaScriptChannel pigeon_instance, String message) postMessage,
+    required void Function(
+      JavaScriptChannel pigeon_instance,
+      String message,
+    ) postMessage,
   }) {
     if (PigeonOverrides.javaScriptChannel_new != null) {
       return PigeonOverrides.javaScriptChannel_new!(
@@ -2573,8 +2841,10 @@ class JavaScriptChannel extends PigeonInternalProxyApiBaseClass {
     required this.channelName,
     required this.postMessage,
   }) {
-    final int pigeonVar_instanceIdentifier = pigeon_instanceManager.addDartCreatedInstance(this);
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecJavaScriptChannel;
+    final int pigeonVar_instanceIdentifier =
+        pigeon_instanceManager.addDartCreatedInstance(this);
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
+        _pigeonVar_codecJavaScriptChannel;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
     const pigeonVar_channelName =
         'dev.flutter.pigeon.webview_flutter_android.JavaScriptChannel.pigeon_defaultConstructor';
@@ -2583,14 +2853,16 @@ class JavaScriptChannel extends PigeonInternalProxyApiBaseClass {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[
-      pigeonVar_instanceIdentifier,
-      channelName,
-    ]);
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel
+        .send(<Object?>[pigeonVar_instanceIdentifier, channelName]);
     () async {
       final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
-      _extractReplyValueOrThrow(pigeonVar_replyList, pigeonVar_channelName, isNullValid: true);
+      _extractReplyValueOrThrow(
+        pigeonVar_replyList,
+        pigeonVar_channelName,
+        isNullValid: true,
+      );
     }();
   }
 
@@ -2606,7 +2878,8 @@ class JavaScriptChannel extends PigeonInternalProxyApiBaseClass {
     required this.postMessage,
   });
 
-  late final _PigeonInternalProxyApiBaseCodec _pigeonVar_codecJavaScriptChannel =
+  late final _PigeonInternalProxyApiBaseCodec
+      _pigeonVar_codecJavaScriptChannel =
       _PigeonInternalProxyApiBaseCodec(pigeon_instanceManager);
 
   final String channelName;
@@ -2630,40 +2903,46 @@ class JavaScriptChannel extends PigeonInternalProxyApiBaseClass {
   ///
   /// Alternatively, [PigeonInstanceManager.removeWeakReference] can be used to
   /// release the associated Native object manually.
-  final void Function(JavaScriptChannel pigeon_instance, String message) postMessage;
+  final void Function(
+    JavaScriptChannel pigeon_instance,
+    String message,
+  ) postMessage;
 
   static void pigeon_setUpMessageHandlers({
     bool pigeon_clearHandlers = false,
     BinaryMessenger? pigeon_binaryMessenger,
     PigeonInstanceManager? pigeon_instanceManager,
-    void Function(JavaScriptChannel pigeon_instance, String message)? postMessage,
+    void Function(
+      JavaScriptChannel pigeon_instance,
+      String message,
+    )? postMessage,
   }) {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _PigeonInternalProxyApiBaseCodec(
-      pigeon_instanceManager ?? PigeonInstanceManager.instance,
-    );
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
+        _PigeonInternalProxyApiBaseCodec(
+            pigeon_instanceManager ?? PigeonInstanceManager.instance);
     final BinaryMessenger? binaryMessenger = pigeon_binaryMessenger;
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-        'dev.flutter.pigeon.webview_flutter_android.JavaScriptChannel.postMessage',
-        pigeonChannelCodec,
-        binaryMessenger: binaryMessenger,
-      );
+          'dev.flutter.pigeon.webview_flutter_android.JavaScriptChannel.postMessage',
+          pigeonChannelCodec,
+          binaryMessenger: binaryMessenger);
       if (pigeon_clearHandlers) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
         pigeonVar_channel.setMessageHandler((Object? message) async {
           final List<Object?> args = message! as List<Object?>;
-          final JavaScriptChannel arg_pigeon_instance = args[0]! as JavaScriptChannel;
+          final JavaScriptChannel arg_pigeon_instance =
+              args[0]! as JavaScriptChannel;
           final String arg_message = args[1]! as String;
           try {
-            (postMessage ?? arg_pigeon_instance.postMessage).call(arg_pigeon_instance, arg_message);
+            (postMessage ?? arg_pigeon_instance.postMessage)
+                .call(arg_pigeon_instance, arg_message);
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
           } catch (e) {
             return wrapResponse(
-              error: PlatformException(code: 'error', message: e.toString()),
-            );
+                error: PlatformException(code: 'error', message: e.toString()));
           }
         });
       }
@@ -2688,71 +2967,101 @@ class WebViewClient extends PigeonInternalProxyApiBaseClass {
   factory WebViewClient({
     BinaryMessenger? pigeon_binaryMessenger,
     PigeonInstanceManager? pigeon_instanceManager,
-    void Function(WebViewClient pigeon_instance, WebView webView, String url)? onPageStarted,
-    void Function(WebViewClient pigeon_instance, WebView webView, String url)? onPageFinished,
+    void Function(
+      WebViewClient pigeon_instance,
+      WebView webView,
+      String url,
+    )? onPageStarted,
+    void Function(
+      WebViewClient pigeon_instance,
+      WebView webView,
+      String url,
+    )? onPageFinished,
     void Function(
       WebViewClient pigeon_instance,
       WebView webView,
       WebResourceRequest request,
       WebResourceResponse response,
-    )?
-    onReceivedHttpError,
+    )? onReceivedHttpError,
     void Function(
       WebViewClient pigeon_instance,
       WebView webView,
       WebResourceRequest request,
       WebResourceError error,
-    )?
-    onReceivedRequestError,
+    )? onReceivedRequestError,
     void Function(
       WebViewClient pigeon_instance,
       WebView webView,
       WebResourceRequest request,
       WebResourceErrorCompat error,
-    )?
-    onReceivedRequestErrorCompat,
-    void Function(WebViewClient pigeon_instance, WebView webView, WebResourceRequest request)?
-    requestLoading,
-    void Function(WebViewClient pigeon_instance, String url)? onCreateWindow,
-    void Function(WebViewClient pigeon_instance, WebView webView, String url)? urlLoading,
-    void Function(WebViewClient pigeon_instance, WebView webView, String url, bool isReload)?
-    doUpdateVisitedHistory,
+    )? onReceivedRequestErrorCompat,
+    void Function(
+      WebViewClient pigeon_instance,
+      WebView webView,
+      WebResourceRequest request,
+    )? requestLoading,
+    void Function(
+      WebViewClient pigeon_instance,
+      WebView webView,
+      String url,
+    )? urlLoading,
+    void Function(
+      WebViewClient pigeon_instance,
+      String url,
+    )? onCreateWindow,
+    void Function(
+      WebViewClient pigeon_instance,
+      WebView webView,
+      String url,
+      bool isReload,
+    )? doUpdateVisitedHistory,
     void Function(
       WebViewClient pigeon_instance,
       WebView webView,
       HttpAuthHandler handler,
       String host,
       String realm,
-    )?
-    onReceivedHttpAuthRequest,
+    )? onReceivedHttpAuthRequest,
     void Function(
       WebViewClient pigeon_instance,
       WebView view,
       AndroidMessage dontResend,
       AndroidMessage resend,
-    )?
-    onFormResubmission,
-    void Function(WebViewClient pigeon_instance, WebView view, String url)? onLoadResource,
-    void Function(WebViewClient pigeon_instance, WebView view, String url)? onPageCommitVisible,
-    void Function(WebViewClient pigeon_instance, WebView view, ClientCertRequest request)?
-    onReceivedClientCertRequest,
+    )? onFormResubmission,
+    void Function(
+      WebViewClient pigeon_instance,
+      WebView view,
+      String url,
+    )? onLoadResource,
+    void Function(
+      WebViewClient pigeon_instance,
+      WebView view,
+      String url,
+    )? onPageCommitVisible,
+    void Function(
+      WebViewClient pigeon_instance,
+      WebView view,
+      ClientCertRequest request,
+    )? onReceivedClientCertRequest,
     void Function(
       WebViewClient pigeon_instance,
       WebView view,
       String realm,
       String? account,
       String args,
-    )?
-    onReceivedLoginRequest,
+    )? onReceivedLoginRequest,
     void Function(
       WebViewClient pigeon_instance,
       WebView view,
       SslErrorHandler handler,
       SslError error,
-    )?
-    onReceivedSslError,
-    void Function(WebViewClient pigeon_instance, WebView view, double oldScale, double newScale)?
-    onScaleChanged,
+    )? onReceivedSslError,
+    void Function(
+      WebViewClient pigeon_instance,
+      WebView view,
+      double oldScale,
+      double newScale,
+    )? onScaleChanged,
   }) {
     if (PigeonOverrides.webViewClient_new != null) {
       return PigeonOverrides.webViewClient_new!(
@@ -2762,8 +3071,8 @@ class WebViewClient extends PigeonInternalProxyApiBaseClass {
         onReceivedRequestError: onReceivedRequestError,
         onReceivedRequestErrorCompat: onReceivedRequestErrorCompat,
         requestLoading: requestLoading,
-        onCreateWindow: onCreateWindow,
         urlLoading: urlLoading,
+        onCreateWindow: onCreateWindow,
         doUpdateVisitedHistory: doUpdateVisitedHistory,
         onReceivedHttpAuthRequest: onReceivedHttpAuthRequest,
         onFormResubmission: onFormResubmission,
@@ -2784,8 +3093,8 @@ class WebViewClient extends PigeonInternalProxyApiBaseClass {
       onReceivedRequestError: onReceivedRequestError,
       onReceivedRequestErrorCompat: onReceivedRequestErrorCompat,
       requestLoading: requestLoading,
-      onCreateWindow: onCreateWindow,
       urlLoading: urlLoading,
+      onCreateWindow: onCreateWindow,
       doUpdateVisitedHistory: doUpdateVisitedHistory,
       onReceivedHttpAuthRequest: onReceivedHttpAuthRequest,
       onFormResubmission: onFormResubmission,
@@ -2808,8 +3117,8 @@ class WebViewClient extends PigeonInternalProxyApiBaseClass {
     this.onReceivedRequestError,
     this.onReceivedRequestErrorCompat,
     this.requestLoading,
-    this.onCreateWindow,
     this.urlLoading,
+    this.onCreateWindow,
     this.doUpdateVisitedHistory,
     this.onReceivedHttpAuthRequest,
     this.onFormResubmission,
@@ -2820,8 +3129,10 @@ class WebViewClient extends PigeonInternalProxyApiBaseClass {
     this.onReceivedSslError,
     this.onScaleChanged,
   }) {
-    final int pigeonVar_instanceIdentifier = pigeon_instanceManager.addDartCreatedInstance(this);
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecWebViewClient;
+    final int pigeonVar_instanceIdentifier =
+        pigeon_instanceManager.addDartCreatedInstance(this);
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
+        _pigeonVar_codecWebViewClient;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
     const pigeonVar_channelName =
         'dev.flutter.pigeon.webview_flutter_android.WebViewClient.pigeon_defaultConstructor';
@@ -2830,13 +3141,16 @@ class WebViewClient extends PigeonInternalProxyApiBaseClass {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[
-      pigeonVar_instanceIdentifier,
-    ]);
+    final Future<Object?> pigeonVar_sendFuture =
+        pigeonVar_channel.send(<Object?>[pigeonVar_instanceIdentifier]);
     () async {
       final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
-      _extractReplyValueOrThrow(pigeonVar_replyList, pigeonVar_channelName, isNullValid: true);
+      _extractReplyValueOrThrow(
+        pigeonVar_replyList,
+        pigeonVar_channelName,
+        isNullValid: true,
+      );
     }();
   }
 
@@ -2854,8 +3168,8 @@ class WebViewClient extends PigeonInternalProxyApiBaseClass {
     this.onReceivedRequestError,
     this.onReceivedRequestErrorCompat,
     this.requestLoading,
-    this.onCreateWindow,
     this.urlLoading,
+    this.onCreateWindow,
     this.doUpdateVisitedHistory,
     this.onReceivedHttpAuthRequest,
     this.onFormResubmission,
@@ -2889,7 +3203,11 @@ class WebViewClient extends PigeonInternalProxyApiBaseClass {
   ///
   /// Alternatively, [PigeonInstanceManager.removeWeakReference] can be used to
   /// release the associated Native object manually.
-  final void Function(WebViewClient pigeon_instance, WebView webView, String url)? onPageStarted;
+  final void Function(
+    WebViewClient pigeon_instance,
+    WebView webView,
+    String url,
+  )? onPageStarted;
 
   /// Notify the host application that a page has finished loading.
   ///
@@ -2910,7 +3228,11 @@ class WebViewClient extends PigeonInternalProxyApiBaseClass {
   ///
   /// Alternatively, [PigeonInstanceManager.removeWeakReference] can be used to
   /// release the associated Native object manually.
-  final void Function(WebViewClient pigeon_instance, WebView webView, String url)? onPageFinished;
+  final void Function(
+    WebViewClient pigeon_instance,
+    WebView webView,
+    String url,
+  )? onPageFinished;
 
   /// Notify the host application that an HTTP error has been received from the
   /// server while loading a resource.
@@ -2937,8 +3259,7 @@ class WebViewClient extends PigeonInternalProxyApiBaseClass {
     WebView webView,
     WebResourceRequest request,
     WebResourceResponse response,
-  )?
-  onReceivedHttpError;
+  )? onReceivedHttpError;
 
   /// Report web resource loading error to the host application.
   ///
@@ -2964,8 +3285,7 @@ class WebViewClient extends PigeonInternalProxyApiBaseClass {
     WebView webView,
     WebResourceRequest request,
     WebResourceError error,
-  )?
-  onReceivedRequestError;
+  )? onReceivedRequestError;
 
   /// Report web resource loading error to the host application.
   ///
@@ -2991,8 +3311,7 @@ class WebViewClient extends PigeonInternalProxyApiBaseClass {
     WebView webView,
     WebResourceRequest request,
     WebResourceErrorCompat error,
-  )?
-  onReceivedRequestErrorCompat;
+  )? onReceivedRequestErrorCompat;
 
   /// Give the host application a chance to take control when a URL is about to
   /// be loaded in the current WebView.
@@ -3014,11 +3333,11 @@ class WebViewClient extends PigeonInternalProxyApiBaseClass {
   ///
   /// Alternatively, [PigeonInstanceManager.removeWeakReference] can be used to
   /// release the associated Native object manually.
-  final void Function(WebViewClient pigeon_instance, WebView webView, WebResourceRequest request)?
-  requestLoading;
-
-  /// Notifies the host that the page requested a new window.
-  final void Function(WebViewClient pigeon_instance, String url)? onCreateWindow;
+  final void Function(
+    WebViewClient pigeon_instance,
+    WebView webView,
+    WebResourceRequest request,
+  )? requestLoading;
 
   /// Give the host application a chance to take control when a URL is about to
   /// be loaded in the current WebView.
@@ -3040,7 +3359,36 @@ class WebViewClient extends PigeonInternalProxyApiBaseClass {
   ///
   /// Alternatively, [PigeonInstanceManager.removeWeakReference] can be used to
   /// release the associated Native object manually.
-  final void Function(WebViewClient pigeon_instance, WebView webView, String url)? urlLoading;
+  final void Function(
+    WebViewClient pigeon_instance,
+    WebView webView,
+    String url,
+  )? urlLoading;
+
+  /// Notifies the host that the page requested a new window
+  /// (`target=_blank` / `window.open`).
+  ///
+  /// For the associated Native object to be automatically garbage collected,
+  /// it is required that the implementation of this `Function` doesn't have a
+  /// strong reference to the encapsulating class instance. When this `Function`
+  /// references a non-local variable, it is strongly recommended to access it
+  /// with a `WeakReference`:
+  ///
+  /// ```dart
+  /// final WeakReference weakMyVariable = WeakReference(myVariable);
+  /// final WebViewClient instance = WebViewClient(
+  ///  onCreateWindow: (WebViewClient pigeon_instance, ...) {
+  ///    print(weakMyVariable?.target);
+  ///  },
+  /// );
+  /// ```
+  ///
+  /// Alternatively, [PigeonInstanceManager.removeWeakReference] can be used to
+  /// release the associated Native object manually.
+  final void Function(
+    WebViewClient pigeon_instance,
+    String url,
+  )? onCreateWindow;
 
   /// Notify the host application to update its visited links database.
   ///
@@ -3061,8 +3409,12 @@ class WebViewClient extends PigeonInternalProxyApiBaseClass {
   ///
   /// Alternatively, [PigeonInstanceManager.removeWeakReference] can be used to
   /// release the associated Native object manually.
-  final void Function(WebViewClient pigeon_instance, WebView webView, String url, bool isReload)?
-  doUpdateVisitedHistory;
+  final void Function(
+    WebViewClient pigeon_instance,
+    WebView webView,
+    String url,
+    bool isReload,
+  )? doUpdateVisitedHistory;
 
   /// Notifies the host application that the WebView received an HTTP
   /// authentication request.
@@ -3090,8 +3442,7 @@ class WebViewClient extends PigeonInternalProxyApiBaseClass {
     HttpAuthHandler handler,
     String host,
     String realm,
-  )?
-  onReceivedHttpAuthRequest;
+  )? onReceivedHttpAuthRequest;
 
   /// Ask the host application if the browser should resend data as the
   /// requested page was a result of a POST.
@@ -3118,8 +3469,7 @@ class WebViewClient extends PigeonInternalProxyApiBaseClass {
     WebView view,
     AndroidMessage dontResend,
     AndroidMessage resend,
-  )?
-  onFormResubmission;
+  )? onFormResubmission;
 
   /// Notify the host application that the WebView will load the resource
   /// specified by the given url.
@@ -3141,7 +3491,11 @@ class WebViewClient extends PigeonInternalProxyApiBaseClass {
   ///
   /// Alternatively, [PigeonInstanceManager.removeWeakReference] can be used to
   /// release the associated Native object manually.
-  final void Function(WebViewClient pigeon_instance, WebView view, String url)? onLoadResource;
+  final void Function(
+    WebViewClient pigeon_instance,
+    WebView view,
+    String url,
+  )? onLoadResource;
 
   /// Notify the host application that WebView content left over from previous
   /// page navigations will no longer be drawn.
@@ -3163,7 +3517,11 @@ class WebViewClient extends PigeonInternalProxyApiBaseClass {
   ///
   /// Alternatively, [PigeonInstanceManager.removeWeakReference] can be used to
   /// release the associated Native object manually.
-  final void Function(WebViewClient pigeon_instance, WebView view, String url)? onPageCommitVisible;
+  final void Function(
+    WebViewClient pigeon_instance,
+    WebView view,
+    String url,
+  )? onPageCommitVisible;
 
   /// Notify the host application to handle a SSL client certificate request.
   ///
@@ -3184,8 +3542,11 @@ class WebViewClient extends PigeonInternalProxyApiBaseClass {
   ///
   /// Alternatively, [PigeonInstanceManager.removeWeakReference] can be used to
   /// release the associated Native object manually.
-  final void Function(WebViewClient pigeon_instance, WebView view, ClientCertRequest request)?
-  onReceivedClientCertRequest;
+  final void Function(
+    WebViewClient pigeon_instance,
+    WebView view,
+    ClientCertRequest request,
+  )? onReceivedClientCertRequest;
 
   /// Notify the host application that a request to automatically log in the
   /// user has been processed.
@@ -3213,8 +3574,7 @@ class WebViewClient extends PigeonInternalProxyApiBaseClass {
     String realm,
     String? account,
     String args,
-  )?
-  onReceivedLoginRequest;
+  )? onReceivedLoginRequest;
 
   /// Notifies the host application that an SSL error occurred while loading a
   /// resource.
@@ -3241,8 +3601,7 @@ class WebViewClient extends PigeonInternalProxyApiBaseClass {
     WebView view,
     SslErrorHandler handler,
     SslError error,
-  )?
-  onReceivedSslError;
+  )? onReceivedSslError;
 
   /// Notify the host application that the scale applied to the WebView has
   /// changed.
@@ -3269,90 +3628,118 @@ class WebViewClient extends PigeonInternalProxyApiBaseClass {
     WebView view,
     double oldScale,
     double newScale,
-  )?
-  onScaleChanged;
+  )? onScaleChanged;
 
   static void pigeon_setUpMessageHandlers({
     bool pigeon_clearHandlers = false,
     BinaryMessenger? pigeon_binaryMessenger,
     PigeonInstanceManager? pigeon_instanceManager,
     WebViewClient Function()? pigeon_newInstance,
-    void Function(WebViewClient pigeon_instance, WebView webView, String url)? onPageStarted,
-    void Function(WebViewClient pigeon_instance, WebView webView, String url)? onPageFinished,
+    void Function(
+      WebViewClient pigeon_instance,
+      WebView webView,
+      String url,
+    )? onPageStarted,
+    void Function(
+      WebViewClient pigeon_instance,
+      WebView webView,
+      String url,
+    )? onPageFinished,
     void Function(
       WebViewClient pigeon_instance,
       WebView webView,
       WebResourceRequest request,
       WebResourceResponse response,
-    )?
-    onReceivedHttpError,
+    )? onReceivedHttpError,
     void Function(
       WebViewClient pigeon_instance,
       WebView webView,
       WebResourceRequest request,
       WebResourceError error,
-    )?
-    onReceivedRequestError,
+    )? onReceivedRequestError,
     void Function(
       WebViewClient pigeon_instance,
       WebView webView,
       WebResourceRequest request,
       WebResourceErrorCompat error,
-    )?
-    onReceivedRequestErrorCompat,
-    void Function(WebViewClient pigeon_instance, WebView webView, WebResourceRequest request)?
-    requestLoading,
-    void Function(WebViewClient pigeon_instance, String url)? onCreateWindow,
-    void Function(WebViewClient pigeon_instance, WebView webView, String url)? urlLoading,
-    void Function(WebViewClient pigeon_instance, WebView webView, String url, bool isReload)?
-    doUpdateVisitedHistory,
+    )? onReceivedRequestErrorCompat,
+    void Function(
+      WebViewClient pigeon_instance,
+      WebView webView,
+      WebResourceRequest request,
+    )? requestLoading,
+    void Function(
+      WebViewClient pigeon_instance,
+      WebView webView,
+      String url,
+    )? urlLoading,
+    void Function(
+      WebViewClient pigeon_instance,
+      String url,
+    )? onCreateWindow,
+    void Function(
+      WebViewClient pigeon_instance,
+      WebView webView,
+      String url,
+      bool isReload,
+    )? doUpdateVisitedHistory,
     void Function(
       WebViewClient pigeon_instance,
       WebView webView,
       HttpAuthHandler handler,
       String host,
       String realm,
-    )?
-    onReceivedHttpAuthRequest,
+    )? onReceivedHttpAuthRequest,
     void Function(
       WebViewClient pigeon_instance,
       WebView view,
       AndroidMessage dontResend,
       AndroidMessage resend,
-    )?
-    onFormResubmission,
-    void Function(WebViewClient pigeon_instance, WebView view, String url)? onLoadResource,
-    void Function(WebViewClient pigeon_instance, WebView view, String url)? onPageCommitVisible,
-    void Function(WebViewClient pigeon_instance, WebView view, ClientCertRequest request)?
-    onReceivedClientCertRequest,
+    )? onFormResubmission,
+    void Function(
+      WebViewClient pigeon_instance,
+      WebView view,
+      String url,
+    )? onLoadResource,
+    void Function(
+      WebViewClient pigeon_instance,
+      WebView view,
+      String url,
+    )? onPageCommitVisible,
+    void Function(
+      WebViewClient pigeon_instance,
+      WebView view,
+      ClientCertRequest request,
+    )? onReceivedClientCertRequest,
     void Function(
       WebViewClient pigeon_instance,
       WebView view,
       String realm,
       String? account,
       String args,
-    )?
-    onReceivedLoginRequest,
+    )? onReceivedLoginRequest,
     void Function(
       WebViewClient pigeon_instance,
       WebView view,
       SslErrorHandler handler,
       SslError error,
-    )?
-    onReceivedSslError,
-    void Function(WebViewClient pigeon_instance, WebView view, double oldScale, double newScale)?
-    onScaleChanged,
+    )? onReceivedSslError,
+    void Function(
+      WebViewClient pigeon_instance,
+      WebView view,
+      double oldScale,
+      double newScale,
+    )? onScaleChanged,
   }) {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _PigeonInternalProxyApiBaseCodec(
-      pigeon_instanceManager ?? PigeonInstanceManager.instance,
-    );
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
+        _PigeonInternalProxyApiBaseCodec(
+            pigeon_instanceManager ?? PigeonInstanceManager.instance);
     final BinaryMessenger? binaryMessenger = pigeon_binaryMessenger;
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-        'dev.flutter.pigeon.webview_flutter_android.WebViewClient.pigeon_newInstance',
-        pigeonChannelCodec,
-        binaryMessenger: binaryMessenger,
-      );
+          'dev.flutter.pigeon.webview_flutter_android.WebViewClient.pigeon_newInstance',
+          pigeonChannelCodec,
+          binaryMessenger: binaryMessenger);
       if (pigeon_clearHandlers) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
@@ -3360,7 +3747,8 @@ class WebViewClient extends PigeonInternalProxyApiBaseClass {
           final List<Object?> args = message! as List<Object?>;
           final int arg_pigeon_instanceIdentifier = args[0]! as int;
           try {
-            (pigeon_instanceManager ?? PigeonInstanceManager.instance).addHostCreatedInstance(
+            (pigeon_instanceManager ?? PigeonInstanceManager.instance)
+                .addHostCreatedInstance(
               pigeon_newInstance?.call() ??
                   WebViewClient.pigeon_detached(
                     pigeon_binaryMessenger: pigeon_binaryMessenger,
@@ -3373,8 +3761,7 @@ class WebViewClient extends PigeonInternalProxyApiBaseClass {
             return wrapResponse(error: e);
           } catch (e) {
             return wrapResponse(
-              error: PlatformException(code: 'error', message: e.toString()),
-            );
+                error: PlatformException(code: 'error', message: e.toString()));
           }
         });
       }
@@ -3382,10 +3769,9 @@ class WebViewClient extends PigeonInternalProxyApiBaseClass {
 
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-        'dev.flutter.pigeon.webview_flutter_android.WebViewClient.onPageStarted',
-        pigeonChannelCodec,
-        binaryMessenger: binaryMessenger,
-      );
+          'dev.flutter.pigeon.webview_flutter_android.WebViewClient.onPageStarted',
+          pigeonChannelCodec,
+          binaryMessenger: binaryMessenger);
       if (pigeon_clearHandlers) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
@@ -3395,18 +3781,14 @@ class WebViewClient extends PigeonInternalProxyApiBaseClass {
           final WebView arg_webView = args[1]! as WebView;
           final String arg_url = args[2]! as String;
           try {
-            (onPageStarted ?? arg_pigeon_instance.onPageStarted)?.call(
-              arg_pigeon_instance,
-              arg_webView,
-              arg_url,
-            );
+            (onPageStarted ?? arg_pigeon_instance.onPageStarted)
+                ?.call(arg_pigeon_instance, arg_webView, arg_url);
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
           } catch (e) {
             return wrapResponse(
-              error: PlatformException(code: 'error', message: e.toString()),
-            );
+                error: PlatformException(code: 'error', message: e.toString()));
           }
         });
       }
@@ -3414,10 +3796,9 @@ class WebViewClient extends PigeonInternalProxyApiBaseClass {
 
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-        'dev.flutter.pigeon.webview_flutter_android.WebViewClient.onPageFinished',
-        pigeonChannelCodec,
-        binaryMessenger: binaryMessenger,
-      );
+          'dev.flutter.pigeon.webview_flutter_android.WebViewClient.onPageFinished',
+          pigeonChannelCodec,
+          binaryMessenger: binaryMessenger);
       if (pigeon_clearHandlers) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
@@ -3427,18 +3808,14 @@ class WebViewClient extends PigeonInternalProxyApiBaseClass {
           final WebView arg_webView = args[1]! as WebView;
           final String arg_url = args[2]! as String;
           try {
-            (onPageFinished ?? arg_pigeon_instance.onPageFinished)?.call(
-              arg_pigeon_instance,
-              arg_webView,
-              arg_url,
-            );
+            (onPageFinished ?? arg_pigeon_instance.onPageFinished)
+                ?.call(arg_pigeon_instance, arg_webView, arg_url);
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
           } catch (e) {
             return wrapResponse(
-              error: PlatformException(code: 'error', message: e.toString()),
-            );
+                error: PlatformException(code: 'error', message: e.toString()));
           }
         });
       }
@@ -3446,10 +3823,9 @@ class WebViewClient extends PigeonInternalProxyApiBaseClass {
 
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-        'dev.flutter.pigeon.webview_flutter_android.WebViewClient.onReceivedHttpError',
-        pigeonChannelCodec,
-        binaryMessenger: binaryMessenger,
-      );
+          'dev.flutter.pigeon.webview_flutter_android.WebViewClient.onReceivedHttpError',
+          pigeonChannelCodec,
+          binaryMessenger: binaryMessenger);
       if (pigeon_clearHandlers) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
@@ -3458,21 +3834,18 @@ class WebViewClient extends PigeonInternalProxyApiBaseClass {
           final WebViewClient arg_pigeon_instance = args[0]! as WebViewClient;
           final WebView arg_webView = args[1]! as WebView;
           final WebResourceRequest arg_request = args[2]! as WebResourceRequest;
-          final WebResourceResponse arg_response = args[3]! as WebResourceResponse;
+          final WebResourceResponse arg_response =
+              args[3]! as WebResourceResponse;
           try {
-            (onReceivedHttpError ?? arg_pigeon_instance.onReceivedHttpError)?.call(
-              arg_pigeon_instance,
-              arg_webView,
-              arg_request,
-              arg_response,
-            );
+            (onReceivedHttpError ?? arg_pigeon_instance.onReceivedHttpError)
+                ?.call(arg_pigeon_instance, arg_webView, arg_request,
+                    arg_response);
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
           } catch (e) {
             return wrapResponse(
-              error: PlatformException(code: 'error', message: e.toString()),
-            );
+                error: PlatformException(code: 'error', message: e.toString()));
           }
         });
       }
@@ -3480,10 +3853,9 @@ class WebViewClient extends PigeonInternalProxyApiBaseClass {
 
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-        'dev.flutter.pigeon.webview_flutter_android.WebViewClient.onReceivedRequestError',
-        pigeonChannelCodec,
-        binaryMessenger: binaryMessenger,
-      );
+          'dev.flutter.pigeon.webview_flutter_android.WebViewClient.onReceivedRequestError',
+          pigeonChannelCodec,
+          binaryMessenger: binaryMessenger);
       if (pigeon_clearHandlers) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
@@ -3494,19 +3866,16 @@ class WebViewClient extends PigeonInternalProxyApiBaseClass {
           final WebResourceRequest arg_request = args[2]! as WebResourceRequest;
           final WebResourceError arg_error = args[3]! as WebResourceError;
           try {
-            (onReceivedRequestError ?? arg_pigeon_instance.onReceivedRequestError)?.call(
-              arg_pigeon_instance,
-              arg_webView,
-              arg_request,
-              arg_error,
-            );
+            (onReceivedRequestError ??
+                    arg_pigeon_instance.onReceivedRequestError)
+                ?.call(
+                    arg_pigeon_instance, arg_webView, arg_request, arg_error);
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
           } catch (e) {
             return wrapResponse(
-              error: PlatformException(code: 'error', message: e.toString()),
-            );
+                error: PlatformException(code: 'error', message: e.toString()));
           }
         });
       }
@@ -3514,10 +3883,9 @@ class WebViewClient extends PigeonInternalProxyApiBaseClass {
 
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-        'dev.flutter.pigeon.webview_flutter_android.WebViewClient.onReceivedRequestErrorCompat',
-        pigeonChannelCodec,
-        binaryMessenger: binaryMessenger,
-      );
+          'dev.flutter.pigeon.webview_flutter_android.WebViewClient.onReceivedRequestErrorCompat',
+          pigeonChannelCodec,
+          binaryMessenger: binaryMessenger);
       if (pigeon_clearHandlers) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
@@ -3526,17 +3894,19 @@ class WebViewClient extends PigeonInternalProxyApiBaseClass {
           final WebViewClient arg_pigeon_instance = args[0]! as WebViewClient;
           final WebView arg_webView = args[1]! as WebView;
           final WebResourceRequest arg_request = args[2]! as WebResourceRequest;
-          final WebResourceErrorCompat arg_error = args[3]! as WebResourceErrorCompat;
+          final WebResourceErrorCompat arg_error =
+              args[3]! as WebResourceErrorCompat;
           try {
-            (onReceivedRequestErrorCompat ?? arg_pigeon_instance.onReceivedRequestErrorCompat)
-                ?.call(arg_pigeon_instance, arg_webView, arg_request, arg_error);
+            (onReceivedRequestErrorCompat ??
+                    arg_pigeon_instance.onReceivedRequestErrorCompat)
+                ?.call(
+                    arg_pigeon_instance, arg_webView, arg_request, arg_error);
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
           } catch (e) {
             return wrapResponse(
-              error: PlatformException(code: 'error', message: e.toString()),
-            );
+                error: PlatformException(code: 'error', message: e.toString()));
           }
         });
       }
@@ -3544,10 +3914,9 @@ class WebViewClient extends PigeonInternalProxyApiBaseClass {
 
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-        'dev.flutter.pigeon.webview_flutter_android.WebViewClient.requestLoading',
-        pigeonChannelCodec,
-        binaryMessenger: binaryMessenger,
-      );
+          'dev.flutter.pigeon.webview_flutter_android.WebViewClient.requestLoading',
+          pigeonChannelCodec,
+          binaryMessenger: binaryMessenger);
       if (pigeon_clearHandlers) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
@@ -3557,18 +3926,14 @@ class WebViewClient extends PigeonInternalProxyApiBaseClass {
           final WebView arg_webView = args[1]! as WebView;
           final WebResourceRequest arg_request = args[2]! as WebResourceRequest;
           try {
-            (requestLoading ?? arg_pigeon_instance.requestLoading)?.call(
-              arg_pigeon_instance,
-              arg_webView,
-              arg_request,
-            );
+            (requestLoading ?? arg_pigeon_instance.requestLoading)
+                ?.call(arg_pigeon_instance, arg_webView, arg_request);
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
           } catch (e) {
             return wrapResponse(
-              error: PlatformException(code: 'error', message: e.toString()),
-            );
+                error: PlatformException(code: 'error', message: e.toString()));
           }
         });
       }
@@ -3576,40 +3941,9 @@ class WebViewClient extends PigeonInternalProxyApiBaseClass {
 
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-        'dev.flutter.pigeon.webview_flutter_android.WebViewClient.onCreateWindow',
-        pigeonChannelCodec,
-        binaryMessenger: binaryMessenger,
-      );
-      if (pigeon_clearHandlers) {
-        pigeonVar_channel.setMessageHandler(null);
-      } else {
-        pigeonVar_channel.setMessageHandler((Object? message) async {
-          final List<Object?> args = message! as List<Object?>;
-          final WebViewClient arg_pigeon_instance = args[0]! as WebViewClient;
-          final String arg_url = args[1]! as String;
-          try {
-            (onCreateWindow ?? arg_pigeon_instance.onCreateWindow)?.call(
-              arg_pigeon_instance,
-              arg_url,
-            );
-            return wrapResponse(empty: true);
-          } on PlatformException catch (e) {
-            return wrapResponse(error: e);
-          } catch (e) {
-            return wrapResponse(
-              error: PlatformException(code: 'error', message: e.toString()),
-            );
-          }
-        });
-      }
-    }
-
-    {
-      final pigeonVar_channel = BasicMessageChannel<Object?>(
-        'dev.flutter.pigeon.webview_flutter_android.WebViewClient.urlLoading',
-        pigeonChannelCodec,
-        binaryMessenger: binaryMessenger,
-      );
+          'dev.flutter.pigeon.webview_flutter_android.WebViewClient.urlLoading',
+          pigeonChannelCodec,
+          binaryMessenger: binaryMessenger);
       if (pigeon_clearHandlers) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
@@ -3619,18 +3953,14 @@ class WebViewClient extends PigeonInternalProxyApiBaseClass {
           final WebView arg_webView = args[1]! as WebView;
           final String arg_url = args[2]! as String;
           try {
-            (urlLoading ?? arg_pigeon_instance.urlLoading)?.call(
-              arg_pigeon_instance,
-              arg_webView,
-              arg_url,
-            );
+            (urlLoading ?? arg_pigeon_instance.urlLoading)
+                ?.call(arg_pigeon_instance, arg_webView, arg_url);
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
           } catch (e) {
             return wrapResponse(
-              error: PlatformException(code: 'error', message: e.toString()),
-            );
+                error: PlatformException(code: 'error', message: e.toString()));
           }
         });
       }
@@ -3638,10 +3968,35 @@ class WebViewClient extends PigeonInternalProxyApiBaseClass {
 
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-        'dev.flutter.pigeon.webview_flutter_android.WebViewClient.doUpdateVisitedHistory',
-        pigeonChannelCodec,
-        binaryMessenger: binaryMessenger,
-      );
+          'dev.flutter.pigeon.webview_flutter_android.WebViewClient.onCreateWindow',
+          pigeonChannelCodec,
+          binaryMessenger: binaryMessenger);
+      if (pigeon_clearHandlers) {
+        pigeonVar_channel.setMessageHandler(null);
+      } else {
+        pigeonVar_channel.setMessageHandler((Object? message) async {
+          final List<Object?> args = message! as List<Object?>;
+          final WebViewClient arg_pigeon_instance = args[0]! as WebViewClient;
+          final String arg_url = args[1]! as String;
+          try {
+            (onCreateWindow ?? arg_pigeon_instance.onCreateWindow)
+                ?.call(arg_pigeon_instance, arg_url);
+            return wrapResponse(empty: true);
+          } on PlatformException catch (e) {
+            return wrapResponse(error: e);
+          } catch (e) {
+            return wrapResponse(
+                error: PlatformException(code: 'error', message: e.toString()));
+          }
+        });
+      }
+    }
+
+    {
+      final pigeonVar_channel = BasicMessageChannel<Object?>(
+          'dev.flutter.pigeon.webview_flutter_android.WebViewClient.doUpdateVisitedHistory',
+          pigeonChannelCodec,
+          binaryMessenger: binaryMessenger);
       if (pigeon_clearHandlers) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
@@ -3652,19 +4007,15 @@ class WebViewClient extends PigeonInternalProxyApiBaseClass {
           final String arg_url = args[2]! as String;
           final bool arg_isReload = args[3]! as bool;
           try {
-            (doUpdateVisitedHistory ?? arg_pigeon_instance.doUpdateVisitedHistory)?.call(
-              arg_pigeon_instance,
-              arg_webView,
-              arg_url,
-              arg_isReload,
-            );
+            (doUpdateVisitedHistory ??
+                    arg_pigeon_instance.doUpdateVisitedHistory)
+                ?.call(arg_pigeon_instance, arg_webView, arg_url, arg_isReload);
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
           } catch (e) {
             return wrapResponse(
-              error: PlatformException(code: 'error', message: e.toString()),
-            );
+                error: PlatformException(code: 'error', message: e.toString()));
           }
         });
       }
@@ -3672,10 +4023,9 @@ class WebViewClient extends PigeonInternalProxyApiBaseClass {
 
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-        'dev.flutter.pigeon.webview_flutter_android.WebViewClient.onReceivedHttpAuthRequest',
-        pigeonChannelCodec,
-        binaryMessenger: binaryMessenger,
-      );
+          'dev.flutter.pigeon.webview_flutter_android.WebViewClient.onReceivedHttpAuthRequest',
+          pigeonChannelCodec,
+          binaryMessenger: binaryMessenger);
       if (pigeon_clearHandlers) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
@@ -3687,20 +4037,16 @@ class WebViewClient extends PigeonInternalProxyApiBaseClass {
           final String arg_host = args[3]! as String;
           final String arg_realm = args[4]! as String;
           try {
-            (onReceivedHttpAuthRequest ?? arg_pigeon_instance.onReceivedHttpAuthRequest)?.call(
-              arg_pigeon_instance,
-              arg_webView,
-              arg_handler,
-              arg_host,
-              arg_realm,
-            );
+            (onReceivedHttpAuthRequest ??
+                    arg_pigeon_instance.onReceivedHttpAuthRequest)
+                ?.call(arg_pigeon_instance, arg_webView, arg_handler, arg_host,
+                    arg_realm);
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
           } catch (e) {
             return wrapResponse(
-              error: PlatformException(code: 'error', message: e.toString()),
-            );
+                error: PlatformException(code: 'error', message: e.toString()));
           }
         });
       }
@@ -3708,10 +4054,9 @@ class WebViewClient extends PigeonInternalProxyApiBaseClass {
 
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-        'dev.flutter.pigeon.webview_flutter_android.WebViewClient.onFormResubmission',
-        pigeonChannelCodec,
-        binaryMessenger: binaryMessenger,
-      );
+          'dev.flutter.pigeon.webview_flutter_android.WebViewClient.onFormResubmission',
+          pigeonChannelCodec,
+          binaryMessenger: binaryMessenger);
       if (pigeon_clearHandlers) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
@@ -3722,19 +4067,15 @@ class WebViewClient extends PigeonInternalProxyApiBaseClass {
           final AndroidMessage arg_dontResend = args[2]! as AndroidMessage;
           final AndroidMessage arg_resend = args[3]! as AndroidMessage;
           try {
-            (onFormResubmission ?? arg_pigeon_instance.onFormResubmission)?.call(
-              arg_pigeon_instance,
-              arg_view,
-              arg_dontResend,
-              arg_resend,
-            );
+            (onFormResubmission ?? arg_pigeon_instance.onFormResubmission)
+                ?.call(
+                    arg_pigeon_instance, arg_view, arg_dontResend, arg_resend);
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
           } catch (e) {
             return wrapResponse(
-              error: PlatformException(code: 'error', message: e.toString()),
-            );
+                error: PlatformException(code: 'error', message: e.toString()));
           }
         });
       }
@@ -3742,10 +4083,9 @@ class WebViewClient extends PigeonInternalProxyApiBaseClass {
 
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-        'dev.flutter.pigeon.webview_flutter_android.WebViewClient.onLoadResource',
-        pigeonChannelCodec,
-        binaryMessenger: binaryMessenger,
-      );
+          'dev.flutter.pigeon.webview_flutter_android.WebViewClient.onLoadResource',
+          pigeonChannelCodec,
+          binaryMessenger: binaryMessenger);
       if (pigeon_clearHandlers) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
@@ -3755,18 +4095,14 @@ class WebViewClient extends PigeonInternalProxyApiBaseClass {
           final WebView arg_view = args[1]! as WebView;
           final String arg_url = args[2]! as String;
           try {
-            (onLoadResource ?? arg_pigeon_instance.onLoadResource)?.call(
-              arg_pigeon_instance,
-              arg_view,
-              arg_url,
-            );
+            (onLoadResource ?? arg_pigeon_instance.onLoadResource)
+                ?.call(arg_pigeon_instance, arg_view, arg_url);
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
           } catch (e) {
             return wrapResponse(
-              error: PlatformException(code: 'error', message: e.toString()),
-            );
+                error: PlatformException(code: 'error', message: e.toString()));
           }
         });
       }
@@ -3774,10 +4110,9 @@ class WebViewClient extends PigeonInternalProxyApiBaseClass {
 
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-        'dev.flutter.pigeon.webview_flutter_android.WebViewClient.onPageCommitVisible',
-        pigeonChannelCodec,
-        binaryMessenger: binaryMessenger,
-      );
+          'dev.flutter.pigeon.webview_flutter_android.WebViewClient.onPageCommitVisible',
+          pigeonChannelCodec,
+          binaryMessenger: binaryMessenger);
       if (pigeon_clearHandlers) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
@@ -3787,18 +4122,14 @@ class WebViewClient extends PigeonInternalProxyApiBaseClass {
           final WebView arg_view = args[1]! as WebView;
           final String arg_url = args[2]! as String;
           try {
-            (onPageCommitVisible ?? arg_pigeon_instance.onPageCommitVisible)?.call(
-              arg_pigeon_instance,
-              arg_view,
-              arg_url,
-            );
+            (onPageCommitVisible ?? arg_pigeon_instance.onPageCommitVisible)
+                ?.call(arg_pigeon_instance, arg_view, arg_url);
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
           } catch (e) {
             return wrapResponse(
-              error: PlatformException(code: 'error', message: e.toString()),
-            );
+                error: PlatformException(code: 'error', message: e.toString()));
           }
         });
       }
@@ -3806,10 +4137,9 @@ class WebViewClient extends PigeonInternalProxyApiBaseClass {
 
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-        'dev.flutter.pigeon.webview_flutter_android.WebViewClient.onReceivedClientCertRequest',
-        pigeonChannelCodec,
-        binaryMessenger: binaryMessenger,
-      );
+          'dev.flutter.pigeon.webview_flutter_android.WebViewClient.onReceivedClientCertRequest',
+          pigeonChannelCodec,
+          binaryMessenger: binaryMessenger);
       if (pigeon_clearHandlers) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
@@ -3819,18 +4149,15 @@ class WebViewClient extends PigeonInternalProxyApiBaseClass {
           final WebView arg_view = args[1]! as WebView;
           final ClientCertRequest arg_request = args[2]! as ClientCertRequest;
           try {
-            (onReceivedClientCertRequest ?? arg_pigeon_instance.onReceivedClientCertRequest)?.call(
-              arg_pigeon_instance,
-              arg_view,
-              arg_request,
-            );
+            (onReceivedClientCertRequest ??
+                    arg_pigeon_instance.onReceivedClientCertRequest)
+                ?.call(arg_pigeon_instance, arg_view, arg_request);
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
           } catch (e) {
             return wrapResponse(
-              error: PlatformException(code: 'error', message: e.toString()),
-            );
+                error: PlatformException(code: 'error', message: e.toString()));
           }
         });
       }
@@ -3838,10 +4165,9 @@ class WebViewClient extends PigeonInternalProxyApiBaseClass {
 
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-        'dev.flutter.pigeon.webview_flutter_android.WebViewClient.onReceivedLoginRequest',
-        pigeonChannelCodec,
-        binaryMessenger: binaryMessenger,
-      );
+          'dev.flutter.pigeon.webview_flutter_android.WebViewClient.onReceivedLoginRequest',
+          pigeonChannelCodec,
+          binaryMessenger: binaryMessenger);
       if (pigeon_clearHandlers) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
@@ -3853,20 +4179,16 @@ class WebViewClient extends PigeonInternalProxyApiBaseClass {
           final String? arg_account = args[3] as String?;
           final String arg_args = args[4]! as String;
           try {
-            (onReceivedLoginRequest ?? arg_pigeon_instance.onReceivedLoginRequest)?.call(
-              arg_pigeon_instance,
-              arg_view,
-              arg_realm,
-              arg_account,
-              arg_args,
-            );
+            (onReceivedLoginRequest ??
+                    arg_pigeon_instance.onReceivedLoginRequest)
+                ?.call(arg_pigeon_instance, arg_view, arg_realm, arg_account,
+                    arg_args);
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
           } catch (e) {
             return wrapResponse(
-              error: PlatformException(code: 'error', message: e.toString()),
-            );
+                error: PlatformException(code: 'error', message: e.toString()));
           }
         });
       }
@@ -3874,10 +4196,9 @@ class WebViewClient extends PigeonInternalProxyApiBaseClass {
 
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-        'dev.flutter.pigeon.webview_flutter_android.WebViewClient.onReceivedSslError',
-        pigeonChannelCodec,
-        binaryMessenger: binaryMessenger,
-      );
+          'dev.flutter.pigeon.webview_flutter_android.WebViewClient.onReceivedSslError',
+          pigeonChannelCodec,
+          binaryMessenger: binaryMessenger);
       if (pigeon_clearHandlers) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
@@ -3888,19 +4209,14 @@ class WebViewClient extends PigeonInternalProxyApiBaseClass {
           final SslErrorHandler arg_handler = args[2]! as SslErrorHandler;
           final SslError arg_error = args[3]! as SslError;
           try {
-            (onReceivedSslError ?? arg_pigeon_instance.onReceivedSslError)?.call(
-              arg_pigeon_instance,
-              arg_view,
-              arg_handler,
-              arg_error,
-            );
+            (onReceivedSslError ?? arg_pigeon_instance.onReceivedSslError)
+                ?.call(arg_pigeon_instance, arg_view, arg_handler, arg_error);
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
           } catch (e) {
             return wrapResponse(
-              error: PlatformException(code: 'error', message: e.toString()),
-            );
+                error: PlatformException(code: 'error', message: e.toString()));
           }
         });
       }
@@ -3908,10 +4224,9 @@ class WebViewClient extends PigeonInternalProxyApiBaseClass {
 
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-        'dev.flutter.pigeon.webview_flutter_android.WebViewClient.onScaleChanged',
-        pigeonChannelCodec,
-        binaryMessenger: binaryMessenger,
-      );
+          'dev.flutter.pigeon.webview_flutter_android.WebViewClient.onScaleChanged',
+          pigeonChannelCodec,
+          binaryMessenger: binaryMessenger);
       if (pigeon_clearHandlers) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
@@ -3923,18 +4238,13 @@ class WebViewClient extends PigeonInternalProxyApiBaseClass {
           final double arg_newScale = args[3]! as double;
           try {
             (onScaleChanged ?? arg_pigeon_instance.onScaleChanged)?.call(
-              arg_pigeon_instance,
-              arg_view,
-              arg_oldScale,
-              arg_newScale,
-            );
+                arg_pigeon_instance, arg_view, arg_oldScale, arg_newScale);
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
           } catch (e) {
             return wrapResponse(
-              error: PlatformException(code: 'error', message: e.toString()),
-            );
+                error: PlatformException(code: 'error', message: e.toString()));
           }
         });
       }
@@ -3953,8 +4263,10 @@ class WebViewClient extends PigeonInternalProxyApiBaseClass {
   /// causes the [WebView] to continue loading a URL as usual.
   ///
   /// Defaults to false.
-  Future<void> setSynchronousReturnValueForShouldOverrideUrlLoading(bool value) async {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecWebViewClient;
+  Future<void> setSynchronousReturnValueForShouldOverrideUrlLoading(
+      bool value) async {
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
+        _pigeonVar_codecWebViewClient;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
     const pigeonVar_channelName =
         'dev.flutter.pigeon.webview_flutter_android.WebViewClient.setSynchronousReturnValueForShouldOverrideUrlLoading';
@@ -3963,10 +4275,15 @@ class WebViewClient extends PigeonInternalProxyApiBaseClass {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[this, value]);
+    final Future<Object?> pigeonVar_sendFuture =
+        pigeonVar_channel.send(<Object?>[this, value]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
-    _extractReplyValueOrThrow(pigeonVar_replyList, pigeonVar_channelName, isNullValid: true);
+    _extractReplyValueOrThrow(
+      pigeonVar_replyList,
+      pigeonVar_channelName,
+      isNullValid: true,
+    );
   }
 
   @override
@@ -3980,8 +4297,8 @@ class WebViewClient extends PigeonInternalProxyApiBaseClass {
       onReceivedRequestError: onReceivedRequestError,
       onReceivedRequestErrorCompat: onReceivedRequestErrorCompat,
       requestLoading: requestLoading,
-      onCreateWindow: onCreateWindow,
       urlLoading: urlLoading,
+      onCreateWindow: onCreateWindow,
       doUpdateVisitedHistory: doUpdateVisitedHistory,
       onReceivedHttpAuthRequest: onReceivedHttpAuthRequest,
       onFormResubmission: onFormResubmission,
@@ -4009,11 +4326,11 @@ class DownloadListener extends PigeonInternalProxyApiBaseClass {
       String contentDisposition,
       String mimetype,
       int contentLength,
-    )
-    onDownloadStart,
+    ) onDownloadStart,
   }) {
     if (PigeonOverrides.downloadListener_new != null) {
-      return PigeonOverrides.downloadListener_new!(onDownloadStart: onDownloadStart);
+      return PigeonOverrides.downloadListener_new!(
+          onDownloadStart: onDownloadStart);
     }
     return DownloadListener.pigeon_new(
       pigeon_binaryMessenger: pigeon_binaryMessenger,
@@ -4028,8 +4345,10 @@ class DownloadListener extends PigeonInternalProxyApiBaseClass {
     super.pigeon_instanceManager,
     required this.onDownloadStart,
   }) {
-    final int pigeonVar_instanceIdentifier = pigeon_instanceManager.addDartCreatedInstance(this);
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecDownloadListener;
+    final int pigeonVar_instanceIdentifier =
+        pigeon_instanceManager.addDartCreatedInstance(this);
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
+        _pigeonVar_codecDownloadListener;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
     const pigeonVar_channelName =
         'dev.flutter.pigeon.webview_flutter_android.DownloadListener.pigeon_defaultConstructor';
@@ -4038,13 +4357,16 @@ class DownloadListener extends PigeonInternalProxyApiBaseClass {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[
-      pigeonVar_instanceIdentifier,
-    ]);
+    final Future<Object?> pigeonVar_sendFuture =
+        pigeonVar_channel.send(<Object?>[pigeonVar_instanceIdentifier]);
     () async {
       final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
-      _extractReplyValueOrThrow(pigeonVar_replyList, pigeonVar_channelName, isNullValid: true);
+      _extractReplyValueOrThrow(
+        pigeonVar_replyList,
+        pigeonVar_channelName,
+        isNullValid: true,
+      );
     }();
   }
 
@@ -4088,8 +4410,7 @@ class DownloadListener extends PigeonInternalProxyApiBaseClass {
     String contentDisposition,
     String mimetype,
     int contentLength,
-  )
-  onDownloadStart;
+  ) onDownloadStart;
 
   static void pigeon_setUpMessageHandlers({
     bool pigeon_clearHandlers = false,
@@ -4102,25 +4423,24 @@ class DownloadListener extends PigeonInternalProxyApiBaseClass {
       String contentDisposition,
       String mimetype,
       int contentLength,
-    )?
-    onDownloadStart,
+    )? onDownloadStart,
   }) {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _PigeonInternalProxyApiBaseCodec(
-      pigeon_instanceManager ?? PigeonInstanceManager.instance,
-    );
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
+        _PigeonInternalProxyApiBaseCodec(
+            pigeon_instanceManager ?? PigeonInstanceManager.instance);
     final BinaryMessenger? binaryMessenger = pigeon_binaryMessenger;
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-        'dev.flutter.pigeon.webview_flutter_android.DownloadListener.onDownloadStart',
-        pigeonChannelCodec,
-        binaryMessenger: binaryMessenger,
-      );
+          'dev.flutter.pigeon.webview_flutter_android.DownloadListener.onDownloadStart',
+          pigeonChannelCodec,
+          binaryMessenger: binaryMessenger);
       if (pigeon_clearHandlers) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
         pigeonVar_channel.setMessageHandler((Object? message) async {
           final List<Object?> args = message! as List<Object?>;
-          final DownloadListener arg_pigeon_instance = args[0]! as DownloadListener;
+          final DownloadListener arg_pigeon_instance =
+              args[0]! as DownloadListener;
           final String arg_url = args[1]! as String;
           final String arg_userAgent = args[2]! as String;
           final String arg_contentDisposition = args[3]! as String;
@@ -4128,20 +4448,18 @@ class DownloadListener extends PigeonInternalProxyApiBaseClass {
           final int arg_contentLength = args[5]! as int;
           try {
             (onDownloadStart ?? arg_pigeon_instance.onDownloadStart).call(
-              arg_pigeon_instance,
-              arg_url,
-              arg_userAgent,
-              arg_contentDisposition,
-              arg_mimetype,
-              arg_contentLength,
-            );
+                arg_pigeon_instance,
+                arg_url,
+                arg_userAgent,
+                arg_contentDisposition,
+                arg_mimetype,
+                arg_contentLength);
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
           } catch (e) {
             return wrapResponse(
-              error: PlatformException(code: 'error', message: e.toString()),
-            );
+                error: PlatformException(code: 'error', message: e.toString()));
           }
         });
       }
@@ -4166,48 +4484,56 @@ class WebChromeClient extends PigeonInternalProxyApiBaseClass {
   factory WebChromeClient({
     BinaryMessenger? pigeon_binaryMessenger,
     PigeonInstanceManager? pigeon_instanceManager,
-    void Function(WebChromeClient pigeon_instance, WebView webView, int progress)?
-    onProgressChanged,
+    void Function(
+      WebChromeClient pigeon_instance,
+      WebView webView,
+      int progress,
+    )? onProgressChanged,
     required Future<List<String>> Function(
       WebChromeClient pigeon_instance,
       WebView webView,
       FileChooserParams params,
-    )
-    onShowFileChooser,
-    void Function(WebChromeClient pigeon_instance, PermissionRequest request)? onPermissionRequest,
-    void Function(WebChromeClient pigeon_instance, View view, CustomViewCallback callback)?
-    onShowCustomView,
+    ) onShowFileChooser,
+    void Function(
+      WebChromeClient pigeon_instance,
+      PermissionRequest request,
+    )? onPermissionRequest,
+    void Function(
+      WebChromeClient pigeon_instance,
+      View view,
+      CustomViewCallback callback,
+    )? onShowCustomView,
     void Function(WebChromeClient pigeon_instance)? onHideCustomView,
     void Function(
       WebChromeClient pigeon_instance,
       String origin,
       GeolocationPermissionsCallback callback,
-    )?
-    onGeolocationPermissionsShowPrompt,
-    void Function(WebChromeClient pigeon_instance)? onGeolocationPermissionsHidePrompt,
-    void Function(WebChromeClient pigeon_instance, ConsoleMessage message)? onConsoleMessage,
+    )? onGeolocationPermissionsShowPrompt,
+    void Function(WebChromeClient pigeon_instance)?
+        onGeolocationPermissionsHidePrompt,
+    void Function(
+      WebChromeClient pigeon_instance,
+      ConsoleMessage message,
+    )? onConsoleMessage,
     Future<void> Function(
       WebChromeClient pigeon_instance,
       WebView webView,
       String url,
       String message,
-    )?
-    onJsAlert,
+    )? onJsAlert,
     required Future<bool> Function(
       WebChromeClient pigeon_instance,
       WebView webView,
       String url,
       String message,
-    )
-    onJsConfirm,
+    ) onJsConfirm,
     Future<String?> Function(
       WebChromeClient pigeon_instance,
       WebView webView,
       String url,
       String message,
       String defaultValue,
-    )?
-    onJsPrompt,
+    )? onJsPrompt,
   }) {
     if (PigeonOverrides.webChromeClient_new != null) {
       return PigeonOverrides.webChromeClient_new!(
@@ -4257,8 +4583,10 @@ class WebChromeClient extends PigeonInternalProxyApiBaseClass {
     required this.onJsConfirm,
     this.onJsPrompt,
   }) {
-    final int pigeonVar_instanceIdentifier = pigeon_instanceManager.addDartCreatedInstance(this);
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecWebChromeClient;
+    final int pigeonVar_instanceIdentifier =
+        pigeon_instanceManager.addDartCreatedInstance(this);
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
+        _pigeonVar_codecWebChromeClient;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
     const pigeonVar_channelName =
         'dev.flutter.pigeon.webview_flutter_android.WebChromeClient.pigeon_defaultConstructor';
@@ -4267,13 +4595,16 @@ class WebChromeClient extends PigeonInternalProxyApiBaseClass {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[
-      pigeonVar_instanceIdentifier,
-    ]);
+    final Future<Object?> pigeonVar_sendFuture =
+        pigeonVar_channel.send(<Object?>[pigeonVar_instanceIdentifier]);
     () async {
       final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
-      _extractReplyValueOrThrow(pigeonVar_replyList, pigeonVar_channelName, isNullValid: true);
+      _extractReplyValueOrThrow(
+        pigeonVar_replyList,
+        pigeonVar_channelName,
+        isNullValid: true,
+      );
     }();
   }
 
@@ -4320,8 +4651,11 @@ class WebChromeClient extends PigeonInternalProxyApiBaseClass {
   ///
   /// Alternatively, [PigeonInstanceManager.removeWeakReference] can be used to
   /// release the associated Native object manually.
-  final void Function(WebChromeClient pigeon_instance, WebView webView, int progress)?
-  onProgressChanged;
+  final void Function(
+    WebChromeClient pigeon_instance,
+    WebView webView,
+    int progress,
+  )? onProgressChanged;
 
   /// Tell the client to show a file chooser.
   ///
@@ -4346,8 +4680,7 @@ class WebChromeClient extends PigeonInternalProxyApiBaseClass {
     WebChromeClient pigeon_instance,
     WebView webView,
     FileChooserParams params,
-  )
-  onShowFileChooser;
+  ) onShowFileChooser;
 
   /// Notify the host application that web content is requesting permission to
   /// access the specified resources and the permission currently isn't granted
@@ -4370,8 +4703,10 @@ class WebChromeClient extends PigeonInternalProxyApiBaseClass {
   ///
   /// Alternatively, [PigeonInstanceManager.removeWeakReference] can be used to
   /// release the associated Native object manually.
-  final void Function(WebChromeClient pigeon_instance, PermissionRequest request)?
-  onPermissionRequest;
+  final void Function(
+    WebChromeClient pigeon_instance,
+    PermissionRequest request,
+  )? onPermissionRequest;
 
   /// Callback to Dart function `WebChromeClient.onShowCustomView`.
   ///
@@ -4392,8 +4727,11 @@ class WebChromeClient extends PigeonInternalProxyApiBaseClass {
   ///
   /// Alternatively, [PigeonInstanceManager.removeWeakReference] can be used to
   /// release the associated Native object manually.
-  final void Function(WebChromeClient pigeon_instance, View view, CustomViewCallback callback)?
-  onShowCustomView;
+  final void Function(
+    WebChromeClient pigeon_instance,
+    View view,
+    CustomViewCallback callback,
+  )? onShowCustomView;
 
   /// Notify the host application that the current page has entered full screen
   /// mode.
@@ -4442,8 +4780,7 @@ class WebChromeClient extends PigeonInternalProxyApiBaseClass {
     WebChromeClient pigeon_instance,
     String origin,
     GeolocationPermissionsCallback callback,
-  )?
-  onGeolocationPermissionsShowPrompt;
+  )? onGeolocationPermissionsShowPrompt;
 
   /// Notify the host application that a request for Geolocation permissions,
   /// made with a previous call to `onGeolocationPermissionsShowPrompt` has been
@@ -4466,7 +4803,8 @@ class WebChromeClient extends PigeonInternalProxyApiBaseClass {
   ///
   /// Alternatively, [PigeonInstanceManager.removeWeakReference] can be used to
   /// release the associated Native object manually.
-  final void Function(WebChromeClient pigeon_instance)? onGeolocationPermissionsHidePrompt;
+  final void Function(WebChromeClient pigeon_instance)?
+      onGeolocationPermissionsHidePrompt;
 
   /// Report a JavaScript console message to the host application.
   ///
@@ -4487,7 +4825,10 @@ class WebChromeClient extends PigeonInternalProxyApiBaseClass {
   ///
   /// Alternatively, [PigeonInstanceManager.removeWeakReference] can be used to
   /// release the associated Native object manually.
-  final void Function(WebChromeClient pigeon_instance, ConsoleMessage message)? onConsoleMessage;
+  final void Function(
+    WebChromeClient pigeon_instance,
+    ConsoleMessage message,
+  )? onConsoleMessage;
 
   /// Notify the host application that the web page wants to display a
   /// JavaScript `alert()` dialog.
@@ -4514,8 +4855,7 @@ class WebChromeClient extends PigeonInternalProxyApiBaseClass {
     WebView webView,
     String url,
     String message,
-  )?
-  onJsAlert;
+  )? onJsAlert;
 
   /// Notify the host application that the web page wants to display a
   /// JavaScript `confirm()` dialog.
@@ -4542,8 +4882,7 @@ class WebChromeClient extends PigeonInternalProxyApiBaseClass {
     WebView webView,
     String url,
     String message,
-  )
-  onJsConfirm;
+  ) onJsConfirm;
 
   /// Notify the host application that the web page wants to display a
   /// JavaScript `prompt()` dialog.
@@ -4571,87 +4910,90 @@ class WebChromeClient extends PigeonInternalProxyApiBaseClass {
     String url,
     String message,
     String defaultValue,
-  )?
-  onJsPrompt;
+  )? onJsPrompt;
 
   static void pigeon_setUpMessageHandlers({
     bool pigeon_clearHandlers = false,
     BinaryMessenger? pigeon_binaryMessenger,
     PigeonInstanceManager? pigeon_instanceManager,
-    void Function(WebChromeClient pigeon_instance, WebView webView, int progress)?
-    onProgressChanged,
+    void Function(
+      WebChromeClient pigeon_instance,
+      WebView webView,
+      int progress,
+    )? onProgressChanged,
     Future<List<String>> Function(
       WebChromeClient pigeon_instance,
       WebView webView,
       FileChooserParams params,
-    )?
-    onShowFileChooser,
-    void Function(WebChromeClient pigeon_instance, PermissionRequest request)? onPermissionRequest,
-    void Function(WebChromeClient pigeon_instance, View view, CustomViewCallback callback)?
-    onShowCustomView,
+    )? onShowFileChooser,
+    void Function(
+      WebChromeClient pigeon_instance,
+      PermissionRequest request,
+    )? onPermissionRequest,
+    void Function(
+      WebChromeClient pigeon_instance,
+      View view,
+      CustomViewCallback callback,
+    )? onShowCustomView,
     void Function(WebChromeClient pigeon_instance)? onHideCustomView,
     void Function(
       WebChromeClient pigeon_instance,
       String origin,
       GeolocationPermissionsCallback callback,
-    )?
-    onGeolocationPermissionsShowPrompt,
-    void Function(WebChromeClient pigeon_instance)? onGeolocationPermissionsHidePrompt,
-    void Function(WebChromeClient pigeon_instance, ConsoleMessage message)? onConsoleMessage,
+    )? onGeolocationPermissionsShowPrompt,
+    void Function(WebChromeClient pigeon_instance)?
+        onGeolocationPermissionsHidePrompt,
+    void Function(
+      WebChromeClient pigeon_instance,
+      ConsoleMessage message,
+    )? onConsoleMessage,
     Future<void> Function(
       WebChromeClient pigeon_instance,
       WebView webView,
       String url,
       String message,
-    )?
-    onJsAlert,
+    )? onJsAlert,
     Future<bool> Function(
       WebChromeClient pigeon_instance,
       WebView webView,
       String url,
       String message,
-    )?
-    onJsConfirm,
+    )? onJsConfirm,
     Future<String?> Function(
       WebChromeClient pigeon_instance,
       WebView webView,
       String url,
       String message,
       String defaultValue,
-    )?
-    onJsPrompt,
+    )? onJsPrompt,
   }) {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _PigeonInternalProxyApiBaseCodec(
-      pigeon_instanceManager ?? PigeonInstanceManager.instance,
-    );
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
+        _PigeonInternalProxyApiBaseCodec(
+            pigeon_instanceManager ?? PigeonInstanceManager.instance);
     final BinaryMessenger? binaryMessenger = pigeon_binaryMessenger;
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-        'dev.flutter.pigeon.webview_flutter_android.WebChromeClient.onProgressChanged',
-        pigeonChannelCodec,
-        binaryMessenger: binaryMessenger,
-      );
+          'dev.flutter.pigeon.webview_flutter_android.WebChromeClient.onProgressChanged',
+          pigeonChannelCodec,
+          binaryMessenger: binaryMessenger);
       if (pigeon_clearHandlers) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
         pigeonVar_channel.setMessageHandler((Object? message) async {
           final List<Object?> args = message! as List<Object?>;
-          final WebChromeClient arg_pigeon_instance = args[0]! as WebChromeClient;
+          final WebChromeClient arg_pigeon_instance =
+              args[0]! as WebChromeClient;
           final WebView arg_webView = args[1]! as WebView;
           final int arg_progress = args[2]! as int;
           try {
-            (onProgressChanged ?? arg_pigeon_instance.onProgressChanged)?.call(
-              arg_pigeon_instance,
-              arg_webView,
-              arg_progress,
-            );
+            (onProgressChanged ?? arg_pigeon_instance.onProgressChanged)
+                ?.call(arg_pigeon_instance, arg_webView, arg_progress);
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
           } catch (e) {
             return wrapResponse(
-              error: PlatformException(code: 'error', message: e.toString()),
-            );
+                error: PlatformException(code: 'error', message: e.toString()));
           }
         });
       }
@@ -4659,32 +5001,28 @@ class WebChromeClient extends PigeonInternalProxyApiBaseClass {
 
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-        'dev.flutter.pigeon.webview_flutter_android.WebChromeClient.onShowFileChooser',
-        pigeonChannelCodec,
-        binaryMessenger: binaryMessenger,
-      );
+          'dev.flutter.pigeon.webview_flutter_android.WebChromeClient.onShowFileChooser',
+          pigeonChannelCodec,
+          binaryMessenger: binaryMessenger);
       if (pigeon_clearHandlers) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
         pigeonVar_channel.setMessageHandler((Object? message) async {
           final List<Object?> args = message! as List<Object?>;
-          final WebChromeClient arg_pigeon_instance = args[0]! as WebChromeClient;
+          final WebChromeClient arg_pigeon_instance =
+              args[0]! as WebChromeClient;
           final WebView arg_webView = args[1]! as WebView;
           final FileChooserParams arg_params = args[2]! as FileChooserParams;
           try {
-            final List<String> output =
-                await (onShowFileChooser ?? arg_pigeon_instance.onShowFileChooser).call(
-                  arg_pigeon_instance,
-                  arg_webView,
-                  arg_params,
-                );
+            final List<String> output = await (onShowFileChooser ??
+                    arg_pigeon_instance.onShowFileChooser)
+                .call(arg_pigeon_instance, arg_webView, arg_params);
             return wrapResponse(result: output);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
           } catch (e) {
             return wrapResponse(
-              error: PlatformException(code: 'error', message: e.toString()),
-            );
+                error: PlatformException(code: 'error', message: e.toString()));
           }
         });
       }
@@ -4692,29 +5030,26 @@ class WebChromeClient extends PigeonInternalProxyApiBaseClass {
 
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-        'dev.flutter.pigeon.webview_flutter_android.WebChromeClient.onPermissionRequest',
-        pigeonChannelCodec,
-        binaryMessenger: binaryMessenger,
-      );
+          'dev.flutter.pigeon.webview_flutter_android.WebChromeClient.onPermissionRequest',
+          pigeonChannelCodec,
+          binaryMessenger: binaryMessenger);
       if (pigeon_clearHandlers) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
         pigeonVar_channel.setMessageHandler((Object? message) async {
           final List<Object?> args = message! as List<Object?>;
-          final WebChromeClient arg_pigeon_instance = args[0]! as WebChromeClient;
+          final WebChromeClient arg_pigeon_instance =
+              args[0]! as WebChromeClient;
           final PermissionRequest arg_request = args[1]! as PermissionRequest;
           try {
-            (onPermissionRequest ?? arg_pigeon_instance.onPermissionRequest)?.call(
-              arg_pigeon_instance,
-              arg_request,
-            );
+            (onPermissionRequest ?? arg_pigeon_instance.onPermissionRequest)
+                ?.call(arg_pigeon_instance, arg_request);
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
           } catch (e) {
             return wrapResponse(
-              error: PlatformException(code: 'error', message: e.toString()),
-            );
+                error: PlatformException(code: 'error', message: e.toString()));
           }
         });
       }
@@ -4722,31 +5057,28 @@ class WebChromeClient extends PigeonInternalProxyApiBaseClass {
 
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-        'dev.flutter.pigeon.webview_flutter_android.WebChromeClient.onShowCustomView',
-        pigeonChannelCodec,
-        binaryMessenger: binaryMessenger,
-      );
+          'dev.flutter.pigeon.webview_flutter_android.WebChromeClient.onShowCustomView',
+          pigeonChannelCodec,
+          binaryMessenger: binaryMessenger);
       if (pigeon_clearHandlers) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
         pigeonVar_channel.setMessageHandler((Object? message) async {
           final List<Object?> args = message! as List<Object?>;
-          final WebChromeClient arg_pigeon_instance = args[0]! as WebChromeClient;
+          final WebChromeClient arg_pigeon_instance =
+              args[0]! as WebChromeClient;
           final View arg_view = args[1]! as View;
-          final CustomViewCallback arg_callback = args[2]! as CustomViewCallback;
+          final CustomViewCallback arg_callback =
+              args[2]! as CustomViewCallback;
           try {
-            (onShowCustomView ?? arg_pigeon_instance.onShowCustomView)?.call(
-              arg_pigeon_instance,
-              arg_view,
-              arg_callback,
-            );
+            (onShowCustomView ?? arg_pigeon_instance.onShowCustomView)
+                ?.call(arg_pigeon_instance, arg_view, arg_callback);
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
           } catch (e) {
             return wrapResponse(
-              error: PlatformException(code: 'error', message: e.toString()),
-            );
+                error: PlatformException(code: 'error', message: e.toString()));
           }
         });
       }
@@ -4754,25 +5086,25 @@ class WebChromeClient extends PigeonInternalProxyApiBaseClass {
 
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-        'dev.flutter.pigeon.webview_flutter_android.WebChromeClient.onHideCustomView',
-        pigeonChannelCodec,
-        binaryMessenger: binaryMessenger,
-      );
+          'dev.flutter.pigeon.webview_flutter_android.WebChromeClient.onHideCustomView',
+          pigeonChannelCodec,
+          binaryMessenger: binaryMessenger);
       if (pigeon_clearHandlers) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
         pigeonVar_channel.setMessageHandler((Object? message) async {
           final List<Object?> args = message! as List<Object?>;
-          final WebChromeClient arg_pigeon_instance = args[0]! as WebChromeClient;
+          final WebChromeClient arg_pigeon_instance =
+              args[0]! as WebChromeClient;
           try {
-            (onHideCustomView ?? arg_pigeon_instance.onHideCustomView)?.call(arg_pigeon_instance);
+            (onHideCustomView ?? arg_pigeon_instance.onHideCustomView)
+                ?.call(arg_pigeon_instance);
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
           } catch (e) {
             return wrapResponse(
-              error: PlatformException(code: 'error', message: e.toString()),
-            );
+                error: PlatformException(code: 'error', message: e.toString()));
           }
         });
       }
@@ -4780,16 +5112,16 @@ class WebChromeClient extends PigeonInternalProxyApiBaseClass {
 
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-        'dev.flutter.pigeon.webview_flutter_android.WebChromeClient.onGeolocationPermissionsShowPrompt',
-        pigeonChannelCodec,
-        binaryMessenger: binaryMessenger,
-      );
+          'dev.flutter.pigeon.webview_flutter_android.WebChromeClient.onGeolocationPermissionsShowPrompt',
+          pigeonChannelCodec,
+          binaryMessenger: binaryMessenger);
       if (pigeon_clearHandlers) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
         pigeonVar_channel.setMessageHandler((Object? message) async {
           final List<Object?> args = message! as List<Object?>;
-          final WebChromeClient arg_pigeon_instance = args[0]! as WebChromeClient;
+          final WebChromeClient arg_pigeon_instance =
+              args[0]! as WebChromeClient;
           final String arg_origin = args[1]! as String;
           final GeolocationPermissionsCallback arg_callback =
               args[2]! as GeolocationPermissionsCallback;
@@ -4802,8 +5134,7 @@ class WebChromeClient extends PigeonInternalProxyApiBaseClass {
             return wrapResponse(error: e);
           } catch (e) {
             return wrapResponse(
-              error: PlatformException(code: 'error', message: e.toString()),
-            );
+                error: PlatformException(code: 'error', message: e.toString()));
           }
         });
       }
@@ -4811,16 +5142,16 @@ class WebChromeClient extends PigeonInternalProxyApiBaseClass {
 
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-        'dev.flutter.pigeon.webview_flutter_android.WebChromeClient.onGeolocationPermissionsHidePrompt',
-        pigeonChannelCodec,
-        binaryMessenger: binaryMessenger,
-      );
+          'dev.flutter.pigeon.webview_flutter_android.WebChromeClient.onGeolocationPermissionsHidePrompt',
+          pigeonChannelCodec,
+          binaryMessenger: binaryMessenger);
       if (pigeon_clearHandlers) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
         pigeonVar_channel.setMessageHandler((Object? message) async {
           final List<Object?> args = message! as List<Object?>;
-          final WebChromeClient arg_pigeon_instance = args[0]! as WebChromeClient;
+          final WebChromeClient arg_pigeon_instance =
+              args[0]! as WebChromeClient;
           try {
             (onGeolocationPermissionsHidePrompt ??
                     arg_pigeon_instance.onGeolocationPermissionsHidePrompt)
@@ -4830,8 +5161,7 @@ class WebChromeClient extends PigeonInternalProxyApiBaseClass {
             return wrapResponse(error: e);
           } catch (e) {
             return wrapResponse(
-              error: PlatformException(code: 'error', message: e.toString()),
-            );
+                error: PlatformException(code: 'error', message: e.toString()));
           }
         });
       }
@@ -4839,29 +5169,26 @@ class WebChromeClient extends PigeonInternalProxyApiBaseClass {
 
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-        'dev.flutter.pigeon.webview_flutter_android.WebChromeClient.onConsoleMessage',
-        pigeonChannelCodec,
-        binaryMessenger: binaryMessenger,
-      );
+          'dev.flutter.pigeon.webview_flutter_android.WebChromeClient.onConsoleMessage',
+          pigeonChannelCodec,
+          binaryMessenger: binaryMessenger);
       if (pigeon_clearHandlers) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
         pigeonVar_channel.setMessageHandler((Object? message) async {
           final List<Object?> args = message! as List<Object?>;
-          final WebChromeClient arg_pigeon_instance = args[0]! as WebChromeClient;
+          final WebChromeClient arg_pigeon_instance =
+              args[0]! as WebChromeClient;
           final ConsoleMessage arg_message = args[1]! as ConsoleMessage;
           try {
-            (onConsoleMessage ?? arg_pigeon_instance.onConsoleMessage)?.call(
-              arg_pigeon_instance,
-              arg_message,
-            );
+            (onConsoleMessage ?? arg_pigeon_instance.onConsoleMessage)
+                ?.call(arg_pigeon_instance, arg_message);
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
           } catch (e) {
             return wrapResponse(
-              error: PlatformException(code: 'error', message: e.toString()),
-            );
+                error: PlatformException(code: 'error', message: e.toString()));
           }
         });
       }
@@ -4869,33 +5196,28 @@ class WebChromeClient extends PigeonInternalProxyApiBaseClass {
 
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-        'dev.flutter.pigeon.webview_flutter_android.WebChromeClient.onJsAlert',
-        pigeonChannelCodec,
-        binaryMessenger: binaryMessenger,
-      );
+          'dev.flutter.pigeon.webview_flutter_android.WebChromeClient.onJsAlert',
+          pigeonChannelCodec,
+          binaryMessenger: binaryMessenger);
       if (pigeon_clearHandlers) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
         pigeonVar_channel.setMessageHandler((Object? message) async {
           final List<Object?> args = message! as List<Object?>;
-          final WebChromeClient arg_pigeon_instance = args[0]! as WebChromeClient;
+          final WebChromeClient arg_pigeon_instance =
+              args[0]! as WebChromeClient;
           final WebView arg_webView = args[1]! as WebView;
           final String arg_url = args[2]! as String;
           final String arg_message = args[3]! as String;
           try {
-            await (onJsAlert ?? arg_pigeon_instance.onJsAlert)?.call(
-              arg_pigeon_instance,
-              arg_webView,
-              arg_url,
-              arg_message,
-            );
+            await (onJsAlert ?? arg_pigeon_instance.onJsAlert)
+                ?.call(arg_pigeon_instance, arg_webView, arg_url, arg_message);
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
           } catch (e) {
             return wrapResponse(
-              error: PlatformException(code: 'error', message: e.toString()),
-            );
+                error: PlatformException(code: 'error', message: e.toString()));
           }
         });
       }
@@ -4903,33 +5225,29 @@ class WebChromeClient extends PigeonInternalProxyApiBaseClass {
 
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-        'dev.flutter.pigeon.webview_flutter_android.WebChromeClient.onJsConfirm',
-        pigeonChannelCodec,
-        binaryMessenger: binaryMessenger,
-      );
+          'dev.flutter.pigeon.webview_flutter_android.WebChromeClient.onJsConfirm',
+          pigeonChannelCodec,
+          binaryMessenger: binaryMessenger);
       if (pigeon_clearHandlers) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
         pigeonVar_channel.setMessageHandler((Object? message) async {
           final List<Object?> args = message! as List<Object?>;
-          final WebChromeClient arg_pigeon_instance = args[0]! as WebChromeClient;
+          final WebChromeClient arg_pigeon_instance =
+              args[0]! as WebChromeClient;
           final WebView arg_webView = args[1]! as WebView;
           final String arg_url = args[2]! as String;
           final String arg_message = args[3]! as String;
           try {
-            final bool output = await (onJsConfirm ?? arg_pigeon_instance.onJsConfirm).call(
-              arg_pigeon_instance,
-              arg_webView,
-              arg_url,
-              arg_message,
-            );
+            final bool output = await (onJsConfirm ??
+                    arg_pigeon_instance.onJsConfirm)
+                .call(arg_pigeon_instance, arg_webView, arg_url, arg_message);
             return wrapResponse(result: output);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
           } catch (e) {
             return wrapResponse(
-              error: PlatformException(code: 'error', message: e.toString()),
-            );
+                error: PlatformException(code: 'error', message: e.toString()));
           }
         });
       }
@@ -4937,35 +5255,34 @@ class WebChromeClient extends PigeonInternalProxyApiBaseClass {
 
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-        'dev.flutter.pigeon.webview_flutter_android.WebChromeClient.onJsPrompt',
-        pigeonChannelCodec,
-        binaryMessenger: binaryMessenger,
-      );
+          'dev.flutter.pigeon.webview_flutter_android.WebChromeClient.onJsPrompt',
+          pigeonChannelCodec,
+          binaryMessenger: binaryMessenger);
       if (pigeon_clearHandlers) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
         pigeonVar_channel.setMessageHandler((Object? message) async {
           final List<Object?> args = message! as List<Object?>;
-          final WebChromeClient arg_pigeon_instance = args[0]! as WebChromeClient;
+          final WebChromeClient arg_pigeon_instance =
+              args[0]! as WebChromeClient;
           final WebView arg_webView = args[1]! as WebView;
           final String arg_url = args[2]! as String;
           final String arg_message = args[3]! as String;
           final String arg_defaultValue = args[4]! as String;
           try {
-            final String? output = await (onJsPrompt ?? arg_pigeon_instance.onJsPrompt)?.call(
-              arg_pigeon_instance,
-              arg_webView,
-              arg_url,
-              arg_message,
-              arg_defaultValue,
-            );
+            final String? output =
+                await (onJsPrompt ?? arg_pigeon_instance.onJsPrompt)?.call(
+                    arg_pigeon_instance,
+                    arg_webView,
+                    arg_url,
+                    arg_message,
+                    arg_defaultValue);
             return wrapResponse(result: output);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
           } catch (e) {
             return wrapResponse(
-              error: PlatformException(code: 'error', message: e.toString()),
-            );
+                error: PlatformException(code: 'error', message: e.toString()));
           }
         });
       }
@@ -4988,7 +5305,8 @@ class WebChromeClient extends PigeonInternalProxyApiBaseClass {
   ///
   /// Defaults to false.
   Future<void> setSynchronousReturnValueForOnShowFileChooser(bool value) async {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecWebChromeClient;
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
+        _pigeonVar_codecWebChromeClient;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
     const pigeonVar_channelName =
         'dev.flutter.pigeon.webview_flutter_android.WebChromeClient.setSynchronousReturnValueForOnShowFileChooser';
@@ -4997,10 +5315,15 @@ class WebChromeClient extends PigeonInternalProxyApiBaseClass {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[this, value]);
+    final Future<Object?> pigeonVar_sendFuture =
+        pigeonVar_channel.send(<Object?>[this, value]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
-    _extractReplyValueOrThrow(pigeonVar_replyList, pigeonVar_channelName, isNullValid: true);
+    _extractReplyValueOrThrow(
+      pigeonVar_replyList,
+      pigeonVar_channelName,
+      isNullValid: true,
+    );
   }
 
   /// Sets the required synchronous return value for the Java method,
@@ -5017,7 +5340,8 @@ class WebChromeClient extends PigeonInternalProxyApiBaseClass {
   ///
   /// Defaults to false.
   Future<void> setSynchronousReturnValueForOnConsoleMessage(bool value) async {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecWebChromeClient;
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
+        _pigeonVar_codecWebChromeClient;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
     const pigeonVar_channelName =
         'dev.flutter.pigeon.webview_flutter_android.WebChromeClient.setSynchronousReturnValueForOnConsoleMessage';
@@ -5026,10 +5350,15 @@ class WebChromeClient extends PigeonInternalProxyApiBaseClass {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[this, value]);
+    final Future<Object?> pigeonVar_sendFuture =
+        pigeonVar_channel.send(<Object?>[this, value]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
-    _extractReplyValueOrThrow(pigeonVar_replyList, pigeonVar_channelName, isNullValid: true);
+    _extractReplyValueOrThrow(
+      pigeonVar_replyList,
+      pigeonVar_channelName,
+      isNullValid: true,
+    );
   }
 
   /// Sets the required synchronous return value for the Java method,
@@ -5046,7 +5375,8 @@ class WebChromeClient extends PigeonInternalProxyApiBaseClass {
   ///
   /// Defaults to false.
   Future<void> setSynchronousReturnValueForOnJsAlert(bool value) async {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecWebChromeClient;
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
+        _pigeonVar_codecWebChromeClient;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
     const pigeonVar_channelName =
         'dev.flutter.pigeon.webview_flutter_android.WebChromeClient.setSynchronousReturnValueForOnJsAlert';
@@ -5055,10 +5385,15 @@ class WebChromeClient extends PigeonInternalProxyApiBaseClass {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[this, value]);
+    final Future<Object?> pigeonVar_sendFuture =
+        pigeonVar_channel.send(<Object?>[this, value]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
-    _extractReplyValueOrThrow(pigeonVar_replyList, pigeonVar_channelName, isNullValid: true);
+    _extractReplyValueOrThrow(
+      pigeonVar_replyList,
+      pigeonVar_channelName,
+      isNullValid: true,
+    );
   }
 
   /// Sets the required synchronous return value for the Java method,
@@ -5075,7 +5410,8 @@ class WebChromeClient extends PigeonInternalProxyApiBaseClass {
   ///
   /// Defaults to false.
   Future<void> setSynchronousReturnValueForOnJsConfirm(bool value) async {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecWebChromeClient;
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
+        _pigeonVar_codecWebChromeClient;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
     const pigeonVar_channelName =
         'dev.flutter.pigeon.webview_flutter_android.WebChromeClient.setSynchronousReturnValueForOnJsConfirm';
@@ -5084,10 +5420,15 @@ class WebChromeClient extends PigeonInternalProxyApiBaseClass {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[this, value]);
+    final Future<Object?> pigeonVar_sendFuture =
+        pigeonVar_channel.send(<Object?>[this, value]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
-    _extractReplyValueOrThrow(pigeonVar_replyList, pigeonVar_channelName, isNullValid: true);
+    _extractReplyValueOrThrow(
+      pigeonVar_replyList,
+      pigeonVar_channelName,
+      isNullValid: true,
+    );
   }
 
   /// Sets the required synchronous return value for the Java method,
@@ -5104,7 +5445,8 @@ class WebChromeClient extends PigeonInternalProxyApiBaseClass {
   ///
   /// Defaults to false.
   Future<void> setSynchronousReturnValueForOnJsPrompt(bool value) async {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecWebChromeClient;
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
+        _pigeonVar_codecWebChromeClient;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
     const pigeonVar_channelName =
         'dev.flutter.pigeon.webview_flutter_android.WebChromeClient.setSynchronousReturnValueForOnJsPrompt';
@@ -5113,10 +5455,15 @@ class WebChromeClient extends PigeonInternalProxyApiBaseClass {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[this, value]);
+    final Future<Object?> pigeonVar_sendFuture =
+        pigeonVar_channel.send(<Object?>[this, value]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
-    _extractReplyValueOrThrow(pigeonVar_replyList, pigeonVar_channelName, isNullValid: true);
+    _extractReplyValueOrThrow(
+      pigeonVar_replyList,
+      pigeonVar_channelName,
+      isNullValid: true,
+    );
   }
 
   @override
@@ -5148,9 +5495,13 @@ class FlutterAssetManager extends PigeonInternalProxyApiBaseClass {
   /// This should only be used by subclasses created by this library or to
   /// create copies for an [PigeonInstanceManager].
   @protected
-  FlutterAssetManager.pigeon_detached({super.pigeon_binaryMessenger, super.pigeon_instanceManager});
+  FlutterAssetManager.pigeon_detached({
+    super.pigeon_binaryMessenger,
+    super.pigeon_instanceManager,
+  });
 
-  late final _PigeonInternalProxyApiBaseCodec _pigeonVar_codecFlutterAssetManager =
+  late final _PigeonInternalProxyApiBaseCodec
+      _pigeonVar_codecFlutterAssetManager =
       _PigeonInternalProxyApiBaseCodec(pigeon_instanceManager);
 
   /// The global instance of the `FlutterAssetManager`.
@@ -5166,16 +5517,15 @@ class FlutterAssetManager extends PigeonInternalProxyApiBaseClass {
     PigeonInstanceManager? pigeon_instanceManager,
     FlutterAssetManager Function()? pigeon_newInstance,
   }) {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _PigeonInternalProxyApiBaseCodec(
-      pigeon_instanceManager ?? PigeonInstanceManager.instance,
-    );
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
+        _PigeonInternalProxyApiBaseCodec(
+            pigeon_instanceManager ?? PigeonInstanceManager.instance);
     final BinaryMessenger? binaryMessenger = pigeon_binaryMessenger;
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-        'dev.flutter.pigeon.webview_flutter_android.FlutterAssetManager.pigeon_newInstance',
-        pigeonChannelCodec,
-        binaryMessenger: binaryMessenger,
-      );
+          'dev.flutter.pigeon.webview_flutter_android.FlutterAssetManager.pigeon_newInstance',
+          pigeonChannelCodec,
+          binaryMessenger: binaryMessenger);
       if (pigeon_clearHandlers) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
@@ -5183,7 +5533,8 @@ class FlutterAssetManager extends PigeonInternalProxyApiBaseClass {
           final List<Object?> args = message! as List<Object?>;
           final int arg_pigeon_instanceIdentifier = args[0]! as int;
           try {
-            (pigeon_instanceManager ?? PigeonInstanceManager.instance).addHostCreatedInstance(
+            (pigeon_instanceManager ?? PigeonInstanceManager.instance)
+                .addHostCreatedInstance(
               pigeon_newInstance?.call() ??
                   FlutterAssetManager.pigeon_detached(
                     pigeon_binaryMessenger: pigeon_binaryMessenger,
@@ -5196,8 +5547,7 @@ class FlutterAssetManager extends PigeonInternalProxyApiBaseClass {
             return wrapResponse(error: e);
           } catch (e) {
             return wrapResponse(
-              error: PlatformException(code: 'error', message: e.toString()),
-            );
+                error: PlatformException(code: 'error', message: e.toString()));
           }
         });
       }
@@ -5205,15 +5555,14 @@ class FlutterAssetManager extends PigeonInternalProxyApiBaseClass {
   }
 
   static FlutterAssetManager pigeonVar_instance() {
-    final FlutterAssetManager pigeonVar_instance = FlutterAssetManager.pigeon_detached();
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _PigeonInternalProxyApiBaseCodec(
-      PigeonInstanceManager.instance,
-    );
+    final FlutterAssetManager pigeonVar_instance =
+        FlutterAssetManager.pigeon_detached();
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
+        _PigeonInternalProxyApiBaseCodec(PigeonInstanceManager.instance);
     final BinaryMessenger pigeonVar_binaryMessenger =
         ServicesBinding.instance.defaultBinaryMessenger;
-    final int pigeonVar_instanceIdentifier = PigeonInstanceManager.instance.addDartCreatedInstance(
-      pigeonVar_instance,
-    );
+    final int pigeonVar_instanceIdentifier = PigeonInstanceManager.instance
+        .addDartCreatedInstance(pigeonVar_instance);
     () async {
       const pigeonVar_channelName =
           'dev.flutter.pigeon.webview_flutter_android.FlutterAssetManager.instance';
@@ -5222,12 +5571,15 @@ class FlutterAssetManager extends PigeonInternalProxyApiBaseClass {
         pigeonChannelCodec,
         binaryMessenger: pigeonVar_binaryMessenger,
       );
-      final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[
-        pigeonVar_instanceIdentifier,
-      ]);
+      final Future<Object?> pigeonVar_sendFuture =
+          pigeonVar_channel.send(<Object?>[pigeonVar_instanceIdentifier]);
       final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
-      _extractReplyValueOrThrow(pigeonVar_replyList, pigeonVar_channelName, isNullValid: true);
+      _extractReplyValueOrThrow(
+        pigeonVar_replyList,
+        pigeonVar_channelName,
+        isNullValid: true,
+      );
     }();
     return pigeonVar_instance;
   }
@@ -5236,7 +5588,8 @@ class FlutterAssetManager extends PigeonInternalProxyApiBaseClass {
   ///
   /// Throws an IOException in case I/O operations were interrupted.
   Future<List<String>> list(String path) async {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecFlutterAssetManager;
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
+        _pigeonVar_codecFlutterAssetManager;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
     const pigeonVar_channelName =
         'dev.flutter.pigeon.webview_flutter_android.FlutterAssetManager.list';
@@ -5245,7 +5598,8 @@ class FlutterAssetManager extends PigeonInternalProxyApiBaseClass {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[this, path]);
+    final Future<Object?> pigeonVar_sendFuture =
+        pigeonVar_channel.send(<Object?>[this, path]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
@@ -5264,7 +5618,8 @@ class FlutterAssetManager extends PigeonInternalProxyApiBaseClass {
   /// Android's AssetManager, but the path is not appropriate to load as an
   /// absolute path.
   Future<String> getAssetFilePathByName(String name) async {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecFlutterAssetManager;
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
+        _pigeonVar_codecFlutterAssetManager;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
     const pigeonVar_channelName =
         'dev.flutter.pigeon.webview_flutter_android.FlutterAssetManager.getAssetFilePathByName';
@@ -5273,7 +5628,8 @@ class FlutterAssetManager extends PigeonInternalProxyApiBaseClass {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[this, name]);
+    final Future<Object?> pigeonVar_sendFuture =
+        pigeonVar_channel.send(<Object?>[this, name]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
@@ -5303,14 +5659,18 @@ class WebStorage extends PigeonInternalProxyApiBaseClass {
   /// This should only be used by subclasses created by this library or to
   /// create copies for an [PigeonInstanceManager].
   @protected
-  WebStorage.pigeon_detached({super.pigeon_binaryMessenger, super.pigeon_instanceManager});
+  WebStorage.pigeon_detached({
+    super.pigeon_binaryMessenger,
+    super.pigeon_instanceManager,
+  });
 
   late final _PigeonInternalProxyApiBaseCodec _pigeonVar_codecWebStorage =
       _PigeonInternalProxyApiBaseCodec(pigeon_instanceManager);
 
   static final WebStorage _instance = pigeonVar_instance();
 
-  static WebStorage get instance => PigeonOverrides.webStorage_instance ?? _instance;
+  static WebStorage get instance =>
+      PigeonOverrides.webStorage_instance ?? _instance;
 
   static void pigeon_setUpMessageHandlers({
     bool pigeon_clearHandlers = false,
@@ -5318,16 +5678,15 @@ class WebStorage extends PigeonInternalProxyApiBaseClass {
     PigeonInstanceManager? pigeon_instanceManager,
     WebStorage Function()? pigeon_newInstance,
   }) {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _PigeonInternalProxyApiBaseCodec(
-      pigeon_instanceManager ?? PigeonInstanceManager.instance,
-    );
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
+        _PigeonInternalProxyApiBaseCodec(
+            pigeon_instanceManager ?? PigeonInstanceManager.instance);
     final BinaryMessenger? binaryMessenger = pigeon_binaryMessenger;
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-        'dev.flutter.pigeon.webview_flutter_android.WebStorage.pigeon_newInstance',
-        pigeonChannelCodec,
-        binaryMessenger: binaryMessenger,
-      );
+          'dev.flutter.pigeon.webview_flutter_android.WebStorage.pigeon_newInstance',
+          pigeonChannelCodec,
+          binaryMessenger: binaryMessenger);
       if (pigeon_clearHandlers) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
@@ -5335,7 +5694,8 @@ class WebStorage extends PigeonInternalProxyApiBaseClass {
           final List<Object?> args = message! as List<Object?>;
           final int arg_pigeon_instanceIdentifier = args[0]! as int;
           try {
-            (pigeon_instanceManager ?? PigeonInstanceManager.instance).addHostCreatedInstance(
+            (pigeon_instanceManager ?? PigeonInstanceManager.instance)
+                .addHostCreatedInstance(
               pigeon_newInstance?.call() ??
                   WebStorage.pigeon_detached(
                     pigeon_binaryMessenger: pigeon_binaryMessenger,
@@ -5348,8 +5708,7 @@ class WebStorage extends PigeonInternalProxyApiBaseClass {
             return wrapResponse(error: e);
           } catch (e) {
             return wrapResponse(
-              error: PlatformException(code: 'error', message: e.toString()),
-            );
+                error: PlatformException(code: 'error', message: e.toString()));
           }
         });
       }
@@ -5358,14 +5717,12 @@ class WebStorage extends PigeonInternalProxyApiBaseClass {
 
   static WebStorage pigeonVar_instance() {
     final WebStorage pigeonVar_instance = WebStorage.pigeon_detached();
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _PigeonInternalProxyApiBaseCodec(
-      PigeonInstanceManager.instance,
-    );
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
+        _PigeonInternalProxyApiBaseCodec(PigeonInstanceManager.instance);
     final BinaryMessenger pigeonVar_binaryMessenger =
         ServicesBinding.instance.defaultBinaryMessenger;
-    final int pigeonVar_instanceIdentifier = PigeonInstanceManager.instance.addDartCreatedInstance(
-      pigeonVar_instance,
-    );
+    final int pigeonVar_instanceIdentifier = PigeonInstanceManager.instance
+        .addDartCreatedInstance(pigeonVar_instance);
     () async {
       const pigeonVar_channelName =
           'dev.flutter.pigeon.webview_flutter_android.WebStorage.instance';
@@ -5374,19 +5731,23 @@ class WebStorage extends PigeonInternalProxyApiBaseClass {
         pigeonChannelCodec,
         binaryMessenger: pigeonVar_binaryMessenger,
       );
-      final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[
-        pigeonVar_instanceIdentifier,
-      ]);
+      final Future<Object?> pigeonVar_sendFuture =
+          pigeonVar_channel.send(<Object?>[pigeonVar_instanceIdentifier]);
       final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
-      _extractReplyValueOrThrow(pigeonVar_replyList, pigeonVar_channelName, isNullValid: true);
+      _extractReplyValueOrThrow(
+        pigeonVar_replyList,
+        pigeonVar_channelName,
+        isNullValid: true,
+      );
     }();
     return pigeonVar_instance;
   }
 
   /// Clears all storage currently being used by the JavaScript storage APIs.
   Future<void> deleteAllData() async {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecWebStorage;
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
+        _pigeonVar_codecWebStorage;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
     const pigeonVar_channelName =
         'dev.flutter.pigeon.webview_flutter_android.WebStorage.deleteAllData';
@@ -5395,10 +5756,15 @@ class WebStorage extends PigeonInternalProxyApiBaseClass {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[this]);
+    final Future<Object?> pigeonVar_sendFuture =
+        pigeonVar_channel.send(<Object?>[this]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
-    _extractReplyValueOrThrow(pigeonVar_replyList, pigeonVar_channelName, isNullValid: true);
+    _extractReplyValueOrThrow(
+      pigeonVar_replyList,
+      pigeonVar_channelName,
+      isNullValid: true,
+    );
   }
 
   @override
@@ -5449,19 +5815,17 @@ class FileChooserParams extends PigeonInternalProxyApiBaseClass {
       List<String> acceptTypes,
       FileChooserMode mode,
       String? filenameHint,
-    )?
-    pigeon_newInstance,
+    )? pigeon_newInstance,
   }) {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _PigeonInternalProxyApiBaseCodec(
-      pigeon_instanceManager ?? PigeonInstanceManager.instance,
-    );
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
+        _PigeonInternalProxyApiBaseCodec(
+            pigeon_instanceManager ?? PigeonInstanceManager.instance);
     final BinaryMessenger? binaryMessenger = pigeon_binaryMessenger;
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-        'dev.flutter.pigeon.webview_flutter_android.FileChooserParams.pigeon_newInstance',
-        pigeonChannelCodec,
-        binaryMessenger: binaryMessenger,
-      );
+          'dev.flutter.pigeon.webview_flutter_android.FileChooserParams.pigeon_newInstance',
+          pigeonChannelCodec,
+          binaryMessenger: binaryMessenger);
       if (pigeon_clearHandlers) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
@@ -5469,17 +5833,15 @@ class FileChooserParams extends PigeonInternalProxyApiBaseClass {
           final List<Object?> args = message! as List<Object?>;
           final int arg_pigeon_instanceIdentifier = args[0]! as int;
           final bool arg_isCaptureEnabled = args[1]! as bool;
-          final List<String> arg_acceptTypes = (args[2]! as List<Object?>).cast<String>();
+          final List<String> arg_acceptTypes =
+              (args[2]! as List<Object?>).cast<String>();
           final FileChooserMode arg_mode = args[3]! as FileChooserMode;
           final String? arg_filenameHint = args[4] as String?;
           try {
-            (pigeon_instanceManager ?? PigeonInstanceManager.instance).addHostCreatedInstance(
-              pigeon_newInstance?.call(
-                    arg_isCaptureEnabled,
-                    arg_acceptTypes,
-                    arg_mode,
-                    arg_filenameHint,
-                  ) ??
+            (pigeon_instanceManager ?? PigeonInstanceManager.instance)
+                .addHostCreatedInstance(
+              pigeon_newInstance?.call(arg_isCaptureEnabled, arg_acceptTypes,
+                      arg_mode, arg_filenameHint) ??
                   FileChooserParams.pigeon_detached(
                     pigeon_binaryMessenger: pigeon_binaryMessenger,
                     pigeon_instanceManager: pigeon_instanceManager,
@@ -5495,8 +5857,7 @@ class FileChooserParams extends PigeonInternalProxyApiBaseClass {
             return wrapResponse(error: e);
           } catch (e) {
             return wrapResponse(
-              error: PlatformException(code: 'error', message: e.toString()),
-            );
+                error: PlatformException(code: 'error', message: e.toString()));
           }
         });
       }
@@ -5532,7 +5893,8 @@ class PermissionRequest extends PigeonInternalProxyApiBaseClass {
     required this.resources,
   });
 
-  late final _PigeonInternalProxyApiBaseCodec _pigeonVar_codecPermissionRequest =
+  late final _PigeonInternalProxyApiBaseCodec
+      _pigeonVar_codecPermissionRequest =
       _PigeonInternalProxyApiBaseCodec(pigeon_instanceManager);
 
   final List<String> resources;
@@ -5543,25 +5905,26 @@ class PermissionRequest extends PigeonInternalProxyApiBaseClass {
     PigeonInstanceManager? pigeon_instanceManager,
     PermissionRequest Function(List<String> resources)? pigeon_newInstance,
   }) {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _PigeonInternalProxyApiBaseCodec(
-      pigeon_instanceManager ?? PigeonInstanceManager.instance,
-    );
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
+        _PigeonInternalProxyApiBaseCodec(
+            pigeon_instanceManager ?? PigeonInstanceManager.instance);
     final BinaryMessenger? binaryMessenger = pigeon_binaryMessenger;
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-        'dev.flutter.pigeon.webview_flutter_android.PermissionRequest.pigeon_newInstance',
-        pigeonChannelCodec,
-        binaryMessenger: binaryMessenger,
-      );
+          'dev.flutter.pigeon.webview_flutter_android.PermissionRequest.pigeon_newInstance',
+          pigeonChannelCodec,
+          binaryMessenger: binaryMessenger);
       if (pigeon_clearHandlers) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
         pigeonVar_channel.setMessageHandler((Object? message) async {
           final List<Object?> args = message! as List<Object?>;
           final int arg_pigeon_instanceIdentifier = args[0]! as int;
-          final List<String> arg_resources = (args[1]! as List<Object?>).cast<String>();
+          final List<String> arg_resources =
+              (args[1]! as List<Object?>).cast<String>();
           try {
-            (pigeon_instanceManager ?? PigeonInstanceManager.instance).addHostCreatedInstance(
+            (pigeon_instanceManager ?? PigeonInstanceManager.instance)
+                .addHostCreatedInstance(
               pigeon_newInstance?.call(arg_resources) ??
                   PermissionRequest.pigeon_detached(
                     pigeon_binaryMessenger: pigeon_binaryMessenger,
@@ -5575,8 +5938,7 @@ class PermissionRequest extends PigeonInternalProxyApiBaseClass {
             return wrapResponse(error: e);
           } catch (e) {
             return wrapResponse(
-              error: PlatformException(code: 'error', message: e.toString()),
-            );
+                error: PlatformException(code: 'error', message: e.toString()));
           }
         });
       }
@@ -5586,7 +5948,8 @@ class PermissionRequest extends PigeonInternalProxyApiBaseClass {
   /// Call this method to grant origin the permission to access the given
   /// resources.
   Future<void> grant(List<String> resources) async {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecPermissionRequest;
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
+        _pigeonVar_codecPermissionRequest;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
     const pigeonVar_channelName =
         'dev.flutter.pigeon.webview_flutter_android.PermissionRequest.grant';
@@ -5595,15 +5958,21 @@ class PermissionRequest extends PigeonInternalProxyApiBaseClass {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[this, resources]);
+    final Future<Object?> pigeonVar_sendFuture =
+        pigeonVar_channel.send(<Object?>[this, resources]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
-    _extractReplyValueOrThrow(pigeonVar_replyList, pigeonVar_channelName, isNullValid: true);
+    _extractReplyValueOrThrow(
+      pigeonVar_replyList,
+      pigeonVar_channelName,
+      isNullValid: true,
+    );
   }
 
   /// Call this method to deny the request.
   Future<void> deny() async {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecPermissionRequest;
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
+        _pigeonVar_codecPermissionRequest;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
     const pigeonVar_channelName =
         'dev.flutter.pigeon.webview_flutter_android.PermissionRequest.deny';
@@ -5612,10 +5981,15 @@ class PermissionRequest extends PigeonInternalProxyApiBaseClass {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[this]);
+    final Future<Object?> pigeonVar_sendFuture =
+        pigeonVar_channel.send(<Object?>[this]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
-    _extractReplyValueOrThrow(pigeonVar_replyList, pigeonVar_channelName, isNullValid: true);
+    _extractReplyValueOrThrow(
+      pigeonVar_replyList,
+      pigeonVar_channelName,
+      isNullValid: true,
+    );
   }
 
   @override
@@ -5638,9 +6012,13 @@ class CustomViewCallback extends PigeonInternalProxyApiBaseClass {
   /// This should only be used by subclasses created by this library or to
   /// create copies for an [PigeonInstanceManager].
   @protected
-  CustomViewCallback.pigeon_detached({super.pigeon_binaryMessenger, super.pigeon_instanceManager});
+  CustomViewCallback.pigeon_detached({
+    super.pigeon_binaryMessenger,
+    super.pigeon_instanceManager,
+  });
 
-  late final _PigeonInternalProxyApiBaseCodec _pigeonVar_codecCustomViewCallback =
+  late final _PigeonInternalProxyApiBaseCodec
+      _pigeonVar_codecCustomViewCallback =
       _PigeonInternalProxyApiBaseCodec(pigeon_instanceManager);
 
   static void pigeon_setUpMessageHandlers({
@@ -5649,16 +6027,15 @@ class CustomViewCallback extends PigeonInternalProxyApiBaseClass {
     PigeonInstanceManager? pigeon_instanceManager,
     CustomViewCallback Function()? pigeon_newInstance,
   }) {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _PigeonInternalProxyApiBaseCodec(
-      pigeon_instanceManager ?? PigeonInstanceManager.instance,
-    );
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
+        _PigeonInternalProxyApiBaseCodec(
+            pigeon_instanceManager ?? PigeonInstanceManager.instance);
     final BinaryMessenger? binaryMessenger = pigeon_binaryMessenger;
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-        'dev.flutter.pigeon.webview_flutter_android.CustomViewCallback.pigeon_newInstance',
-        pigeonChannelCodec,
-        binaryMessenger: binaryMessenger,
-      );
+          'dev.flutter.pigeon.webview_flutter_android.CustomViewCallback.pigeon_newInstance',
+          pigeonChannelCodec,
+          binaryMessenger: binaryMessenger);
       if (pigeon_clearHandlers) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
@@ -5666,7 +6043,8 @@ class CustomViewCallback extends PigeonInternalProxyApiBaseClass {
           final List<Object?> args = message! as List<Object?>;
           final int arg_pigeon_instanceIdentifier = args[0]! as int;
           try {
-            (pigeon_instanceManager ?? PigeonInstanceManager.instance).addHostCreatedInstance(
+            (pigeon_instanceManager ?? PigeonInstanceManager.instance)
+                .addHostCreatedInstance(
               pigeon_newInstance?.call() ??
                   CustomViewCallback.pigeon_detached(
                     pigeon_binaryMessenger: pigeon_binaryMessenger,
@@ -5679,8 +6057,7 @@ class CustomViewCallback extends PigeonInternalProxyApiBaseClass {
             return wrapResponse(error: e);
           } catch (e) {
             return wrapResponse(
-              error: PlatformException(code: 'error', message: e.toString()),
-            );
+                error: PlatformException(code: 'error', message: e.toString()));
           }
         });
       }
@@ -5689,7 +6066,8 @@ class CustomViewCallback extends PigeonInternalProxyApiBaseClass {
 
   /// Invoked when the host application dismisses the custom view.
   Future<void> onCustomViewHidden() async {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecCustomViewCallback;
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
+        _pigeonVar_codecCustomViewCallback;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
     const pigeonVar_channelName =
         'dev.flutter.pigeon.webview_flutter_android.CustomViewCallback.onCustomViewHidden';
@@ -5698,10 +6076,15 @@ class CustomViewCallback extends PigeonInternalProxyApiBaseClass {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[this]);
+    final Future<Object?> pigeonVar_sendFuture =
+        pigeonVar_channel.send(<Object?>[this]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
-    _extractReplyValueOrThrow(pigeonVar_replyList, pigeonVar_channelName, isNullValid: true);
+    _extractReplyValueOrThrow(
+      pigeonVar_replyList,
+      pigeonVar_channelName,
+      isNullValid: true,
+    );
   }
 
   @override
@@ -5723,7 +6106,10 @@ class View extends PigeonInternalProxyApiBaseClass {
   /// This should only be used by subclasses created by this library or to
   /// create copies for an [PigeonInstanceManager].
   @protected
-  View.pigeon_detached({super.pigeon_binaryMessenger, super.pigeon_instanceManager});
+  View.pigeon_detached({
+    super.pigeon_binaryMessenger,
+    super.pigeon_instanceManager,
+  });
 
   late final _PigeonInternalProxyApiBaseCodec _pigeonVar_codecView =
       _PigeonInternalProxyApiBaseCodec(pigeon_instanceManager);
@@ -5734,16 +6120,15 @@ class View extends PigeonInternalProxyApiBaseClass {
     PigeonInstanceManager? pigeon_instanceManager,
     View Function()? pigeon_newInstance,
   }) {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _PigeonInternalProxyApiBaseCodec(
-      pigeon_instanceManager ?? PigeonInstanceManager.instance,
-    );
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
+        _PigeonInternalProxyApiBaseCodec(
+            pigeon_instanceManager ?? PigeonInstanceManager.instance);
     final BinaryMessenger? binaryMessenger = pigeon_binaryMessenger;
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-        'dev.flutter.pigeon.webview_flutter_android.View.pigeon_newInstance',
-        pigeonChannelCodec,
-        binaryMessenger: binaryMessenger,
-      );
+          'dev.flutter.pigeon.webview_flutter_android.View.pigeon_newInstance',
+          pigeonChannelCodec,
+          binaryMessenger: binaryMessenger);
       if (pigeon_clearHandlers) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
@@ -5751,7 +6136,8 @@ class View extends PigeonInternalProxyApiBaseClass {
           final List<Object?> args = message! as List<Object?>;
           final int arg_pigeon_instanceIdentifier = args[0]! as int;
           try {
-            (pigeon_instanceManager ?? PigeonInstanceManager.instance).addHostCreatedInstance(
+            (pigeon_instanceManager ?? PigeonInstanceManager.instance)
+                .addHostCreatedInstance(
               pigeon_newInstance?.call() ??
                   View.pigeon_detached(
                     pigeon_binaryMessenger: pigeon_binaryMessenger,
@@ -5764,8 +6150,7 @@ class View extends PigeonInternalProxyApiBaseClass {
             return wrapResponse(error: e);
           } catch (e) {
             return wrapResponse(
-              error: PlatformException(code: 'error', message: e.toString()),
-            );
+                error: PlatformException(code: 'error', message: e.toString()));
           }
         });
       }
@@ -5773,40 +6158,61 @@ class View extends PigeonInternalProxyApiBaseClass {
   }
 
   /// Set the scrolled position of your view.
-  Future<void> scrollTo(int x, int y) async {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecView;
+  Future<void> scrollTo(
+    int x,
+    int y,
+  ) async {
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
+        _pigeonVar_codecView;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
-    const pigeonVar_channelName = 'dev.flutter.pigeon.webview_flutter_android.View.scrollTo';
+    const pigeonVar_channelName =
+        'dev.flutter.pigeon.webview_flutter_android.View.scrollTo';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[this, x, y]);
+    final Future<Object?> pigeonVar_sendFuture =
+        pigeonVar_channel.send(<Object?>[this, x, y]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
-    _extractReplyValueOrThrow(pigeonVar_replyList, pigeonVar_channelName, isNullValid: true);
+    _extractReplyValueOrThrow(
+      pigeonVar_replyList,
+      pigeonVar_channelName,
+      isNullValid: true,
+    );
   }
 
   /// Move the scrolled position of your view.
-  Future<void> scrollBy(int x, int y) async {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecView;
+  Future<void> scrollBy(
+    int x,
+    int y,
+  ) async {
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
+        _pigeonVar_codecView;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
-    const pigeonVar_channelName = 'dev.flutter.pigeon.webview_flutter_android.View.scrollBy';
+    const pigeonVar_channelName =
+        'dev.flutter.pigeon.webview_flutter_android.View.scrollBy';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[this, x, y]);
+    final Future<Object?> pigeonVar_sendFuture =
+        pigeonVar_channel.send(<Object?>[this, x, y]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
-    _extractReplyValueOrThrow(pigeonVar_replyList, pigeonVar_channelName, isNullValid: true);
+    _extractReplyValueOrThrow(
+      pigeonVar_replyList,
+      pigeonVar_channelName,
+      isNullValid: true,
+    );
   }
 
   /// Return the scrolled position of this view.
   Future<WebViewPoint> getScrollPosition() async {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecView;
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
+        _pigeonVar_codecView;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
     const pigeonVar_channelName =
         'dev.flutter.pigeon.webview_flutter_android.View.getScrollPosition';
@@ -5815,7 +6221,8 @@ class View extends PigeonInternalProxyApiBaseClass {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[this]);
+    final Future<Object?> pigeonVar_sendFuture =
+        pigeonVar_channel.send(<Object?>[this]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
@@ -5830,7 +6237,8 @@ class View extends PigeonInternalProxyApiBaseClass {
   ///
   /// The scrollbar is not drawn by default.
   Future<void> setVerticalScrollBarEnabled(bool enabled) async {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecView;
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
+        _pigeonVar_codecView;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
     const pigeonVar_channelName =
         'dev.flutter.pigeon.webview_flutter_android.View.setVerticalScrollBarEnabled';
@@ -5839,17 +6247,23 @@ class View extends PigeonInternalProxyApiBaseClass {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[this, enabled]);
+    final Future<Object?> pigeonVar_sendFuture =
+        pigeonVar_channel.send(<Object?>[this, enabled]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
-    _extractReplyValueOrThrow(pigeonVar_replyList, pigeonVar_channelName, isNullValid: true);
+    _extractReplyValueOrThrow(
+      pigeonVar_replyList,
+      pigeonVar_channelName,
+      isNullValid: true,
+    );
   }
 
   /// Define whether the horizontal scrollbar should be drawn or not.
   ///
   /// The scrollbar is not drawn by default.
   Future<void> setHorizontalScrollBarEnabled(bool enabled) async {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecView;
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
+        _pigeonVar_codecView;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
     const pigeonVar_channelName =
         'dev.flutter.pigeon.webview_flutter_android.View.setHorizontalScrollBarEnabled';
@@ -5858,15 +6272,21 @@ class View extends PigeonInternalProxyApiBaseClass {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[this, enabled]);
+    final Future<Object?> pigeonVar_sendFuture =
+        pigeonVar_channel.send(<Object?>[this, enabled]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
-    _extractReplyValueOrThrow(pigeonVar_replyList, pigeonVar_channelName, isNullValid: true);
+    _extractReplyValueOrThrow(
+      pigeonVar_replyList,
+      pigeonVar_channelName,
+      isNullValid: true,
+    );
   }
 
   /// Set the over-scroll mode for this view.
   Future<void> setOverScrollMode(OverScrollMode mode) async {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecView;
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
+        _pigeonVar_codecView;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
     const pigeonVar_channelName =
         'dev.flutter.pigeon.webview_flutter_android.View.setOverScrollMode';
@@ -5875,10 +6295,15 @@ class View extends PigeonInternalProxyApiBaseClass {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[this, mode]);
+    final Future<Object?> pigeonVar_sendFuture =
+        pigeonVar_channel.send(<Object?>[this, mode]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
-    _extractReplyValueOrThrow(pigeonVar_replyList, pigeonVar_channelName, isNullValid: true);
+    _extractReplyValueOrThrow(
+      pigeonVar_replyList,
+      pigeonVar_channelName,
+      isNullValid: true,
+    );
   }
 
   /// Sets the listener to the native method
@@ -5887,8 +6312,10 @@ class View extends PigeonInternalProxyApiBaseClass {
   ///
   /// This is a convenience method because `View.OnApplyWindowInsetsListener`
   /// requires implementing a callback that requires a synchronous return value.
-  Future<void> setInsetListenerToSetInsetsToZero(List<WindowInsetsType> types) async {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecView;
+  Future<void> setInsetListenerToSetInsetsToZero(
+      List<WindowInsetsType> types) async {
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
+        _pigeonVar_codecView;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
     const pigeonVar_channelName =
         'dev.flutter.pigeon.webview_flutter_android.View.setInsetListenerToSetInsetsToZero';
@@ -5897,10 +6324,15 @@ class View extends PigeonInternalProxyApiBaseClass {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[this, types]);
+    final Future<Object?> pigeonVar_sendFuture =
+        pigeonVar_channel.send(<Object?>[this, types]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
-    _extractReplyValueOrThrow(pigeonVar_replyList, pigeonVar_channelName, isNullValid: true);
+    _extractReplyValueOrThrow(
+      pigeonVar_replyList,
+      pigeonVar_channelName,
+      isNullValid: true,
+    );
   }
 
   @override
@@ -5927,7 +6359,8 @@ class GeolocationPermissionsCallback extends PigeonInternalProxyApiBaseClass {
     super.pigeon_instanceManager,
   });
 
-  late final _PigeonInternalProxyApiBaseCodec _pigeonVar_codecGeolocationPermissionsCallback =
+  late final _PigeonInternalProxyApiBaseCodec
+      _pigeonVar_codecGeolocationPermissionsCallback =
       _PigeonInternalProxyApiBaseCodec(pigeon_instanceManager);
 
   static void pigeon_setUpMessageHandlers({
@@ -5936,16 +6369,15 @@ class GeolocationPermissionsCallback extends PigeonInternalProxyApiBaseClass {
     PigeonInstanceManager? pigeon_instanceManager,
     GeolocationPermissionsCallback Function()? pigeon_newInstance,
   }) {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _PigeonInternalProxyApiBaseCodec(
-      pigeon_instanceManager ?? PigeonInstanceManager.instance,
-    );
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
+        _PigeonInternalProxyApiBaseCodec(
+            pigeon_instanceManager ?? PigeonInstanceManager.instance);
     final BinaryMessenger? binaryMessenger = pigeon_binaryMessenger;
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-        'dev.flutter.pigeon.webview_flutter_android.GeolocationPermissionsCallback.pigeon_newInstance',
-        pigeonChannelCodec,
-        binaryMessenger: binaryMessenger,
-      );
+          'dev.flutter.pigeon.webview_flutter_android.GeolocationPermissionsCallback.pigeon_newInstance',
+          pigeonChannelCodec,
+          binaryMessenger: binaryMessenger);
       if (pigeon_clearHandlers) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
@@ -5953,7 +6385,8 @@ class GeolocationPermissionsCallback extends PigeonInternalProxyApiBaseClass {
           final List<Object?> args = message! as List<Object?>;
           final int arg_pigeon_instanceIdentifier = args[0]! as int;
           try {
-            (pigeon_instanceManager ?? PigeonInstanceManager.instance).addHostCreatedInstance(
+            (pigeon_instanceManager ?? PigeonInstanceManager.instance)
+                .addHostCreatedInstance(
               pigeon_newInstance?.call() ??
                   GeolocationPermissionsCallback.pigeon_detached(
                     pigeon_binaryMessenger: pigeon_binaryMessenger,
@@ -5966,8 +6399,7 @@ class GeolocationPermissionsCallback extends PigeonInternalProxyApiBaseClass {
             return wrapResponse(error: e);
           } catch (e) {
             return wrapResponse(
-              error: PlatformException(code: 'error', message: e.toString()),
-            );
+                error: PlatformException(code: 'error', message: e.toString()));
           }
         });
       }
@@ -5975,7 +6407,11 @@ class GeolocationPermissionsCallback extends PigeonInternalProxyApiBaseClass {
   }
 
   /// Sets the Geolocation permission state for the supplied origin.
-  Future<void> invoke(String origin, bool allow, bool retain) async {
+  Future<void> invoke(
+    String origin,
+    bool allow,
+    bool retain,
+  ) async {
     final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
         _pigeonVar_codecGeolocationPermissionsCallback;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
@@ -5986,15 +6422,15 @@ class GeolocationPermissionsCallback extends PigeonInternalProxyApiBaseClass {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[
-      this,
-      origin,
-      allow,
-      retain,
-    ]);
+    final Future<Object?> pigeonVar_sendFuture =
+        pigeonVar_channel.send(<Object?>[this, origin, allow, retain]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
-    _extractReplyValueOrThrow(pigeonVar_replyList, pigeonVar_channelName, isNullValid: true);
+    _extractReplyValueOrThrow(
+      pigeonVar_replyList,
+      pigeonVar_channelName,
+      isNullValid: true,
+    );
   }
 
   @override
@@ -6015,7 +6451,10 @@ class HttpAuthHandler extends PigeonInternalProxyApiBaseClass {
   /// This should only be used by subclasses created by this library or to
   /// create copies for an [PigeonInstanceManager].
   @protected
-  HttpAuthHandler.pigeon_detached({super.pigeon_binaryMessenger, super.pigeon_instanceManager});
+  HttpAuthHandler.pigeon_detached({
+    super.pigeon_binaryMessenger,
+    super.pigeon_instanceManager,
+  });
 
   late final _PigeonInternalProxyApiBaseCodec _pigeonVar_codecHttpAuthHandler =
       _PigeonInternalProxyApiBaseCodec(pigeon_instanceManager);
@@ -6026,16 +6465,15 @@ class HttpAuthHandler extends PigeonInternalProxyApiBaseClass {
     PigeonInstanceManager? pigeon_instanceManager,
     HttpAuthHandler Function()? pigeon_newInstance,
   }) {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _PigeonInternalProxyApiBaseCodec(
-      pigeon_instanceManager ?? PigeonInstanceManager.instance,
-    );
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
+        _PigeonInternalProxyApiBaseCodec(
+            pigeon_instanceManager ?? PigeonInstanceManager.instance);
     final BinaryMessenger? binaryMessenger = pigeon_binaryMessenger;
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-        'dev.flutter.pigeon.webview_flutter_android.HttpAuthHandler.pigeon_newInstance',
-        pigeonChannelCodec,
-        binaryMessenger: binaryMessenger,
-      );
+          'dev.flutter.pigeon.webview_flutter_android.HttpAuthHandler.pigeon_newInstance',
+          pigeonChannelCodec,
+          binaryMessenger: binaryMessenger);
       if (pigeon_clearHandlers) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
@@ -6043,7 +6481,8 @@ class HttpAuthHandler extends PigeonInternalProxyApiBaseClass {
           final List<Object?> args = message! as List<Object?>;
           final int arg_pigeon_instanceIdentifier = args[0]! as int;
           try {
-            (pigeon_instanceManager ?? PigeonInstanceManager.instance).addHostCreatedInstance(
+            (pigeon_instanceManager ?? PigeonInstanceManager.instance)
+                .addHostCreatedInstance(
               pigeon_newInstance?.call() ??
                   HttpAuthHandler.pigeon_detached(
                     pigeon_binaryMessenger: pigeon_binaryMessenger,
@@ -6056,8 +6495,7 @@ class HttpAuthHandler extends PigeonInternalProxyApiBaseClass {
             return wrapResponse(error: e);
           } catch (e) {
             return wrapResponse(
-              error: PlatformException(code: 'error', message: e.toString()),
-            );
+                error: PlatformException(code: 'error', message: e.toString()));
           }
         });
       }
@@ -6068,7 +6506,8 @@ class HttpAuthHandler extends PigeonInternalProxyApiBaseClass {
   /// for which `WebViewClient.onReceivedHttpAuthRequest` was called) are
   /// suitable for use.
   Future<bool> useHttpAuthUsernamePassword() async {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecHttpAuthHandler;
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
+        _pigeonVar_codecHttpAuthHandler;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
     const pigeonVar_channelName =
         'dev.flutter.pigeon.webview_flutter_android.HttpAuthHandler.useHttpAuthUsernamePassword';
@@ -6077,7 +6516,8 @@ class HttpAuthHandler extends PigeonInternalProxyApiBaseClass {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[this]);
+    final Future<Object?> pigeonVar_sendFuture =
+        pigeonVar_channel.send(<Object?>[this]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
@@ -6090,7 +6530,8 @@ class HttpAuthHandler extends PigeonInternalProxyApiBaseClass {
 
   /// Instructs the WebView to cancel the authentication request..
   Future<void> cancel() async {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecHttpAuthHandler;
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
+        _pigeonVar_codecHttpAuthHandler;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
     const pigeonVar_channelName =
         'dev.flutter.pigeon.webview_flutter_android.HttpAuthHandler.cancel';
@@ -6099,16 +6540,25 @@ class HttpAuthHandler extends PigeonInternalProxyApiBaseClass {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[this]);
+    final Future<Object?> pigeonVar_sendFuture =
+        pigeonVar_channel.send(<Object?>[this]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
-    _extractReplyValueOrThrow(pigeonVar_replyList, pigeonVar_channelName, isNullValid: true);
+    _extractReplyValueOrThrow(
+      pigeonVar_replyList,
+      pigeonVar_channelName,
+      isNullValid: true,
+    );
   }
 
   /// Instructs the WebView to proceed with the authentication with the given
   /// credentials.
-  Future<void> proceed(String username, String password) async {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecHttpAuthHandler;
+  Future<void> proceed(
+    String username,
+    String password,
+  ) async {
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
+        _pigeonVar_codecHttpAuthHandler;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
     const pigeonVar_channelName =
         'dev.flutter.pigeon.webview_flutter_android.HttpAuthHandler.proceed';
@@ -6117,14 +6567,15 @@ class HttpAuthHandler extends PigeonInternalProxyApiBaseClass {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[
-      this,
-      username,
-      password,
-    ]);
+    final Future<Object?> pigeonVar_sendFuture =
+        pigeonVar_channel.send(<Object?>[this, username, password]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
-    _extractReplyValueOrThrow(pigeonVar_replyList, pigeonVar_channelName, isNullValid: true);
+    _extractReplyValueOrThrow(
+      pigeonVar_replyList,
+      pigeonVar_channelName,
+      isNullValid: true,
+    );
   }
 
   @override
@@ -6146,7 +6597,10 @@ class AndroidMessage extends PigeonInternalProxyApiBaseClass {
   /// This should only be used by subclasses created by this library or to
   /// create copies for an [PigeonInstanceManager].
   @protected
-  AndroidMessage.pigeon_detached({super.pigeon_binaryMessenger, super.pigeon_instanceManager});
+  AndroidMessage.pigeon_detached({
+    super.pigeon_binaryMessenger,
+    super.pigeon_instanceManager,
+  });
 
   late final _PigeonInternalProxyApiBaseCodec _pigeonVar_codecAndroidMessage =
       _PigeonInternalProxyApiBaseCodec(pigeon_instanceManager);
@@ -6157,16 +6611,15 @@ class AndroidMessage extends PigeonInternalProxyApiBaseClass {
     PigeonInstanceManager? pigeon_instanceManager,
     AndroidMessage Function()? pigeon_newInstance,
   }) {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _PigeonInternalProxyApiBaseCodec(
-      pigeon_instanceManager ?? PigeonInstanceManager.instance,
-    );
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
+        _PigeonInternalProxyApiBaseCodec(
+            pigeon_instanceManager ?? PigeonInstanceManager.instance);
     final BinaryMessenger? binaryMessenger = pigeon_binaryMessenger;
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-        'dev.flutter.pigeon.webview_flutter_android.AndroidMessage.pigeon_newInstance',
-        pigeonChannelCodec,
-        binaryMessenger: binaryMessenger,
-      );
+          'dev.flutter.pigeon.webview_flutter_android.AndroidMessage.pigeon_newInstance',
+          pigeonChannelCodec,
+          binaryMessenger: binaryMessenger);
       if (pigeon_clearHandlers) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
@@ -6174,7 +6627,8 @@ class AndroidMessage extends PigeonInternalProxyApiBaseClass {
           final List<Object?> args = message! as List<Object?>;
           final int arg_pigeon_instanceIdentifier = args[0]! as int;
           try {
-            (pigeon_instanceManager ?? PigeonInstanceManager.instance).addHostCreatedInstance(
+            (pigeon_instanceManager ?? PigeonInstanceManager.instance)
+                .addHostCreatedInstance(
               pigeon_newInstance?.call() ??
                   AndroidMessage.pigeon_detached(
                     pigeon_binaryMessenger: pigeon_binaryMessenger,
@@ -6187,8 +6641,7 @@ class AndroidMessage extends PigeonInternalProxyApiBaseClass {
             return wrapResponse(error: e);
           } catch (e) {
             return wrapResponse(
-              error: PlatformException(code: 'error', message: e.toString()),
-            );
+                error: PlatformException(code: 'error', message: e.toString()));
           }
         });
       }
@@ -6200,7 +6653,8 @@ class AndroidMessage extends PigeonInternalProxyApiBaseClass {
   ///
   /// Throws a null pointer exception if this field has not been set.
   Future<void> sendToTarget() async {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecAndroidMessage;
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
+        _pigeonVar_codecAndroidMessage;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
     const pigeonVar_channelName =
         'dev.flutter.pigeon.webview_flutter_android.AndroidMessage.sendToTarget';
@@ -6209,10 +6663,15 @@ class AndroidMessage extends PigeonInternalProxyApiBaseClass {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[this]);
+    final Future<Object?> pigeonVar_sendFuture =
+        pigeonVar_channel.send(<Object?>[this]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
-    _extractReplyValueOrThrow(pigeonVar_replyList, pigeonVar_channelName, isNullValid: true);
+    _extractReplyValueOrThrow(
+      pigeonVar_replyList,
+      pigeonVar_channelName,
+      isNullValid: true,
+    );
   }
 
   @override
@@ -6234,9 +6693,13 @@ class ClientCertRequest extends PigeonInternalProxyApiBaseClass {
   /// This should only be used by subclasses created by this library or to
   /// create copies for an [PigeonInstanceManager].
   @protected
-  ClientCertRequest.pigeon_detached({super.pigeon_binaryMessenger, super.pigeon_instanceManager});
+  ClientCertRequest.pigeon_detached({
+    super.pigeon_binaryMessenger,
+    super.pigeon_instanceManager,
+  });
 
-  late final _PigeonInternalProxyApiBaseCodec _pigeonVar_codecClientCertRequest =
+  late final _PigeonInternalProxyApiBaseCodec
+      _pigeonVar_codecClientCertRequest =
       _PigeonInternalProxyApiBaseCodec(pigeon_instanceManager);
 
   static void pigeon_setUpMessageHandlers({
@@ -6245,16 +6708,15 @@ class ClientCertRequest extends PigeonInternalProxyApiBaseClass {
     PigeonInstanceManager? pigeon_instanceManager,
     ClientCertRequest Function()? pigeon_newInstance,
   }) {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _PigeonInternalProxyApiBaseCodec(
-      pigeon_instanceManager ?? PigeonInstanceManager.instance,
-    );
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
+        _PigeonInternalProxyApiBaseCodec(
+            pigeon_instanceManager ?? PigeonInstanceManager.instance);
     final BinaryMessenger? binaryMessenger = pigeon_binaryMessenger;
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-        'dev.flutter.pigeon.webview_flutter_android.ClientCertRequest.pigeon_newInstance',
-        pigeonChannelCodec,
-        binaryMessenger: binaryMessenger,
-      );
+          'dev.flutter.pigeon.webview_flutter_android.ClientCertRequest.pigeon_newInstance',
+          pigeonChannelCodec,
+          binaryMessenger: binaryMessenger);
       if (pigeon_clearHandlers) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
@@ -6262,7 +6724,8 @@ class ClientCertRequest extends PigeonInternalProxyApiBaseClass {
           final List<Object?> args = message! as List<Object?>;
           final int arg_pigeon_instanceIdentifier = args[0]! as int;
           try {
-            (pigeon_instanceManager ?? PigeonInstanceManager.instance).addHostCreatedInstance(
+            (pigeon_instanceManager ?? PigeonInstanceManager.instance)
+                .addHostCreatedInstance(
               pigeon_newInstance?.call() ??
                   ClientCertRequest.pigeon_detached(
                     pigeon_binaryMessenger: pigeon_binaryMessenger,
@@ -6275,8 +6738,7 @@ class ClientCertRequest extends PigeonInternalProxyApiBaseClass {
             return wrapResponse(error: e);
           } catch (e) {
             return wrapResponse(
-              error: PlatformException(code: 'error', message: e.toString()),
-            );
+                error: PlatformException(code: 'error', message: e.toString()));
           }
         });
       }
@@ -6285,7 +6747,8 @@ class ClientCertRequest extends PigeonInternalProxyApiBaseClass {
 
   /// Cancel this request.
   Future<void> cancel() async {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecClientCertRequest;
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
+        _pigeonVar_codecClientCertRequest;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
     const pigeonVar_channelName =
         'dev.flutter.pigeon.webview_flutter_android.ClientCertRequest.cancel';
@@ -6294,15 +6757,21 @@ class ClientCertRequest extends PigeonInternalProxyApiBaseClass {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[this]);
+    final Future<Object?> pigeonVar_sendFuture =
+        pigeonVar_channel.send(<Object?>[this]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
-    _extractReplyValueOrThrow(pigeonVar_replyList, pigeonVar_channelName, isNullValid: true);
+    _extractReplyValueOrThrow(
+      pigeonVar_replyList,
+      pigeonVar_channelName,
+      isNullValid: true,
+    );
   }
 
   /// Ignore the request for now.
   Future<void> ignore() async {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecClientCertRequest;
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
+        _pigeonVar_codecClientCertRequest;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
     const pigeonVar_channelName =
         'dev.flutter.pigeon.webview_flutter_android.ClientCertRequest.ignore';
@@ -6311,15 +6780,24 @@ class ClientCertRequest extends PigeonInternalProxyApiBaseClass {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[this]);
+    final Future<Object?> pigeonVar_sendFuture =
+        pigeonVar_channel.send(<Object?>[this]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
-    _extractReplyValueOrThrow(pigeonVar_replyList, pigeonVar_channelName, isNullValid: true);
+    _extractReplyValueOrThrow(
+      pigeonVar_replyList,
+      pigeonVar_channelName,
+      isNullValid: true,
+    );
   }
 
   /// Proceed with the specified private key and client certificate chain.
-  Future<void> proceed(PrivateKey privateKey, List<X509Certificate> chain) async {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecClientCertRequest;
+  Future<void> proceed(
+    PrivateKey privateKey,
+    List<X509Certificate> chain,
+  ) async {
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
+        _pigeonVar_codecClientCertRequest;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
     const pigeonVar_channelName =
         'dev.flutter.pigeon.webview_flutter_android.ClientCertRequest.proceed';
@@ -6328,14 +6806,15 @@ class ClientCertRequest extends PigeonInternalProxyApiBaseClass {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[
-      this,
-      privateKey,
-      chain,
-    ]);
+    final Future<Object?> pigeonVar_sendFuture =
+        pigeonVar_channel.send(<Object?>[this, privateKey, chain]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
-    _extractReplyValueOrThrow(pigeonVar_replyList, pigeonVar_channelName, isNullValid: true);
+    _extractReplyValueOrThrow(
+      pigeonVar_replyList,
+      pigeonVar_channelName,
+      isNullValid: true,
+    );
   }
 
   @override
@@ -6359,7 +6838,10 @@ class PrivateKey extends PigeonInternalProxyApiBaseClass {
   /// This should only be used by subclasses created by this library or to
   /// create copies for an [PigeonInstanceManager].
   @protected
-  PrivateKey.pigeon_detached({super.pigeon_binaryMessenger, super.pigeon_instanceManager});
+  PrivateKey.pigeon_detached({
+    super.pigeon_binaryMessenger,
+    super.pigeon_instanceManager,
+  });
 
   static void pigeon_setUpMessageHandlers({
     bool pigeon_clearHandlers = false,
@@ -6367,16 +6849,15 @@ class PrivateKey extends PigeonInternalProxyApiBaseClass {
     PigeonInstanceManager? pigeon_instanceManager,
     PrivateKey Function()? pigeon_newInstance,
   }) {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _PigeonInternalProxyApiBaseCodec(
-      pigeon_instanceManager ?? PigeonInstanceManager.instance,
-    );
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
+        _PigeonInternalProxyApiBaseCodec(
+            pigeon_instanceManager ?? PigeonInstanceManager.instance);
     final BinaryMessenger? binaryMessenger = pigeon_binaryMessenger;
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-        'dev.flutter.pigeon.webview_flutter_android.PrivateKey.pigeon_newInstance',
-        pigeonChannelCodec,
-        binaryMessenger: binaryMessenger,
-      );
+          'dev.flutter.pigeon.webview_flutter_android.PrivateKey.pigeon_newInstance',
+          pigeonChannelCodec,
+          binaryMessenger: binaryMessenger);
       if (pigeon_clearHandlers) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
@@ -6384,7 +6865,8 @@ class PrivateKey extends PigeonInternalProxyApiBaseClass {
           final List<Object?> args = message! as List<Object?>;
           final int arg_pigeon_instanceIdentifier = args[0]! as int;
           try {
-            (pigeon_instanceManager ?? PigeonInstanceManager.instance).addHostCreatedInstance(
+            (pigeon_instanceManager ?? PigeonInstanceManager.instance)
+                .addHostCreatedInstance(
               pigeon_newInstance?.call() ??
                   PrivateKey.pigeon_detached(
                     pigeon_binaryMessenger: pigeon_binaryMessenger,
@@ -6397,8 +6879,7 @@ class PrivateKey extends PigeonInternalProxyApiBaseClass {
             return wrapResponse(error: e);
           } catch (e) {
             return wrapResponse(
-              error: PlatformException(code: 'error', message: e.toString()),
-            );
+                error: PlatformException(code: 'error', message: e.toString()));
           }
         });
       }
@@ -6426,8 +6907,10 @@ class X509Certificate extends Certificate {
   /// This should only be used by subclasses created by this library or to
   /// create copies for an [PigeonInstanceManager].
   @protected
-  X509Certificate.pigeon_detached({super.pigeon_binaryMessenger, super.pigeon_instanceManager})
-    : super.pigeon_detached();
+  X509Certificate.pigeon_detached({
+    super.pigeon_binaryMessenger,
+    super.pigeon_instanceManager,
+  }) : super.pigeon_detached();
 
   static void pigeon_setUpMessageHandlers({
     bool pigeon_clearHandlers = false,
@@ -6435,16 +6918,15 @@ class X509Certificate extends Certificate {
     PigeonInstanceManager? pigeon_instanceManager,
     X509Certificate Function()? pigeon_newInstance,
   }) {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _PigeonInternalProxyApiBaseCodec(
-      pigeon_instanceManager ?? PigeonInstanceManager.instance,
-    );
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
+        _PigeonInternalProxyApiBaseCodec(
+            pigeon_instanceManager ?? PigeonInstanceManager.instance);
     final BinaryMessenger? binaryMessenger = pigeon_binaryMessenger;
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-        'dev.flutter.pigeon.webview_flutter_android.X509Certificate.pigeon_newInstance',
-        pigeonChannelCodec,
-        binaryMessenger: binaryMessenger,
-      );
+          'dev.flutter.pigeon.webview_flutter_android.X509Certificate.pigeon_newInstance',
+          pigeonChannelCodec,
+          binaryMessenger: binaryMessenger);
       if (pigeon_clearHandlers) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
@@ -6452,7 +6934,8 @@ class X509Certificate extends Certificate {
           final List<Object?> args = message! as List<Object?>;
           final int arg_pigeon_instanceIdentifier = args[0]! as int;
           try {
-            (pigeon_instanceManager ?? PigeonInstanceManager.instance).addHostCreatedInstance(
+            (pigeon_instanceManager ?? PigeonInstanceManager.instance)
+                .addHostCreatedInstance(
               pigeon_newInstance?.call() ??
                   X509Certificate.pigeon_detached(
                     pigeon_binaryMessenger: pigeon_binaryMessenger,
@@ -6465,8 +6948,7 @@ class X509Certificate extends Certificate {
             return wrapResponse(error: e);
           } catch (e) {
             return wrapResponse(
-              error: PlatformException(code: 'error', message: e.toString()),
-            );
+                error: PlatformException(code: 'error', message: e.toString()));
           }
         });
       }
@@ -6491,7 +6973,10 @@ class SslErrorHandler extends PigeonInternalProxyApiBaseClass {
   /// This should only be used by subclasses created by this library or to
   /// create copies for an [PigeonInstanceManager].
   @protected
-  SslErrorHandler.pigeon_detached({super.pigeon_binaryMessenger, super.pigeon_instanceManager});
+  SslErrorHandler.pigeon_detached({
+    super.pigeon_binaryMessenger,
+    super.pigeon_instanceManager,
+  });
 
   late final _PigeonInternalProxyApiBaseCodec _pigeonVar_codecSslErrorHandler =
       _PigeonInternalProxyApiBaseCodec(pigeon_instanceManager);
@@ -6502,16 +6987,15 @@ class SslErrorHandler extends PigeonInternalProxyApiBaseClass {
     PigeonInstanceManager? pigeon_instanceManager,
     SslErrorHandler Function()? pigeon_newInstance,
   }) {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _PigeonInternalProxyApiBaseCodec(
-      pigeon_instanceManager ?? PigeonInstanceManager.instance,
-    );
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
+        _PigeonInternalProxyApiBaseCodec(
+            pigeon_instanceManager ?? PigeonInstanceManager.instance);
     final BinaryMessenger? binaryMessenger = pigeon_binaryMessenger;
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-        'dev.flutter.pigeon.webview_flutter_android.SslErrorHandler.pigeon_newInstance',
-        pigeonChannelCodec,
-        binaryMessenger: binaryMessenger,
-      );
+          'dev.flutter.pigeon.webview_flutter_android.SslErrorHandler.pigeon_newInstance',
+          pigeonChannelCodec,
+          binaryMessenger: binaryMessenger);
       if (pigeon_clearHandlers) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
@@ -6519,7 +7003,8 @@ class SslErrorHandler extends PigeonInternalProxyApiBaseClass {
           final List<Object?> args = message! as List<Object?>;
           final int arg_pigeon_instanceIdentifier = args[0]! as int;
           try {
-            (pigeon_instanceManager ?? PigeonInstanceManager.instance).addHostCreatedInstance(
+            (pigeon_instanceManager ?? PigeonInstanceManager.instance)
+                .addHostCreatedInstance(
               pigeon_newInstance?.call() ??
                   SslErrorHandler.pigeon_detached(
                     pigeon_binaryMessenger: pigeon_binaryMessenger,
@@ -6532,8 +7017,7 @@ class SslErrorHandler extends PigeonInternalProxyApiBaseClass {
             return wrapResponse(error: e);
           } catch (e) {
             return wrapResponse(
-              error: PlatformException(code: 'error', message: e.toString()),
-            );
+                error: PlatformException(code: 'error', message: e.toString()));
           }
         });
       }
@@ -6543,7 +7027,8 @@ class SslErrorHandler extends PigeonInternalProxyApiBaseClass {
   /// Instructs the WebView that encountered the SSL certificate error to
   /// terminate communication with the server.
   Future<void> cancel() async {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecSslErrorHandler;
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
+        _pigeonVar_codecSslErrorHandler;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
     const pigeonVar_channelName =
         'dev.flutter.pigeon.webview_flutter_android.SslErrorHandler.cancel';
@@ -6552,16 +7037,22 @@ class SslErrorHandler extends PigeonInternalProxyApiBaseClass {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[this]);
+    final Future<Object?> pigeonVar_sendFuture =
+        pigeonVar_channel.send(<Object?>[this]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
-    _extractReplyValueOrThrow(pigeonVar_replyList, pigeonVar_channelName, isNullValid: true);
+    _extractReplyValueOrThrow(
+      pigeonVar_replyList,
+      pigeonVar_channelName,
+      isNullValid: true,
+    );
   }
 
   /// Instructs the WebView that encountered the SSL certificate error to ignore
   /// the error and continue communicating with the server.
   Future<void> proceed() async {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecSslErrorHandler;
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
+        _pigeonVar_codecSslErrorHandler;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
     const pigeonVar_channelName =
         'dev.flutter.pigeon.webview_flutter_android.SslErrorHandler.proceed';
@@ -6570,10 +7061,15 @@ class SslErrorHandler extends PigeonInternalProxyApiBaseClass {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[this]);
+    final Future<Object?> pigeonVar_sendFuture =
+        pigeonVar_channel.send(<Object?>[this]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
-    _extractReplyValueOrThrow(pigeonVar_replyList, pigeonVar_channelName, isNullValid: true);
+    _extractReplyValueOrThrow(
+      pigeonVar_replyList,
+      pigeonVar_channelName,
+      isNullValid: true,
+    );
   }
 
   @override
@@ -6615,18 +7111,20 @@ class SslError extends PigeonInternalProxyApiBaseClass {
     bool pigeon_clearHandlers = false,
     BinaryMessenger? pigeon_binaryMessenger,
     PigeonInstanceManager? pigeon_instanceManager,
-    SslError Function(SslCertificate certificate, String url)? pigeon_newInstance,
+    SslError Function(
+      SslCertificate certificate,
+      String url,
+    )? pigeon_newInstance,
   }) {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _PigeonInternalProxyApiBaseCodec(
-      pigeon_instanceManager ?? PigeonInstanceManager.instance,
-    );
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
+        _PigeonInternalProxyApiBaseCodec(
+            pigeon_instanceManager ?? PigeonInstanceManager.instance);
     final BinaryMessenger? binaryMessenger = pigeon_binaryMessenger;
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-        'dev.flutter.pigeon.webview_flutter_android.SslError.pigeon_newInstance',
-        pigeonChannelCodec,
-        binaryMessenger: binaryMessenger,
-      );
+          'dev.flutter.pigeon.webview_flutter_android.SslError.pigeon_newInstance',
+          pigeonChannelCodec,
+          binaryMessenger: binaryMessenger);
       if (pigeon_clearHandlers) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
@@ -6636,7 +7134,8 @@ class SslError extends PigeonInternalProxyApiBaseClass {
           final SslCertificate arg_certificate = args[1]! as SslCertificate;
           final String arg_url = args[2]! as String;
           try {
-            (pigeon_instanceManager ?? PigeonInstanceManager.instance).addHostCreatedInstance(
+            (pigeon_instanceManager ?? PigeonInstanceManager.instance)
+                .addHostCreatedInstance(
               pigeon_newInstance?.call(arg_certificate, arg_url) ??
                   SslError.pigeon_detached(
                     pigeon_binaryMessenger: pigeon_binaryMessenger,
@@ -6651,8 +7150,7 @@ class SslError extends PigeonInternalProxyApiBaseClass {
             return wrapResponse(error: e);
           } catch (e) {
             return wrapResponse(
-              error: PlatformException(code: 'error', message: e.toString()),
-            );
+                error: PlatformException(code: 'error', message: e.toString()));
           }
         });
       }
@@ -6661,7 +7159,8 @@ class SslError extends PigeonInternalProxyApiBaseClass {
 
   /// Gets the most severe SSL error in this object's set of errors.
   Future<SslErrorType> getPrimaryError() async {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecSslError;
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
+        _pigeonVar_codecSslError;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
     const pigeonVar_channelName =
         'dev.flutter.pigeon.webview_flutter_android.SslError.getPrimaryError';
@@ -6670,7 +7169,8 @@ class SslError extends PigeonInternalProxyApiBaseClass {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[this]);
+    final Future<Object?> pigeonVar_sendFuture =
+        pigeonVar_channel.send(<Object?>[this]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
@@ -6683,15 +7183,18 @@ class SslError extends PigeonInternalProxyApiBaseClass {
 
   /// Determines whether this object includes the supplied error.
   Future<bool> hasError(SslErrorType error) async {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecSslError;
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
+        _pigeonVar_codecSslError;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
-    const pigeonVar_channelName = 'dev.flutter.pigeon.webview_flutter_android.SslError.hasError';
+    const pigeonVar_channelName =
+        'dev.flutter.pigeon.webview_flutter_android.SslError.hasError';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[this, error]);
+    final Future<Object?> pigeonVar_sendFuture =
+        pigeonVar_channel.send(<Object?>[this, error]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
@@ -6725,9 +7228,13 @@ class SslCertificateDName extends PigeonInternalProxyApiBaseClass {
   /// This should only be used by subclasses created by this library or to
   /// create copies for an [PigeonInstanceManager].
   @protected
-  SslCertificateDName.pigeon_detached({super.pigeon_binaryMessenger, super.pigeon_instanceManager});
+  SslCertificateDName.pigeon_detached({
+    super.pigeon_binaryMessenger,
+    super.pigeon_instanceManager,
+  });
 
-  late final _PigeonInternalProxyApiBaseCodec _pigeonVar_codecSslCertificateDName =
+  late final _PigeonInternalProxyApiBaseCodec
+      _pigeonVar_codecSslCertificateDName =
       _PigeonInternalProxyApiBaseCodec(pigeon_instanceManager);
 
   static void pigeon_setUpMessageHandlers({
@@ -6736,16 +7243,15 @@ class SslCertificateDName extends PigeonInternalProxyApiBaseClass {
     PigeonInstanceManager? pigeon_instanceManager,
     SslCertificateDName Function()? pigeon_newInstance,
   }) {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _PigeonInternalProxyApiBaseCodec(
-      pigeon_instanceManager ?? PigeonInstanceManager.instance,
-    );
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
+        _PigeonInternalProxyApiBaseCodec(
+            pigeon_instanceManager ?? PigeonInstanceManager.instance);
     final BinaryMessenger? binaryMessenger = pigeon_binaryMessenger;
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-        'dev.flutter.pigeon.webview_flutter_android.SslCertificateDName.pigeon_newInstance',
-        pigeonChannelCodec,
-        binaryMessenger: binaryMessenger,
-      );
+          'dev.flutter.pigeon.webview_flutter_android.SslCertificateDName.pigeon_newInstance',
+          pigeonChannelCodec,
+          binaryMessenger: binaryMessenger);
       if (pigeon_clearHandlers) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
@@ -6753,7 +7259,8 @@ class SslCertificateDName extends PigeonInternalProxyApiBaseClass {
           final List<Object?> args = message! as List<Object?>;
           final int arg_pigeon_instanceIdentifier = args[0]! as int;
           try {
-            (pigeon_instanceManager ?? PigeonInstanceManager.instance).addHostCreatedInstance(
+            (pigeon_instanceManager ?? PigeonInstanceManager.instance)
+                .addHostCreatedInstance(
               pigeon_newInstance?.call() ??
                   SslCertificateDName.pigeon_detached(
                     pigeon_binaryMessenger: pigeon_binaryMessenger,
@@ -6766,8 +7273,7 @@ class SslCertificateDName extends PigeonInternalProxyApiBaseClass {
             return wrapResponse(error: e);
           } catch (e) {
             return wrapResponse(
-              error: PlatformException(code: 'error', message: e.toString()),
-            );
+                error: PlatformException(code: 'error', message: e.toString()));
           }
         });
       }
@@ -6776,7 +7282,8 @@ class SslCertificateDName extends PigeonInternalProxyApiBaseClass {
 
   /// The most specific Common-name (CN) component of this name.
   Future<String> getCName() async {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecSslCertificateDName;
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
+        _pigeonVar_codecSslCertificateDName;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
     const pigeonVar_channelName =
         'dev.flutter.pigeon.webview_flutter_android.SslCertificateDName.getCName';
@@ -6785,7 +7292,8 @@ class SslCertificateDName extends PigeonInternalProxyApiBaseClass {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[this]);
+    final Future<Object?> pigeonVar_sendFuture =
+        pigeonVar_channel.send(<Object?>[this]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
@@ -6798,7 +7306,8 @@ class SslCertificateDName extends PigeonInternalProxyApiBaseClass {
 
   /// The distinguished name (normally includes CN, O, and OU names).
   Future<String> getDName() async {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecSslCertificateDName;
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
+        _pigeonVar_codecSslCertificateDName;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
     const pigeonVar_channelName =
         'dev.flutter.pigeon.webview_flutter_android.SslCertificateDName.getDName';
@@ -6807,7 +7316,8 @@ class SslCertificateDName extends PigeonInternalProxyApiBaseClass {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[this]);
+    final Future<Object?> pigeonVar_sendFuture =
+        pigeonVar_channel.send(<Object?>[this]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
@@ -6820,7 +7330,8 @@ class SslCertificateDName extends PigeonInternalProxyApiBaseClass {
 
   /// The most specific Organization (O) component of this name.
   Future<String> getOName() async {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecSslCertificateDName;
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
+        _pigeonVar_codecSslCertificateDName;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
     const pigeonVar_channelName =
         'dev.flutter.pigeon.webview_flutter_android.SslCertificateDName.getOName';
@@ -6829,7 +7340,8 @@ class SslCertificateDName extends PigeonInternalProxyApiBaseClass {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[this]);
+    final Future<Object?> pigeonVar_sendFuture =
+        pigeonVar_channel.send(<Object?>[this]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
@@ -6842,7 +7354,8 @@ class SslCertificateDName extends PigeonInternalProxyApiBaseClass {
 
   /// The most specific Organizational Unit (OU) component of this name.
   Future<String> getUName() async {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecSslCertificateDName;
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
+        _pigeonVar_codecSslCertificateDName;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
     const pigeonVar_channelName =
         'dev.flutter.pigeon.webview_flutter_android.SslCertificateDName.getUName';
@@ -6851,7 +7364,8 @@ class SslCertificateDName extends PigeonInternalProxyApiBaseClass {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[this]);
+    final Future<Object?> pigeonVar_sendFuture =
+        pigeonVar_channel.send(<Object?>[this]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
@@ -6880,7 +7394,10 @@ class SslCertificate extends PigeonInternalProxyApiBaseClass {
   /// This should only be used by subclasses created by this library or to
   /// create copies for an [PigeonInstanceManager].
   @protected
-  SslCertificate.pigeon_detached({super.pigeon_binaryMessenger, super.pigeon_instanceManager});
+  SslCertificate.pigeon_detached({
+    super.pigeon_binaryMessenger,
+    super.pigeon_instanceManager,
+  });
 
   late final _PigeonInternalProxyApiBaseCodec _pigeonVar_codecSslCertificate =
       _PigeonInternalProxyApiBaseCodec(pigeon_instanceManager);
@@ -6891,16 +7408,15 @@ class SslCertificate extends PigeonInternalProxyApiBaseClass {
     PigeonInstanceManager? pigeon_instanceManager,
     SslCertificate Function()? pigeon_newInstance,
   }) {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _PigeonInternalProxyApiBaseCodec(
-      pigeon_instanceManager ?? PigeonInstanceManager.instance,
-    );
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
+        _PigeonInternalProxyApiBaseCodec(
+            pigeon_instanceManager ?? PigeonInstanceManager.instance);
     final BinaryMessenger? binaryMessenger = pigeon_binaryMessenger;
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-        'dev.flutter.pigeon.webview_flutter_android.SslCertificate.pigeon_newInstance',
-        pigeonChannelCodec,
-        binaryMessenger: binaryMessenger,
-      );
+          'dev.flutter.pigeon.webview_flutter_android.SslCertificate.pigeon_newInstance',
+          pigeonChannelCodec,
+          binaryMessenger: binaryMessenger);
       if (pigeon_clearHandlers) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
@@ -6908,7 +7424,8 @@ class SslCertificate extends PigeonInternalProxyApiBaseClass {
           final List<Object?> args = message! as List<Object?>;
           final int arg_pigeon_instanceIdentifier = args[0]! as int;
           try {
-            (pigeon_instanceManager ?? PigeonInstanceManager.instance).addHostCreatedInstance(
+            (pigeon_instanceManager ?? PigeonInstanceManager.instance)
+                .addHostCreatedInstance(
               pigeon_newInstance?.call() ??
                   SslCertificate.pigeon_detached(
                     pigeon_binaryMessenger: pigeon_binaryMessenger,
@@ -6921,8 +7438,7 @@ class SslCertificate extends PigeonInternalProxyApiBaseClass {
             return wrapResponse(error: e);
           } catch (e) {
             return wrapResponse(
-              error: PlatformException(code: 'error', message: e.toString()),
-            );
+                error: PlatformException(code: 'error', message: e.toString()));
           }
         });
       }
@@ -6931,7 +7447,8 @@ class SslCertificate extends PigeonInternalProxyApiBaseClass {
 
   /// Issued-by distinguished name or null if none has been set.
   Future<SslCertificateDName?> getIssuedBy() async {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecSslCertificate;
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
+        _pigeonVar_codecSslCertificate;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
     const pigeonVar_channelName =
         'dev.flutter.pigeon.webview_flutter_android.SslCertificate.getIssuedBy';
@@ -6940,7 +7457,8 @@ class SslCertificate extends PigeonInternalProxyApiBaseClass {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[this]);
+    final Future<Object?> pigeonVar_sendFuture =
+        pigeonVar_channel.send(<Object?>[this]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
@@ -6953,7 +7471,8 @@ class SslCertificate extends PigeonInternalProxyApiBaseClass {
 
   /// Issued-to distinguished name or null if none has been set.
   Future<SslCertificateDName?> getIssuedTo() async {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecSslCertificate;
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
+        _pigeonVar_codecSslCertificate;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
     const pigeonVar_channelName =
         'dev.flutter.pigeon.webview_flutter_android.SslCertificate.getIssuedTo';
@@ -6962,7 +7481,8 @@ class SslCertificate extends PigeonInternalProxyApiBaseClass {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[this]);
+    final Future<Object?> pigeonVar_sendFuture =
+        pigeonVar_channel.send(<Object?>[this]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
@@ -6976,7 +7496,8 @@ class SslCertificate extends PigeonInternalProxyApiBaseClass {
   /// Not-after date from the certificate validity period or null if none has been
   /// set.
   Future<int?> getValidNotAfterMsSinceEpoch() async {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecSslCertificate;
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
+        _pigeonVar_codecSslCertificate;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
     const pigeonVar_channelName =
         'dev.flutter.pigeon.webview_flutter_android.SslCertificate.getValidNotAfterMsSinceEpoch';
@@ -6985,7 +7506,8 @@ class SslCertificate extends PigeonInternalProxyApiBaseClass {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[this]);
+    final Future<Object?> pigeonVar_sendFuture =
+        pigeonVar_channel.send(<Object?>[this]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
@@ -6999,7 +7521,8 @@ class SslCertificate extends PigeonInternalProxyApiBaseClass {
   /// Not-before date from the certificate validity period or null if none has
   /// been set.
   Future<int?> getValidNotBeforeMsSinceEpoch() async {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecSslCertificate;
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
+        _pigeonVar_codecSslCertificate;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
     const pigeonVar_channelName =
         'dev.flutter.pigeon.webview_flutter_android.SslCertificate.getValidNotBeforeMsSinceEpoch';
@@ -7008,7 +7531,8 @@ class SslCertificate extends PigeonInternalProxyApiBaseClass {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[this]);
+    final Future<Object?> pigeonVar_sendFuture =
+        pigeonVar_channel.send(<Object?>[this]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
@@ -7024,7 +7548,8 @@ class SslCertificate extends PigeonInternalProxyApiBaseClass {
   ///
   /// Always returns null on Android versions below Q.
   Future<X509Certificate?> getX509Certificate() async {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecSslCertificate;
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
+        _pigeonVar_codecSslCertificate;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
     const pigeonVar_channelName =
         'dev.flutter.pigeon.webview_flutter_android.SslCertificate.getX509Certificate';
@@ -7033,7 +7558,8 @@ class SslCertificate extends PigeonInternalProxyApiBaseClass {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[this]);
+    final Future<Object?> pigeonVar_sendFuture =
+        pigeonVar_channel.send(<Object?>[this]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
@@ -7062,7 +7588,10 @@ class Certificate extends PigeonInternalProxyApiBaseClass {
   /// This should only be used by subclasses created by this library or to
   /// create copies for an [PigeonInstanceManager].
   @protected
-  Certificate.pigeon_detached({super.pigeon_binaryMessenger, super.pigeon_instanceManager});
+  Certificate.pigeon_detached({
+    super.pigeon_binaryMessenger,
+    super.pigeon_instanceManager,
+  });
 
   late final _PigeonInternalProxyApiBaseCodec _pigeonVar_codecCertificate =
       _PigeonInternalProxyApiBaseCodec(pigeon_instanceManager);
@@ -7073,16 +7602,15 @@ class Certificate extends PigeonInternalProxyApiBaseClass {
     PigeonInstanceManager? pigeon_instanceManager,
     Certificate Function()? pigeon_newInstance,
   }) {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _PigeonInternalProxyApiBaseCodec(
-      pigeon_instanceManager ?? PigeonInstanceManager.instance,
-    );
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
+        _PigeonInternalProxyApiBaseCodec(
+            pigeon_instanceManager ?? PigeonInstanceManager.instance);
     final BinaryMessenger? binaryMessenger = pigeon_binaryMessenger;
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-        'dev.flutter.pigeon.webview_flutter_android.Certificate.pigeon_newInstance',
-        pigeonChannelCodec,
-        binaryMessenger: binaryMessenger,
-      );
+          'dev.flutter.pigeon.webview_flutter_android.Certificate.pigeon_newInstance',
+          pigeonChannelCodec,
+          binaryMessenger: binaryMessenger);
       if (pigeon_clearHandlers) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
@@ -7090,7 +7618,8 @@ class Certificate extends PigeonInternalProxyApiBaseClass {
           final List<Object?> args = message! as List<Object?>;
           final int arg_pigeon_instanceIdentifier = args[0]! as int;
           try {
-            (pigeon_instanceManager ?? PigeonInstanceManager.instance).addHostCreatedInstance(
+            (pigeon_instanceManager ?? PigeonInstanceManager.instance)
+                .addHostCreatedInstance(
               pigeon_newInstance?.call() ??
                   Certificate.pigeon_detached(
                     pigeon_binaryMessenger: pigeon_binaryMessenger,
@@ -7103,8 +7632,7 @@ class Certificate extends PigeonInternalProxyApiBaseClass {
             return wrapResponse(error: e);
           } catch (e) {
             return wrapResponse(
-              error: PlatformException(code: 'error', message: e.toString()),
-            );
+                error: PlatformException(code: 'error', message: e.toString()));
           }
         });
       }
@@ -7113,7 +7641,8 @@ class Certificate extends PigeonInternalProxyApiBaseClass {
 
   /// The encoded form of this certificate.
   Future<Uint8List> getEncoded() async {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecCertificate;
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
+        _pigeonVar_codecCertificate;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
     const pigeonVar_channelName =
         'dev.flutter.pigeon.webview_flutter_android.Certificate.getEncoded';
@@ -7122,7 +7651,8 @@ class Certificate extends PigeonInternalProxyApiBaseClass {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[this]);
+    final Future<Object?> pigeonVar_sendFuture =
+        pigeonVar_channel.send(<Object?>[this]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
@@ -7151,9 +7681,13 @@ class WebSettingsCompat extends PigeonInternalProxyApiBaseClass {
   /// This should only be used by subclasses created by this library or to
   /// create copies for an [PigeonInstanceManager].
   @protected
-  WebSettingsCompat.pigeon_detached({super.pigeon_binaryMessenger, super.pigeon_instanceManager});
+  WebSettingsCompat.pigeon_detached({
+    super.pigeon_binaryMessenger,
+    super.pigeon_instanceManager,
+  });
 
-  late final _PigeonInternalProxyApiBaseCodec _pigeonVar_codecWebSettingsCompat =
+  late final _PigeonInternalProxyApiBaseCodec
+      _pigeonVar_codecWebSettingsCompat =
       _PigeonInternalProxyApiBaseCodec(pigeon_instanceManager);
 
   static void pigeon_setUpMessageHandlers({
@@ -7162,16 +7696,15 @@ class WebSettingsCompat extends PigeonInternalProxyApiBaseClass {
     PigeonInstanceManager? pigeon_instanceManager,
     WebSettingsCompat Function()? pigeon_newInstance,
   }) {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _PigeonInternalProxyApiBaseCodec(
-      pigeon_instanceManager ?? PigeonInstanceManager.instance,
-    );
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
+        _PigeonInternalProxyApiBaseCodec(
+            pigeon_instanceManager ?? PigeonInstanceManager.instance);
     final BinaryMessenger? binaryMessenger = pigeon_binaryMessenger;
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-        'dev.flutter.pigeon.webview_flutter_android.WebSettingsCompat.pigeon_newInstance',
-        pigeonChannelCodec,
-        binaryMessenger: binaryMessenger,
-      );
+          'dev.flutter.pigeon.webview_flutter_android.WebSettingsCompat.pigeon_newInstance',
+          pigeonChannelCodec,
+          binaryMessenger: binaryMessenger);
       if (pigeon_clearHandlers) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
@@ -7179,7 +7712,8 @@ class WebSettingsCompat extends PigeonInternalProxyApiBaseClass {
           final List<Object?> args = message! as List<Object?>;
           final int arg_pigeon_instanceIdentifier = args[0]! as int;
           try {
-            (pigeon_instanceManager ?? PigeonInstanceManager.instance).addHostCreatedInstance(
+            (pigeon_instanceManager ?? PigeonInstanceManager.instance)
+                .addHostCreatedInstance(
               pigeon_newInstance?.call() ??
                   WebSettingsCompat.pigeon_detached(
                     pigeon_binaryMessenger: pigeon_binaryMessenger,
@@ -7192,8 +7726,7 @@ class WebSettingsCompat extends PigeonInternalProxyApiBaseClass {
             return wrapResponse(error: e);
           } catch (e) {
             return wrapResponse(
-              error: PlatformException(code: 'error', message: e.toString()),
-            );
+                error: PlatformException(code: 'error', message: e.toString()));
           }
         });
       }
@@ -7207,11 +7740,14 @@ class WebSettingsCompat extends PigeonInternalProxyApiBaseClass {
     PigeonInstanceManager? pigeon_instanceManager,
   }) async {
     if (PigeonOverrides.webSettingsCompat_setPaymentRequestEnabled != null) {
-      return PigeonOverrides.webSettingsCompat_setPaymentRequestEnabled!(webSettings, enabled);
+      return PigeonOverrides.webSettingsCompat_setPaymentRequestEnabled!(
+        webSettings,
+        enabled,
+      );
     }
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _PigeonInternalProxyApiBaseCodec(
-      pigeon_instanceManager ?? PigeonInstanceManager.instance,
-    );
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
+        _PigeonInternalProxyApiBaseCodec(
+            pigeon_instanceManager ?? PigeonInstanceManager.instance);
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
     const pigeonVar_channelName =
         'dev.flutter.pigeon.webview_flutter_android.WebSettingsCompat.setPaymentRequestEnabled';
@@ -7220,13 +7756,15 @@ class WebSettingsCompat extends PigeonInternalProxyApiBaseClass {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[
-      webSettings,
-      enabled,
-    ]);
+    final Future<Object?> pigeonVar_sendFuture =
+        pigeonVar_channel.send(<Object?>[webSettings, enabled]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
-    _extractReplyValueOrThrow(pigeonVar_replyList, pigeonVar_channelName, isNullValid: true);
+    _extractReplyValueOrThrow(
+      pigeonVar_replyList,
+      pigeonVar_channelName,
+      isNullValid: true,
+    );
   }
 
   @override
@@ -7247,7 +7785,10 @@ class WebViewFeature extends PigeonInternalProxyApiBaseClass {
   /// This should only be used by subclasses created by this library or to
   /// create copies for an [PigeonInstanceManager].
   @protected
-  WebViewFeature.pigeon_detached({super.pigeon_binaryMessenger, super.pigeon_instanceManager});
+  WebViewFeature.pigeon_detached({
+    super.pigeon_binaryMessenger,
+    super.pigeon_instanceManager,
+  });
 
   late final _PigeonInternalProxyApiBaseCodec _pigeonVar_codecWebViewFeature =
       _PigeonInternalProxyApiBaseCodec(pigeon_instanceManager);
@@ -7258,16 +7799,15 @@ class WebViewFeature extends PigeonInternalProxyApiBaseClass {
     PigeonInstanceManager? pigeon_instanceManager,
     WebViewFeature Function()? pigeon_newInstance,
   }) {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _PigeonInternalProxyApiBaseCodec(
-      pigeon_instanceManager ?? PigeonInstanceManager.instance,
-    );
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
+        _PigeonInternalProxyApiBaseCodec(
+            pigeon_instanceManager ?? PigeonInstanceManager.instance);
     final BinaryMessenger? binaryMessenger = pigeon_binaryMessenger;
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-        'dev.flutter.pigeon.webview_flutter_android.WebViewFeature.pigeon_newInstance',
-        pigeonChannelCodec,
-        binaryMessenger: binaryMessenger,
-      );
+          'dev.flutter.pigeon.webview_flutter_android.WebViewFeature.pigeon_newInstance',
+          pigeonChannelCodec,
+          binaryMessenger: binaryMessenger);
       if (pigeon_clearHandlers) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
@@ -7275,7 +7815,8 @@ class WebViewFeature extends PigeonInternalProxyApiBaseClass {
           final List<Object?> args = message! as List<Object?>;
           final int arg_pigeon_instanceIdentifier = args[0]! as int;
           try {
-            (pigeon_instanceManager ?? PigeonInstanceManager.instance).addHostCreatedInstance(
+            (pigeon_instanceManager ?? PigeonInstanceManager.instance)
+                .addHostCreatedInstance(
               pigeon_newInstance?.call() ??
                   WebViewFeature.pigeon_detached(
                     pigeon_binaryMessenger: pigeon_binaryMessenger,
@@ -7288,8 +7829,7 @@ class WebViewFeature extends PigeonInternalProxyApiBaseClass {
             return wrapResponse(error: e);
           } catch (e) {
             return wrapResponse(
-              error: PlatformException(code: 'error', message: e.toString()),
-            );
+                error: PlatformException(code: 'error', message: e.toString()));
           }
         });
       }
@@ -7304,9 +7844,9 @@ class WebViewFeature extends PigeonInternalProxyApiBaseClass {
     if (PigeonOverrides.webViewFeature_isFeatureSupported != null) {
       return PigeonOverrides.webViewFeature_isFeatureSupported!(feature);
     }
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _PigeonInternalProxyApiBaseCodec(
-      pigeon_instanceManager ?? PigeonInstanceManager.instance,
-    );
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
+        _PigeonInternalProxyApiBaseCodec(
+            pigeon_instanceManager ?? PigeonInstanceManager.instance);
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
     const pigeonVar_channelName =
         'dev.flutter.pigeon.webview_flutter_android.WebViewFeature.isFeatureSupported';
@@ -7315,7 +7855,8 @@ class WebViewFeature extends PigeonInternalProxyApiBaseClass {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[feature]);
+    final Future<Object?> pigeonVar_sendFuture =
+        pigeonVar_channel.send(<Object?>[feature]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
@@ -7334,3 +7875,4 @@ class WebViewFeature extends PigeonInternalProxyApiBaseClass {
     );
   }
 }
+

--- a/packages/webview_flutter/webview_flutter_android/lib/src/android_webkit.g.dart
+++ b/packages/webview_flutter/webview_flutter_android/lib/src/android_webkit.g.dart
@@ -99,6 +99,7 @@ class PigeonOverrides {
     onReceivedRequestErrorCompat,
     void Function(WebViewClient pigeon_instance, WebView webView, WebResourceRequest request)?
     requestLoading,
+    void Function(WebViewClient pigeon_instance, String url)? onCreateWindow,
     void Function(WebViewClient pigeon_instance, WebView webView, String url)? urlLoading,
     void Function(WebViewClient pigeon_instance, WebView webView, String url, bool isReload)?
     doUpdateVisitedHistory,
@@ -2712,6 +2713,7 @@ class WebViewClient extends PigeonInternalProxyApiBaseClass {
     onReceivedRequestErrorCompat,
     void Function(WebViewClient pigeon_instance, WebView webView, WebResourceRequest request)?
     requestLoading,
+    void Function(WebViewClient pigeon_instance, String url)? onCreateWindow,
     void Function(WebViewClient pigeon_instance, WebView webView, String url)? urlLoading,
     void Function(WebViewClient pigeon_instance, WebView webView, String url, bool isReload)?
     doUpdateVisitedHistory,
@@ -2760,6 +2762,7 @@ class WebViewClient extends PigeonInternalProxyApiBaseClass {
         onReceivedRequestError: onReceivedRequestError,
         onReceivedRequestErrorCompat: onReceivedRequestErrorCompat,
         requestLoading: requestLoading,
+        onCreateWindow: onCreateWindow,
         urlLoading: urlLoading,
         doUpdateVisitedHistory: doUpdateVisitedHistory,
         onReceivedHttpAuthRequest: onReceivedHttpAuthRequest,
@@ -2781,6 +2784,7 @@ class WebViewClient extends PigeonInternalProxyApiBaseClass {
       onReceivedRequestError: onReceivedRequestError,
       onReceivedRequestErrorCompat: onReceivedRequestErrorCompat,
       requestLoading: requestLoading,
+      onCreateWindow: onCreateWindow,
       urlLoading: urlLoading,
       doUpdateVisitedHistory: doUpdateVisitedHistory,
       onReceivedHttpAuthRequest: onReceivedHttpAuthRequest,
@@ -2804,6 +2808,7 @@ class WebViewClient extends PigeonInternalProxyApiBaseClass {
     this.onReceivedRequestError,
     this.onReceivedRequestErrorCompat,
     this.requestLoading,
+    this.onCreateWindow,
     this.urlLoading,
     this.doUpdateVisitedHistory,
     this.onReceivedHttpAuthRequest,
@@ -2849,6 +2854,7 @@ class WebViewClient extends PigeonInternalProxyApiBaseClass {
     this.onReceivedRequestError,
     this.onReceivedRequestErrorCompat,
     this.requestLoading,
+    this.onCreateWindow,
     this.urlLoading,
     this.doUpdateVisitedHistory,
     this.onReceivedHttpAuthRequest,
@@ -3010,6 +3016,9 @@ class WebViewClient extends PigeonInternalProxyApiBaseClass {
   /// release the associated Native object manually.
   final void Function(WebViewClient pigeon_instance, WebView webView, WebResourceRequest request)?
   requestLoading;
+
+  /// Notifies the host that the page requested a new window.
+  final void Function(WebViewClient pigeon_instance, String url)? onCreateWindow;
 
   /// Give the host application a chance to take control when a URL is about to
   /// be loaded in the current WebView.
@@ -3293,6 +3302,7 @@ class WebViewClient extends PigeonInternalProxyApiBaseClass {
     onReceivedRequestErrorCompat,
     void Function(WebViewClient pigeon_instance, WebView webView, WebResourceRequest request)?
     requestLoading,
+    void Function(WebViewClient pigeon_instance, String url)? onCreateWindow,
     void Function(WebViewClient pigeon_instance, WebView webView, String url)? urlLoading,
     void Function(WebViewClient pigeon_instance, WebView webView, String url, bool isReload)?
     doUpdateVisitedHistory,
@@ -3551,6 +3561,36 @@ class WebViewClient extends PigeonInternalProxyApiBaseClass {
               arg_pigeon_instance,
               arg_webView,
               arg_request,
+            );
+            return wrapResponse(empty: true);
+          } on PlatformException catch (e) {
+            return wrapResponse(error: e);
+          } catch (e) {
+            return wrapResponse(
+              error: PlatformException(code: 'error', message: e.toString()),
+            );
+          }
+        });
+      }
+    }
+
+    {
+      final pigeonVar_channel = BasicMessageChannel<Object?>(
+        'dev.flutter.pigeon.webview_flutter_android.WebViewClient.onCreateWindow',
+        pigeonChannelCodec,
+        binaryMessenger: binaryMessenger,
+      );
+      if (pigeon_clearHandlers) {
+        pigeonVar_channel.setMessageHandler(null);
+      } else {
+        pigeonVar_channel.setMessageHandler((Object? message) async {
+          final List<Object?> args = message! as List<Object?>;
+          final WebViewClient arg_pigeon_instance = args[0]! as WebViewClient;
+          final String arg_url = args[1]! as String;
+          try {
+            (onCreateWindow ?? arg_pigeon_instance.onCreateWindow)?.call(
+              arg_pigeon_instance,
+              arg_url,
             );
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
@@ -3940,6 +3980,7 @@ class WebViewClient extends PigeonInternalProxyApiBaseClass {
       onReceivedRequestError: onReceivedRequestError,
       onReceivedRequestErrorCompat: onReceivedRequestErrorCompat,
       requestLoading: requestLoading,
+      onCreateWindow: onCreateWindow,
       urlLoading: urlLoading,
       doUpdateVisitedHistory: doUpdateVisitedHistory,
       onReceivedHttpAuthRequest: onReceivedHttpAuthRequest,

--- a/packages/webview_flutter/webview_flutter_android/lib/src/android_webkit.g.dart
+++ b/packages/webview_flutter/webview_flutter_android/lib/src/android_webkit.g.dart
@@ -15,9 +15,9 @@ import 'package:flutter/widgets.dart' show WidgetsFlutterBinding;
 import 'package:meta/meta.dart' show immutable, protected, visibleForTesting;
 
 Object? _extractReplyValueOrThrow(
-    List<Object?>? replyList,
-    String channelName, {
-    required bool isNullValid,
+  List<Object?>? replyList,
+  String channelName, {
+  required bool isNullValid,
 }) {
   if (replyList == null) {
     throw PlatformException(
@@ -39,7 +39,6 @@ Object? _extractReplyValueOrThrow(
   return replyList.firstOrNull;
 }
 
-
 List<Object?> wrapResponse({Object? result, PlatformException? error, bool empty = false}) {
   if (empty) {
     return <Object?>[];
@@ -49,6 +48,7 @@ List<Object?> wrapResponse({Object? result, PlatformException? error, bool empty
   }
   return <Object?>[error.code, error.message, error.details];
 }
+
 /// Provides overrides for the constructors and static members of each
 /// Dart proxy class.
 ///
@@ -59,133 +59,102 @@ List<Object?> wrapResponse({Object? result, PlatformException? error, bool empty
 @visibleForTesting
 class PigeonOverrides {
   /// Overrides [WebView.new].
-  static WebView Function(
-      {void Function(
-        WebView pigeon_instance,
-        int left,
-        int top,
-        int oldLeft,
-        int oldTop,
-      )? onScrollChanged})? webView_new;
+  static WebView Function({
+    void Function(WebView pigeon_instance, int left, int top, int oldLeft, int oldTop)?
+    onScrollChanged,
+  })?
+  webView_new;
 
   /// Overrides [JavaScriptChannel.new].
   static JavaScriptChannel Function({
     required String channelName,
-    required void Function(
-      JavaScriptChannel pigeon_instance,
-      String message,
-    ) postMessage,
-  })? javaScriptChannel_new;
+    required void Function(JavaScriptChannel pigeon_instance, String message) postMessage,
+  })?
+  javaScriptChannel_new;
 
   /// Overrides [WebViewClient.new].
   static WebViewClient Function({
-    void Function(
-      WebViewClient pigeon_instance,
-      WebView webView,
-      String url,
-    )? onPageStarted,
-    void Function(
-      WebViewClient pigeon_instance,
-      WebView webView,
-      String url,
-    )? onPageFinished,
+    void Function(WebViewClient pigeon_instance, WebView webView, String url)? onPageStarted,
+    void Function(WebViewClient pigeon_instance, WebView webView, String url)? onPageFinished,
     void Function(
       WebViewClient pigeon_instance,
       WebView webView,
       WebResourceRequest request,
       WebResourceResponse response,
-    )? onReceivedHttpError,
+    )?
+    onReceivedHttpError,
     void Function(
       WebViewClient pigeon_instance,
       WebView webView,
       WebResourceRequest request,
       WebResourceError error,
-    )? onReceivedRequestError,
+    )?
+    onReceivedRequestError,
     void Function(
       WebViewClient pigeon_instance,
       WebView webView,
       WebResourceRequest request,
       WebResourceErrorCompat error,
-    )? onReceivedRequestErrorCompat,
-    void Function(
-      WebViewClient pigeon_instance,
-      WebView webView,
-      WebResourceRequest request,
-    )? requestLoading,
-    void Function(
-      WebViewClient pigeon_instance,
-      WebView webView,
-      String url,
-    )? urlLoading,
-    void Function(
-      WebViewClient pigeon_instance,
-      String url,
-    )? onCreateWindow,
-    void Function(
-      WebViewClient pigeon_instance,
-      WebView webView,
-      String url,
-      bool isReload,
-    )? doUpdateVisitedHistory,
+    )?
+    onReceivedRequestErrorCompat,
+    void Function(WebViewClient pigeon_instance, WebView webView, WebResourceRequest request)?
+    requestLoading,
+    void Function(WebViewClient pigeon_instance, WebView webView, String url)? urlLoading,
+    void Function(WebViewClient pigeon_instance, String url)? onCreateWindow,
+    void Function(WebViewClient pigeon_instance, WebView webView, String url, bool isReload)?
+    doUpdateVisitedHistory,
     void Function(
       WebViewClient pigeon_instance,
       WebView webView,
       HttpAuthHandler handler,
       String host,
       String realm,
-    )? onReceivedHttpAuthRequest,
+    )?
+    onReceivedHttpAuthRequest,
     void Function(
       WebViewClient pigeon_instance,
       WebView view,
       AndroidMessage dontResend,
       AndroidMessage resend,
-    )? onFormResubmission,
-    void Function(
-      WebViewClient pigeon_instance,
-      WebView view,
-      String url,
-    )? onLoadResource,
-    void Function(
-      WebViewClient pigeon_instance,
-      WebView view,
-      String url,
-    )? onPageCommitVisible,
-    void Function(
-      WebViewClient pigeon_instance,
-      WebView view,
-      ClientCertRequest request,
-    )? onReceivedClientCertRequest,
+    )?
+    onFormResubmission,
+    void Function(WebViewClient pigeon_instance, WebView view, String url)? onLoadResource,
+    void Function(WebViewClient pigeon_instance, WebView view, String url)? onPageCommitVisible,
+    void Function(WebViewClient pigeon_instance, WebView view, ClientCertRequest request)?
+    onReceivedClientCertRequest,
     void Function(
       WebViewClient pigeon_instance,
       WebView view,
       String realm,
       String? account,
       String args,
-    )? onReceivedLoginRequest,
+    )?
+    onReceivedLoginRequest,
     void Function(
       WebViewClient pigeon_instance,
       WebView view,
       SslErrorHandler handler,
       SslError error,
-    )? onReceivedSslError,
-    void Function(
-      WebViewClient pigeon_instance,
-      WebView view,
-      double oldScale,
-      double newScale,
-    )? onScaleChanged,
-  })? webViewClient_new;
+    )?
+    onReceivedSslError,
+    void Function(WebViewClient pigeon_instance, WebView view, double oldScale, double newScale)?
+    onScaleChanged,
+  })?
+  webViewClient_new;
 
   /// Overrides [DownloadListener.new].
-  static DownloadListener Function(
-      {required void Function(
-        DownloadListener pigeon_instance,
-        String url,
-        String userAgent,
-        String contentDisposition,
-        String mimetype,
-        int contentLength,
-      ) onDownloadStart})? downloadListener_new;
+  static DownloadListener Function({
+    required void Function(
+      DownloadListener pigeon_instance,
+      String url,
+      String userAgent,
+      String contentDisposition,
+      String mimetype,
+      int contentLength,
+    )
+    onDownloadStart,
+  })?
+  downloadListener_new;
 
   /// Overrides [WebChromeClient.new].
   static WebChromeClient Function({
@@ -193,53 +162,46 @@ class PigeonOverrides {
       WebChromeClient pigeon_instance,
       WebView webView,
       FileChooserParams params,
-    ) onShowFileChooser,
+    )
+    onShowFileChooser,
     required Future<bool> Function(
       WebChromeClient pigeon_instance,
       WebView webView,
       String url,
       String message,
-    ) onJsConfirm,
-    void Function(
-      WebChromeClient pigeon_instance,
-      WebView webView,
-      int progress,
-    )? onProgressChanged,
-    void Function(
-      WebChromeClient pigeon_instance,
-      PermissionRequest request,
-    )? onPermissionRequest,
-    void Function(
-      WebChromeClient pigeon_instance,
-      View view,
-      CustomViewCallback callback,
-    )? onShowCustomView,
+    )
+    onJsConfirm,
+    void Function(WebChromeClient pigeon_instance, WebView webView, int progress)?
+    onProgressChanged,
+    void Function(WebChromeClient pigeon_instance, PermissionRequest request)? onPermissionRequest,
+    void Function(WebChromeClient pigeon_instance, View view, CustomViewCallback callback)?
+    onShowCustomView,
     void Function(WebChromeClient pigeon_instance)? onHideCustomView,
     void Function(
       WebChromeClient pigeon_instance,
       String origin,
       GeolocationPermissionsCallback callback,
-    )? onGeolocationPermissionsShowPrompt,
-    void Function(WebChromeClient pigeon_instance)?
-        onGeolocationPermissionsHidePrompt,
-    void Function(
-      WebChromeClient pigeon_instance,
-      ConsoleMessage message,
-    )? onConsoleMessage,
+    )?
+    onGeolocationPermissionsShowPrompt,
+    void Function(WebChromeClient pigeon_instance)? onGeolocationPermissionsHidePrompt,
+    void Function(WebChromeClient pigeon_instance, ConsoleMessage message)? onConsoleMessage,
     Future<void> Function(
       WebChromeClient pigeon_instance,
       WebView webView,
       String url,
       String message,
-    )? onJsAlert,
+    )?
+    onJsAlert,
     Future<String?> Function(
       WebChromeClient pigeon_instance,
       WebView webView,
       String url,
       String message,
       String defaultValue,
-    )? onJsPrompt,
-  })? webChromeClient_new;
+    )?
+    onJsPrompt,
+  })?
+  webChromeClient_new;
 
   /// Overrides [CookieManager.instance].
   static CookieManager? cookieManager_instance;
@@ -254,10 +216,7 @@ class PigeonOverrides {
   static Future<void> Function(bool)? webView_setWebContentsDebuggingEnabled;
 
   /// Overrides [WebSettingsCompat.setPaymentRequestEnabled].
-  static Future<void> Function(
-    WebSettings,
-    bool,
-  )? webSettingsCompat_setPaymentRequestEnabled;
+  static Future<void> Function(WebSettings, bool)? webSettingsCompat_setPaymentRequestEnabled;
 
   /// Overrides [WebViewFeature.isFeatureSupported].
   static Future<bool> Function(String)? webViewFeature_isFeatureSupported;
@@ -289,8 +248,7 @@ abstract class PigeonInternalProxyApiBaseClass {
   PigeonInternalProxyApiBaseClass({
     this.pigeon_binaryMessenger,
     PigeonInstanceManager? pigeon_instanceManager,
-  }) : pigeon_instanceManager =
-            pigeon_instanceManager ?? PigeonInstanceManager.instance;
+  }) : pigeon_instanceManager = pigeon_instanceManager ?? PigeonInstanceManager.instance;
 
   /// Sends and receives binary data across the Flutter platform barrier.
   ///
@@ -362,7 +320,8 @@ class PigeonInstanceManager {
   final Expando<int> _identifiers = Expando<int>();
   final Map<int, WeakReference<PigeonInternalProxyApiBaseClass>> _weakInstances =
       <int, WeakReference<PigeonInternalProxyApiBaseClass>>{};
-  final Map<int, PigeonInternalProxyApiBaseClass> _strongInstances = <int, PigeonInternalProxyApiBaseClass>{};
+  final Map<int, PigeonInternalProxyApiBaseClass> _strongInstances =
+      <int, PigeonInternalProxyApiBaseClass>{};
   late final Finalizer<int> _finalizer;
   int _nextIdentifier = 0;
 
@@ -403,7 +362,9 @@ class PigeonInstanceManager {
     PermissionRequest.pigeon_setUpMessageHandlers(pigeon_instanceManager: instanceManager);
     CustomViewCallback.pigeon_setUpMessageHandlers(pigeon_instanceManager: instanceManager);
     View.pigeon_setUpMessageHandlers(pigeon_instanceManager: instanceManager);
-    GeolocationPermissionsCallback.pigeon_setUpMessageHandlers(pigeon_instanceManager: instanceManager);
+    GeolocationPermissionsCallback.pigeon_setUpMessageHandlers(
+      pigeon_instanceManager: instanceManager,
+    );
     HttpAuthHandler.pigeon_setUpMessageHandlers(pigeon_instanceManager: instanceManager);
     AndroidMessage.pigeon_setUpMessageHandlers(pigeon_instanceManager: instanceManager);
     ClientCertRequest.pigeon_setUpMessageHandlers(pigeon_instanceManager: instanceManager);
@@ -432,8 +393,7 @@ class PigeonInstanceManager {
 
     final int identifier = _nextUniqueIdentifier();
     _identifiers[instance] = identifier;
-    _weakInstances[identifier] =
-        WeakReference<PigeonInternalProxyApiBaseClass>(instance);
+    _weakInstances[identifier] = WeakReference<PigeonInternalProxyApiBaseClass>(instance);
     _finalizer.attach(instance, identifier, detach: instance);
 
     final PigeonInternalProxyApiBaseClass copy = instance.pigeon_copy();
@@ -535,8 +495,7 @@ class PigeonInstanceManager {
 
   /// Whether this manager contains the given [identifier].
   bool containsIdentifier(int identifier) {
-    return _weakInstances.containsKey(identifier) ||
-        _strongInstances.containsKey(identifier);
+    return _weakInstances.containsKey(identifier) || _strongInstances.containsKey(identifier);
   }
 
   int _nextUniqueIdentifier() {
@@ -553,7 +512,7 @@ class PigeonInstanceManager {
 class _PigeonInternalInstanceManagerApi {
   /// Constructor for [_PigeonInternalInstanceManagerApi].
   _PigeonInternalInstanceManagerApi({BinaryMessenger? binaryMessenger})
-      : pigeonVar_binaryMessenger = binaryMessenger;
+    : pigeonVar_binaryMessenger = binaryMessenger;
 
   final BinaryMessenger? pigeonVar_binaryMessenger;
 
@@ -566,9 +525,10 @@ class _PigeonInternalInstanceManagerApi {
   }) {
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-          'dev.flutter.pigeon.webview_flutter_android.PigeonInternalInstanceManager.removeStrongReference',
-          pigeonChannelCodec,
-          binaryMessenger: binaryMessenger);
+        'dev.flutter.pigeon.webview_flutter_android.PigeonInternalInstanceManager.removeStrongReference',
+        pigeonChannelCodec,
+        binaryMessenger: binaryMessenger,
+      );
       if (pigeon_clearHandlers) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
@@ -576,14 +536,14 @@ class _PigeonInternalInstanceManagerApi {
           final List<Object?> args = message! as List<Object?>;
           final int arg_identifier = args[0]! as int;
           try {
-            (instanceManager ?? PigeonInstanceManager.instance)
-                .remove(arg_identifier);
+            (instanceManager ?? PigeonInstanceManager.instance).remove(arg_identifier);
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
           } catch (e) {
             return wrapResponse(
-                error: PlatformException(code: 'error', message: e.toString()));
+              error: PlatformException(code: 'error', message: e.toString()),
+            );
           }
         });
       }
@@ -598,15 +558,10 @@ class _PigeonInternalInstanceManagerApi {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture =
-        pigeonVar_channel.send(<Object?>[identifier]);
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[identifier]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
-    _extractReplyValueOrThrow(
-      pigeonVar_replyList,
-      pigeonVar_channelName,
-      isNullValid: true,
-    );
+    _extractReplyValueOrThrow(pigeonVar_replyList, pigeonVar_channelName, isNullValid: true);
   }
 
   /// Clear the native `PigeonInstanceManager`.
@@ -623,38 +578,33 @@ class _PigeonInternalInstanceManagerApi {
     final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(null);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
-    _extractReplyValueOrThrow(
-      pigeonVar_replyList,
-      pigeonVar_channelName,
-      isNullValid: true,
-    );
+    _extractReplyValueOrThrow(pigeonVar_replyList, pigeonVar_channelName, isNullValid: true);
   }
 }
 
 class _PigeonInternalProxyApiBaseCodec extends _PigeonCodec {
- const _PigeonInternalProxyApiBaseCodec(this.instanceManager);
- final PigeonInstanceManager instanceManager;
- @override
- void writeValue(WriteBuffer buffer, Object? value) {
-   if (value is PigeonInternalProxyApiBaseClass) {
-     buffer.putUint8(128);
-     writeValue(buffer, instanceManager.getIdentifier(value));
-   } else {
-     super.writeValue(buffer, value);
-   }
- }
- @override
- Object? readValueOfType(int type, ReadBuffer buffer) {
-   switch (type) {
-     case 128:
-       return instanceManager
-           .getInstanceWithWeakReference(readValue(buffer)! as int);
-     default:
-       return super.readValueOfType(type, buffer);
-   }
- }
-}
+  const _PigeonInternalProxyApiBaseCodec(this.instanceManager);
+  final PigeonInstanceManager instanceManager;
+  @override
+  void writeValue(WriteBuffer buffer, Object? value) {
+    if (value is PigeonInternalProxyApiBaseClass) {
+      buffer.putUint8(128);
+      writeValue(buffer, instanceManager.getIdentifier(value));
+    } else {
+      super.writeValue(buffer, value);
+    }
+  }
 
+  @override
+  Object? readValueOfType(int type, ReadBuffer buffer) {
+    switch (type) {
+      case 128:
+        return instanceManager.getInstanceWithWeakReference(readValue(buffer)! as int);
+      default:
+        return super.readValueOfType(type, buffer);
+    }
+  }
+}
 
 /// Mode of how to select files for a file chooser.
 ///
@@ -665,14 +615,17 @@ enum FileChooserMode {
   ///
   /// See https://developer.android.com/reference/android/webkit/WebChromeClient.FileChooserParams#MODE_OPEN.
   open,
+
   /// Similar to [open] but allows multiple files to be selected.
   ///
   /// See https://developer.android.com/reference/android/webkit/WebChromeClient.FileChooserParams#MODE_OPEN_MULTIPLE.
   openMultiple,
+
   /// Allows picking a nonexistent file and saving it.
   ///
   /// See https://developer.android.com/reference/android/webkit/WebChromeClient.FileChooserParams#MODE_SAVE.
   save,
+
   /// Indicates a `FileChooserMode` with an unknown mode.
   ///
   /// This does not represent an actual value provided by the platform and only
@@ -688,22 +641,27 @@ enum ConsoleMessageLevel {
   ///
   /// See https://developer.android.com/reference/android/webkit/ConsoleMessage.MessageLevel#DEBUG.
   debug,
+
   /// Indicates a message is provided as an error.
   ///
   /// See https://developer.android.com/reference/android/webkit/ConsoleMessage.MessageLevel#ERROR.
   error,
+
   /// Indicates a message is provided as a basic log message.
   ///
   /// See https://developer.android.com/reference/android/webkit/ConsoleMessage.MessageLevel#LOG.
   log,
+
   /// Indicates a message is provided as a tip.
   ///
   /// See https://developer.android.com/reference/android/webkit/ConsoleMessage.MessageLevel#TIP.
   tip,
+
   /// Indicates a message is provided as a warning.
   ///
   /// See https://developer.android.com/reference/android/webkit/ConsoleMessage.MessageLevel#WARNING.
   warning,
+
   /// Indicates a message with an unknown level.
   ///
   /// This does not represent an actual value provided by the platform and only
@@ -718,11 +676,14 @@ enum OverScrollMode {
   /// Always allow a user to over-scroll this view, provided it is a view that
   /// can scroll.
   always,
+
   /// Allow a user to over-scroll this view only if the content is large enough
   /// to meaningfully scroll, provided it is a view that can scroll.
   ifContentScrolls,
+
   /// Never allow a user to over-scroll this view.
   never,
+
   /// The type is not recognized by this wrapper.
   unknown,
 }
@@ -733,16 +694,22 @@ enum OverScrollMode {
 enum SslErrorType {
   /// The date of the certificate is invalid.
   dateInvalid,
+
   /// The certificate has expired.
   expired,
+
   /// Hostname mismatch.
   idMismatch,
+
   /// A generic error occurred.
   invalid,
+
   /// The certificate is not yet valid.
   notYetValid,
+
   /// The certificate authority is not trusted.
   untrusted,
+
   /// The type is not recognized by this wrapper.
   unknown,
 }
@@ -754,9 +721,11 @@ enum MixedContentMode {
   /// The WebView will allow a secure origin to load content from any other
   /// origin, even if that origin is insecure.
   alwaysAllow,
+
   /// The WebView will attempt to be compatible with the approach of a modern
   /// web browser with regard to mixed content.
   compatibilityMode,
+
   /// The WebView will not allow a secure origin to load content from an
   /// insecure origin.
   neverAllow,
@@ -771,17 +740,23 @@ enum WindowInsetsType {
   /// Includes statusBars(), captionBar() as well as navigationBars(),
   /// systemOverlays(), but not ime().
   systemBars,
+
   /// An inset type representing the area that used by DisplayCutout.
   displayCutout,
+
   /// An insets type representing the window of a caption bar.
   captionBar,
+
   /// An insets type representing the window of an InputMethod.
   ime,
   mandatorySystemGestures,
+
   /// An insets type representing any system bars for navigation.
   navigationBars,
+
   /// An insets type representing any system bars for displaying status.
   statusBars,
+
   /// An insets type representing the system gesture insets.
   ///
   /// The system gesture insets represent the area of a window where system
@@ -792,7 +767,6 @@ enum WindowInsetsType {
   tappableElement,
 }
 
-
 class _PigeonCodec extends StandardMessageCodec {
   const _PigeonCodec();
   @override
@@ -800,22 +774,22 @@ class _PigeonCodec extends StandardMessageCodec {
     if (value is int) {
       buffer.putUint8(4);
       buffer.putInt64(value);
-    }    else if (value is FileChooserMode) {
+    } else if (value is FileChooserMode) {
       buffer.putUint8(129);
       writeValue(buffer, value.index);
-    }    else if (value is ConsoleMessageLevel) {
+    } else if (value is ConsoleMessageLevel) {
       buffer.putUint8(130);
       writeValue(buffer, value.index);
-    }    else if (value is OverScrollMode) {
+    } else if (value is OverScrollMode) {
       buffer.putUint8(131);
       writeValue(buffer, value.index);
-    }    else if (value is SslErrorType) {
+    } else if (value is SslErrorType) {
       buffer.putUint8(132);
       writeValue(buffer, value.index);
-    }    else if (value is MixedContentMode) {
+    } else if (value is MixedContentMode) {
       buffer.putUint8(133);
       writeValue(buffer, value.index);
-    }    else if (value is WindowInsetsType) {
+    } else if (value is WindowInsetsType) {
       buffer.putUint8(134);
       writeValue(buffer, value.index);
     } else {
@@ -849,6 +823,7 @@ class _PigeonCodec extends StandardMessageCodec {
     }
   }
 }
+
 /// Encompasses parameters to the `WebViewClient.shouldInterceptRequest` method.
 ///
 /// See https://developer.android.com/reference/android/webkit/WebResourceRequest.
@@ -898,17 +873,19 @@ class WebResourceRequest extends PigeonInternalProxyApiBaseClass {
       bool hasGesture,
       String method,
       Map<String, String>? requestHeaders,
-    )? pigeon_newInstance,
+    )?
+    pigeon_newInstance,
   }) {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
-        _PigeonInternalProxyApiBaseCodec(
-            pigeon_instanceManager ?? PigeonInstanceManager.instance);
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _PigeonInternalProxyApiBaseCodec(
+      pigeon_instanceManager ?? PigeonInstanceManager.instance,
+    );
     final BinaryMessenger? binaryMessenger = pigeon_binaryMessenger;
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-          'dev.flutter.pigeon.webview_flutter_android.WebResourceRequest.pigeon_newInstance',
-          pigeonChannelCodec,
-          binaryMessenger: binaryMessenger);
+        'dev.flutter.pigeon.webview_flutter_android.WebResourceRequest.pigeon_newInstance',
+        pigeonChannelCodec,
+        binaryMessenger: binaryMessenger,
+      );
       if (pigeon_clearHandlers) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
@@ -920,18 +897,18 @@ class WebResourceRequest extends PigeonInternalProxyApiBaseClass {
           final bool arg_isRedirect = args[3]! as bool;
           final bool arg_hasGesture = args[4]! as bool;
           final String arg_method = args[5]! as String;
-          final Map<String, String>? arg_requestHeaders =
-              (args[6] as Map<Object?, Object?>?)?.cast<String, String>();
+          final Map<String, String>? arg_requestHeaders = (args[6] as Map<Object?, Object?>?)
+              ?.cast<String, String>();
           try {
-            (pigeon_instanceManager ?? PigeonInstanceManager.instance)
-                .addHostCreatedInstance(
+            (pigeon_instanceManager ?? PigeonInstanceManager.instance).addHostCreatedInstance(
               pigeon_newInstance?.call(
-                      arg_url,
-                      arg_isForMainFrame,
-                      arg_isRedirect,
-                      arg_hasGesture,
-                      arg_method,
-                      arg_requestHeaders) ??
+                    arg_url,
+                    arg_isForMainFrame,
+                    arg_isRedirect,
+                    arg_hasGesture,
+                    arg_method,
+                    arg_requestHeaders,
+                  ) ??
                   WebResourceRequest.pigeon_detached(
                     pigeon_binaryMessenger: pigeon_binaryMessenger,
                     pigeon_instanceManager: pigeon_instanceManager,
@@ -949,7 +926,8 @@ class WebResourceRequest extends PigeonInternalProxyApiBaseClass {
             return wrapResponse(error: e);
           } catch (e) {
             return wrapResponse(
-                error: PlatformException(code: 'error', message: e.toString()));
+              error: PlatformException(code: 'error', message: e.toString()),
+            );
           }
         });
       }
@@ -995,15 +973,16 @@ class WebResourceResponse extends PigeonInternalProxyApiBaseClass {
     PigeonInstanceManager? pigeon_instanceManager,
     WebResourceResponse Function(int statusCode)? pigeon_newInstance,
   }) {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
-        _PigeonInternalProxyApiBaseCodec(
-            pigeon_instanceManager ?? PigeonInstanceManager.instance);
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _PigeonInternalProxyApiBaseCodec(
+      pigeon_instanceManager ?? PigeonInstanceManager.instance,
+    );
     final BinaryMessenger? binaryMessenger = pigeon_binaryMessenger;
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-          'dev.flutter.pigeon.webview_flutter_android.WebResourceResponse.pigeon_newInstance',
-          pigeonChannelCodec,
-          binaryMessenger: binaryMessenger);
+        'dev.flutter.pigeon.webview_flutter_android.WebResourceResponse.pigeon_newInstance',
+        pigeonChannelCodec,
+        binaryMessenger: binaryMessenger,
+      );
       if (pigeon_clearHandlers) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
@@ -1012,8 +991,7 @@ class WebResourceResponse extends PigeonInternalProxyApiBaseClass {
           final int arg_pigeon_instanceIdentifier = args[0]! as int;
           final int arg_statusCode = args[1]! as int;
           try {
-            (pigeon_instanceManager ?? PigeonInstanceManager.instance)
-                .addHostCreatedInstance(
+            (pigeon_instanceManager ?? PigeonInstanceManager.instance).addHostCreatedInstance(
               pigeon_newInstance?.call(arg_statusCode) ??
                   WebResourceResponse.pigeon_detached(
                     pigeon_binaryMessenger: pigeon_binaryMessenger,
@@ -1027,7 +1005,8 @@ class WebResourceResponse extends PigeonInternalProxyApiBaseClass {
             return wrapResponse(error: e);
           } catch (e) {
             return wrapResponse(
-                error: PlatformException(code: 'error', message: e.toString()));
+              error: PlatformException(code: 'error', message: e.toString()),
+            );
           }
         });
       }
@@ -1071,20 +1050,18 @@ class WebResourceError extends PigeonInternalProxyApiBaseClass {
     bool pigeon_clearHandlers = false,
     BinaryMessenger? pigeon_binaryMessenger,
     PigeonInstanceManager? pigeon_instanceManager,
-    WebResourceError Function(
-      int errorCode,
-      String description,
-    )? pigeon_newInstance,
+    WebResourceError Function(int errorCode, String description)? pigeon_newInstance,
   }) {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
-        _PigeonInternalProxyApiBaseCodec(
-            pigeon_instanceManager ?? PigeonInstanceManager.instance);
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _PigeonInternalProxyApiBaseCodec(
+      pigeon_instanceManager ?? PigeonInstanceManager.instance,
+    );
     final BinaryMessenger? binaryMessenger = pigeon_binaryMessenger;
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-          'dev.flutter.pigeon.webview_flutter_android.WebResourceError.pigeon_newInstance',
-          pigeonChannelCodec,
-          binaryMessenger: binaryMessenger);
+        'dev.flutter.pigeon.webview_flutter_android.WebResourceError.pigeon_newInstance',
+        pigeonChannelCodec,
+        binaryMessenger: binaryMessenger,
+      );
       if (pigeon_clearHandlers) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
@@ -1094,8 +1071,7 @@ class WebResourceError extends PigeonInternalProxyApiBaseClass {
           final int arg_errorCode = args[1]! as int;
           final String arg_description = args[2]! as String;
           try {
-            (pigeon_instanceManager ?? PigeonInstanceManager.instance)
-                .addHostCreatedInstance(
+            (pigeon_instanceManager ?? PigeonInstanceManager.instance).addHostCreatedInstance(
               pigeon_newInstance?.call(arg_errorCode, arg_description) ??
                   WebResourceError.pigeon_detached(
                     pigeon_binaryMessenger: pigeon_binaryMessenger,
@@ -1110,7 +1086,8 @@ class WebResourceError extends PigeonInternalProxyApiBaseClass {
             return wrapResponse(error: e);
           } catch (e) {
             return wrapResponse(
-                error: PlatformException(code: 'error', message: e.toString()));
+              error: PlatformException(code: 'error', message: e.toString()),
+            );
           }
         });
       }
@@ -1155,20 +1132,18 @@ class WebResourceErrorCompat extends PigeonInternalProxyApiBaseClass {
     bool pigeon_clearHandlers = false,
     BinaryMessenger? pigeon_binaryMessenger,
     PigeonInstanceManager? pigeon_instanceManager,
-    WebResourceErrorCompat Function(
-      int errorCode,
-      String description,
-    )? pigeon_newInstance,
+    WebResourceErrorCompat Function(int errorCode, String description)? pigeon_newInstance,
   }) {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
-        _PigeonInternalProxyApiBaseCodec(
-            pigeon_instanceManager ?? PigeonInstanceManager.instance);
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _PigeonInternalProxyApiBaseCodec(
+      pigeon_instanceManager ?? PigeonInstanceManager.instance,
+    );
     final BinaryMessenger? binaryMessenger = pigeon_binaryMessenger;
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-          'dev.flutter.pigeon.webview_flutter_android.WebResourceErrorCompat.pigeon_newInstance',
-          pigeonChannelCodec,
-          binaryMessenger: binaryMessenger);
+        'dev.flutter.pigeon.webview_flutter_android.WebResourceErrorCompat.pigeon_newInstance',
+        pigeonChannelCodec,
+        binaryMessenger: binaryMessenger,
+      );
       if (pigeon_clearHandlers) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
@@ -1178,8 +1153,7 @@ class WebResourceErrorCompat extends PigeonInternalProxyApiBaseClass {
           final int arg_errorCode = args[1]! as int;
           final String arg_description = args[2]! as String;
           try {
-            (pigeon_instanceManager ?? PigeonInstanceManager.instance)
-                .addHostCreatedInstance(
+            (pigeon_instanceManager ?? PigeonInstanceManager.instance).addHostCreatedInstance(
               pigeon_newInstance?.call(arg_errorCode, arg_description) ??
                   WebResourceErrorCompat.pigeon_detached(
                     pigeon_binaryMessenger: pigeon_binaryMessenger,
@@ -1194,7 +1168,8 @@ class WebResourceErrorCompat extends PigeonInternalProxyApiBaseClass {
             return wrapResponse(error: e);
           } catch (e) {
             return wrapResponse(
-                error: PlatformException(code: 'error', message: e.toString()));
+              error: PlatformException(code: 'error', message: e.toString()),
+            );
           }
         });
       }
@@ -1236,20 +1211,18 @@ class WebViewPoint extends PigeonInternalProxyApiBaseClass {
     bool pigeon_clearHandlers = false,
     BinaryMessenger? pigeon_binaryMessenger,
     PigeonInstanceManager? pigeon_instanceManager,
-    WebViewPoint Function(
-      int x,
-      int y,
-    )? pigeon_newInstance,
+    WebViewPoint Function(int x, int y)? pigeon_newInstance,
   }) {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
-        _PigeonInternalProxyApiBaseCodec(
-            pigeon_instanceManager ?? PigeonInstanceManager.instance);
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _PigeonInternalProxyApiBaseCodec(
+      pigeon_instanceManager ?? PigeonInstanceManager.instance,
+    );
     final BinaryMessenger? binaryMessenger = pigeon_binaryMessenger;
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-          'dev.flutter.pigeon.webview_flutter_android.WebViewPoint.pigeon_newInstance',
-          pigeonChannelCodec,
-          binaryMessenger: binaryMessenger);
+        'dev.flutter.pigeon.webview_flutter_android.WebViewPoint.pigeon_newInstance',
+        pigeonChannelCodec,
+        binaryMessenger: binaryMessenger,
+      );
       if (pigeon_clearHandlers) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
@@ -1259,8 +1232,7 @@ class WebViewPoint extends PigeonInternalProxyApiBaseClass {
           final int arg_x = args[1]! as int;
           final int arg_y = args[2]! as int;
           try {
-            (pigeon_instanceManager ?? PigeonInstanceManager.instance)
-                .addHostCreatedInstance(
+            (pigeon_instanceManager ?? PigeonInstanceManager.instance).addHostCreatedInstance(
               pigeon_newInstance?.call(arg_x, arg_y) ??
                   WebViewPoint.pigeon_detached(
                     pigeon_binaryMessenger: pigeon_binaryMessenger,
@@ -1275,7 +1247,8 @@ class WebViewPoint extends PigeonInternalProxyApiBaseClass {
             return wrapResponse(error: e);
           } catch (e) {
             return wrapResponse(
-                error: PlatformException(code: 'error', message: e.toString()));
+              error: PlatformException(code: 'error', message: e.toString()),
+            );
           }
         });
       }
@@ -1328,17 +1301,19 @@ class ConsoleMessage extends PigeonInternalProxyApiBaseClass {
       String message,
       ConsoleMessageLevel level,
       String sourceId,
-    )? pigeon_newInstance,
+    )?
+    pigeon_newInstance,
   }) {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
-        _PigeonInternalProxyApiBaseCodec(
-            pigeon_instanceManager ?? PigeonInstanceManager.instance);
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _PigeonInternalProxyApiBaseCodec(
+      pigeon_instanceManager ?? PigeonInstanceManager.instance,
+    );
     final BinaryMessenger? binaryMessenger = pigeon_binaryMessenger;
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-          'dev.flutter.pigeon.webview_flutter_android.ConsoleMessage.pigeon_newInstance',
-          pigeonChannelCodec,
-          binaryMessenger: binaryMessenger);
+        'dev.flutter.pigeon.webview_flutter_android.ConsoleMessage.pigeon_newInstance',
+        pigeonChannelCodec,
+        binaryMessenger: binaryMessenger,
+      );
       if (pigeon_clearHandlers) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
@@ -1350,10 +1325,8 @@ class ConsoleMessage extends PigeonInternalProxyApiBaseClass {
           final ConsoleMessageLevel arg_level = args[3]! as ConsoleMessageLevel;
           final String arg_sourceId = args[4]! as String;
           try {
-            (pigeon_instanceManager ?? PigeonInstanceManager.instance)
-                .addHostCreatedInstance(
-              pigeon_newInstance?.call(
-                      arg_lineNumber, arg_message, arg_level, arg_sourceId) ??
+            (pigeon_instanceManager ?? PigeonInstanceManager.instance).addHostCreatedInstance(
+              pigeon_newInstance?.call(arg_lineNumber, arg_message, arg_level, arg_sourceId) ??
                   ConsoleMessage.pigeon_detached(
                     pigeon_binaryMessenger: pigeon_binaryMessenger,
                     pigeon_instanceManager: pigeon_instanceManager,
@@ -1369,7 +1342,8 @@ class ConsoleMessage extends PigeonInternalProxyApiBaseClass {
             return wrapResponse(error: e);
           } catch (e) {
             return wrapResponse(
-                error: PlatformException(code: 'error', message: e.toString()));
+              error: PlatformException(code: 'error', message: e.toString()),
+            );
           }
         });
       }
@@ -1398,18 +1372,14 @@ class CookieManager extends PigeonInternalProxyApiBaseClass {
   /// This should only be used by subclasses created by this library or to
   /// create copies for an [PigeonInstanceManager].
   @protected
-  CookieManager.pigeon_detached({
-    super.pigeon_binaryMessenger,
-    super.pigeon_instanceManager,
-  });
+  CookieManager.pigeon_detached({super.pigeon_binaryMessenger, super.pigeon_instanceManager});
 
   late final _PigeonInternalProxyApiBaseCodec _pigeonVar_codecCookieManager =
       _PigeonInternalProxyApiBaseCodec(pigeon_instanceManager);
 
   static final CookieManager _instance = pigeonVar_instance();
 
-  static CookieManager get instance =>
-      PigeonOverrides.cookieManager_instance ?? _instance;
+  static CookieManager get instance => PigeonOverrides.cookieManager_instance ?? _instance;
 
   static void pigeon_setUpMessageHandlers({
     bool pigeon_clearHandlers = false,
@@ -1417,15 +1387,16 @@ class CookieManager extends PigeonInternalProxyApiBaseClass {
     PigeonInstanceManager? pigeon_instanceManager,
     CookieManager Function()? pigeon_newInstance,
   }) {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
-        _PigeonInternalProxyApiBaseCodec(
-            pigeon_instanceManager ?? PigeonInstanceManager.instance);
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _PigeonInternalProxyApiBaseCodec(
+      pigeon_instanceManager ?? PigeonInstanceManager.instance,
+    );
     final BinaryMessenger? binaryMessenger = pigeon_binaryMessenger;
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-          'dev.flutter.pigeon.webview_flutter_android.CookieManager.pigeon_newInstance',
-          pigeonChannelCodec,
-          binaryMessenger: binaryMessenger);
+        'dev.flutter.pigeon.webview_flutter_android.CookieManager.pigeon_newInstance',
+        pigeonChannelCodec,
+        binaryMessenger: binaryMessenger,
+      );
       if (pigeon_clearHandlers) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
@@ -1433,8 +1404,7 @@ class CookieManager extends PigeonInternalProxyApiBaseClass {
           final List<Object?> args = message! as List<Object?>;
           final int arg_pigeon_instanceIdentifier = args[0]! as int;
           try {
-            (pigeon_instanceManager ?? PigeonInstanceManager.instance)
-                .addHostCreatedInstance(
+            (pigeon_instanceManager ?? PigeonInstanceManager.instance).addHostCreatedInstance(
               pigeon_newInstance?.call() ??
                   CookieManager.pigeon_detached(
                     pigeon_binaryMessenger: pigeon_binaryMessenger,
@@ -1447,7 +1417,8 @@ class CookieManager extends PigeonInternalProxyApiBaseClass {
             return wrapResponse(error: e);
           } catch (e) {
             return wrapResponse(
-                error: PlatformException(code: 'error', message: e.toString()));
+              error: PlatformException(code: 'error', message: e.toString()),
+            );
           }
         });
       }
@@ -1456,12 +1427,14 @@ class CookieManager extends PigeonInternalProxyApiBaseClass {
 
   static CookieManager pigeonVar_instance() {
     final CookieManager pigeonVar_instance = CookieManager.pigeon_detached();
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
-        _PigeonInternalProxyApiBaseCodec(PigeonInstanceManager.instance);
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _PigeonInternalProxyApiBaseCodec(
+      PigeonInstanceManager.instance,
+    );
     final BinaryMessenger pigeonVar_binaryMessenger =
         ServicesBinding.instance.defaultBinaryMessenger;
-    final int pigeonVar_instanceIdentifier = PigeonInstanceManager.instance
-        .addDartCreatedInstance(pigeonVar_instance);
+    final int pigeonVar_instanceIdentifier = PigeonInstanceManager.instance.addDartCreatedInstance(
+      pigeonVar_instance,
+    );
     () async {
       const pigeonVar_channelName =
           'dev.flutter.pigeon.webview_flutter_android.CookieManager.instance';
@@ -1470,26 +1443,19 @@ class CookieManager extends PigeonInternalProxyApiBaseClass {
         pigeonChannelCodec,
         binaryMessenger: pigeonVar_binaryMessenger,
       );
-      final Future<Object?> pigeonVar_sendFuture =
-          pigeonVar_channel.send(<Object?>[pigeonVar_instanceIdentifier]);
+      final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[
+        pigeonVar_instanceIdentifier,
+      ]);
       final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
-      _extractReplyValueOrThrow(
-        pigeonVar_replyList,
-        pigeonVar_channelName,
-        isNullValid: true,
-      );
+      _extractReplyValueOrThrow(pigeonVar_replyList, pigeonVar_channelName, isNullValid: true);
     }();
     return pigeonVar_instance;
   }
 
   /// Sets a single cookie (key-value pair) for the given URL.
-  Future<void> setCookie(
-    String url,
-    String value,
-  ) async {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
-        _pigeonVar_codecCookieManager;
+  Future<void> setCookie(String url, String value) async {
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecCookieManager;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
     const pigeonVar_channelName =
         'dev.flutter.pigeon.webview_flutter_android.CookieManager.setCookie';
@@ -1498,21 +1464,19 @@ class CookieManager extends PigeonInternalProxyApiBaseClass {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture =
-        pigeonVar_channel.send(<Object?>[this, url, value]);
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[
+      this,
+      url,
+      value,
+    ]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
-    _extractReplyValueOrThrow(
-      pigeonVar_replyList,
-      pigeonVar_channelName,
-      isNullValid: true,
-    );
+    _extractReplyValueOrThrow(pigeonVar_replyList, pigeonVar_channelName, isNullValid: true);
   }
 
   /// Removes all cookies.
   Future<bool> removeAllCookies() async {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
-        _pigeonVar_codecCookieManager;
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecCookieManager;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
     const pigeonVar_channelName =
         'dev.flutter.pigeon.webview_flutter_android.CookieManager.removeAllCookies';
@@ -1521,8 +1485,7 @@ class CookieManager extends PigeonInternalProxyApiBaseClass {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture =
-        pigeonVar_channel.send(<Object?>[this]);
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[this]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
@@ -1534,12 +1497,8 @@ class CookieManager extends PigeonInternalProxyApiBaseClass {
   }
 
   /// Sets whether the `WebView` should allow third party cookies to be set.
-  Future<void> setAcceptThirdPartyCookies(
-    WebView webView,
-    bool accept,
-  ) async {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
-        _pigeonVar_codecCookieManager;
+  Future<void> setAcceptThirdPartyCookies(WebView webView, bool accept) async {
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecCookieManager;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
     const pigeonVar_channelName =
         'dev.flutter.pigeon.webview_flutter_android.CookieManager.setAcceptThirdPartyCookies';
@@ -1548,15 +1507,14 @@ class CookieManager extends PigeonInternalProxyApiBaseClass {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture =
-        pigeonVar_channel.send(<Object?>[this, webView, accept]);
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[
+      this,
+      webView,
+      accept,
+    ]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
-    _extractReplyValueOrThrow(
-      pigeonVar_replyList,
-      pigeonVar_channelName,
-      isNullValid: true,
-    );
+    _extractReplyValueOrThrow(pigeonVar_replyList, pigeonVar_channelName, isNullValid: true);
   }
 
   /// Gets all the cookies for the given URL.
@@ -1567,8 +1525,7 @@ class CookieManager extends PigeonInternalProxyApiBaseClass {
   ///
   /// Note: Any cookies set with the "Partitioned" attribute will only be returned for the top-level partition of url.
   Future<String?> getCookies(String url) async {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
-        _pigeonVar_codecCookieManager;
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecCookieManager;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
     const pigeonVar_channelName =
         'dev.flutter.pigeon.webview_flutter_android.CookieManager.getCookies';
@@ -1577,8 +1534,7 @@ class CookieManager extends PigeonInternalProxyApiBaseClass {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture =
-        pigeonVar_channel.send(<Object?>[this, url]);
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[this, url]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
@@ -1605,13 +1561,8 @@ class WebView extends View {
   factory WebView({
     BinaryMessenger? pigeon_binaryMessenger,
     PigeonInstanceManager? pigeon_instanceManager,
-    void Function(
-      WebView pigeon_instance,
-      int left,
-      int top,
-      int oldLeft,
-      int oldTop,
-    )? onScrollChanged,
+    void Function(WebView pigeon_instance, int left, int top, int oldLeft, int oldTop)?
+    onScrollChanged,
   }) {
     if (PigeonOverrides.webView_new != null) {
       return PigeonOverrides.webView_new!(onScrollChanged: onScrollChanged);
@@ -1629,10 +1580,8 @@ class WebView extends View {
     super.pigeon_instanceManager,
     this.onScrollChanged,
   }) : super.pigeon_detached() {
-    final int pigeonVar_instanceIdentifier =
-        pigeon_instanceManager.addDartCreatedInstance(this);
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
-        _pigeonVar_codecWebView;
+    final int pigeonVar_instanceIdentifier = pigeon_instanceManager.addDartCreatedInstance(this);
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecWebView;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
     const pigeonVar_channelName =
         'dev.flutter.pigeon.webview_flutter_android.WebView.pigeon_defaultConstructor';
@@ -1641,16 +1590,13 @@ class WebView extends View {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture =
-        pigeonVar_channel.send(<Object?>[pigeonVar_instanceIdentifier]);
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[
+      pigeonVar_instanceIdentifier,
+    ]);
     () async {
       final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
-      _extractReplyValueOrThrow(
-        pigeonVar_replyList,
-        pigeonVar_channelName,
-        isNullValid: true,
-      );
+      _extractReplyValueOrThrow(pigeonVar_replyList, pigeonVar_channelName, isNullValid: true);
     }();
   }
 
@@ -1688,13 +1634,8 @@ class WebView extends View {
   ///
   /// Alternatively, [PigeonInstanceManager.removeWeakReference] can be used to
   /// release the associated Native object manually.
-  final void Function(
-    WebView pigeon_instance,
-    int left,
-    int top,
-    int oldLeft,
-    int oldTop,
-  )? onScrollChanged;
+  final void Function(WebView pigeon_instance, int left, int top, int oldLeft, int oldTop)?
+  onScrollChanged;
 
   /// The WebSettings object used to control the settings for this WebView.
   late final WebSettings settings = pigeonVar_settings();
@@ -1704,23 +1645,19 @@ class WebView extends View {
     BinaryMessenger? pigeon_binaryMessenger,
     PigeonInstanceManager? pigeon_instanceManager,
     WebView Function()? pigeon_newInstance,
-    void Function(
-      WebView pigeon_instance,
-      int left,
-      int top,
-      int oldLeft,
-      int oldTop,
-    )? onScrollChanged,
+    void Function(WebView pigeon_instance, int left, int top, int oldLeft, int oldTop)?
+    onScrollChanged,
   }) {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
-        _PigeonInternalProxyApiBaseCodec(
-            pigeon_instanceManager ?? PigeonInstanceManager.instance);
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _PigeonInternalProxyApiBaseCodec(
+      pigeon_instanceManager ?? PigeonInstanceManager.instance,
+    );
     final BinaryMessenger? binaryMessenger = pigeon_binaryMessenger;
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-          'dev.flutter.pigeon.webview_flutter_android.WebView.pigeon_newInstance',
-          pigeonChannelCodec,
-          binaryMessenger: binaryMessenger);
+        'dev.flutter.pigeon.webview_flutter_android.WebView.pigeon_newInstance',
+        pigeonChannelCodec,
+        binaryMessenger: binaryMessenger,
+      );
       if (pigeon_clearHandlers) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
@@ -1728,8 +1665,7 @@ class WebView extends View {
           final List<Object?> args = message! as List<Object?>;
           final int arg_pigeon_instanceIdentifier = args[0]! as int;
           try {
-            (pigeon_instanceManager ?? PigeonInstanceManager.instance)
-                .addHostCreatedInstance(
+            (pigeon_instanceManager ?? PigeonInstanceManager.instance).addHostCreatedInstance(
               pigeon_newInstance?.call() ??
                   WebView.pigeon_detached(
                     pigeon_binaryMessenger: pigeon_binaryMessenger,
@@ -1742,7 +1678,8 @@ class WebView extends View {
             return wrapResponse(error: e);
           } catch (e) {
             return wrapResponse(
-                error: PlatformException(code: 'error', message: e.toString()));
+              error: PlatformException(code: 'error', message: e.toString()),
+            );
           }
         });
       }
@@ -1750,9 +1687,10 @@ class WebView extends View {
 
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-          'dev.flutter.pigeon.webview_flutter_android.WebView.onScrollChanged',
-          pigeonChannelCodec,
-          binaryMessenger: binaryMessenger);
+        'dev.flutter.pigeon.webview_flutter_android.WebView.onScrollChanged',
+        pigeonChannelCodec,
+        binaryMessenger: binaryMessenger,
+      );
       if (pigeon_clearHandlers) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
@@ -1765,17 +1703,19 @@ class WebView extends View {
           final int arg_oldTop = args[4]! as int;
           try {
             (onScrollChanged ?? arg_pigeon_instance.onScrollChanged)?.call(
-                arg_pigeon_instance,
-                arg_left,
-                arg_top,
-                arg_oldLeft,
-                arg_oldTop);
+              arg_pigeon_instance,
+              arg_left,
+              arg_top,
+              arg_oldLeft,
+              arg_oldTop,
+            );
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
           } catch (e) {
             return wrapResponse(
-                error: PlatformException(code: 'error', message: e.toString()));
+              error: PlatformException(code: 'error', message: e.toString()),
+            );
           }
         });
       }
@@ -1787,57 +1727,48 @@ class WebView extends View {
       pigeon_binaryMessenger: pigeon_binaryMessenger,
       pigeon_instanceManager: pigeon_instanceManager,
     );
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
-        _pigeonVar_codecWebView;
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecWebView;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
-    final int pigeonVar_instanceIdentifier =
-        pigeon_instanceManager.addDartCreatedInstance(pigeonVar_instance);
+    final int pigeonVar_instanceIdentifier = pigeon_instanceManager.addDartCreatedInstance(
+      pigeonVar_instance,
+    );
     () async {
-      const pigeonVar_channelName =
-          'dev.flutter.pigeon.webview_flutter_android.WebView.settings';
+      const pigeonVar_channelName = 'dev.flutter.pigeon.webview_flutter_android.WebView.settings';
       final pigeonVar_channel = BasicMessageChannel<Object?>(
         pigeonVar_channelName,
         pigeonChannelCodec,
         binaryMessenger: pigeonVar_binaryMessenger,
       );
-      final Future<Object?> pigeonVar_sendFuture =
-          pigeonVar_channel.send(<Object?>[this, pigeonVar_instanceIdentifier]);
+      final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[
+        this,
+        pigeonVar_instanceIdentifier,
+      ]);
       final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
-      _extractReplyValueOrThrow(
-        pigeonVar_replyList,
-        pigeonVar_channelName,
-        isNullValid: true,
-      );
+      _extractReplyValueOrThrow(pigeonVar_replyList, pigeonVar_channelName, isNullValid: true);
     }();
     return pigeonVar_instance;
   }
 
   /// Loads the given data into this WebView using a 'data' scheme URL.
-  Future<void> loadData(
-    String data,
-    String? mimeType,
-    String? encoding,
-  ) async {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
-        _pigeonVar_codecWebView;
+  Future<void> loadData(String data, String? mimeType, String? encoding) async {
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecWebView;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
-    const pigeonVar_channelName =
-        'dev.flutter.pigeon.webview_flutter_android.WebView.loadData';
+    const pigeonVar_channelName = 'dev.flutter.pigeon.webview_flutter_android.WebView.loadData';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture =
-        pigeonVar_channel.send(<Object?>[this, data, mimeType, encoding]);
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[
+      this,
+      data,
+      mimeType,
+      encoding,
+    ]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
-    _extractReplyValueOrThrow(
-      pigeonVar_replyList,
-      pigeonVar_channelName,
-      isNullValid: true,
-    );
+    _extractReplyValueOrThrow(pigeonVar_replyList, pigeonVar_channelName, isNullValid: true);
   }
 
   /// Loads the given data into this WebView, using baseUrl as the base URL for
@@ -1849,8 +1780,7 @@ class WebView extends View {
     String? encoding,
     String? historyUrl,
   ) async {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
-        _pigeonVar_codecWebView;
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecWebView;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
     const pigeonVar_channelName =
         'dev.flutter.pigeon.webview_flutter_android.WebView.loadDataWithBaseUrl';
@@ -1859,83 +1789,66 @@ class WebView extends View {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel
-        .send(<Object?>[this, baseUrl, data, mimeType, encoding, historyUrl]);
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[
+      this,
+      baseUrl,
+      data,
+      mimeType,
+      encoding,
+      historyUrl,
+    ]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
-    _extractReplyValueOrThrow(
-      pigeonVar_replyList,
-      pigeonVar_channelName,
-      isNullValid: true,
-    );
+    _extractReplyValueOrThrow(pigeonVar_replyList, pigeonVar_channelName, isNullValid: true);
   }
 
   /// Loads the given URL.
-  Future<void> loadUrl(
-    String url,
-    Map<String, String> headers,
-  ) async {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
-        _pigeonVar_codecWebView;
+  Future<void> loadUrl(String url, Map<String, String> headers) async {
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecWebView;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
-    const pigeonVar_channelName =
-        'dev.flutter.pigeon.webview_flutter_android.WebView.loadUrl';
+    const pigeonVar_channelName = 'dev.flutter.pigeon.webview_flutter_android.WebView.loadUrl';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture =
-        pigeonVar_channel.send(<Object?>[this, url, headers]);
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[
+      this,
+      url,
+      headers,
+    ]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
-    _extractReplyValueOrThrow(
-      pigeonVar_replyList,
-      pigeonVar_channelName,
-      isNullValid: true,
-    );
+    _extractReplyValueOrThrow(pigeonVar_replyList, pigeonVar_channelName, isNullValid: true);
   }
 
   /// Loads the URL with postData using "POST" method into this WebView.
-  Future<void> postUrl(
-    String url,
-    Uint8List data,
-  ) async {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
-        _pigeonVar_codecWebView;
+  Future<void> postUrl(String url, Uint8List data) async {
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecWebView;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
-    const pigeonVar_channelName =
-        'dev.flutter.pigeon.webview_flutter_android.WebView.postUrl';
+    const pigeonVar_channelName = 'dev.flutter.pigeon.webview_flutter_android.WebView.postUrl';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture =
-        pigeonVar_channel.send(<Object?>[this, url, data]);
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[this, url, data]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
-    _extractReplyValueOrThrow(
-      pigeonVar_replyList,
-      pigeonVar_channelName,
-      isNullValid: true,
-    );
+    _extractReplyValueOrThrow(pigeonVar_replyList, pigeonVar_channelName, isNullValid: true);
   }
 
   /// Gets the URL for the current page.
   Future<String?> getUrl() async {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
-        _pigeonVar_codecWebView;
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecWebView;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
-    const pigeonVar_channelName =
-        'dev.flutter.pigeon.webview_flutter_android.WebView.getUrl';
+    const pigeonVar_channelName = 'dev.flutter.pigeon.webview_flutter_android.WebView.getUrl';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture =
-        pigeonVar_channel.send(<Object?>[this]);
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[this]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
@@ -1948,18 +1861,15 @@ class WebView extends View {
 
   /// Gets whether this WebView has a back history item.
   Future<bool> canGoBack() async {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
-        _pigeonVar_codecWebView;
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecWebView;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
-    const pigeonVar_channelName =
-        'dev.flutter.pigeon.webview_flutter_android.WebView.canGoBack';
+    const pigeonVar_channelName = 'dev.flutter.pigeon.webview_flutter_android.WebView.canGoBack';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture =
-        pigeonVar_channel.send(<Object?>[this]);
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[this]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
@@ -1972,18 +1882,15 @@ class WebView extends View {
 
   /// Gets whether this WebView has a forward history item.
   Future<bool> canGoForward() async {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
-        _pigeonVar_codecWebView;
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecWebView;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
-    const pigeonVar_channelName =
-        'dev.flutter.pigeon.webview_flutter_android.WebView.canGoForward';
+    const pigeonVar_channelName = 'dev.flutter.pigeon.webview_flutter_android.WebView.canGoForward';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture =
-        pigeonVar_channel.send(<Object?>[this]);
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[this]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
@@ -1996,101 +1903,75 @@ class WebView extends View {
 
   /// Goes back in the history of this WebView.
   Future<void> goBack() async {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
-        _pigeonVar_codecWebView;
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecWebView;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
-    const pigeonVar_channelName =
-        'dev.flutter.pigeon.webview_flutter_android.WebView.goBack';
+    const pigeonVar_channelName = 'dev.flutter.pigeon.webview_flutter_android.WebView.goBack';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture =
-        pigeonVar_channel.send(<Object?>[this]);
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[this]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
-    _extractReplyValueOrThrow(
-      pigeonVar_replyList,
-      pigeonVar_channelName,
-      isNullValid: true,
-    );
+    _extractReplyValueOrThrow(pigeonVar_replyList, pigeonVar_channelName, isNullValid: true);
   }
 
   /// Goes forward in the history of this WebView.
   Future<void> goForward() async {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
-        _pigeonVar_codecWebView;
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecWebView;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
-    const pigeonVar_channelName =
-        'dev.flutter.pigeon.webview_flutter_android.WebView.goForward';
+    const pigeonVar_channelName = 'dev.flutter.pigeon.webview_flutter_android.WebView.goForward';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture =
-        pigeonVar_channel.send(<Object?>[this]);
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[this]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
-    _extractReplyValueOrThrow(
-      pigeonVar_replyList,
-      pigeonVar_channelName,
-      isNullValid: true,
-    );
+    _extractReplyValueOrThrow(pigeonVar_replyList, pigeonVar_channelName, isNullValid: true);
   }
 
   /// Reloads the current URL.
   Future<void> reload() async {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
-        _pigeonVar_codecWebView;
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecWebView;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
-    const pigeonVar_channelName =
-        'dev.flutter.pigeon.webview_flutter_android.WebView.reload';
+    const pigeonVar_channelName = 'dev.flutter.pigeon.webview_flutter_android.WebView.reload';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture =
-        pigeonVar_channel.send(<Object?>[this]);
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[this]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
-    _extractReplyValueOrThrow(
-      pigeonVar_replyList,
-      pigeonVar_channelName,
-      isNullValid: true,
-    );
+    _extractReplyValueOrThrow(pigeonVar_replyList, pigeonVar_channelName, isNullValid: true);
   }
 
   /// Clears the resource cache.
   Future<void> clearCache(bool includeDiskFiles) async {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
-        _pigeonVar_codecWebView;
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecWebView;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
-    const pigeonVar_channelName =
-        'dev.flutter.pigeon.webview_flutter_android.WebView.clearCache';
+    const pigeonVar_channelName = 'dev.flutter.pigeon.webview_flutter_android.WebView.clearCache';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture =
-        pigeonVar_channel.send(<Object?>[this, includeDiskFiles]);
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[
+      this,
+      includeDiskFiles,
+    ]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
-    _extractReplyValueOrThrow(
-      pigeonVar_replyList,
-      pigeonVar_channelName,
-      isNullValid: true,
-    );
+    _extractReplyValueOrThrow(pigeonVar_replyList, pigeonVar_channelName, isNullValid: true);
   }
 
   /// Asynchronously evaluates JavaScript in the context of the currently
   /// displayed page.
   Future<String?> evaluateJavascript(String javascriptString) async {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
-        _pigeonVar_codecWebView;
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecWebView;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
     const pigeonVar_channelName =
         'dev.flutter.pigeon.webview_flutter_android.WebView.evaluateJavascript';
@@ -2099,8 +1980,10 @@ class WebView extends View {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture =
-        pigeonVar_channel.send(<Object?>[this, javascriptString]);
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[
+      this,
+      javascriptString,
+    ]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
@@ -2113,18 +1996,15 @@ class WebView extends View {
 
   /// Gets the title for the current page.
   Future<String?> getTitle() async {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
-        _pigeonVar_codecWebView;
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecWebView;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
-    const pigeonVar_channelName =
-        'dev.flutter.pigeon.webview_flutter_android.WebView.getTitle';
+    const pigeonVar_channelName = 'dev.flutter.pigeon.webview_flutter_android.WebView.getTitle';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture =
-        pigeonVar_channel.send(<Object?>[this]);
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[this]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
@@ -2145,9 +2025,9 @@ class WebView extends View {
     if (PigeonOverrides.webView_setWebContentsDebuggingEnabled != null) {
       return PigeonOverrides.webView_setWebContentsDebuggingEnabled!(enabled);
     }
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
-        _PigeonInternalProxyApiBaseCodec(
-            pigeon_instanceManager ?? PigeonInstanceManager.instance);
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _PigeonInternalProxyApiBaseCodec(
+      pigeon_instanceManager ?? PigeonInstanceManager.instance,
+    );
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
     const pigeonVar_channelName =
         'dev.flutter.pigeon.webview_flutter_android.WebView.setWebContentsDebuggingEnabled';
@@ -2156,22 +2036,16 @@ class WebView extends View {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture =
-        pigeonVar_channel.send(<Object?>[enabled]);
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[enabled]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
-    _extractReplyValueOrThrow(
-      pigeonVar_replyList,
-      pigeonVar_channelName,
-      isNullValid: true,
-    );
+    _extractReplyValueOrThrow(pigeonVar_replyList, pigeonVar_channelName, isNullValid: true);
   }
 
   /// Sets the WebViewClient that will receive various notifications and
   /// requests.
   Future<void> setWebViewClient(WebViewClient? client) async {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
-        _pigeonVar_codecWebView;
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecWebView;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
     const pigeonVar_channelName =
         'dev.flutter.pigeon.webview_flutter_android.WebView.setWebViewClient';
@@ -2180,21 +2054,15 @@ class WebView extends View {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture =
-        pigeonVar_channel.send(<Object?>[this, client]);
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[this, client]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
-    _extractReplyValueOrThrow(
-      pigeonVar_replyList,
-      pigeonVar_channelName,
-      isNullValid: true,
-    );
+    _extractReplyValueOrThrow(pigeonVar_replyList, pigeonVar_channelName, isNullValid: true);
   }
 
   /// Injects the supplied Java object into this WebView.
   Future<void> addJavaScriptChannel(JavaScriptChannel channel) async {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
-        _pigeonVar_codecWebView;
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecWebView;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
     const pigeonVar_channelName =
         'dev.flutter.pigeon.webview_flutter_android.WebView.addJavaScriptChannel';
@@ -2203,21 +2071,15 @@ class WebView extends View {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture =
-        pigeonVar_channel.send(<Object?>[this, channel]);
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[this, channel]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
-    _extractReplyValueOrThrow(
-      pigeonVar_replyList,
-      pigeonVar_channelName,
-      isNullValid: true,
-    );
+    _extractReplyValueOrThrow(pigeonVar_replyList, pigeonVar_channelName, isNullValid: true);
   }
 
   /// Removes a previously injected Java object from this WebView.
   Future<void> removeJavaScriptChannel(String name) async {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
-        _pigeonVar_codecWebView;
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecWebView;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
     const pigeonVar_channelName =
         'dev.flutter.pigeon.webview_flutter_android.WebView.removeJavaScriptChannel';
@@ -2226,22 +2088,16 @@ class WebView extends View {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture =
-        pigeonVar_channel.send(<Object?>[this, name]);
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[this, name]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
-    _extractReplyValueOrThrow(
-      pigeonVar_replyList,
-      pigeonVar_channelName,
-      isNullValid: true,
-    );
+    _extractReplyValueOrThrow(pigeonVar_replyList, pigeonVar_channelName, isNullValid: true);
   }
 
   /// Registers the interface to be used when content can not be handled by the
   /// rendering engine, and should be downloaded instead.
   Future<void> setDownloadListener(DownloadListener? listener) async {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
-        _pigeonVar_codecWebView;
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecWebView;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
     const pigeonVar_channelName =
         'dev.flutter.pigeon.webview_flutter_android.WebView.setDownloadListener';
@@ -2250,21 +2106,15 @@ class WebView extends View {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture =
-        pigeonVar_channel.send(<Object?>[this, listener]);
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[this, listener]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
-    _extractReplyValueOrThrow(
-      pigeonVar_replyList,
-      pigeonVar_channelName,
-      isNullValid: true,
-    );
+    _extractReplyValueOrThrow(pigeonVar_replyList, pigeonVar_channelName, isNullValid: true);
   }
 
   /// Sets the chrome handler.
   Future<void> setWebChromeClient(WebChromeClient? client) async {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
-        _pigeonVar_codecWebView;
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecWebView;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
     const pigeonVar_channelName =
         'dev.flutter.pigeon.webview_flutter_android.WebView.setWebChromeClient';
@@ -2273,21 +2123,15 @@ class WebView extends View {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture =
-        pigeonVar_channel.send(<Object?>[this, client]);
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[this, client]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
-    _extractReplyValueOrThrow(
-      pigeonVar_replyList,
-      pigeonVar_channelName,
-      isNullValid: true,
-    );
+    _extractReplyValueOrThrow(pigeonVar_replyList, pigeonVar_channelName, isNullValid: true);
   }
 
   /// Sets the background color for this view.
   Future<void> setBackgroundColor(int color) async {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
-        _pigeonVar_codecWebView;
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecWebView;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
     const pigeonVar_channelName =
         'dev.flutter.pigeon.webview_flutter_android.WebView.setBackgroundColor';
@@ -2296,38 +2140,26 @@ class WebView extends View {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture =
-        pigeonVar_channel.send(<Object?>[this, color]);
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[this, color]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
-    _extractReplyValueOrThrow(
-      pigeonVar_replyList,
-      pigeonVar_channelName,
-      isNullValid: true,
-    );
+    _extractReplyValueOrThrow(pigeonVar_replyList, pigeonVar_channelName, isNullValid: true);
   }
 
   /// Destroys the internal state of this WebView.
   Future<void> destroy() async {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
-        _pigeonVar_codecWebView;
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecWebView;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
-    const pigeonVar_channelName =
-        'dev.flutter.pigeon.webview_flutter_android.WebView.destroy';
+    const pigeonVar_channelName = 'dev.flutter.pigeon.webview_flutter_android.WebView.destroy';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture =
-        pigeonVar_channel.send(<Object?>[this]);
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[this]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
-    _extractReplyValueOrThrow(
-      pigeonVar_replyList,
-      pigeonVar_channelName,
-      isNullValid: true,
-    );
+    _extractReplyValueOrThrow(pigeonVar_replyList, pigeonVar_channelName, isNullValid: true);
   }
 
   @override
@@ -2349,10 +2181,7 @@ class WebSettings extends PigeonInternalProxyApiBaseClass {
   /// This should only be used by subclasses created by this library or to
   /// create copies for an [PigeonInstanceManager].
   @protected
-  WebSettings.pigeon_detached({
-    super.pigeon_binaryMessenger,
-    super.pigeon_instanceManager,
-  });
+  WebSettings.pigeon_detached({super.pigeon_binaryMessenger, super.pigeon_instanceManager});
 
   late final _PigeonInternalProxyApiBaseCodec _pigeonVar_codecWebSettings =
       _PigeonInternalProxyApiBaseCodec(pigeon_instanceManager);
@@ -2363,15 +2192,16 @@ class WebSettings extends PigeonInternalProxyApiBaseClass {
     PigeonInstanceManager? pigeon_instanceManager,
     WebSettings Function()? pigeon_newInstance,
   }) {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
-        _PigeonInternalProxyApiBaseCodec(
-            pigeon_instanceManager ?? PigeonInstanceManager.instance);
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _PigeonInternalProxyApiBaseCodec(
+      pigeon_instanceManager ?? PigeonInstanceManager.instance,
+    );
     final BinaryMessenger? binaryMessenger = pigeon_binaryMessenger;
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-          'dev.flutter.pigeon.webview_flutter_android.WebSettings.pigeon_newInstance',
-          pigeonChannelCodec,
-          binaryMessenger: binaryMessenger);
+        'dev.flutter.pigeon.webview_flutter_android.WebSettings.pigeon_newInstance',
+        pigeonChannelCodec,
+        binaryMessenger: binaryMessenger,
+      );
       if (pigeon_clearHandlers) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
@@ -2379,8 +2209,7 @@ class WebSettings extends PigeonInternalProxyApiBaseClass {
           final List<Object?> args = message! as List<Object?>;
           final int arg_pigeon_instanceIdentifier = args[0]! as int;
           try {
-            (pigeon_instanceManager ?? PigeonInstanceManager.instance)
-                .addHostCreatedInstance(
+            (pigeon_instanceManager ?? PigeonInstanceManager.instance).addHostCreatedInstance(
               pigeon_newInstance?.call() ??
                   WebSettings.pigeon_detached(
                     pigeon_binaryMessenger: pigeon_binaryMessenger,
@@ -2393,7 +2222,8 @@ class WebSettings extends PigeonInternalProxyApiBaseClass {
             return wrapResponse(error: e);
           } catch (e) {
             return wrapResponse(
-                error: PlatformException(code: 'error', message: e.toString()));
+              error: PlatformException(code: 'error', message: e.toString()),
+            );
           }
         });
       }
@@ -2402,8 +2232,7 @@ class WebSettings extends PigeonInternalProxyApiBaseClass {
 
   /// Sets whether the DOM storage API is enabled.
   Future<void> setDomStorageEnabled(bool flag) async {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
-        _pigeonVar_codecWebSettings;
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecWebSettings;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
     const pigeonVar_channelName =
         'dev.flutter.pigeon.webview_flutter_android.WebSettings.setDomStorageEnabled';
@@ -2412,21 +2241,15 @@ class WebSettings extends PigeonInternalProxyApiBaseClass {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture =
-        pigeonVar_channel.send(<Object?>[this, flag]);
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[this, flag]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
-    _extractReplyValueOrThrow(
-      pigeonVar_replyList,
-      pigeonVar_channelName,
-      isNullValid: true,
-    );
+    _extractReplyValueOrThrow(pigeonVar_replyList, pigeonVar_channelName, isNullValid: true);
   }
 
   /// Tells JavaScript to open windows automatically.
   Future<void> setJavaScriptCanOpenWindowsAutomatically(bool flag) async {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
-        _pigeonVar_codecWebSettings;
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecWebSettings;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
     const pigeonVar_channelName =
         'dev.flutter.pigeon.webview_flutter_android.WebSettings.setJavaScriptCanOpenWindowsAutomatically';
@@ -2435,21 +2258,15 @@ class WebSettings extends PigeonInternalProxyApiBaseClass {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture =
-        pigeonVar_channel.send(<Object?>[this, flag]);
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[this, flag]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
-    _extractReplyValueOrThrow(
-      pigeonVar_replyList,
-      pigeonVar_channelName,
-      isNullValid: true,
-    );
+    _extractReplyValueOrThrow(pigeonVar_replyList, pigeonVar_channelName, isNullValid: true);
   }
 
   /// Sets whether the WebView whether supports multiple windows.
   Future<void> setSupportMultipleWindows(bool support) async {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
-        _pigeonVar_codecWebSettings;
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecWebSettings;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
     const pigeonVar_channelName =
         'dev.flutter.pigeon.webview_flutter_android.WebSettings.setSupportMultipleWindows';
@@ -2458,21 +2275,15 @@ class WebSettings extends PigeonInternalProxyApiBaseClass {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture =
-        pigeonVar_channel.send(<Object?>[this, support]);
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[this, support]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
-    _extractReplyValueOrThrow(
-      pigeonVar_replyList,
-      pigeonVar_channelName,
-      isNullValid: true,
-    );
+    _extractReplyValueOrThrow(pigeonVar_replyList, pigeonVar_channelName, isNullValid: true);
   }
 
   /// Tells the WebView to enable JavaScript execution.
   Future<void> setJavaScriptEnabled(bool flag) async {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
-        _pigeonVar_codecWebSettings;
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecWebSettings;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
     const pigeonVar_channelName =
         'dev.flutter.pigeon.webview_flutter_android.WebSettings.setJavaScriptEnabled';
@@ -2481,21 +2292,15 @@ class WebSettings extends PigeonInternalProxyApiBaseClass {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture =
-        pigeonVar_channel.send(<Object?>[this, flag]);
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[this, flag]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
-    _extractReplyValueOrThrow(
-      pigeonVar_replyList,
-      pigeonVar_channelName,
-      isNullValid: true,
-    );
+    _extractReplyValueOrThrow(pigeonVar_replyList, pigeonVar_channelName, isNullValid: true);
   }
 
   /// Sets the WebView's user-agent string.
   Future<void> setUserAgentString(String? userAgentString) async {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
-        _pigeonVar_codecWebSettings;
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecWebSettings;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
     const pigeonVar_channelName =
         'dev.flutter.pigeon.webview_flutter_android.WebSettings.setUserAgentString';
@@ -2504,21 +2309,18 @@ class WebSettings extends PigeonInternalProxyApiBaseClass {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture =
-        pigeonVar_channel.send(<Object?>[this, userAgentString]);
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[
+      this,
+      userAgentString,
+    ]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
-    _extractReplyValueOrThrow(
-      pigeonVar_replyList,
-      pigeonVar_channelName,
-      isNullValid: true,
-    );
+    _extractReplyValueOrThrow(pigeonVar_replyList, pigeonVar_channelName, isNullValid: true);
   }
 
   /// Sets whether the WebView requires a user gesture to play media.
   Future<void> setMediaPlaybackRequiresUserGesture(bool require) async {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
-        _pigeonVar_codecWebSettings;
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecWebSettings;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
     const pigeonVar_channelName =
         'dev.flutter.pigeon.webview_flutter_android.WebSettings.setMediaPlaybackRequiresUserGesture';
@@ -2527,22 +2329,16 @@ class WebSettings extends PigeonInternalProxyApiBaseClass {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture =
-        pigeonVar_channel.send(<Object?>[this, require]);
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[this, require]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
-    _extractReplyValueOrThrow(
-      pigeonVar_replyList,
-      pigeonVar_channelName,
-      isNullValid: true,
-    );
+    _extractReplyValueOrThrow(pigeonVar_replyList, pigeonVar_channelName, isNullValid: true);
   }
 
   /// Sets whether the WebView should support zooming using its on-screen zoom
   /// controls and gestures.
   Future<void> setSupportZoom(bool support) async {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
-        _pigeonVar_codecWebSettings;
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecWebSettings;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
     const pigeonVar_channelName =
         'dev.flutter.pigeon.webview_flutter_android.WebSettings.setSupportZoom';
@@ -2551,22 +2347,16 @@ class WebSettings extends PigeonInternalProxyApiBaseClass {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture =
-        pigeonVar_channel.send(<Object?>[this, support]);
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[this, support]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
-    _extractReplyValueOrThrow(
-      pigeonVar_replyList,
-      pigeonVar_channelName,
-      isNullValid: true,
-    );
+    _extractReplyValueOrThrow(pigeonVar_replyList, pigeonVar_channelName, isNullValid: true);
   }
 
   /// Sets whether the WebView loads pages in overview mode, that is, zooms out
   /// the content to fit on screen by width.
   Future<void> setLoadWithOverviewMode(bool overview) async {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
-        _pigeonVar_codecWebSettings;
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecWebSettings;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
     const pigeonVar_channelName =
         'dev.flutter.pigeon.webview_flutter_android.WebSettings.setLoadWithOverviewMode';
@@ -2575,22 +2365,16 @@ class WebSettings extends PigeonInternalProxyApiBaseClass {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture =
-        pigeonVar_channel.send(<Object?>[this, overview]);
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[this, overview]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
-    _extractReplyValueOrThrow(
-      pigeonVar_replyList,
-      pigeonVar_channelName,
-      isNullValid: true,
-    );
+    _extractReplyValueOrThrow(pigeonVar_replyList, pigeonVar_channelName, isNullValid: true);
   }
 
   /// Sets whether the WebView should enable support for the "viewport" HTML
   /// meta tag or should use a wide viewport.
   Future<void> setUseWideViewPort(bool use) async {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
-        _pigeonVar_codecWebSettings;
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecWebSettings;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
     const pigeonVar_channelName =
         'dev.flutter.pigeon.webview_flutter_android.WebSettings.setUseWideViewPort';
@@ -2599,22 +2383,16 @@ class WebSettings extends PigeonInternalProxyApiBaseClass {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture =
-        pigeonVar_channel.send(<Object?>[this, use]);
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[this, use]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
-    _extractReplyValueOrThrow(
-      pigeonVar_replyList,
-      pigeonVar_channelName,
-      isNullValid: true,
-    );
+    _extractReplyValueOrThrow(pigeonVar_replyList, pigeonVar_channelName, isNullValid: true);
   }
 
   /// Sets whether the WebView should display on-screen zoom controls when using
   /// the built-in zoom mechanisms.
   Future<void> setDisplayZoomControls(bool enabled) async {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
-        _pigeonVar_codecWebSettings;
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecWebSettings;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
     const pigeonVar_channelName =
         'dev.flutter.pigeon.webview_flutter_android.WebSettings.setDisplayZoomControls';
@@ -2623,22 +2401,16 @@ class WebSettings extends PigeonInternalProxyApiBaseClass {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture =
-        pigeonVar_channel.send(<Object?>[this, enabled]);
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[this, enabled]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
-    _extractReplyValueOrThrow(
-      pigeonVar_replyList,
-      pigeonVar_channelName,
-      isNullValid: true,
-    );
+    _extractReplyValueOrThrow(pigeonVar_replyList, pigeonVar_channelName, isNullValid: true);
   }
 
   /// Sets whether the WebView should display on-screen zoom controls when using
   /// the built-in zoom mechanisms.
   Future<void> setBuiltInZoomControls(bool enabled) async {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
-        _pigeonVar_codecWebSettings;
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecWebSettings;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
     const pigeonVar_channelName =
         'dev.flutter.pigeon.webview_flutter_android.WebSettings.setBuiltInZoomControls';
@@ -2647,21 +2419,15 @@ class WebSettings extends PigeonInternalProxyApiBaseClass {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture =
-        pigeonVar_channel.send(<Object?>[this, enabled]);
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[this, enabled]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
-    _extractReplyValueOrThrow(
-      pigeonVar_replyList,
-      pigeonVar_channelName,
-      isNullValid: true,
-    );
+    _extractReplyValueOrThrow(pigeonVar_replyList, pigeonVar_channelName, isNullValid: true);
   }
 
   /// Enables or disables file access within WebView.
   Future<void> setAllowFileAccess(bool enabled) async {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
-        _pigeonVar_codecWebSettings;
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecWebSettings;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
     const pigeonVar_channelName =
         'dev.flutter.pigeon.webview_flutter_android.WebSettings.setAllowFileAccess';
@@ -2670,21 +2436,15 @@ class WebSettings extends PigeonInternalProxyApiBaseClass {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture =
-        pigeonVar_channel.send(<Object?>[this, enabled]);
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[this, enabled]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
-    _extractReplyValueOrThrow(
-      pigeonVar_replyList,
-      pigeonVar_channelName,
-      isNullValid: true,
-    );
+    _extractReplyValueOrThrow(pigeonVar_replyList, pigeonVar_channelName, isNullValid: true);
   }
 
   /// Enables or disables content URL access within WebView.
   Future<void> setAllowContentAccess(bool enabled) async {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
-        _pigeonVar_codecWebSettings;
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecWebSettings;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
     const pigeonVar_channelName =
         'dev.flutter.pigeon.webview_flutter_android.WebSettings.setAllowContentAccess';
@@ -2693,21 +2453,15 @@ class WebSettings extends PigeonInternalProxyApiBaseClass {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture =
-        pigeonVar_channel.send(<Object?>[this, enabled]);
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[this, enabled]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
-    _extractReplyValueOrThrow(
-      pigeonVar_replyList,
-      pigeonVar_channelName,
-      isNullValid: true,
-    );
+    _extractReplyValueOrThrow(pigeonVar_replyList, pigeonVar_channelName, isNullValid: true);
   }
 
   /// Sets whether Geolocation is enabled within WebView.
   Future<void> setGeolocationEnabled(bool enabled) async {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
-        _pigeonVar_codecWebSettings;
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecWebSettings;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
     const pigeonVar_channelName =
         'dev.flutter.pigeon.webview_flutter_android.WebSettings.setGeolocationEnabled';
@@ -2716,21 +2470,15 @@ class WebSettings extends PigeonInternalProxyApiBaseClass {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture =
-        pigeonVar_channel.send(<Object?>[this, enabled]);
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[this, enabled]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
-    _extractReplyValueOrThrow(
-      pigeonVar_replyList,
-      pigeonVar_channelName,
-      isNullValid: true,
-    );
+    _extractReplyValueOrThrow(pigeonVar_replyList, pigeonVar_channelName, isNullValid: true);
   }
 
   /// Sets the text zoom of the page in percent.
   Future<void> setTextZoom(int textZoom) async {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
-        _pigeonVar_codecWebSettings;
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecWebSettings;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
     const pigeonVar_channelName =
         'dev.flutter.pigeon.webview_flutter_android.WebSettings.setTextZoom';
@@ -2739,21 +2487,15 @@ class WebSettings extends PigeonInternalProxyApiBaseClass {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture =
-        pigeonVar_channel.send(<Object?>[this, textZoom]);
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[this, textZoom]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
-    _extractReplyValueOrThrow(
-      pigeonVar_replyList,
-      pigeonVar_channelName,
-      isNullValid: true,
-    );
+    _extractReplyValueOrThrow(pigeonVar_replyList, pigeonVar_channelName, isNullValid: true);
   }
 
   /// Gets the WebView's user-agent string.
   Future<String> getUserAgentString() async {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
-        _pigeonVar_codecWebSettings;
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecWebSettings;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
     const pigeonVar_channelName =
         'dev.flutter.pigeon.webview_flutter_android.WebSettings.getUserAgentString';
@@ -2762,8 +2504,7 @@ class WebSettings extends PigeonInternalProxyApiBaseClass {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture =
-        pigeonVar_channel.send(<Object?>[this]);
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[this]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
@@ -2776,8 +2517,7 @@ class WebSettings extends PigeonInternalProxyApiBaseClass {
 
   /// Configures the WebView's behavior when handling mixed content.
   Future<void> setMixedContentMode(MixedContentMode mode) async {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
-        _pigeonVar_codecWebSettings;
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecWebSettings;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
     const pigeonVar_channelName =
         'dev.flutter.pigeon.webview_flutter_android.WebSettings.setMixedContentMode';
@@ -2786,15 +2526,10 @@ class WebSettings extends PigeonInternalProxyApiBaseClass {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture =
-        pigeonVar_channel.send(<Object?>[this, mode]);
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[this, mode]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
-    _extractReplyValueOrThrow(
-      pigeonVar_replyList,
-      pigeonVar_channelName,
-      isNullValid: true,
-    );
+    _extractReplyValueOrThrow(pigeonVar_replyList, pigeonVar_channelName, isNullValid: true);
   }
 
   @override
@@ -2815,10 +2550,7 @@ class JavaScriptChannel extends PigeonInternalProxyApiBaseClass {
     BinaryMessenger? pigeon_binaryMessenger,
     PigeonInstanceManager? pigeon_instanceManager,
     required String channelName,
-    required void Function(
-      JavaScriptChannel pigeon_instance,
-      String message,
-    ) postMessage,
+    required void Function(JavaScriptChannel pigeon_instance, String message) postMessage,
   }) {
     if (PigeonOverrides.javaScriptChannel_new != null) {
       return PigeonOverrides.javaScriptChannel_new!(
@@ -2841,10 +2573,8 @@ class JavaScriptChannel extends PigeonInternalProxyApiBaseClass {
     required this.channelName,
     required this.postMessage,
   }) {
-    final int pigeonVar_instanceIdentifier =
-        pigeon_instanceManager.addDartCreatedInstance(this);
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
-        _pigeonVar_codecJavaScriptChannel;
+    final int pigeonVar_instanceIdentifier = pigeon_instanceManager.addDartCreatedInstance(this);
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecJavaScriptChannel;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
     const pigeonVar_channelName =
         'dev.flutter.pigeon.webview_flutter_android.JavaScriptChannel.pigeon_defaultConstructor';
@@ -2853,16 +2583,14 @@ class JavaScriptChannel extends PigeonInternalProxyApiBaseClass {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel
-        .send(<Object?>[pigeonVar_instanceIdentifier, channelName]);
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[
+      pigeonVar_instanceIdentifier,
+      channelName,
+    ]);
     () async {
       final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
-      _extractReplyValueOrThrow(
-        pigeonVar_replyList,
-        pigeonVar_channelName,
-        isNullValid: true,
-      );
+      _extractReplyValueOrThrow(pigeonVar_replyList, pigeonVar_channelName, isNullValid: true);
     }();
   }
 
@@ -2878,8 +2606,7 @@ class JavaScriptChannel extends PigeonInternalProxyApiBaseClass {
     required this.postMessage,
   });
 
-  late final _PigeonInternalProxyApiBaseCodec
-      _pigeonVar_codecJavaScriptChannel =
+  late final _PigeonInternalProxyApiBaseCodec _pigeonVar_codecJavaScriptChannel =
       _PigeonInternalProxyApiBaseCodec(pigeon_instanceManager);
 
   final String channelName;
@@ -2903,46 +2630,40 @@ class JavaScriptChannel extends PigeonInternalProxyApiBaseClass {
   ///
   /// Alternatively, [PigeonInstanceManager.removeWeakReference] can be used to
   /// release the associated Native object manually.
-  final void Function(
-    JavaScriptChannel pigeon_instance,
-    String message,
-  ) postMessage;
+  final void Function(JavaScriptChannel pigeon_instance, String message) postMessage;
 
   static void pigeon_setUpMessageHandlers({
     bool pigeon_clearHandlers = false,
     BinaryMessenger? pigeon_binaryMessenger,
     PigeonInstanceManager? pigeon_instanceManager,
-    void Function(
-      JavaScriptChannel pigeon_instance,
-      String message,
-    )? postMessage,
+    void Function(JavaScriptChannel pigeon_instance, String message)? postMessage,
   }) {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
-        _PigeonInternalProxyApiBaseCodec(
-            pigeon_instanceManager ?? PigeonInstanceManager.instance);
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _PigeonInternalProxyApiBaseCodec(
+      pigeon_instanceManager ?? PigeonInstanceManager.instance,
+    );
     final BinaryMessenger? binaryMessenger = pigeon_binaryMessenger;
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-          'dev.flutter.pigeon.webview_flutter_android.JavaScriptChannel.postMessage',
-          pigeonChannelCodec,
-          binaryMessenger: binaryMessenger);
+        'dev.flutter.pigeon.webview_flutter_android.JavaScriptChannel.postMessage',
+        pigeonChannelCodec,
+        binaryMessenger: binaryMessenger,
+      );
       if (pigeon_clearHandlers) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
         pigeonVar_channel.setMessageHandler((Object? message) async {
           final List<Object?> args = message! as List<Object?>;
-          final JavaScriptChannel arg_pigeon_instance =
-              args[0]! as JavaScriptChannel;
+          final JavaScriptChannel arg_pigeon_instance = args[0]! as JavaScriptChannel;
           final String arg_message = args[1]! as String;
           try {
-            (postMessage ?? arg_pigeon_instance.postMessage)
-                .call(arg_pigeon_instance, arg_message);
+            (postMessage ?? arg_pigeon_instance.postMessage).call(arg_pigeon_instance, arg_message);
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
           } catch (e) {
             return wrapResponse(
-                error: PlatformException(code: 'error', message: e.toString()));
+              error: PlatformException(code: 'error', message: e.toString()),
+            );
           }
         });
       }
@@ -2967,101 +2688,71 @@ class WebViewClient extends PigeonInternalProxyApiBaseClass {
   factory WebViewClient({
     BinaryMessenger? pigeon_binaryMessenger,
     PigeonInstanceManager? pigeon_instanceManager,
-    void Function(
-      WebViewClient pigeon_instance,
-      WebView webView,
-      String url,
-    )? onPageStarted,
-    void Function(
-      WebViewClient pigeon_instance,
-      WebView webView,
-      String url,
-    )? onPageFinished,
+    void Function(WebViewClient pigeon_instance, WebView webView, String url)? onPageStarted,
+    void Function(WebViewClient pigeon_instance, WebView webView, String url)? onPageFinished,
     void Function(
       WebViewClient pigeon_instance,
       WebView webView,
       WebResourceRequest request,
       WebResourceResponse response,
-    )? onReceivedHttpError,
+    )?
+    onReceivedHttpError,
     void Function(
       WebViewClient pigeon_instance,
       WebView webView,
       WebResourceRequest request,
       WebResourceError error,
-    )? onReceivedRequestError,
+    )?
+    onReceivedRequestError,
     void Function(
       WebViewClient pigeon_instance,
       WebView webView,
       WebResourceRequest request,
       WebResourceErrorCompat error,
-    )? onReceivedRequestErrorCompat,
-    void Function(
-      WebViewClient pigeon_instance,
-      WebView webView,
-      WebResourceRequest request,
-    )? requestLoading,
-    void Function(
-      WebViewClient pigeon_instance,
-      WebView webView,
-      String url,
-    )? urlLoading,
-    void Function(
-      WebViewClient pigeon_instance,
-      String url,
-    )? onCreateWindow,
-    void Function(
-      WebViewClient pigeon_instance,
-      WebView webView,
-      String url,
-      bool isReload,
-    )? doUpdateVisitedHistory,
+    )?
+    onReceivedRequestErrorCompat,
+    void Function(WebViewClient pigeon_instance, WebView webView, WebResourceRequest request)?
+    requestLoading,
+    void Function(WebViewClient pigeon_instance, WebView webView, String url)? urlLoading,
+    void Function(WebViewClient pigeon_instance, String url)? onCreateWindow,
+    void Function(WebViewClient pigeon_instance, WebView webView, String url, bool isReload)?
+    doUpdateVisitedHistory,
     void Function(
       WebViewClient pigeon_instance,
       WebView webView,
       HttpAuthHandler handler,
       String host,
       String realm,
-    )? onReceivedHttpAuthRequest,
+    )?
+    onReceivedHttpAuthRequest,
     void Function(
       WebViewClient pigeon_instance,
       WebView view,
       AndroidMessage dontResend,
       AndroidMessage resend,
-    )? onFormResubmission,
-    void Function(
-      WebViewClient pigeon_instance,
-      WebView view,
-      String url,
-    )? onLoadResource,
-    void Function(
-      WebViewClient pigeon_instance,
-      WebView view,
-      String url,
-    )? onPageCommitVisible,
-    void Function(
-      WebViewClient pigeon_instance,
-      WebView view,
-      ClientCertRequest request,
-    )? onReceivedClientCertRequest,
+    )?
+    onFormResubmission,
+    void Function(WebViewClient pigeon_instance, WebView view, String url)? onLoadResource,
+    void Function(WebViewClient pigeon_instance, WebView view, String url)? onPageCommitVisible,
+    void Function(WebViewClient pigeon_instance, WebView view, ClientCertRequest request)?
+    onReceivedClientCertRequest,
     void Function(
       WebViewClient pigeon_instance,
       WebView view,
       String realm,
       String? account,
       String args,
-    )? onReceivedLoginRequest,
+    )?
+    onReceivedLoginRequest,
     void Function(
       WebViewClient pigeon_instance,
       WebView view,
       SslErrorHandler handler,
       SslError error,
-    )? onReceivedSslError,
-    void Function(
-      WebViewClient pigeon_instance,
-      WebView view,
-      double oldScale,
-      double newScale,
-    )? onScaleChanged,
+    )?
+    onReceivedSslError,
+    void Function(WebViewClient pigeon_instance, WebView view, double oldScale, double newScale)?
+    onScaleChanged,
   }) {
     if (PigeonOverrides.webViewClient_new != null) {
       return PigeonOverrides.webViewClient_new!(
@@ -3129,10 +2820,8 @@ class WebViewClient extends PigeonInternalProxyApiBaseClass {
     this.onReceivedSslError,
     this.onScaleChanged,
   }) {
-    final int pigeonVar_instanceIdentifier =
-        pigeon_instanceManager.addDartCreatedInstance(this);
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
-        _pigeonVar_codecWebViewClient;
+    final int pigeonVar_instanceIdentifier = pigeon_instanceManager.addDartCreatedInstance(this);
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecWebViewClient;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
     const pigeonVar_channelName =
         'dev.flutter.pigeon.webview_flutter_android.WebViewClient.pigeon_defaultConstructor';
@@ -3141,16 +2830,13 @@ class WebViewClient extends PigeonInternalProxyApiBaseClass {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture =
-        pigeonVar_channel.send(<Object?>[pigeonVar_instanceIdentifier]);
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[
+      pigeonVar_instanceIdentifier,
+    ]);
     () async {
       final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
-      _extractReplyValueOrThrow(
-        pigeonVar_replyList,
-        pigeonVar_channelName,
-        isNullValid: true,
-      );
+      _extractReplyValueOrThrow(pigeonVar_replyList, pigeonVar_channelName, isNullValid: true);
     }();
   }
 
@@ -3203,11 +2889,7 @@ class WebViewClient extends PigeonInternalProxyApiBaseClass {
   ///
   /// Alternatively, [PigeonInstanceManager.removeWeakReference] can be used to
   /// release the associated Native object manually.
-  final void Function(
-    WebViewClient pigeon_instance,
-    WebView webView,
-    String url,
-  )? onPageStarted;
+  final void Function(WebViewClient pigeon_instance, WebView webView, String url)? onPageStarted;
 
   /// Notify the host application that a page has finished loading.
   ///
@@ -3228,11 +2910,7 @@ class WebViewClient extends PigeonInternalProxyApiBaseClass {
   ///
   /// Alternatively, [PigeonInstanceManager.removeWeakReference] can be used to
   /// release the associated Native object manually.
-  final void Function(
-    WebViewClient pigeon_instance,
-    WebView webView,
-    String url,
-  )? onPageFinished;
+  final void Function(WebViewClient pigeon_instance, WebView webView, String url)? onPageFinished;
 
   /// Notify the host application that an HTTP error has been received from the
   /// server while loading a resource.
@@ -3259,7 +2937,8 @@ class WebViewClient extends PigeonInternalProxyApiBaseClass {
     WebView webView,
     WebResourceRequest request,
     WebResourceResponse response,
-  )? onReceivedHttpError;
+  )?
+  onReceivedHttpError;
 
   /// Report web resource loading error to the host application.
   ///
@@ -3285,7 +2964,8 @@ class WebViewClient extends PigeonInternalProxyApiBaseClass {
     WebView webView,
     WebResourceRequest request,
     WebResourceError error,
-  )? onReceivedRequestError;
+  )?
+  onReceivedRequestError;
 
   /// Report web resource loading error to the host application.
   ///
@@ -3311,7 +2991,8 @@ class WebViewClient extends PigeonInternalProxyApiBaseClass {
     WebView webView,
     WebResourceRequest request,
     WebResourceErrorCompat error,
-  )? onReceivedRequestErrorCompat;
+  )?
+  onReceivedRequestErrorCompat;
 
   /// Give the host application a chance to take control when a URL is about to
   /// be loaded in the current WebView.
@@ -3333,11 +3014,8 @@ class WebViewClient extends PigeonInternalProxyApiBaseClass {
   ///
   /// Alternatively, [PigeonInstanceManager.removeWeakReference] can be used to
   /// release the associated Native object manually.
-  final void Function(
-    WebViewClient pigeon_instance,
-    WebView webView,
-    WebResourceRequest request,
-  )? requestLoading;
+  final void Function(WebViewClient pigeon_instance, WebView webView, WebResourceRequest request)?
+  requestLoading;
 
   /// Give the host application a chance to take control when a URL is about to
   /// be loaded in the current WebView.
@@ -3359,11 +3037,7 @@ class WebViewClient extends PigeonInternalProxyApiBaseClass {
   ///
   /// Alternatively, [PigeonInstanceManager.removeWeakReference] can be used to
   /// release the associated Native object manually.
-  final void Function(
-    WebViewClient pigeon_instance,
-    WebView webView,
-    String url,
-  )? urlLoading;
+  final void Function(WebViewClient pigeon_instance, WebView webView, String url)? urlLoading;
 
   /// Notifies the host that the page requested a new window
   /// (`target=_blank` / `window.open`).
@@ -3385,10 +3059,7 @@ class WebViewClient extends PigeonInternalProxyApiBaseClass {
   ///
   /// Alternatively, [PigeonInstanceManager.removeWeakReference] can be used to
   /// release the associated Native object manually.
-  final void Function(
-    WebViewClient pigeon_instance,
-    String url,
-  )? onCreateWindow;
+  final void Function(WebViewClient pigeon_instance, String url)? onCreateWindow;
 
   /// Notify the host application to update its visited links database.
   ///
@@ -3409,12 +3080,8 @@ class WebViewClient extends PigeonInternalProxyApiBaseClass {
   ///
   /// Alternatively, [PigeonInstanceManager.removeWeakReference] can be used to
   /// release the associated Native object manually.
-  final void Function(
-    WebViewClient pigeon_instance,
-    WebView webView,
-    String url,
-    bool isReload,
-  )? doUpdateVisitedHistory;
+  final void Function(WebViewClient pigeon_instance, WebView webView, String url, bool isReload)?
+  doUpdateVisitedHistory;
 
   /// Notifies the host application that the WebView received an HTTP
   /// authentication request.
@@ -3442,7 +3109,8 @@ class WebViewClient extends PigeonInternalProxyApiBaseClass {
     HttpAuthHandler handler,
     String host,
     String realm,
-  )? onReceivedHttpAuthRequest;
+  )?
+  onReceivedHttpAuthRequest;
 
   /// Ask the host application if the browser should resend data as the
   /// requested page was a result of a POST.
@@ -3469,7 +3137,8 @@ class WebViewClient extends PigeonInternalProxyApiBaseClass {
     WebView view,
     AndroidMessage dontResend,
     AndroidMessage resend,
-  )? onFormResubmission;
+  )?
+  onFormResubmission;
 
   /// Notify the host application that the WebView will load the resource
   /// specified by the given url.
@@ -3491,11 +3160,7 @@ class WebViewClient extends PigeonInternalProxyApiBaseClass {
   ///
   /// Alternatively, [PigeonInstanceManager.removeWeakReference] can be used to
   /// release the associated Native object manually.
-  final void Function(
-    WebViewClient pigeon_instance,
-    WebView view,
-    String url,
-  )? onLoadResource;
+  final void Function(WebViewClient pigeon_instance, WebView view, String url)? onLoadResource;
 
   /// Notify the host application that WebView content left over from previous
   /// page navigations will no longer be drawn.
@@ -3517,11 +3182,7 @@ class WebViewClient extends PigeonInternalProxyApiBaseClass {
   ///
   /// Alternatively, [PigeonInstanceManager.removeWeakReference] can be used to
   /// release the associated Native object manually.
-  final void Function(
-    WebViewClient pigeon_instance,
-    WebView view,
-    String url,
-  )? onPageCommitVisible;
+  final void Function(WebViewClient pigeon_instance, WebView view, String url)? onPageCommitVisible;
 
   /// Notify the host application to handle a SSL client certificate request.
   ///
@@ -3542,11 +3203,8 @@ class WebViewClient extends PigeonInternalProxyApiBaseClass {
   ///
   /// Alternatively, [PigeonInstanceManager.removeWeakReference] can be used to
   /// release the associated Native object manually.
-  final void Function(
-    WebViewClient pigeon_instance,
-    WebView view,
-    ClientCertRequest request,
-  )? onReceivedClientCertRequest;
+  final void Function(WebViewClient pigeon_instance, WebView view, ClientCertRequest request)?
+  onReceivedClientCertRequest;
 
   /// Notify the host application that a request to automatically log in the
   /// user has been processed.
@@ -3574,7 +3232,8 @@ class WebViewClient extends PigeonInternalProxyApiBaseClass {
     String realm,
     String? account,
     String args,
-  )? onReceivedLoginRequest;
+  )?
+  onReceivedLoginRequest;
 
   /// Notifies the host application that an SSL error occurred while loading a
   /// resource.
@@ -3601,7 +3260,8 @@ class WebViewClient extends PigeonInternalProxyApiBaseClass {
     WebView view,
     SslErrorHandler handler,
     SslError error,
-  )? onReceivedSslError;
+  )?
+  onReceivedSslError;
 
   /// Notify the host application that the scale applied to the WebView has
   /// changed.
@@ -3628,118 +3288,90 @@ class WebViewClient extends PigeonInternalProxyApiBaseClass {
     WebView view,
     double oldScale,
     double newScale,
-  )? onScaleChanged;
+  )?
+  onScaleChanged;
 
   static void pigeon_setUpMessageHandlers({
     bool pigeon_clearHandlers = false,
     BinaryMessenger? pigeon_binaryMessenger,
     PigeonInstanceManager? pigeon_instanceManager,
     WebViewClient Function()? pigeon_newInstance,
-    void Function(
-      WebViewClient pigeon_instance,
-      WebView webView,
-      String url,
-    )? onPageStarted,
-    void Function(
-      WebViewClient pigeon_instance,
-      WebView webView,
-      String url,
-    )? onPageFinished,
+    void Function(WebViewClient pigeon_instance, WebView webView, String url)? onPageStarted,
+    void Function(WebViewClient pigeon_instance, WebView webView, String url)? onPageFinished,
     void Function(
       WebViewClient pigeon_instance,
       WebView webView,
       WebResourceRequest request,
       WebResourceResponse response,
-    )? onReceivedHttpError,
+    )?
+    onReceivedHttpError,
     void Function(
       WebViewClient pigeon_instance,
       WebView webView,
       WebResourceRequest request,
       WebResourceError error,
-    )? onReceivedRequestError,
+    )?
+    onReceivedRequestError,
     void Function(
       WebViewClient pigeon_instance,
       WebView webView,
       WebResourceRequest request,
       WebResourceErrorCompat error,
-    )? onReceivedRequestErrorCompat,
-    void Function(
-      WebViewClient pigeon_instance,
-      WebView webView,
-      WebResourceRequest request,
-    )? requestLoading,
-    void Function(
-      WebViewClient pigeon_instance,
-      WebView webView,
-      String url,
-    )? urlLoading,
-    void Function(
-      WebViewClient pigeon_instance,
-      String url,
-    )? onCreateWindow,
-    void Function(
-      WebViewClient pigeon_instance,
-      WebView webView,
-      String url,
-      bool isReload,
-    )? doUpdateVisitedHistory,
+    )?
+    onReceivedRequestErrorCompat,
+    void Function(WebViewClient pigeon_instance, WebView webView, WebResourceRequest request)?
+    requestLoading,
+    void Function(WebViewClient pigeon_instance, WebView webView, String url)? urlLoading,
+    void Function(WebViewClient pigeon_instance, String url)? onCreateWindow,
+    void Function(WebViewClient pigeon_instance, WebView webView, String url, bool isReload)?
+    doUpdateVisitedHistory,
     void Function(
       WebViewClient pigeon_instance,
       WebView webView,
       HttpAuthHandler handler,
       String host,
       String realm,
-    )? onReceivedHttpAuthRequest,
+    )?
+    onReceivedHttpAuthRequest,
     void Function(
       WebViewClient pigeon_instance,
       WebView view,
       AndroidMessage dontResend,
       AndroidMessage resend,
-    )? onFormResubmission,
-    void Function(
-      WebViewClient pigeon_instance,
-      WebView view,
-      String url,
-    )? onLoadResource,
-    void Function(
-      WebViewClient pigeon_instance,
-      WebView view,
-      String url,
-    )? onPageCommitVisible,
-    void Function(
-      WebViewClient pigeon_instance,
-      WebView view,
-      ClientCertRequest request,
-    )? onReceivedClientCertRequest,
+    )?
+    onFormResubmission,
+    void Function(WebViewClient pigeon_instance, WebView view, String url)? onLoadResource,
+    void Function(WebViewClient pigeon_instance, WebView view, String url)? onPageCommitVisible,
+    void Function(WebViewClient pigeon_instance, WebView view, ClientCertRequest request)?
+    onReceivedClientCertRequest,
     void Function(
       WebViewClient pigeon_instance,
       WebView view,
       String realm,
       String? account,
       String args,
-    )? onReceivedLoginRequest,
+    )?
+    onReceivedLoginRequest,
     void Function(
       WebViewClient pigeon_instance,
       WebView view,
       SslErrorHandler handler,
       SslError error,
-    )? onReceivedSslError,
-    void Function(
-      WebViewClient pigeon_instance,
-      WebView view,
-      double oldScale,
-      double newScale,
-    )? onScaleChanged,
+    )?
+    onReceivedSslError,
+    void Function(WebViewClient pigeon_instance, WebView view, double oldScale, double newScale)?
+    onScaleChanged,
   }) {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
-        _PigeonInternalProxyApiBaseCodec(
-            pigeon_instanceManager ?? PigeonInstanceManager.instance);
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _PigeonInternalProxyApiBaseCodec(
+      pigeon_instanceManager ?? PigeonInstanceManager.instance,
+    );
     final BinaryMessenger? binaryMessenger = pigeon_binaryMessenger;
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-          'dev.flutter.pigeon.webview_flutter_android.WebViewClient.pigeon_newInstance',
-          pigeonChannelCodec,
-          binaryMessenger: binaryMessenger);
+        'dev.flutter.pigeon.webview_flutter_android.WebViewClient.pigeon_newInstance',
+        pigeonChannelCodec,
+        binaryMessenger: binaryMessenger,
+      );
       if (pigeon_clearHandlers) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
@@ -3747,8 +3379,7 @@ class WebViewClient extends PigeonInternalProxyApiBaseClass {
           final List<Object?> args = message! as List<Object?>;
           final int arg_pigeon_instanceIdentifier = args[0]! as int;
           try {
-            (pigeon_instanceManager ?? PigeonInstanceManager.instance)
-                .addHostCreatedInstance(
+            (pigeon_instanceManager ?? PigeonInstanceManager.instance).addHostCreatedInstance(
               pigeon_newInstance?.call() ??
                   WebViewClient.pigeon_detached(
                     pigeon_binaryMessenger: pigeon_binaryMessenger,
@@ -3761,7 +3392,8 @@ class WebViewClient extends PigeonInternalProxyApiBaseClass {
             return wrapResponse(error: e);
           } catch (e) {
             return wrapResponse(
-                error: PlatformException(code: 'error', message: e.toString()));
+              error: PlatformException(code: 'error', message: e.toString()),
+            );
           }
         });
       }
@@ -3769,9 +3401,10 @@ class WebViewClient extends PigeonInternalProxyApiBaseClass {
 
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-          'dev.flutter.pigeon.webview_flutter_android.WebViewClient.onPageStarted',
-          pigeonChannelCodec,
-          binaryMessenger: binaryMessenger);
+        'dev.flutter.pigeon.webview_flutter_android.WebViewClient.onPageStarted',
+        pigeonChannelCodec,
+        binaryMessenger: binaryMessenger,
+      );
       if (pigeon_clearHandlers) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
@@ -3781,14 +3414,18 @@ class WebViewClient extends PigeonInternalProxyApiBaseClass {
           final WebView arg_webView = args[1]! as WebView;
           final String arg_url = args[2]! as String;
           try {
-            (onPageStarted ?? arg_pigeon_instance.onPageStarted)
-                ?.call(arg_pigeon_instance, arg_webView, arg_url);
+            (onPageStarted ?? arg_pigeon_instance.onPageStarted)?.call(
+              arg_pigeon_instance,
+              arg_webView,
+              arg_url,
+            );
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
           } catch (e) {
             return wrapResponse(
-                error: PlatformException(code: 'error', message: e.toString()));
+              error: PlatformException(code: 'error', message: e.toString()),
+            );
           }
         });
       }
@@ -3796,9 +3433,10 @@ class WebViewClient extends PigeonInternalProxyApiBaseClass {
 
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-          'dev.flutter.pigeon.webview_flutter_android.WebViewClient.onPageFinished',
-          pigeonChannelCodec,
-          binaryMessenger: binaryMessenger);
+        'dev.flutter.pigeon.webview_flutter_android.WebViewClient.onPageFinished',
+        pigeonChannelCodec,
+        binaryMessenger: binaryMessenger,
+      );
       if (pigeon_clearHandlers) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
@@ -3808,14 +3446,18 @@ class WebViewClient extends PigeonInternalProxyApiBaseClass {
           final WebView arg_webView = args[1]! as WebView;
           final String arg_url = args[2]! as String;
           try {
-            (onPageFinished ?? arg_pigeon_instance.onPageFinished)
-                ?.call(arg_pigeon_instance, arg_webView, arg_url);
+            (onPageFinished ?? arg_pigeon_instance.onPageFinished)?.call(
+              arg_pigeon_instance,
+              arg_webView,
+              arg_url,
+            );
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
           } catch (e) {
             return wrapResponse(
-                error: PlatformException(code: 'error', message: e.toString()));
+              error: PlatformException(code: 'error', message: e.toString()),
+            );
           }
         });
       }
@@ -3823,9 +3465,10 @@ class WebViewClient extends PigeonInternalProxyApiBaseClass {
 
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-          'dev.flutter.pigeon.webview_flutter_android.WebViewClient.onReceivedHttpError',
-          pigeonChannelCodec,
-          binaryMessenger: binaryMessenger);
+        'dev.flutter.pigeon.webview_flutter_android.WebViewClient.onReceivedHttpError',
+        pigeonChannelCodec,
+        binaryMessenger: binaryMessenger,
+      );
       if (pigeon_clearHandlers) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
@@ -3834,18 +3477,21 @@ class WebViewClient extends PigeonInternalProxyApiBaseClass {
           final WebViewClient arg_pigeon_instance = args[0]! as WebViewClient;
           final WebView arg_webView = args[1]! as WebView;
           final WebResourceRequest arg_request = args[2]! as WebResourceRequest;
-          final WebResourceResponse arg_response =
-              args[3]! as WebResourceResponse;
+          final WebResourceResponse arg_response = args[3]! as WebResourceResponse;
           try {
-            (onReceivedHttpError ?? arg_pigeon_instance.onReceivedHttpError)
-                ?.call(arg_pigeon_instance, arg_webView, arg_request,
-                    arg_response);
+            (onReceivedHttpError ?? arg_pigeon_instance.onReceivedHttpError)?.call(
+              arg_pigeon_instance,
+              arg_webView,
+              arg_request,
+              arg_response,
+            );
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
           } catch (e) {
             return wrapResponse(
-                error: PlatformException(code: 'error', message: e.toString()));
+              error: PlatformException(code: 'error', message: e.toString()),
+            );
           }
         });
       }
@@ -3853,9 +3499,10 @@ class WebViewClient extends PigeonInternalProxyApiBaseClass {
 
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-          'dev.flutter.pigeon.webview_flutter_android.WebViewClient.onReceivedRequestError',
-          pigeonChannelCodec,
-          binaryMessenger: binaryMessenger);
+        'dev.flutter.pigeon.webview_flutter_android.WebViewClient.onReceivedRequestError',
+        pigeonChannelCodec,
+        binaryMessenger: binaryMessenger,
+      );
       if (pigeon_clearHandlers) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
@@ -3866,16 +3513,19 @@ class WebViewClient extends PigeonInternalProxyApiBaseClass {
           final WebResourceRequest arg_request = args[2]! as WebResourceRequest;
           final WebResourceError arg_error = args[3]! as WebResourceError;
           try {
-            (onReceivedRequestError ??
-                    arg_pigeon_instance.onReceivedRequestError)
-                ?.call(
-                    arg_pigeon_instance, arg_webView, arg_request, arg_error);
+            (onReceivedRequestError ?? arg_pigeon_instance.onReceivedRequestError)?.call(
+              arg_pigeon_instance,
+              arg_webView,
+              arg_request,
+              arg_error,
+            );
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
           } catch (e) {
             return wrapResponse(
-                error: PlatformException(code: 'error', message: e.toString()));
+              error: PlatformException(code: 'error', message: e.toString()),
+            );
           }
         });
       }
@@ -3883,9 +3533,10 @@ class WebViewClient extends PigeonInternalProxyApiBaseClass {
 
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-          'dev.flutter.pigeon.webview_flutter_android.WebViewClient.onReceivedRequestErrorCompat',
-          pigeonChannelCodec,
-          binaryMessenger: binaryMessenger);
+        'dev.flutter.pigeon.webview_flutter_android.WebViewClient.onReceivedRequestErrorCompat',
+        pigeonChannelCodec,
+        binaryMessenger: binaryMessenger,
+      );
       if (pigeon_clearHandlers) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
@@ -3894,19 +3545,17 @@ class WebViewClient extends PigeonInternalProxyApiBaseClass {
           final WebViewClient arg_pigeon_instance = args[0]! as WebViewClient;
           final WebView arg_webView = args[1]! as WebView;
           final WebResourceRequest arg_request = args[2]! as WebResourceRequest;
-          final WebResourceErrorCompat arg_error =
-              args[3]! as WebResourceErrorCompat;
+          final WebResourceErrorCompat arg_error = args[3]! as WebResourceErrorCompat;
           try {
-            (onReceivedRequestErrorCompat ??
-                    arg_pigeon_instance.onReceivedRequestErrorCompat)
-                ?.call(
-                    arg_pigeon_instance, arg_webView, arg_request, arg_error);
+            (onReceivedRequestErrorCompat ?? arg_pigeon_instance.onReceivedRequestErrorCompat)
+                ?.call(arg_pigeon_instance, arg_webView, arg_request, arg_error);
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
           } catch (e) {
             return wrapResponse(
-                error: PlatformException(code: 'error', message: e.toString()));
+              error: PlatformException(code: 'error', message: e.toString()),
+            );
           }
         });
       }
@@ -3914,9 +3563,10 @@ class WebViewClient extends PigeonInternalProxyApiBaseClass {
 
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-          'dev.flutter.pigeon.webview_flutter_android.WebViewClient.requestLoading',
-          pigeonChannelCodec,
-          binaryMessenger: binaryMessenger);
+        'dev.flutter.pigeon.webview_flutter_android.WebViewClient.requestLoading',
+        pigeonChannelCodec,
+        binaryMessenger: binaryMessenger,
+      );
       if (pigeon_clearHandlers) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
@@ -3926,14 +3576,18 @@ class WebViewClient extends PigeonInternalProxyApiBaseClass {
           final WebView arg_webView = args[1]! as WebView;
           final WebResourceRequest arg_request = args[2]! as WebResourceRequest;
           try {
-            (requestLoading ?? arg_pigeon_instance.requestLoading)
-                ?.call(arg_pigeon_instance, arg_webView, arg_request);
+            (requestLoading ?? arg_pigeon_instance.requestLoading)?.call(
+              arg_pigeon_instance,
+              arg_webView,
+              arg_request,
+            );
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
           } catch (e) {
             return wrapResponse(
-                error: PlatformException(code: 'error', message: e.toString()));
+              error: PlatformException(code: 'error', message: e.toString()),
+            );
           }
         });
       }
@@ -3941,9 +3595,10 @@ class WebViewClient extends PigeonInternalProxyApiBaseClass {
 
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-          'dev.flutter.pigeon.webview_flutter_android.WebViewClient.urlLoading',
-          pigeonChannelCodec,
-          binaryMessenger: binaryMessenger);
+        'dev.flutter.pigeon.webview_flutter_android.WebViewClient.urlLoading',
+        pigeonChannelCodec,
+        binaryMessenger: binaryMessenger,
+      );
       if (pigeon_clearHandlers) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
@@ -3953,14 +3608,18 @@ class WebViewClient extends PigeonInternalProxyApiBaseClass {
           final WebView arg_webView = args[1]! as WebView;
           final String arg_url = args[2]! as String;
           try {
-            (urlLoading ?? arg_pigeon_instance.urlLoading)
-                ?.call(arg_pigeon_instance, arg_webView, arg_url);
+            (urlLoading ?? arg_pigeon_instance.urlLoading)?.call(
+              arg_pigeon_instance,
+              arg_webView,
+              arg_url,
+            );
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
           } catch (e) {
             return wrapResponse(
-                error: PlatformException(code: 'error', message: e.toString()));
+              error: PlatformException(code: 'error', message: e.toString()),
+            );
           }
         });
       }
@@ -3968,9 +3627,10 @@ class WebViewClient extends PigeonInternalProxyApiBaseClass {
 
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-          'dev.flutter.pigeon.webview_flutter_android.WebViewClient.onCreateWindow',
-          pigeonChannelCodec,
-          binaryMessenger: binaryMessenger);
+        'dev.flutter.pigeon.webview_flutter_android.WebViewClient.onCreateWindow',
+        pigeonChannelCodec,
+        binaryMessenger: binaryMessenger,
+      );
       if (pigeon_clearHandlers) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
@@ -3979,14 +3639,17 @@ class WebViewClient extends PigeonInternalProxyApiBaseClass {
           final WebViewClient arg_pigeon_instance = args[0]! as WebViewClient;
           final String arg_url = args[1]! as String;
           try {
-            (onCreateWindow ?? arg_pigeon_instance.onCreateWindow)
-                ?.call(arg_pigeon_instance, arg_url);
+            (onCreateWindow ?? arg_pigeon_instance.onCreateWindow)?.call(
+              arg_pigeon_instance,
+              arg_url,
+            );
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
           } catch (e) {
             return wrapResponse(
-                error: PlatformException(code: 'error', message: e.toString()));
+              error: PlatformException(code: 'error', message: e.toString()),
+            );
           }
         });
       }
@@ -3994,9 +3657,10 @@ class WebViewClient extends PigeonInternalProxyApiBaseClass {
 
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-          'dev.flutter.pigeon.webview_flutter_android.WebViewClient.doUpdateVisitedHistory',
-          pigeonChannelCodec,
-          binaryMessenger: binaryMessenger);
+        'dev.flutter.pigeon.webview_flutter_android.WebViewClient.doUpdateVisitedHistory',
+        pigeonChannelCodec,
+        binaryMessenger: binaryMessenger,
+      );
       if (pigeon_clearHandlers) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
@@ -4007,15 +3671,19 @@ class WebViewClient extends PigeonInternalProxyApiBaseClass {
           final String arg_url = args[2]! as String;
           final bool arg_isReload = args[3]! as bool;
           try {
-            (doUpdateVisitedHistory ??
-                    arg_pigeon_instance.doUpdateVisitedHistory)
-                ?.call(arg_pigeon_instance, arg_webView, arg_url, arg_isReload);
+            (doUpdateVisitedHistory ?? arg_pigeon_instance.doUpdateVisitedHistory)?.call(
+              arg_pigeon_instance,
+              arg_webView,
+              arg_url,
+              arg_isReload,
+            );
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
           } catch (e) {
             return wrapResponse(
-                error: PlatformException(code: 'error', message: e.toString()));
+              error: PlatformException(code: 'error', message: e.toString()),
+            );
           }
         });
       }
@@ -4023,9 +3691,10 @@ class WebViewClient extends PigeonInternalProxyApiBaseClass {
 
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-          'dev.flutter.pigeon.webview_flutter_android.WebViewClient.onReceivedHttpAuthRequest',
-          pigeonChannelCodec,
-          binaryMessenger: binaryMessenger);
+        'dev.flutter.pigeon.webview_flutter_android.WebViewClient.onReceivedHttpAuthRequest',
+        pigeonChannelCodec,
+        binaryMessenger: binaryMessenger,
+      );
       if (pigeon_clearHandlers) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
@@ -4037,16 +3706,20 @@ class WebViewClient extends PigeonInternalProxyApiBaseClass {
           final String arg_host = args[3]! as String;
           final String arg_realm = args[4]! as String;
           try {
-            (onReceivedHttpAuthRequest ??
-                    arg_pigeon_instance.onReceivedHttpAuthRequest)
-                ?.call(arg_pigeon_instance, arg_webView, arg_handler, arg_host,
-                    arg_realm);
+            (onReceivedHttpAuthRequest ?? arg_pigeon_instance.onReceivedHttpAuthRequest)?.call(
+              arg_pigeon_instance,
+              arg_webView,
+              arg_handler,
+              arg_host,
+              arg_realm,
+            );
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
           } catch (e) {
             return wrapResponse(
-                error: PlatformException(code: 'error', message: e.toString()));
+              error: PlatformException(code: 'error', message: e.toString()),
+            );
           }
         });
       }
@@ -4054,9 +3727,10 @@ class WebViewClient extends PigeonInternalProxyApiBaseClass {
 
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-          'dev.flutter.pigeon.webview_flutter_android.WebViewClient.onFormResubmission',
-          pigeonChannelCodec,
-          binaryMessenger: binaryMessenger);
+        'dev.flutter.pigeon.webview_flutter_android.WebViewClient.onFormResubmission',
+        pigeonChannelCodec,
+        binaryMessenger: binaryMessenger,
+      );
       if (pigeon_clearHandlers) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
@@ -4067,15 +3741,19 @@ class WebViewClient extends PigeonInternalProxyApiBaseClass {
           final AndroidMessage arg_dontResend = args[2]! as AndroidMessage;
           final AndroidMessage arg_resend = args[3]! as AndroidMessage;
           try {
-            (onFormResubmission ?? arg_pigeon_instance.onFormResubmission)
-                ?.call(
-                    arg_pigeon_instance, arg_view, arg_dontResend, arg_resend);
+            (onFormResubmission ?? arg_pigeon_instance.onFormResubmission)?.call(
+              arg_pigeon_instance,
+              arg_view,
+              arg_dontResend,
+              arg_resend,
+            );
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
           } catch (e) {
             return wrapResponse(
-                error: PlatformException(code: 'error', message: e.toString()));
+              error: PlatformException(code: 'error', message: e.toString()),
+            );
           }
         });
       }
@@ -4083,9 +3761,10 @@ class WebViewClient extends PigeonInternalProxyApiBaseClass {
 
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-          'dev.flutter.pigeon.webview_flutter_android.WebViewClient.onLoadResource',
-          pigeonChannelCodec,
-          binaryMessenger: binaryMessenger);
+        'dev.flutter.pigeon.webview_flutter_android.WebViewClient.onLoadResource',
+        pigeonChannelCodec,
+        binaryMessenger: binaryMessenger,
+      );
       if (pigeon_clearHandlers) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
@@ -4095,14 +3774,18 @@ class WebViewClient extends PigeonInternalProxyApiBaseClass {
           final WebView arg_view = args[1]! as WebView;
           final String arg_url = args[2]! as String;
           try {
-            (onLoadResource ?? arg_pigeon_instance.onLoadResource)
-                ?.call(arg_pigeon_instance, arg_view, arg_url);
+            (onLoadResource ?? arg_pigeon_instance.onLoadResource)?.call(
+              arg_pigeon_instance,
+              arg_view,
+              arg_url,
+            );
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
           } catch (e) {
             return wrapResponse(
-                error: PlatformException(code: 'error', message: e.toString()));
+              error: PlatformException(code: 'error', message: e.toString()),
+            );
           }
         });
       }
@@ -4110,9 +3793,10 @@ class WebViewClient extends PigeonInternalProxyApiBaseClass {
 
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-          'dev.flutter.pigeon.webview_flutter_android.WebViewClient.onPageCommitVisible',
-          pigeonChannelCodec,
-          binaryMessenger: binaryMessenger);
+        'dev.flutter.pigeon.webview_flutter_android.WebViewClient.onPageCommitVisible',
+        pigeonChannelCodec,
+        binaryMessenger: binaryMessenger,
+      );
       if (pigeon_clearHandlers) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
@@ -4122,14 +3806,18 @@ class WebViewClient extends PigeonInternalProxyApiBaseClass {
           final WebView arg_view = args[1]! as WebView;
           final String arg_url = args[2]! as String;
           try {
-            (onPageCommitVisible ?? arg_pigeon_instance.onPageCommitVisible)
-                ?.call(arg_pigeon_instance, arg_view, arg_url);
+            (onPageCommitVisible ?? arg_pigeon_instance.onPageCommitVisible)?.call(
+              arg_pigeon_instance,
+              arg_view,
+              arg_url,
+            );
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
           } catch (e) {
             return wrapResponse(
-                error: PlatformException(code: 'error', message: e.toString()));
+              error: PlatformException(code: 'error', message: e.toString()),
+            );
           }
         });
       }
@@ -4137,9 +3825,10 @@ class WebViewClient extends PigeonInternalProxyApiBaseClass {
 
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-          'dev.flutter.pigeon.webview_flutter_android.WebViewClient.onReceivedClientCertRequest',
-          pigeonChannelCodec,
-          binaryMessenger: binaryMessenger);
+        'dev.flutter.pigeon.webview_flutter_android.WebViewClient.onReceivedClientCertRequest',
+        pigeonChannelCodec,
+        binaryMessenger: binaryMessenger,
+      );
       if (pigeon_clearHandlers) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
@@ -4149,15 +3838,18 @@ class WebViewClient extends PigeonInternalProxyApiBaseClass {
           final WebView arg_view = args[1]! as WebView;
           final ClientCertRequest arg_request = args[2]! as ClientCertRequest;
           try {
-            (onReceivedClientCertRequest ??
-                    arg_pigeon_instance.onReceivedClientCertRequest)
-                ?.call(arg_pigeon_instance, arg_view, arg_request);
+            (onReceivedClientCertRequest ?? arg_pigeon_instance.onReceivedClientCertRequest)?.call(
+              arg_pigeon_instance,
+              arg_view,
+              arg_request,
+            );
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
           } catch (e) {
             return wrapResponse(
-                error: PlatformException(code: 'error', message: e.toString()));
+              error: PlatformException(code: 'error', message: e.toString()),
+            );
           }
         });
       }
@@ -4165,9 +3857,10 @@ class WebViewClient extends PigeonInternalProxyApiBaseClass {
 
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-          'dev.flutter.pigeon.webview_flutter_android.WebViewClient.onReceivedLoginRequest',
-          pigeonChannelCodec,
-          binaryMessenger: binaryMessenger);
+        'dev.flutter.pigeon.webview_flutter_android.WebViewClient.onReceivedLoginRequest',
+        pigeonChannelCodec,
+        binaryMessenger: binaryMessenger,
+      );
       if (pigeon_clearHandlers) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
@@ -4179,16 +3872,20 @@ class WebViewClient extends PigeonInternalProxyApiBaseClass {
           final String? arg_account = args[3] as String?;
           final String arg_args = args[4]! as String;
           try {
-            (onReceivedLoginRequest ??
-                    arg_pigeon_instance.onReceivedLoginRequest)
-                ?.call(arg_pigeon_instance, arg_view, arg_realm, arg_account,
-                    arg_args);
+            (onReceivedLoginRequest ?? arg_pigeon_instance.onReceivedLoginRequest)?.call(
+              arg_pigeon_instance,
+              arg_view,
+              arg_realm,
+              arg_account,
+              arg_args,
+            );
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
           } catch (e) {
             return wrapResponse(
-                error: PlatformException(code: 'error', message: e.toString()));
+              error: PlatformException(code: 'error', message: e.toString()),
+            );
           }
         });
       }
@@ -4196,9 +3893,10 @@ class WebViewClient extends PigeonInternalProxyApiBaseClass {
 
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-          'dev.flutter.pigeon.webview_flutter_android.WebViewClient.onReceivedSslError',
-          pigeonChannelCodec,
-          binaryMessenger: binaryMessenger);
+        'dev.flutter.pigeon.webview_flutter_android.WebViewClient.onReceivedSslError',
+        pigeonChannelCodec,
+        binaryMessenger: binaryMessenger,
+      );
       if (pigeon_clearHandlers) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
@@ -4209,14 +3907,19 @@ class WebViewClient extends PigeonInternalProxyApiBaseClass {
           final SslErrorHandler arg_handler = args[2]! as SslErrorHandler;
           final SslError arg_error = args[3]! as SslError;
           try {
-            (onReceivedSslError ?? arg_pigeon_instance.onReceivedSslError)
-                ?.call(arg_pigeon_instance, arg_view, arg_handler, arg_error);
+            (onReceivedSslError ?? arg_pigeon_instance.onReceivedSslError)?.call(
+              arg_pigeon_instance,
+              arg_view,
+              arg_handler,
+              arg_error,
+            );
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
           } catch (e) {
             return wrapResponse(
-                error: PlatformException(code: 'error', message: e.toString()));
+              error: PlatformException(code: 'error', message: e.toString()),
+            );
           }
         });
       }
@@ -4224,9 +3927,10 @@ class WebViewClient extends PigeonInternalProxyApiBaseClass {
 
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-          'dev.flutter.pigeon.webview_flutter_android.WebViewClient.onScaleChanged',
-          pigeonChannelCodec,
-          binaryMessenger: binaryMessenger);
+        'dev.flutter.pigeon.webview_flutter_android.WebViewClient.onScaleChanged',
+        pigeonChannelCodec,
+        binaryMessenger: binaryMessenger,
+      );
       if (pigeon_clearHandlers) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
@@ -4238,13 +3942,18 @@ class WebViewClient extends PigeonInternalProxyApiBaseClass {
           final double arg_newScale = args[3]! as double;
           try {
             (onScaleChanged ?? arg_pigeon_instance.onScaleChanged)?.call(
-                arg_pigeon_instance, arg_view, arg_oldScale, arg_newScale);
+              arg_pigeon_instance,
+              arg_view,
+              arg_oldScale,
+              arg_newScale,
+            );
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
           } catch (e) {
             return wrapResponse(
-                error: PlatformException(code: 'error', message: e.toString()));
+              error: PlatformException(code: 'error', message: e.toString()),
+            );
           }
         });
       }
@@ -4263,10 +3972,8 @@ class WebViewClient extends PigeonInternalProxyApiBaseClass {
   /// causes the [WebView] to continue loading a URL as usual.
   ///
   /// Defaults to false.
-  Future<void> setSynchronousReturnValueForShouldOverrideUrlLoading(
-      bool value) async {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
-        _pigeonVar_codecWebViewClient;
+  Future<void> setSynchronousReturnValueForShouldOverrideUrlLoading(bool value) async {
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecWebViewClient;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
     const pigeonVar_channelName =
         'dev.flutter.pigeon.webview_flutter_android.WebViewClient.setSynchronousReturnValueForShouldOverrideUrlLoading';
@@ -4275,15 +3982,10 @@ class WebViewClient extends PigeonInternalProxyApiBaseClass {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture =
-        pigeonVar_channel.send(<Object?>[this, value]);
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[this, value]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
-    _extractReplyValueOrThrow(
-      pigeonVar_replyList,
-      pigeonVar_channelName,
-      isNullValid: true,
-    );
+    _extractReplyValueOrThrow(pigeonVar_replyList, pigeonVar_channelName, isNullValid: true);
   }
 
   @override
@@ -4326,11 +4028,11 @@ class DownloadListener extends PigeonInternalProxyApiBaseClass {
       String contentDisposition,
       String mimetype,
       int contentLength,
-    ) onDownloadStart,
+    )
+    onDownloadStart,
   }) {
     if (PigeonOverrides.downloadListener_new != null) {
-      return PigeonOverrides.downloadListener_new!(
-          onDownloadStart: onDownloadStart);
+      return PigeonOverrides.downloadListener_new!(onDownloadStart: onDownloadStart);
     }
     return DownloadListener.pigeon_new(
       pigeon_binaryMessenger: pigeon_binaryMessenger,
@@ -4345,10 +4047,8 @@ class DownloadListener extends PigeonInternalProxyApiBaseClass {
     super.pigeon_instanceManager,
     required this.onDownloadStart,
   }) {
-    final int pigeonVar_instanceIdentifier =
-        pigeon_instanceManager.addDartCreatedInstance(this);
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
-        _pigeonVar_codecDownloadListener;
+    final int pigeonVar_instanceIdentifier = pigeon_instanceManager.addDartCreatedInstance(this);
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecDownloadListener;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
     const pigeonVar_channelName =
         'dev.flutter.pigeon.webview_flutter_android.DownloadListener.pigeon_defaultConstructor';
@@ -4357,16 +4057,13 @@ class DownloadListener extends PigeonInternalProxyApiBaseClass {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture =
-        pigeonVar_channel.send(<Object?>[pigeonVar_instanceIdentifier]);
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[
+      pigeonVar_instanceIdentifier,
+    ]);
     () async {
       final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
-      _extractReplyValueOrThrow(
-        pigeonVar_replyList,
-        pigeonVar_channelName,
-        isNullValid: true,
-      );
+      _extractReplyValueOrThrow(pigeonVar_replyList, pigeonVar_channelName, isNullValid: true);
     }();
   }
 
@@ -4410,7 +4107,8 @@ class DownloadListener extends PigeonInternalProxyApiBaseClass {
     String contentDisposition,
     String mimetype,
     int contentLength,
-  ) onDownloadStart;
+  )
+  onDownloadStart;
 
   static void pigeon_setUpMessageHandlers({
     bool pigeon_clearHandlers = false,
@@ -4423,24 +4121,25 @@ class DownloadListener extends PigeonInternalProxyApiBaseClass {
       String contentDisposition,
       String mimetype,
       int contentLength,
-    )? onDownloadStart,
+    )?
+    onDownloadStart,
   }) {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
-        _PigeonInternalProxyApiBaseCodec(
-            pigeon_instanceManager ?? PigeonInstanceManager.instance);
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _PigeonInternalProxyApiBaseCodec(
+      pigeon_instanceManager ?? PigeonInstanceManager.instance,
+    );
     final BinaryMessenger? binaryMessenger = pigeon_binaryMessenger;
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-          'dev.flutter.pigeon.webview_flutter_android.DownloadListener.onDownloadStart',
-          pigeonChannelCodec,
-          binaryMessenger: binaryMessenger);
+        'dev.flutter.pigeon.webview_flutter_android.DownloadListener.onDownloadStart',
+        pigeonChannelCodec,
+        binaryMessenger: binaryMessenger,
+      );
       if (pigeon_clearHandlers) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
         pigeonVar_channel.setMessageHandler((Object? message) async {
           final List<Object?> args = message! as List<Object?>;
-          final DownloadListener arg_pigeon_instance =
-              args[0]! as DownloadListener;
+          final DownloadListener arg_pigeon_instance = args[0]! as DownloadListener;
           final String arg_url = args[1]! as String;
           final String arg_userAgent = args[2]! as String;
           final String arg_contentDisposition = args[3]! as String;
@@ -4448,18 +4147,20 @@ class DownloadListener extends PigeonInternalProxyApiBaseClass {
           final int arg_contentLength = args[5]! as int;
           try {
             (onDownloadStart ?? arg_pigeon_instance.onDownloadStart).call(
-                arg_pigeon_instance,
-                arg_url,
-                arg_userAgent,
-                arg_contentDisposition,
-                arg_mimetype,
-                arg_contentLength);
+              arg_pigeon_instance,
+              arg_url,
+              arg_userAgent,
+              arg_contentDisposition,
+              arg_mimetype,
+              arg_contentLength,
+            );
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
           } catch (e) {
             return wrapResponse(
-                error: PlatformException(code: 'error', message: e.toString()));
+              error: PlatformException(code: 'error', message: e.toString()),
+            );
           }
         });
       }
@@ -4484,56 +4185,48 @@ class WebChromeClient extends PigeonInternalProxyApiBaseClass {
   factory WebChromeClient({
     BinaryMessenger? pigeon_binaryMessenger,
     PigeonInstanceManager? pigeon_instanceManager,
-    void Function(
-      WebChromeClient pigeon_instance,
-      WebView webView,
-      int progress,
-    )? onProgressChanged,
+    void Function(WebChromeClient pigeon_instance, WebView webView, int progress)?
+    onProgressChanged,
     required Future<List<String>> Function(
       WebChromeClient pigeon_instance,
       WebView webView,
       FileChooserParams params,
-    ) onShowFileChooser,
-    void Function(
-      WebChromeClient pigeon_instance,
-      PermissionRequest request,
-    )? onPermissionRequest,
-    void Function(
-      WebChromeClient pigeon_instance,
-      View view,
-      CustomViewCallback callback,
-    )? onShowCustomView,
+    )
+    onShowFileChooser,
+    void Function(WebChromeClient pigeon_instance, PermissionRequest request)? onPermissionRequest,
+    void Function(WebChromeClient pigeon_instance, View view, CustomViewCallback callback)?
+    onShowCustomView,
     void Function(WebChromeClient pigeon_instance)? onHideCustomView,
     void Function(
       WebChromeClient pigeon_instance,
       String origin,
       GeolocationPermissionsCallback callback,
-    )? onGeolocationPermissionsShowPrompt,
-    void Function(WebChromeClient pigeon_instance)?
-        onGeolocationPermissionsHidePrompt,
-    void Function(
-      WebChromeClient pigeon_instance,
-      ConsoleMessage message,
-    )? onConsoleMessage,
+    )?
+    onGeolocationPermissionsShowPrompt,
+    void Function(WebChromeClient pigeon_instance)? onGeolocationPermissionsHidePrompt,
+    void Function(WebChromeClient pigeon_instance, ConsoleMessage message)? onConsoleMessage,
     Future<void> Function(
       WebChromeClient pigeon_instance,
       WebView webView,
       String url,
       String message,
-    )? onJsAlert,
+    )?
+    onJsAlert,
     required Future<bool> Function(
       WebChromeClient pigeon_instance,
       WebView webView,
       String url,
       String message,
-    ) onJsConfirm,
+    )
+    onJsConfirm,
     Future<String?> Function(
       WebChromeClient pigeon_instance,
       WebView webView,
       String url,
       String message,
       String defaultValue,
-    )? onJsPrompt,
+    )?
+    onJsPrompt,
   }) {
     if (PigeonOverrides.webChromeClient_new != null) {
       return PigeonOverrides.webChromeClient_new!(
@@ -4583,10 +4276,8 @@ class WebChromeClient extends PigeonInternalProxyApiBaseClass {
     required this.onJsConfirm,
     this.onJsPrompt,
   }) {
-    final int pigeonVar_instanceIdentifier =
-        pigeon_instanceManager.addDartCreatedInstance(this);
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
-        _pigeonVar_codecWebChromeClient;
+    final int pigeonVar_instanceIdentifier = pigeon_instanceManager.addDartCreatedInstance(this);
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecWebChromeClient;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
     const pigeonVar_channelName =
         'dev.flutter.pigeon.webview_flutter_android.WebChromeClient.pigeon_defaultConstructor';
@@ -4595,16 +4286,13 @@ class WebChromeClient extends PigeonInternalProxyApiBaseClass {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture =
-        pigeonVar_channel.send(<Object?>[pigeonVar_instanceIdentifier]);
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[
+      pigeonVar_instanceIdentifier,
+    ]);
     () async {
       final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
-      _extractReplyValueOrThrow(
-        pigeonVar_replyList,
-        pigeonVar_channelName,
-        isNullValid: true,
-      );
+      _extractReplyValueOrThrow(pigeonVar_replyList, pigeonVar_channelName, isNullValid: true);
     }();
   }
 
@@ -4651,11 +4339,8 @@ class WebChromeClient extends PigeonInternalProxyApiBaseClass {
   ///
   /// Alternatively, [PigeonInstanceManager.removeWeakReference] can be used to
   /// release the associated Native object manually.
-  final void Function(
-    WebChromeClient pigeon_instance,
-    WebView webView,
-    int progress,
-  )? onProgressChanged;
+  final void Function(WebChromeClient pigeon_instance, WebView webView, int progress)?
+  onProgressChanged;
 
   /// Tell the client to show a file chooser.
   ///
@@ -4680,7 +4365,8 @@ class WebChromeClient extends PigeonInternalProxyApiBaseClass {
     WebChromeClient pigeon_instance,
     WebView webView,
     FileChooserParams params,
-  ) onShowFileChooser;
+  )
+  onShowFileChooser;
 
   /// Notify the host application that web content is requesting permission to
   /// access the specified resources and the permission currently isn't granted
@@ -4703,10 +4389,8 @@ class WebChromeClient extends PigeonInternalProxyApiBaseClass {
   ///
   /// Alternatively, [PigeonInstanceManager.removeWeakReference] can be used to
   /// release the associated Native object manually.
-  final void Function(
-    WebChromeClient pigeon_instance,
-    PermissionRequest request,
-  )? onPermissionRequest;
+  final void Function(WebChromeClient pigeon_instance, PermissionRequest request)?
+  onPermissionRequest;
 
   /// Callback to Dart function `WebChromeClient.onShowCustomView`.
   ///
@@ -4727,11 +4411,8 @@ class WebChromeClient extends PigeonInternalProxyApiBaseClass {
   ///
   /// Alternatively, [PigeonInstanceManager.removeWeakReference] can be used to
   /// release the associated Native object manually.
-  final void Function(
-    WebChromeClient pigeon_instance,
-    View view,
-    CustomViewCallback callback,
-  )? onShowCustomView;
+  final void Function(WebChromeClient pigeon_instance, View view, CustomViewCallback callback)?
+  onShowCustomView;
 
   /// Notify the host application that the current page has entered full screen
   /// mode.
@@ -4780,7 +4461,8 @@ class WebChromeClient extends PigeonInternalProxyApiBaseClass {
     WebChromeClient pigeon_instance,
     String origin,
     GeolocationPermissionsCallback callback,
-  )? onGeolocationPermissionsShowPrompt;
+  )?
+  onGeolocationPermissionsShowPrompt;
 
   /// Notify the host application that a request for Geolocation permissions,
   /// made with a previous call to `onGeolocationPermissionsShowPrompt` has been
@@ -4803,8 +4485,7 @@ class WebChromeClient extends PigeonInternalProxyApiBaseClass {
   ///
   /// Alternatively, [PigeonInstanceManager.removeWeakReference] can be used to
   /// release the associated Native object manually.
-  final void Function(WebChromeClient pigeon_instance)?
-      onGeolocationPermissionsHidePrompt;
+  final void Function(WebChromeClient pigeon_instance)? onGeolocationPermissionsHidePrompt;
 
   /// Report a JavaScript console message to the host application.
   ///
@@ -4825,10 +4506,7 @@ class WebChromeClient extends PigeonInternalProxyApiBaseClass {
   ///
   /// Alternatively, [PigeonInstanceManager.removeWeakReference] can be used to
   /// release the associated Native object manually.
-  final void Function(
-    WebChromeClient pigeon_instance,
-    ConsoleMessage message,
-  )? onConsoleMessage;
+  final void Function(WebChromeClient pigeon_instance, ConsoleMessage message)? onConsoleMessage;
 
   /// Notify the host application that the web page wants to display a
   /// JavaScript `alert()` dialog.
@@ -4855,7 +4533,8 @@ class WebChromeClient extends PigeonInternalProxyApiBaseClass {
     WebView webView,
     String url,
     String message,
-  )? onJsAlert;
+  )?
+  onJsAlert;
 
   /// Notify the host application that the web page wants to display a
   /// JavaScript `confirm()` dialog.
@@ -4882,7 +4561,8 @@ class WebChromeClient extends PigeonInternalProxyApiBaseClass {
     WebView webView,
     String url,
     String message,
-  ) onJsConfirm;
+  )
+  onJsConfirm;
 
   /// Notify the host application that the web page wants to display a
   /// JavaScript `prompt()` dialog.
@@ -4910,90 +4590,87 @@ class WebChromeClient extends PigeonInternalProxyApiBaseClass {
     String url,
     String message,
     String defaultValue,
-  )? onJsPrompt;
+  )?
+  onJsPrompt;
 
   static void pigeon_setUpMessageHandlers({
     bool pigeon_clearHandlers = false,
     BinaryMessenger? pigeon_binaryMessenger,
     PigeonInstanceManager? pigeon_instanceManager,
-    void Function(
-      WebChromeClient pigeon_instance,
-      WebView webView,
-      int progress,
-    )? onProgressChanged,
+    void Function(WebChromeClient pigeon_instance, WebView webView, int progress)?
+    onProgressChanged,
     Future<List<String>> Function(
       WebChromeClient pigeon_instance,
       WebView webView,
       FileChooserParams params,
-    )? onShowFileChooser,
-    void Function(
-      WebChromeClient pigeon_instance,
-      PermissionRequest request,
-    )? onPermissionRequest,
-    void Function(
-      WebChromeClient pigeon_instance,
-      View view,
-      CustomViewCallback callback,
-    )? onShowCustomView,
+    )?
+    onShowFileChooser,
+    void Function(WebChromeClient pigeon_instance, PermissionRequest request)? onPermissionRequest,
+    void Function(WebChromeClient pigeon_instance, View view, CustomViewCallback callback)?
+    onShowCustomView,
     void Function(WebChromeClient pigeon_instance)? onHideCustomView,
     void Function(
       WebChromeClient pigeon_instance,
       String origin,
       GeolocationPermissionsCallback callback,
-    )? onGeolocationPermissionsShowPrompt,
-    void Function(WebChromeClient pigeon_instance)?
-        onGeolocationPermissionsHidePrompt,
-    void Function(
-      WebChromeClient pigeon_instance,
-      ConsoleMessage message,
-    )? onConsoleMessage,
+    )?
+    onGeolocationPermissionsShowPrompt,
+    void Function(WebChromeClient pigeon_instance)? onGeolocationPermissionsHidePrompt,
+    void Function(WebChromeClient pigeon_instance, ConsoleMessage message)? onConsoleMessage,
     Future<void> Function(
       WebChromeClient pigeon_instance,
       WebView webView,
       String url,
       String message,
-    )? onJsAlert,
+    )?
+    onJsAlert,
     Future<bool> Function(
       WebChromeClient pigeon_instance,
       WebView webView,
       String url,
       String message,
-    )? onJsConfirm,
+    )?
+    onJsConfirm,
     Future<String?> Function(
       WebChromeClient pigeon_instance,
       WebView webView,
       String url,
       String message,
       String defaultValue,
-    )? onJsPrompt,
+    )?
+    onJsPrompt,
   }) {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
-        _PigeonInternalProxyApiBaseCodec(
-            pigeon_instanceManager ?? PigeonInstanceManager.instance);
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _PigeonInternalProxyApiBaseCodec(
+      pigeon_instanceManager ?? PigeonInstanceManager.instance,
+    );
     final BinaryMessenger? binaryMessenger = pigeon_binaryMessenger;
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-          'dev.flutter.pigeon.webview_flutter_android.WebChromeClient.onProgressChanged',
-          pigeonChannelCodec,
-          binaryMessenger: binaryMessenger);
+        'dev.flutter.pigeon.webview_flutter_android.WebChromeClient.onProgressChanged',
+        pigeonChannelCodec,
+        binaryMessenger: binaryMessenger,
+      );
       if (pigeon_clearHandlers) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
         pigeonVar_channel.setMessageHandler((Object? message) async {
           final List<Object?> args = message! as List<Object?>;
-          final WebChromeClient arg_pigeon_instance =
-              args[0]! as WebChromeClient;
+          final WebChromeClient arg_pigeon_instance = args[0]! as WebChromeClient;
           final WebView arg_webView = args[1]! as WebView;
           final int arg_progress = args[2]! as int;
           try {
-            (onProgressChanged ?? arg_pigeon_instance.onProgressChanged)
-                ?.call(arg_pigeon_instance, arg_webView, arg_progress);
+            (onProgressChanged ?? arg_pigeon_instance.onProgressChanged)?.call(
+              arg_pigeon_instance,
+              arg_webView,
+              arg_progress,
+            );
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
           } catch (e) {
             return wrapResponse(
-                error: PlatformException(code: 'error', message: e.toString()));
+              error: PlatformException(code: 'error', message: e.toString()),
+            );
           }
         });
       }
@@ -5001,28 +4678,32 @@ class WebChromeClient extends PigeonInternalProxyApiBaseClass {
 
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-          'dev.flutter.pigeon.webview_flutter_android.WebChromeClient.onShowFileChooser',
-          pigeonChannelCodec,
-          binaryMessenger: binaryMessenger);
+        'dev.flutter.pigeon.webview_flutter_android.WebChromeClient.onShowFileChooser',
+        pigeonChannelCodec,
+        binaryMessenger: binaryMessenger,
+      );
       if (pigeon_clearHandlers) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
         pigeonVar_channel.setMessageHandler((Object? message) async {
           final List<Object?> args = message! as List<Object?>;
-          final WebChromeClient arg_pigeon_instance =
-              args[0]! as WebChromeClient;
+          final WebChromeClient arg_pigeon_instance = args[0]! as WebChromeClient;
           final WebView arg_webView = args[1]! as WebView;
           final FileChooserParams arg_params = args[2]! as FileChooserParams;
           try {
-            final List<String> output = await (onShowFileChooser ??
-                    arg_pigeon_instance.onShowFileChooser)
-                .call(arg_pigeon_instance, arg_webView, arg_params);
+            final List<String> output =
+                await (onShowFileChooser ?? arg_pigeon_instance.onShowFileChooser).call(
+                  arg_pigeon_instance,
+                  arg_webView,
+                  arg_params,
+                );
             return wrapResponse(result: output);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
           } catch (e) {
             return wrapResponse(
-                error: PlatformException(code: 'error', message: e.toString()));
+              error: PlatformException(code: 'error', message: e.toString()),
+            );
           }
         });
       }
@@ -5030,26 +4711,29 @@ class WebChromeClient extends PigeonInternalProxyApiBaseClass {
 
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-          'dev.flutter.pigeon.webview_flutter_android.WebChromeClient.onPermissionRequest',
-          pigeonChannelCodec,
-          binaryMessenger: binaryMessenger);
+        'dev.flutter.pigeon.webview_flutter_android.WebChromeClient.onPermissionRequest',
+        pigeonChannelCodec,
+        binaryMessenger: binaryMessenger,
+      );
       if (pigeon_clearHandlers) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
         pigeonVar_channel.setMessageHandler((Object? message) async {
           final List<Object?> args = message! as List<Object?>;
-          final WebChromeClient arg_pigeon_instance =
-              args[0]! as WebChromeClient;
+          final WebChromeClient arg_pigeon_instance = args[0]! as WebChromeClient;
           final PermissionRequest arg_request = args[1]! as PermissionRequest;
           try {
-            (onPermissionRequest ?? arg_pigeon_instance.onPermissionRequest)
-                ?.call(arg_pigeon_instance, arg_request);
+            (onPermissionRequest ?? arg_pigeon_instance.onPermissionRequest)?.call(
+              arg_pigeon_instance,
+              arg_request,
+            );
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
           } catch (e) {
             return wrapResponse(
-                error: PlatformException(code: 'error', message: e.toString()));
+              error: PlatformException(code: 'error', message: e.toString()),
+            );
           }
         });
       }
@@ -5057,28 +4741,31 @@ class WebChromeClient extends PigeonInternalProxyApiBaseClass {
 
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-          'dev.flutter.pigeon.webview_flutter_android.WebChromeClient.onShowCustomView',
-          pigeonChannelCodec,
-          binaryMessenger: binaryMessenger);
+        'dev.flutter.pigeon.webview_flutter_android.WebChromeClient.onShowCustomView',
+        pigeonChannelCodec,
+        binaryMessenger: binaryMessenger,
+      );
       if (pigeon_clearHandlers) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
         pigeonVar_channel.setMessageHandler((Object? message) async {
           final List<Object?> args = message! as List<Object?>;
-          final WebChromeClient arg_pigeon_instance =
-              args[0]! as WebChromeClient;
+          final WebChromeClient arg_pigeon_instance = args[0]! as WebChromeClient;
           final View arg_view = args[1]! as View;
-          final CustomViewCallback arg_callback =
-              args[2]! as CustomViewCallback;
+          final CustomViewCallback arg_callback = args[2]! as CustomViewCallback;
           try {
-            (onShowCustomView ?? arg_pigeon_instance.onShowCustomView)
-                ?.call(arg_pigeon_instance, arg_view, arg_callback);
+            (onShowCustomView ?? arg_pigeon_instance.onShowCustomView)?.call(
+              arg_pigeon_instance,
+              arg_view,
+              arg_callback,
+            );
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
           } catch (e) {
             return wrapResponse(
-                error: PlatformException(code: 'error', message: e.toString()));
+              error: PlatformException(code: 'error', message: e.toString()),
+            );
           }
         });
       }
@@ -5086,25 +4773,25 @@ class WebChromeClient extends PigeonInternalProxyApiBaseClass {
 
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-          'dev.flutter.pigeon.webview_flutter_android.WebChromeClient.onHideCustomView',
-          pigeonChannelCodec,
-          binaryMessenger: binaryMessenger);
+        'dev.flutter.pigeon.webview_flutter_android.WebChromeClient.onHideCustomView',
+        pigeonChannelCodec,
+        binaryMessenger: binaryMessenger,
+      );
       if (pigeon_clearHandlers) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
         pigeonVar_channel.setMessageHandler((Object? message) async {
           final List<Object?> args = message! as List<Object?>;
-          final WebChromeClient arg_pigeon_instance =
-              args[0]! as WebChromeClient;
+          final WebChromeClient arg_pigeon_instance = args[0]! as WebChromeClient;
           try {
-            (onHideCustomView ?? arg_pigeon_instance.onHideCustomView)
-                ?.call(arg_pigeon_instance);
+            (onHideCustomView ?? arg_pigeon_instance.onHideCustomView)?.call(arg_pigeon_instance);
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
           } catch (e) {
             return wrapResponse(
-                error: PlatformException(code: 'error', message: e.toString()));
+              error: PlatformException(code: 'error', message: e.toString()),
+            );
           }
         });
       }
@@ -5112,16 +4799,16 @@ class WebChromeClient extends PigeonInternalProxyApiBaseClass {
 
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-          'dev.flutter.pigeon.webview_flutter_android.WebChromeClient.onGeolocationPermissionsShowPrompt',
-          pigeonChannelCodec,
-          binaryMessenger: binaryMessenger);
+        'dev.flutter.pigeon.webview_flutter_android.WebChromeClient.onGeolocationPermissionsShowPrompt',
+        pigeonChannelCodec,
+        binaryMessenger: binaryMessenger,
+      );
       if (pigeon_clearHandlers) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
         pigeonVar_channel.setMessageHandler((Object? message) async {
           final List<Object?> args = message! as List<Object?>;
-          final WebChromeClient arg_pigeon_instance =
-              args[0]! as WebChromeClient;
+          final WebChromeClient arg_pigeon_instance = args[0]! as WebChromeClient;
           final String arg_origin = args[1]! as String;
           final GeolocationPermissionsCallback arg_callback =
               args[2]! as GeolocationPermissionsCallback;
@@ -5134,7 +4821,8 @@ class WebChromeClient extends PigeonInternalProxyApiBaseClass {
             return wrapResponse(error: e);
           } catch (e) {
             return wrapResponse(
-                error: PlatformException(code: 'error', message: e.toString()));
+              error: PlatformException(code: 'error', message: e.toString()),
+            );
           }
         });
       }
@@ -5142,16 +4830,16 @@ class WebChromeClient extends PigeonInternalProxyApiBaseClass {
 
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-          'dev.flutter.pigeon.webview_flutter_android.WebChromeClient.onGeolocationPermissionsHidePrompt',
-          pigeonChannelCodec,
-          binaryMessenger: binaryMessenger);
+        'dev.flutter.pigeon.webview_flutter_android.WebChromeClient.onGeolocationPermissionsHidePrompt',
+        pigeonChannelCodec,
+        binaryMessenger: binaryMessenger,
+      );
       if (pigeon_clearHandlers) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
         pigeonVar_channel.setMessageHandler((Object? message) async {
           final List<Object?> args = message! as List<Object?>;
-          final WebChromeClient arg_pigeon_instance =
-              args[0]! as WebChromeClient;
+          final WebChromeClient arg_pigeon_instance = args[0]! as WebChromeClient;
           try {
             (onGeolocationPermissionsHidePrompt ??
                     arg_pigeon_instance.onGeolocationPermissionsHidePrompt)
@@ -5161,7 +4849,8 @@ class WebChromeClient extends PigeonInternalProxyApiBaseClass {
             return wrapResponse(error: e);
           } catch (e) {
             return wrapResponse(
-                error: PlatformException(code: 'error', message: e.toString()));
+              error: PlatformException(code: 'error', message: e.toString()),
+            );
           }
         });
       }
@@ -5169,26 +4858,29 @@ class WebChromeClient extends PigeonInternalProxyApiBaseClass {
 
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-          'dev.flutter.pigeon.webview_flutter_android.WebChromeClient.onConsoleMessage',
-          pigeonChannelCodec,
-          binaryMessenger: binaryMessenger);
+        'dev.flutter.pigeon.webview_flutter_android.WebChromeClient.onConsoleMessage',
+        pigeonChannelCodec,
+        binaryMessenger: binaryMessenger,
+      );
       if (pigeon_clearHandlers) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
         pigeonVar_channel.setMessageHandler((Object? message) async {
           final List<Object?> args = message! as List<Object?>;
-          final WebChromeClient arg_pigeon_instance =
-              args[0]! as WebChromeClient;
+          final WebChromeClient arg_pigeon_instance = args[0]! as WebChromeClient;
           final ConsoleMessage arg_message = args[1]! as ConsoleMessage;
           try {
-            (onConsoleMessage ?? arg_pigeon_instance.onConsoleMessage)
-                ?.call(arg_pigeon_instance, arg_message);
+            (onConsoleMessage ?? arg_pigeon_instance.onConsoleMessage)?.call(
+              arg_pigeon_instance,
+              arg_message,
+            );
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
           } catch (e) {
             return wrapResponse(
-                error: PlatformException(code: 'error', message: e.toString()));
+              error: PlatformException(code: 'error', message: e.toString()),
+            );
           }
         });
       }
@@ -5196,28 +4888,33 @@ class WebChromeClient extends PigeonInternalProxyApiBaseClass {
 
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-          'dev.flutter.pigeon.webview_flutter_android.WebChromeClient.onJsAlert',
-          pigeonChannelCodec,
-          binaryMessenger: binaryMessenger);
+        'dev.flutter.pigeon.webview_flutter_android.WebChromeClient.onJsAlert',
+        pigeonChannelCodec,
+        binaryMessenger: binaryMessenger,
+      );
       if (pigeon_clearHandlers) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
         pigeonVar_channel.setMessageHandler((Object? message) async {
           final List<Object?> args = message! as List<Object?>;
-          final WebChromeClient arg_pigeon_instance =
-              args[0]! as WebChromeClient;
+          final WebChromeClient arg_pigeon_instance = args[0]! as WebChromeClient;
           final WebView arg_webView = args[1]! as WebView;
           final String arg_url = args[2]! as String;
           final String arg_message = args[3]! as String;
           try {
-            await (onJsAlert ?? arg_pigeon_instance.onJsAlert)
-                ?.call(arg_pigeon_instance, arg_webView, arg_url, arg_message);
+            await (onJsAlert ?? arg_pigeon_instance.onJsAlert)?.call(
+              arg_pigeon_instance,
+              arg_webView,
+              arg_url,
+              arg_message,
+            );
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
           } catch (e) {
             return wrapResponse(
-                error: PlatformException(code: 'error', message: e.toString()));
+              error: PlatformException(code: 'error', message: e.toString()),
+            );
           }
         });
       }
@@ -5225,29 +4922,33 @@ class WebChromeClient extends PigeonInternalProxyApiBaseClass {
 
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-          'dev.flutter.pigeon.webview_flutter_android.WebChromeClient.onJsConfirm',
-          pigeonChannelCodec,
-          binaryMessenger: binaryMessenger);
+        'dev.flutter.pigeon.webview_flutter_android.WebChromeClient.onJsConfirm',
+        pigeonChannelCodec,
+        binaryMessenger: binaryMessenger,
+      );
       if (pigeon_clearHandlers) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
         pigeonVar_channel.setMessageHandler((Object? message) async {
           final List<Object?> args = message! as List<Object?>;
-          final WebChromeClient arg_pigeon_instance =
-              args[0]! as WebChromeClient;
+          final WebChromeClient arg_pigeon_instance = args[0]! as WebChromeClient;
           final WebView arg_webView = args[1]! as WebView;
           final String arg_url = args[2]! as String;
           final String arg_message = args[3]! as String;
           try {
-            final bool output = await (onJsConfirm ??
-                    arg_pigeon_instance.onJsConfirm)
-                .call(arg_pigeon_instance, arg_webView, arg_url, arg_message);
+            final bool output = await (onJsConfirm ?? arg_pigeon_instance.onJsConfirm).call(
+              arg_pigeon_instance,
+              arg_webView,
+              arg_url,
+              arg_message,
+            );
             return wrapResponse(result: output);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
           } catch (e) {
             return wrapResponse(
-                error: PlatformException(code: 'error', message: e.toString()));
+              error: PlatformException(code: 'error', message: e.toString()),
+            );
           }
         });
       }
@@ -5255,34 +4956,35 @@ class WebChromeClient extends PigeonInternalProxyApiBaseClass {
 
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-          'dev.flutter.pigeon.webview_flutter_android.WebChromeClient.onJsPrompt',
-          pigeonChannelCodec,
-          binaryMessenger: binaryMessenger);
+        'dev.flutter.pigeon.webview_flutter_android.WebChromeClient.onJsPrompt',
+        pigeonChannelCodec,
+        binaryMessenger: binaryMessenger,
+      );
       if (pigeon_clearHandlers) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
         pigeonVar_channel.setMessageHandler((Object? message) async {
           final List<Object?> args = message! as List<Object?>;
-          final WebChromeClient arg_pigeon_instance =
-              args[0]! as WebChromeClient;
+          final WebChromeClient arg_pigeon_instance = args[0]! as WebChromeClient;
           final WebView arg_webView = args[1]! as WebView;
           final String arg_url = args[2]! as String;
           final String arg_message = args[3]! as String;
           final String arg_defaultValue = args[4]! as String;
           try {
-            final String? output =
-                await (onJsPrompt ?? arg_pigeon_instance.onJsPrompt)?.call(
-                    arg_pigeon_instance,
-                    arg_webView,
-                    arg_url,
-                    arg_message,
-                    arg_defaultValue);
+            final String? output = await (onJsPrompt ?? arg_pigeon_instance.onJsPrompt)?.call(
+              arg_pigeon_instance,
+              arg_webView,
+              arg_url,
+              arg_message,
+              arg_defaultValue,
+            );
             return wrapResponse(result: output);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
           } catch (e) {
             return wrapResponse(
-                error: PlatformException(code: 'error', message: e.toString()));
+              error: PlatformException(code: 'error', message: e.toString()),
+            );
           }
         });
       }
@@ -5305,8 +5007,7 @@ class WebChromeClient extends PigeonInternalProxyApiBaseClass {
   ///
   /// Defaults to false.
   Future<void> setSynchronousReturnValueForOnShowFileChooser(bool value) async {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
-        _pigeonVar_codecWebChromeClient;
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecWebChromeClient;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
     const pigeonVar_channelName =
         'dev.flutter.pigeon.webview_flutter_android.WebChromeClient.setSynchronousReturnValueForOnShowFileChooser';
@@ -5315,15 +5016,10 @@ class WebChromeClient extends PigeonInternalProxyApiBaseClass {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture =
-        pigeonVar_channel.send(<Object?>[this, value]);
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[this, value]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
-    _extractReplyValueOrThrow(
-      pigeonVar_replyList,
-      pigeonVar_channelName,
-      isNullValid: true,
-    );
+    _extractReplyValueOrThrow(pigeonVar_replyList, pigeonVar_channelName, isNullValid: true);
   }
 
   /// Sets the required synchronous return value for the Java method,
@@ -5340,8 +5036,7 @@ class WebChromeClient extends PigeonInternalProxyApiBaseClass {
   ///
   /// Defaults to false.
   Future<void> setSynchronousReturnValueForOnConsoleMessage(bool value) async {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
-        _pigeonVar_codecWebChromeClient;
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecWebChromeClient;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
     const pigeonVar_channelName =
         'dev.flutter.pigeon.webview_flutter_android.WebChromeClient.setSynchronousReturnValueForOnConsoleMessage';
@@ -5350,15 +5045,10 @@ class WebChromeClient extends PigeonInternalProxyApiBaseClass {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture =
-        pigeonVar_channel.send(<Object?>[this, value]);
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[this, value]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
-    _extractReplyValueOrThrow(
-      pigeonVar_replyList,
-      pigeonVar_channelName,
-      isNullValid: true,
-    );
+    _extractReplyValueOrThrow(pigeonVar_replyList, pigeonVar_channelName, isNullValid: true);
   }
 
   /// Sets the required synchronous return value for the Java method,
@@ -5375,8 +5065,7 @@ class WebChromeClient extends PigeonInternalProxyApiBaseClass {
   ///
   /// Defaults to false.
   Future<void> setSynchronousReturnValueForOnJsAlert(bool value) async {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
-        _pigeonVar_codecWebChromeClient;
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecWebChromeClient;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
     const pigeonVar_channelName =
         'dev.flutter.pigeon.webview_flutter_android.WebChromeClient.setSynchronousReturnValueForOnJsAlert';
@@ -5385,15 +5074,10 @@ class WebChromeClient extends PigeonInternalProxyApiBaseClass {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture =
-        pigeonVar_channel.send(<Object?>[this, value]);
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[this, value]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
-    _extractReplyValueOrThrow(
-      pigeonVar_replyList,
-      pigeonVar_channelName,
-      isNullValid: true,
-    );
+    _extractReplyValueOrThrow(pigeonVar_replyList, pigeonVar_channelName, isNullValid: true);
   }
 
   /// Sets the required synchronous return value for the Java method,
@@ -5410,8 +5094,7 @@ class WebChromeClient extends PigeonInternalProxyApiBaseClass {
   ///
   /// Defaults to false.
   Future<void> setSynchronousReturnValueForOnJsConfirm(bool value) async {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
-        _pigeonVar_codecWebChromeClient;
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecWebChromeClient;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
     const pigeonVar_channelName =
         'dev.flutter.pigeon.webview_flutter_android.WebChromeClient.setSynchronousReturnValueForOnJsConfirm';
@@ -5420,15 +5103,10 @@ class WebChromeClient extends PigeonInternalProxyApiBaseClass {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture =
-        pigeonVar_channel.send(<Object?>[this, value]);
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[this, value]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
-    _extractReplyValueOrThrow(
-      pigeonVar_replyList,
-      pigeonVar_channelName,
-      isNullValid: true,
-    );
+    _extractReplyValueOrThrow(pigeonVar_replyList, pigeonVar_channelName, isNullValid: true);
   }
 
   /// Sets the required synchronous return value for the Java method,
@@ -5445,8 +5123,7 @@ class WebChromeClient extends PigeonInternalProxyApiBaseClass {
   ///
   /// Defaults to false.
   Future<void> setSynchronousReturnValueForOnJsPrompt(bool value) async {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
-        _pigeonVar_codecWebChromeClient;
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecWebChromeClient;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
     const pigeonVar_channelName =
         'dev.flutter.pigeon.webview_flutter_android.WebChromeClient.setSynchronousReturnValueForOnJsPrompt';
@@ -5455,15 +5132,10 @@ class WebChromeClient extends PigeonInternalProxyApiBaseClass {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture =
-        pigeonVar_channel.send(<Object?>[this, value]);
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[this, value]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
-    _extractReplyValueOrThrow(
-      pigeonVar_replyList,
-      pigeonVar_channelName,
-      isNullValid: true,
-    );
+    _extractReplyValueOrThrow(pigeonVar_replyList, pigeonVar_channelName, isNullValid: true);
   }
 
   @override
@@ -5495,13 +5167,9 @@ class FlutterAssetManager extends PigeonInternalProxyApiBaseClass {
   /// This should only be used by subclasses created by this library or to
   /// create copies for an [PigeonInstanceManager].
   @protected
-  FlutterAssetManager.pigeon_detached({
-    super.pigeon_binaryMessenger,
-    super.pigeon_instanceManager,
-  });
+  FlutterAssetManager.pigeon_detached({super.pigeon_binaryMessenger, super.pigeon_instanceManager});
 
-  late final _PigeonInternalProxyApiBaseCodec
-      _pigeonVar_codecFlutterAssetManager =
+  late final _PigeonInternalProxyApiBaseCodec _pigeonVar_codecFlutterAssetManager =
       _PigeonInternalProxyApiBaseCodec(pigeon_instanceManager);
 
   /// The global instance of the `FlutterAssetManager`.
@@ -5517,15 +5185,16 @@ class FlutterAssetManager extends PigeonInternalProxyApiBaseClass {
     PigeonInstanceManager? pigeon_instanceManager,
     FlutterAssetManager Function()? pigeon_newInstance,
   }) {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
-        _PigeonInternalProxyApiBaseCodec(
-            pigeon_instanceManager ?? PigeonInstanceManager.instance);
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _PigeonInternalProxyApiBaseCodec(
+      pigeon_instanceManager ?? PigeonInstanceManager.instance,
+    );
     final BinaryMessenger? binaryMessenger = pigeon_binaryMessenger;
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-          'dev.flutter.pigeon.webview_flutter_android.FlutterAssetManager.pigeon_newInstance',
-          pigeonChannelCodec,
-          binaryMessenger: binaryMessenger);
+        'dev.flutter.pigeon.webview_flutter_android.FlutterAssetManager.pigeon_newInstance',
+        pigeonChannelCodec,
+        binaryMessenger: binaryMessenger,
+      );
       if (pigeon_clearHandlers) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
@@ -5533,8 +5202,7 @@ class FlutterAssetManager extends PigeonInternalProxyApiBaseClass {
           final List<Object?> args = message! as List<Object?>;
           final int arg_pigeon_instanceIdentifier = args[0]! as int;
           try {
-            (pigeon_instanceManager ?? PigeonInstanceManager.instance)
-                .addHostCreatedInstance(
+            (pigeon_instanceManager ?? PigeonInstanceManager.instance).addHostCreatedInstance(
               pigeon_newInstance?.call() ??
                   FlutterAssetManager.pigeon_detached(
                     pigeon_binaryMessenger: pigeon_binaryMessenger,
@@ -5547,7 +5215,8 @@ class FlutterAssetManager extends PigeonInternalProxyApiBaseClass {
             return wrapResponse(error: e);
           } catch (e) {
             return wrapResponse(
-                error: PlatformException(code: 'error', message: e.toString()));
+              error: PlatformException(code: 'error', message: e.toString()),
+            );
           }
         });
       }
@@ -5555,14 +5224,15 @@ class FlutterAssetManager extends PigeonInternalProxyApiBaseClass {
   }
 
   static FlutterAssetManager pigeonVar_instance() {
-    final FlutterAssetManager pigeonVar_instance =
-        FlutterAssetManager.pigeon_detached();
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
-        _PigeonInternalProxyApiBaseCodec(PigeonInstanceManager.instance);
+    final FlutterAssetManager pigeonVar_instance = FlutterAssetManager.pigeon_detached();
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _PigeonInternalProxyApiBaseCodec(
+      PigeonInstanceManager.instance,
+    );
     final BinaryMessenger pigeonVar_binaryMessenger =
         ServicesBinding.instance.defaultBinaryMessenger;
-    final int pigeonVar_instanceIdentifier = PigeonInstanceManager.instance
-        .addDartCreatedInstance(pigeonVar_instance);
+    final int pigeonVar_instanceIdentifier = PigeonInstanceManager.instance.addDartCreatedInstance(
+      pigeonVar_instance,
+    );
     () async {
       const pigeonVar_channelName =
           'dev.flutter.pigeon.webview_flutter_android.FlutterAssetManager.instance';
@@ -5571,15 +5241,12 @@ class FlutterAssetManager extends PigeonInternalProxyApiBaseClass {
         pigeonChannelCodec,
         binaryMessenger: pigeonVar_binaryMessenger,
       );
-      final Future<Object?> pigeonVar_sendFuture =
-          pigeonVar_channel.send(<Object?>[pigeonVar_instanceIdentifier]);
+      final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[
+        pigeonVar_instanceIdentifier,
+      ]);
       final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
-      _extractReplyValueOrThrow(
-        pigeonVar_replyList,
-        pigeonVar_channelName,
-        isNullValid: true,
-      );
+      _extractReplyValueOrThrow(pigeonVar_replyList, pigeonVar_channelName, isNullValid: true);
     }();
     return pigeonVar_instance;
   }
@@ -5588,8 +5255,7 @@ class FlutterAssetManager extends PigeonInternalProxyApiBaseClass {
   ///
   /// Throws an IOException in case I/O operations were interrupted.
   Future<List<String>> list(String path) async {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
-        _pigeonVar_codecFlutterAssetManager;
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecFlutterAssetManager;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
     const pigeonVar_channelName =
         'dev.flutter.pigeon.webview_flutter_android.FlutterAssetManager.list';
@@ -5598,8 +5264,7 @@ class FlutterAssetManager extends PigeonInternalProxyApiBaseClass {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture =
-        pigeonVar_channel.send(<Object?>[this, path]);
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[this, path]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
@@ -5618,8 +5283,7 @@ class FlutterAssetManager extends PigeonInternalProxyApiBaseClass {
   /// Android's AssetManager, but the path is not appropriate to load as an
   /// absolute path.
   Future<String> getAssetFilePathByName(String name) async {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
-        _pigeonVar_codecFlutterAssetManager;
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecFlutterAssetManager;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
     const pigeonVar_channelName =
         'dev.flutter.pigeon.webview_flutter_android.FlutterAssetManager.getAssetFilePathByName';
@@ -5628,8 +5292,7 @@ class FlutterAssetManager extends PigeonInternalProxyApiBaseClass {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture =
-        pigeonVar_channel.send(<Object?>[this, name]);
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[this, name]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
@@ -5659,18 +5322,14 @@ class WebStorage extends PigeonInternalProxyApiBaseClass {
   /// This should only be used by subclasses created by this library or to
   /// create copies for an [PigeonInstanceManager].
   @protected
-  WebStorage.pigeon_detached({
-    super.pigeon_binaryMessenger,
-    super.pigeon_instanceManager,
-  });
+  WebStorage.pigeon_detached({super.pigeon_binaryMessenger, super.pigeon_instanceManager});
 
   late final _PigeonInternalProxyApiBaseCodec _pigeonVar_codecWebStorage =
       _PigeonInternalProxyApiBaseCodec(pigeon_instanceManager);
 
   static final WebStorage _instance = pigeonVar_instance();
 
-  static WebStorage get instance =>
-      PigeonOverrides.webStorage_instance ?? _instance;
+  static WebStorage get instance => PigeonOverrides.webStorage_instance ?? _instance;
 
   static void pigeon_setUpMessageHandlers({
     bool pigeon_clearHandlers = false,
@@ -5678,15 +5337,16 @@ class WebStorage extends PigeonInternalProxyApiBaseClass {
     PigeonInstanceManager? pigeon_instanceManager,
     WebStorage Function()? pigeon_newInstance,
   }) {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
-        _PigeonInternalProxyApiBaseCodec(
-            pigeon_instanceManager ?? PigeonInstanceManager.instance);
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _PigeonInternalProxyApiBaseCodec(
+      pigeon_instanceManager ?? PigeonInstanceManager.instance,
+    );
     final BinaryMessenger? binaryMessenger = pigeon_binaryMessenger;
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-          'dev.flutter.pigeon.webview_flutter_android.WebStorage.pigeon_newInstance',
-          pigeonChannelCodec,
-          binaryMessenger: binaryMessenger);
+        'dev.flutter.pigeon.webview_flutter_android.WebStorage.pigeon_newInstance',
+        pigeonChannelCodec,
+        binaryMessenger: binaryMessenger,
+      );
       if (pigeon_clearHandlers) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
@@ -5694,8 +5354,7 @@ class WebStorage extends PigeonInternalProxyApiBaseClass {
           final List<Object?> args = message! as List<Object?>;
           final int arg_pigeon_instanceIdentifier = args[0]! as int;
           try {
-            (pigeon_instanceManager ?? PigeonInstanceManager.instance)
-                .addHostCreatedInstance(
+            (pigeon_instanceManager ?? PigeonInstanceManager.instance).addHostCreatedInstance(
               pigeon_newInstance?.call() ??
                   WebStorage.pigeon_detached(
                     pigeon_binaryMessenger: pigeon_binaryMessenger,
@@ -5708,7 +5367,8 @@ class WebStorage extends PigeonInternalProxyApiBaseClass {
             return wrapResponse(error: e);
           } catch (e) {
             return wrapResponse(
-                error: PlatformException(code: 'error', message: e.toString()));
+              error: PlatformException(code: 'error', message: e.toString()),
+            );
           }
         });
       }
@@ -5717,12 +5377,14 @@ class WebStorage extends PigeonInternalProxyApiBaseClass {
 
   static WebStorage pigeonVar_instance() {
     final WebStorage pigeonVar_instance = WebStorage.pigeon_detached();
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
-        _PigeonInternalProxyApiBaseCodec(PigeonInstanceManager.instance);
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _PigeonInternalProxyApiBaseCodec(
+      PigeonInstanceManager.instance,
+    );
     final BinaryMessenger pigeonVar_binaryMessenger =
         ServicesBinding.instance.defaultBinaryMessenger;
-    final int pigeonVar_instanceIdentifier = PigeonInstanceManager.instance
-        .addDartCreatedInstance(pigeonVar_instance);
+    final int pigeonVar_instanceIdentifier = PigeonInstanceManager.instance.addDartCreatedInstance(
+      pigeonVar_instance,
+    );
     () async {
       const pigeonVar_channelName =
           'dev.flutter.pigeon.webview_flutter_android.WebStorage.instance';
@@ -5731,23 +5393,19 @@ class WebStorage extends PigeonInternalProxyApiBaseClass {
         pigeonChannelCodec,
         binaryMessenger: pigeonVar_binaryMessenger,
       );
-      final Future<Object?> pigeonVar_sendFuture =
-          pigeonVar_channel.send(<Object?>[pigeonVar_instanceIdentifier]);
+      final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[
+        pigeonVar_instanceIdentifier,
+      ]);
       final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
-      _extractReplyValueOrThrow(
-        pigeonVar_replyList,
-        pigeonVar_channelName,
-        isNullValid: true,
-      );
+      _extractReplyValueOrThrow(pigeonVar_replyList, pigeonVar_channelName, isNullValid: true);
     }();
     return pigeonVar_instance;
   }
 
   /// Clears all storage currently being used by the JavaScript storage APIs.
   Future<void> deleteAllData() async {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
-        _pigeonVar_codecWebStorage;
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecWebStorage;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
     const pigeonVar_channelName =
         'dev.flutter.pigeon.webview_flutter_android.WebStorage.deleteAllData';
@@ -5756,15 +5414,10 @@ class WebStorage extends PigeonInternalProxyApiBaseClass {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture =
-        pigeonVar_channel.send(<Object?>[this]);
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[this]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
-    _extractReplyValueOrThrow(
-      pigeonVar_replyList,
-      pigeonVar_channelName,
-      isNullValid: true,
-    );
+    _extractReplyValueOrThrow(pigeonVar_replyList, pigeonVar_channelName, isNullValid: true);
   }
 
   @override
@@ -5815,17 +5468,19 @@ class FileChooserParams extends PigeonInternalProxyApiBaseClass {
       List<String> acceptTypes,
       FileChooserMode mode,
       String? filenameHint,
-    )? pigeon_newInstance,
+    )?
+    pigeon_newInstance,
   }) {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
-        _PigeonInternalProxyApiBaseCodec(
-            pigeon_instanceManager ?? PigeonInstanceManager.instance);
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _PigeonInternalProxyApiBaseCodec(
+      pigeon_instanceManager ?? PigeonInstanceManager.instance,
+    );
     final BinaryMessenger? binaryMessenger = pigeon_binaryMessenger;
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-          'dev.flutter.pigeon.webview_flutter_android.FileChooserParams.pigeon_newInstance',
-          pigeonChannelCodec,
-          binaryMessenger: binaryMessenger);
+        'dev.flutter.pigeon.webview_flutter_android.FileChooserParams.pigeon_newInstance',
+        pigeonChannelCodec,
+        binaryMessenger: binaryMessenger,
+      );
       if (pigeon_clearHandlers) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
@@ -5833,15 +5488,17 @@ class FileChooserParams extends PigeonInternalProxyApiBaseClass {
           final List<Object?> args = message! as List<Object?>;
           final int arg_pigeon_instanceIdentifier = args[0]! as int;
           final bool arg_isCaptureEnabled = args[1]! as bool;
-          final List<String> arg_acceptTypes =
-              (args[2]! as List<Object?>).cast<String>();
+          final List<String> arg_acceptTypes = (args[2]! as List<Object?>).cast<String>();
           final FileChooserMode arg_mode = args[3]! as FileChooserMode;
           final String? arg_filenameHint = args[4] as String?;
           try {
-            (pigeon_instanceManager ?? PigeonInstanceManager.instance)
-                .addHostCreatedInstance(
-              pigeon_newInstance?.call(arg_isCaptureEnabled, arg_acceptTypes,
-                      arg_mode, arg_filenameHint) ??
+            (pigeon_instanceManager ?? PigeonInstanceManager.instance).addHostCreatedInstance(
+              pigeon_newInstance?.call(
+                    arg_isCaptureEnabled,
+                    arg_acceptTypes,
+                    arg_mode,
+                    arg_filenameHint,
+                  ) ??
                   FileChooserParams.pigeon_detached(
                     pigeon_binaryMessenger: pigeon_binaryMessenger,
                     pigeon_instanceManager: pigeon_instanceManager,
@@ -5857,7 +5514,8 @@ class FileChooserParams extends PigeonInternalProxyApiBaseClass {
             return wrapResponse(error: e);
           } catch (e) {
             return wrapResponse(
-                error: PlatformException(code: 'error', message: e.toString()));
+              error: PlatformException(code: 'error', message: e.toString()),
+            );
           }
         });
       }
@@ -5893,8 +5551,7 @@ class PermissionRequest extends PigeonInternalProxyApiBaseClass {
     required this.resources,
   });
 
-  late final _PigeonInternalProxyApiBaseCodec
-      _pigeonVar_codecPermissionRequest =
+  late final _PigeonInternalProxyApiBaseCodec _pigeonVar_codecPermissionRequest =
       _PigeonInternalProxyApiBaseCodec(pigeon_instanceManager);
 
   final List<String> resources;
@@ -5905,26 +5562,25 @@ class PermissionRequest extends PigeonInternalProxyApiBaseClass {
     PigeonInstanceManager? pigeon_instanceManager,
     PermissionRequest Function(List<String> resources)? pigeon_newInstance,
   }) {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
-        _PigeonInternalProxyApiBaseCodec(
-            pigeon_instanceManager ?? PigeonInstanceManager.instance);
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _PigeonInternalProxyApiBaseCodec(
+      pigeon_instanceManager ?? PigeonInstanceManager.instance,
+    );
     final BinaryMessenger? binaryMessenger = pigeon_binaryMessenger;
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-          'dev.flutter.pigeon.webview_flutter_android.PermissionRequest.pigeon_newInstance',
-          pigeonChannelCodec,
-          binaryMessenger: binaryMessenger);
+        'dev.flutter.pigeon.webview_flutter_android.PermissionRequest.pigeon_newInstance',
+        pigeonChannelCodec,
+        binaryMessenger: binaryMessenger,
+      );
       if (pigeon_clearHandlers) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
         pigeonVar_channel.setMessageHandler((Object? message) async {
           final List<Object?> args = message! as List<Object?>;
           final int arg_pigeon_instanceIdentifier = args[0]! as int;
-          final List<String> arg_resources =
-              (args[1]! as List<Object?>).cast<String>();
+          final List<String> arg_resources = (args[1]! as List<Object?>).cast<String>();
           try {
-            (pigeon_instanceManager ?? PigeonInstanceManager.instance)
-                .addHostCreatedInstance(
+            (pigeon_instanceManager ?? PigeonInstanceManager.instance).addHostCreatedInstance(
               pigeon_newInstance?.call(arg_resources) ??
                   PermissionRequest.pigeon_detached(
                     pigeon_binaryMessenger: pigeon_binaryMessenger,
@@ -5938,7 +5594,8 @@ class PermissionRequest extends PigeonInternalProxyApiBaseClass {
             return wrapResponse(error: e);
           } catch (e) {
             return wrapResponse(
-                error: PlatformException(code: 'error', message: e.toString()));
+              error: PlatformException(code: 'error', message: e.toString()),
+            );
           }
         });
       }
@@ -5948,8 +5605,7 @@ class PermissionRequest extends PigeonInternalProxyApiBaseClass {
   /// Call this method to grant origin the permission to access the given
   /// resources.
   Future<void> grant(List<String> resources) async {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
-        _pigeonVar_codecPermissionRequest;
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecPermissionRequest;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
     const pigeonVar_channelName =
         'dev.flutter.pigeon.webview_flutter_android.PermissionRequest.grant';
@@ -5958,21 +5614,15 @@ class PermissionRequest extends PigeonInternalProxyApiBaseClass {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture =
-        pigeonVar_channel.send(<Object?>[this, resources]);
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[this, resources]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
-    _extractReplyValueOrThrow(
-      pigeonVar_replyList,
-      pigeonVar_channelName,
-      isNullValid: true,
-    );
+    _extractReplyValueOrThrow(pigeonVar_replyList, pigeonVar_channelName, isNullValid: true);
   }
 
   /// Call this method to deny the request.
   Future<void> deny() async {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
-        _pigeonVar_codecPermissionRequest;
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecPermissionRequest;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
     const pigeonVar_channelName =
         'dev.flutter.pigeon.webview_flutter_android.PermissionRequest.deny';
@@ -5981,15 +5631,10 @@ class PermissionRequest extends PigeonInternalProxyApiBaseClass {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture =
-        pigeonVar_channel.send(<Object?>[this]);
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[this]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
-    _extractReplyValueOrThrow(
-      pigeonVar_replyList,
-      pigeonVar_channelName,
-      isNullValid: true,
-    );
+    _extractReplyValueOrThrow(pigeonVar_replyList, pigeonVar_channelName, isNullValid: true);
   }
 
   @override
@@ -6012,13 +5657,9 @@ class CustomViewCallback extends PigeonInternalProxyApiBaseClass {
   /// This should only be used by subclasses created by this library or to
   /// create copies for an [PigeonInstanceManager].
   @protected
-  CustomViewCallback.pigeon_detached({
-    super.pigeon_binaryMessenger,
-    super.pigeon_instanceManager,
-  });
+  CustomViewCallback.pigeon_detached({super.pigeon_binaryMessenger, super.pigeon_instanceManager});
 
-  late final _PigeonInternalProxyApiBaseCodec
-      _pigeonVar_codecCustomViewCallback =
+  late final _PigeonInternalProxyApiBaseCodec _pigeonVar_codecCustomViewCallback =
       _PigeonInternalProxyApiBaseCodec(pigeon_instanceManager);
 
   static void pigeon_setUpMessageHandlers({
@@ -6027,15 +5668,16 @@ class CustomViewCallback extends PigeonInternalProxyApiBaseClass {
     PigeonInstanceManager? pigeon_instanceManager,
     CustomViewCallback Function()? pigeon_newInstance,
   }) {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
-        _PigeonInternalProxyApiBaseCodec(
-            pigeon_instanceManager ?? PigeonInstanceManager.instance);
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _PigeonInternalProxyApiBaseCodec(
+      pigeon_instanceManager ?? PigeonInstanceManager.instance,
+    );
     final BinaryMessenger? binaryMessenger = pigeon_binaryMessenger;
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-          'dev.flutter.pigeon.webview_flutter_android.CustomViewCallback.pigeon_newInstance',
-          pigeonChannelCodec,
-          binaryMessenger: binaryMessenger);
+        'dev.flutter.pigeon.webview_flutter_android.CustomViewCallback.pigeon_newInstance',
+        pigeonChannelCodec,
+        binaryMessenger: binaryMessenger,
+      );
       if (pigeon_clearHandlers) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
@@ -6043,8 +5685,7 @@ class CustomViewCallback extends PigeonInternalProxyApiBaseClass {
           final List<Object?> args = message! as List<Object?>;
           final int arg_pigeon_instanceIdentifier = args[0]! as int;
           try {
-            (pigeon_instanceManager ?? PigeonInstanceManager.instance)
-                .addHostCreatedInstance(
+            (pigeon_instanceManager ?? PigeonInstanceManager.instance).addHostCreatedInstance(
               pigeon_newInstance?.call() ??
                   CustomViewCallback.pigeon_detached(
                     pigeon_binaryMessenger: pigeon_binaryMessenger,
@@ -6057,7 +5698,8 @@ class CustomViewCallback extends PigeonInternalProxyApiBaseClass {
             return wrapResponse(error: e);
           } catch (e) {
             return wrapResponse(
-                error: PlatformException(code: 'error', message: e.toString()));
+              error: PlatformException(code: 'error', message: e.toString()),
+            );
           }
         });
       }
@@ -6066,8 +5708,7 @@ class CustomViewCallback extends PigeonInternalProxyApiBaseClass {
 
   /// Invoked when the host application dismisses the custom view.
   Future<void> onCustomViewHidden() async {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
-        _pigeonVar_codecCustomViewCallback;
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecCustomViewCallback;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
     const pigeonVar_channelName =
         'dev.flutter.pigeon.webview_flutter_android.CustomViewCallback.onCustomViewHidden';
@@ -6076,15 +5717,10 @@ class CustomViewCallback extends PigeonInternalProxyApiBaseClass {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture =
-        pigeonVar_channel.send(<Object?>[this]);
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[this]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
-    _extractReplyValueOrThrow(
-      pigeonVar_replyList,
-      pigeonVar_channelName,
-      isNullValid: true,
-    );
+    _extractReplyValueOrThrow(pigeonVar_replyList, pigeonVar_channelName, isNullValid: true);
   }
 
   @override
@@ -6106,10 +5742,7 @@ class View extends PigeonInternalProxyApiBaseClass {
   /// This should only be used by subclasses created by this library or to
   /// create copies for an [PigeonInstanceManager].
   @protected
-  View.pigeon_detached({
-    super.pigeon_binaryMessenger,
-    super.pigeon_instanceManager,
-  });
+  View.pigeon_detached({super.pigeon_binaryMessenger, super.pigeon_instanceManager});
 
   late final _PigeonInternalProxyApiBaseCodec _pigeonVar_codecView =
       _PigeonInternalProxyApiBaseCodec(pigeon_instanceManager);
@@ -6120,15 +5753,16 @@ class View extends PigeonInternalProxyApiBaseClass {
     PigeonInstanceManager? pigeon_instanceManager,
     View Function()? pigeon_newInstance,
   }) {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
-        _PigeonInternalProxyApiBaseCodec(
-            pigeon_instanceManager ?? PigeonInstanceManager.instance);
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _PigeonInternalProxyApiBaseCodec(
+      pigeon_instanceManager ?? PigeonInstanceManager.instance,
+    );
     final BinaryMessenger? binaryMessenger = pigeon_binaryMessenger;
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-          'dev.flutter.pigeon.webview_flutter_android.View.pigeon_newInstance',
-          pigeonChannelCodec,
-          binaryMessenger: binaryMessenger);
+        'dev.flutter.pigeon.webview_flutter_android.View.pigeon_newInstance',
+        pigeonChannelCodec,
+        binaryMessenger: binaryMessenger,
+      );
       if (pigeon_clearHandlers) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
@@ -6136,8 +5770,7 @@ class View extends PigeonInternalProxyApiBaseClass {
           final List<Object?> args = message! as List<Object?>;
           final int arg_pigeon_instanceIdentifier = args[0]! as int;
           try {
-            (pigeon_instanceManager ?? PigeonInstanceManager.instance)
-                .addHostCreatedInstance(
+            (pigeon_instanceManager ?? PigeonInstanceManager.instance).addHostCreatedInstance(
               pigeon_newInstance?.call() ??
                   View.pigeon_detached(
                     pigeon_binaryMessenger: pigeon_binaryMessenger,
@@ -6150,7 +5783,8 @@ class View extends PigeonInternalProxyApiBaseClass {
             return wrapResponse(error: e);
           } catch (e) {
             return wrapResponse(
-                error: PlatformException(code: 'error', message: e.toString()));
+              error: PlatformException(code: 'error', message: e.toString()),
+            );
           }
         });
       }
@@ -6158,61 +5792,40 @@ class View extends PigeonInternalProxyApiBaseClass {
   }
 
   /// Set the scrolled position of your view.
-  Future<void> scrollTo(
-    int x,
-    int y,
-  ) async {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
-        _pigeonVar_codecView;
+  Future<void> scrollTo(int x, int y) async {
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecView;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
-    const pigeonVar_channelName =
-        'dev.flutter.pigeon.webview_flutter_android.View.scrollTo';
+    const pigeonVar_channelName = 'dev.flutter.pigeon.webview_flutter_android.View.scrollTo';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture =
-        pigeonVar_channel.send(<Object?>[this, x, y]);
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[this, x, y]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
-    _extractReplyValueOrThrow(
-      pigeonVar_replyList,
-      pigeonVar_channelName,
-      isNullValid: true,
-    );
+    _extractReplyValueOrThrow(pigeonVar_replyList, pigeonVar_channelName, isNullValid: true);
   }
 
   /// Move the scrolled position of your view.
-  Future<void> scrollBy(
-    int x,
-    int y,
-  ) async {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
-        _pigeonVar_codecView;
+  Future<void> scrollBy(int x, int y) async {
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecView;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
-    const pigeonVar_channelName =
-        'dev.flutter.pigeon.webview_flutter_android.View.scrollBy';
+    const pigeonVar_channelName = 'dev.flutter.pigeon.webview_flutter_android.View.scrollBy';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture =
-        pigeonVar_channel.send(<Object?>[this, x, y]);
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[this, x, y]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
-    _extractReplyValueOrThrow(
-      pigeonVar_replyList,
-      pigeonVar_channelName,
-      isNullValid: true,
-    );
+    _extractReplyValueOrThrow(pigeonVar_replyList, pigeonVar_channelName, isNullValid: true);
   }
 
   /// Return the scrolled position of this view.
   Future<WebViewPoint> getScrollPosition() async {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
-        _pigeonVar_codecView;
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecView;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
     const pigeonVar_channelName =
         'dev.flutter.pigeon.webview_flutter_android.View.getScrollPosition';
@@ -6221,8 +5834,7 @@ class View extends PigeonInternalProxyApiBaseClass {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture =
-        pigeonVar_channel.send(<Object?>[this]);
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[this]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
@@ -6237,8 +5849,7 @@ class View extends PigeonInternalProxyApiBaseClass {
   ///
   /// The scrollbar is not drawn by default.
   Future<void> setVerticalScrollBarEnabled(bool enabled) async {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
-        _pigeonVar_codecView;
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecView;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
     const pigeonVar_channelName =
         'dev.flutter.pigeon.webview_flutter_android.View.setVerticalScrollBarEnabled';
@@ -6247,23 +5858,17 @@ class View extends PigeonInternalProxyApiBaseClass {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture =
-        pigeonVar_channel.send(<Object?>[this, enabled]);
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[this, enabled]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
-    _extractReplyValueOrThrow(
-      pigeonVar_replyList,
-      pigeonVar_channelName,
-      isNullValid: true,
-    );
+    _extractReplyValueOrThrow(pigeonVar_replyList, pigeonVar_channelName, isNullValid: true);
   }
 
   /// Define whether the horizontal scrollbar should be drawn or not.
   ///
   /// The scrollbar is not drawn by default.
   Future<void> setHorizontalScrollBarEnabled(bool enabled) async {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
-        _pigeonVar_codecView;
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecView;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
     const pigeonVar_channelName =
         'dev.flutter.pigeon.webview_flutter_android.View.setHorizontalScrollBarEnabled';
@@ -6272,21 +5877,15 @@ class View extends PigeonInternalProxyApiBaseClass {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture =
-        pigeonVar_channel.send(<Object?>[this, enabled]);
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[this, enabled]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
-    _extractReplyValueOrThrow(
-      pigeonVar_replyList,
-      pigeonVar_channelName,
-      isNullValid: true,
-    );
+    _extractReplyValueOrThrow(pigeonVar_replyList, pigeonVar_channelName, isNullValid: true);
   }
 
   /// Set the over-scroll mode for this view.
   Future<void> setOverScrollMode(OverScrollMode mode) async {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
-        _pigeonVar_codecView;
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecView;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
     const pigeonVar_channelName =
         'dev.flutter.pigeon.webview_flutter_android.View.setOverScrollMode';
@@ -6295,15 +5894,10 @@ class View extends PigeonInternalProxyApiBaseClass {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture =
-        pigeonVar_channel.send(<Object?>[this, mode]);
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[this, mode]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
-    _extractReplyValueOrThrow(
-      pigeonVar_replyList,
-      pigeonVar_channelName,
-      isNullValid: true,
-    );
+    _extractReplyValueOrThrow(pigeonVar_replyList, pigeonVar_channelName, isNullValid: true);
   }
 
   /// Sets the listener to the native method
@@ -6312,10 +5906,8 @@ class View extends PigeonInternalProxyApiBaseClass {
   ///
   /// This is a convenience method because `View.OnApplyWindowInsetsListener`
   /// requires implementing a callback that requires a synchronous return value.
-  Future<void> setInsetListenerToSetInsetsToZero(
-      List<WindowInsetsType> types) async {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
-        _pigeonVar_codecView;
+  Future<void> setInsetListenerToSetInsetsToZero(List<WindowInsetsType> types) async {
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecView;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
     const pigeonVar_channelName =
         'dev.flutter.pigeon.webview_flutter_android.View.setInsetListenerToSetInsetsToZero';
@@ -6324,15 +5916,10 @@ class View extends PigeonInternalProxyApiBaseClass {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture =
-        pigeonVar_channel.send(<Object?>[this, types]);
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[this, types]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
-    _extractReplyValueOrThrow(
-      pigeonVar_replyList,
-      pigeonVar_channelName,
-      isNullValid: true,
-    );
+    _extractReplyValueOrThrow(pigeonVar_replyList, pigeonVar_channelName, isNullValid: true);
   }
 
   @override
@@ -6359,8 +5946,7 @@ class GeolocationPermissionsCallback extends PigeonInternalProxyApiBaseClass {
     super.pigeon_instanceManager,
   });
 
-  late final _PigeonInternalProxyApiBaseCodec
-      _pigeonVar_codecGeolocationPermissionsCallback =
+  late final _PigeonInternalProxyApiBaseCodec _pigeonVar_codecGeolocationPermissionsCallback =
       _PigeonInternalProxyApiBaseCodec(pigeon_instanceManager);
 
   static void pigeon_setUpMessageHandlers({
@@ -6369,15 +5955,16 @@ class GeolocationPermissionsCallback extends PigeonInternalProxyApiBaseClass {
     PigeonInstanceManager? pigeon_instanceManager,
     GeolocationPermissionsCallback Function()? pigeon_newInstance,
   }) {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
-        _PigeonInternalProxyApiBaseCodec(
-            pigeon_instanceManager ?? PigeonInstanceManager.instance);
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _PigeonInternalProxyApiBaseCodec(
+      pigeon_instanceManager ?? PigeonInstanceManager.instance,
+    );
     final BinaryMessenger? binaryMessenger = pigeon_binaryMessenger;
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-          'dev.flutter.pigeon.webview_flutter_android.GeolocationPermissionsCallback.pigeon_newInstance',
-          pigeonChannelCodec,
-          binaryMessenger: binaryMessenger);
+        'dev.flutter.pigeon.webview_flutter_android.GeolocationPermissionsCallback.pigeon_newInstance',
+        pigeonChannelCodec,
+        binaryMessenger: binaryMessenger,
+      );
       if (pigeon_clearHandlers) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
@@ -6385,8 +5972,7 @@ class GeolocationPermissionsCallback extends PigeonInternalProxyApiBaseClass {
           final List<Object?> args = message! as List<Object?>;
           final int arg_pigeon_instanceIdentifier = args[0]! as int;
           try {
-            (pigeon_instanceManager ?? PigeonInstanceManager.instance)
-                .addHostCreatedInstance(
+            (pigeon_instanceManager ?? PigeonInstanceManager.instance).addHostCreatedInstance(
               pigeon_newInstance?.call() ??
                   GeolocationPermissionsCallback.pigeon_detached(
                     pigeon_binaryMessenger: pigeon_binaryMessenger,
@@ -6399,7 +5985,8 @@ class GeolocationPermissionsCallback extends PigeonInternalProxyApiBaseClass {
             return wrapResponse(error: e);
           } catch (e) {
             return wrapResponse(
-                error: PlatformException(code: 'error', message: e.toString()));
+              error: PlatformException(code: 'error', message: e.toString()),
+            );
           }
         });
       }
@@ -6407,11 +5994,7 @@ class GeolocationPermissionsCallback extends PigeonInternalProxyApiBaseClass {
   }
 
   /// Sets the Geolocation permission state for the supplied origin.
-  Future<void> invoke(
-    String origin,
-    bool allow,
-    bool retain,
-  ) async {
+  Future<void> invoke(String origin, bool allow, bool retain) async {
     final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
         _pigeonVar_codecGeolocationPermissionsCallback;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
@@ -6422,15 +6005,15 @@ class GeolocationPermissionsCallback extends PigeonInternalProxyApiBaseClass {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture =
-        pigeonVar_channel.send(<Object?>[this, origin, allow, retain]);
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[
+      this,
+      origin,
+      allow,
+      retain,
+    ]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
-    _extractReplyValueOrThrow(
-      pigeonVar_replyList,
-      pigeonVar_channelName,
-      isNullValid: true,
-    );
+    _extractReplyValueOrThrow(pigeonVar_replyList, pigeonVar_channelName, isNullValid: true);
   }
 
   @override
@@ -6451,10 +6034,7 @@ class HttpAuthHandler extends PigeonInternalProxyApiBaseClass {
   /// This should only be used by subclasses created by this library or to
   /// create copies for an [PigeonInstanceManager].
   @protected
-  HttpAuthHandler.pigeon_detached({
-    super.pigeon_binaryMessenger,
-    super.pigeon_instanceManager,
-  });
+  HttpAuthHandler.pigeon_detached({super.pigeon_binaryMessenger, super.pigeon_instanceManager});
 
   late final _PigeonInternalProxyApiBaseCodec _pigeonVar_codecHttpAuthHandler =
       _PigeonInternalProxyApiBaseCodec(pigeon_instanceManager);
@@ -6465,15 +6045,16 @@ class HttpAuthHandler extends PigeonInternalProxyApiBaseClass {
     PigeonInstanceManager? pigeon_instanceManager,
     HttpAuthHandler Function()? pigeon_newInstance,
   }) {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
-        _PigeonInternalProxyApiBaseCodec(
-            pigeon_instanceManager ?? PigeonInstanceManager.instance);
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _PigeonInternalProxyApiBaseCodec(
+      pigeon_instanceManager ?? PigeonInstanceManager.instance,
+    );
     final BinaryMessenger? binaryMessenger = pigeon_binaryMessenger;
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-          'dev.flutter.pigeon.webview_flutter_android.HttpAuthHandler.pigeon_newInstance',
-          pigeonChannelCodec,
-          binaryMessenger: binaryMessenger);
+        'dev.flutter.pigeon.webview_flutter_android.HttpAuthHandler.pigeon_newInstance',
+        pigeonChannelCodec,
+        binaryMessenger: binaryMessenger,
+      );
       if (pigeon_clearHandlers) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
@@ -6481,8 +6062,7 @@ class HttpAuthHandler extends PigeonInternalProxyApiBaseClass {
           final List<Object?> args = message! as List<Object?>;
           final int arg_pigeon_instanceIdentifier = args[0]! as int;
           try {
-            (pigeon_instanceManager ?? PigeonInstanceManager.instance)
-                .addHostCreatedInstance(
+            (pigeon_instanceManager ?? PigeonInstanceManager.instance).addHostCreatedInstance(
               pigeon_newInstance?.call() ??
                   HttpAuthHandler.pigeon_detached(
                     pigeon_binaryMessenger: pigeon_binaryMessenger,
@@ -6495,7 +6075,8 @@ class HttpAuthHandler extends PigeonInternalProxyApiBaseClass {
             return wrapResponse(error: e);
           } catch (e) {
             return wrapResponse(
-                error: PlatformException(code: 'error', message: e.toString()));
+              error: PlatformException(code: 'error', message: e.toString()),
+            );
           }
         });
       }
@@ -6506,8 +6087,7 @@ class HttpAuthHandler extends PigeonInternalProxyApiBaseClass {
   /// for which `WebViewClient.onReceivedHttpAuthRequest` was called) are
   /// suitable for use.
   Future<bool> useHttpAuthUsernamePassword() async {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
-        _pigeonVar_codecHttpAuthHandler;
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecHttpAuthHandler;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
     const pigeonVar_channelName =
         'dev.flutter.pigeon.webview_flutter_android.HttpAuthHandler.useHttpAuthUsernamePassword';
@@ -6516,8 +6096,7 @@ class HttpAuthHandler extends PigeonInternalProxyApiBaseClass {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture =
-        pigeonVar_channel.send(<Object?>[this]);
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[this]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
@@ -6530,8 +6109,7 @@ class HttpAuthHandler extends PigeonInternalProxyApiBaseClass {
 
   /// Instructs the WebView to cancel the authentication request..
   Future<void> cancel() async {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
-        _pigeonVar_codecHttpAuthHandler;
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecHttpAuthHandler;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
     const pigeonVar_channelName =
         'dev.flutter.pigeon.webview_flutter_android.HttpAuthHandler.cancel';
@@ -6540,25 +6118,16 @@ class HttpAuthHandler extends PigeonInternalProxyApiBaseClass {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture =
-        pigeonVar_channel.send(<Object?>[this]);
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[this]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
-    _extractReplyValueOrThrow(
-      pigeonVar_replyList,
-      pigeonVar_channelName,
-      isNullValid: true,
-    );
+    _extractReplyValueOrThrow(pigeonVar_replyList, pigeonVar_channelName, isNullValid: true);
   }
 
   /// Instructs the WebView to proceed with the authentication with the given
   /// credentials.
-  Future<void> proceed(
-    String username,
-    String password,
-  ) async {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
-        _pigeonVar_codecHttpAuthHandler;
+  Future<void> proceed(String username, String password) async {
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecHttpAuthHandler;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
     const pigeonVar_channelName =
         'dev.flutter.pigeon.webview_flutter_android.HttpAuthHandler.proceed';
@@ -6567,15 +6136,14 @@ class HttpAuthHandler extends PigeonInternalProxyApiBaseClass {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture =
-        pigeonVar_channel.send(<Object?>[this, username, password]);
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[
+      this,
+      username,
+      password,
+    ]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
-    _extractReplyValueOrThrow(
-      pigeonVar_replyList,
-      pigeonVar_channelName,
-      isNullValid: true,
-    );
+    _extractReplyValueOrThrow(pigeonVar_replyList, pigeonVar_channelName, isNullValid: true);
   }
 
   @override
@@ -6597,10 +6165,7 @@ class AndroidMessage extends PigeonInternalProxyApiBaseClass {
   /// This should only be used by subclasses created by this library or to
   /// create copies for an [PigeonInstanceManager].
   @protected
-  AndroidMessage.pigeon_detached({
-    super.pigeon_binaryMessenger,
-    super.pigeon_instanceManager,
-  });
+  AndroidMessage.pigeon_detached({super.pigeon_binaryMessenger, super.pigeon_instanceManager});
 
   late final _PigeonInternalProxyApiBaseCodec _pigeonVar_codecAndroidMessage =
       _PigeonInternalProxyApiBaseCodec(pigeon_instanceManager);
@@ -6611,15 +6176,16 @@ class AndroidMessage extends PigeonInternalProxyApiBaseClass {
     PigeonInstanceManager? pigeon_instanceManager,
     AndroidMessage Function()? pigeon_newInstance,
   }) {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
-        _PigeonInternalProxyApiBaseCodec(
-            pigeon_instanceManager ?? PigeonInstanceManager.instance);
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _PigeonInternalProxyApiBaseCodec(
+      pigeon_instanceManager ?? PigeonInstanceManager.instance,
+    );
     final BinaryMessenger? binaryMessenger = pigeon_binaryMessenger;
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-          'dev.flutter.pigeon.webview_flutter_android.AndroidMessage.pigeon_newInstance',
-          pigeonChannelCodec,
-          binaryMessenger: binaryMessenger);
+        'dev.flutter.pigeon.webview_flutter_android.AndroidMessage.pigeon_newInstance',
+        pigeonChannelCodec,
+        binaryMessenger: binaryMessenger,
+      );
       if (pigeon_clearHandlers) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
@@ -6627,8 +6193,7 @@ class AndroidMessage extends PigeonInternalProxyApiBaseClass {
           final List<Object?> args = message! as List<Object?>;
           final int arg_pigeon_instanceIdentifier = args[0]! as int;
           try {
-            (pigeon_instanceManager ?? PigeonInstanceManager.instance)
-                .addHostCreatedInstance(
+            (pigeon_instanceManager ?? PigeonInstanceManager.instance).addHostCreatedInstance(
               pigeon_newInstance?.call() ??
                   AndroidMessage.pigeon_detached(
                     pigeon_binaryMessenger: pigeon_binaryMessenger,
@@ -6641,7 +6206,8 @@ class AndroidMessage extends PigeonInternalProxyApiBaseClass {
             return wrapResponse(error: e);
           } catch (e) {
             return wrapResponse(
-                error: PlatformException(code: 'error', message: e.toString()));
+              error: PlatformException(code: 'error', message: e.toString()),
+            );
           }
         });
       }
@@ -6653,8 +6219,7 @@ class AndroidMessage extends PigeonInternalProxyApiBaseClass {
   ///
   /// Throws a null pointer exception if this field has not been set.
   Future<void> sendToTarget() async {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
-        _pigeonVar_codecAndroidMessage;
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecAndroidMessage;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
     const pigeonVar_channelName =
         'dev.flutter.pigeon.webview_flutter_android.AndroidMessage.sendToTarget';
@@ -6663,15 +6228,10 @@ class AndroidMessage extends PigeonInternalProxyApiBaseClass {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture =
-        pigeonVar_channel.send(<Object?>[this]);
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[this]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
-    _extractReplyValueOrThrow(
-      pigeonVar_replyList,
-      pigeonVar_channelName,
-      isNullValid: true,
-    );
+    _extractReplyValueOrThrow(pigeonVar_replyList, pigeonVar_channelName, isNullValid: true);
   }
 
   @override
@@ -6693,13 +6253,9 @@ class ClientCertRequest extends PigeonInternalProxyApiBaseClass {
   /// This should only be used by subclasses created by this library or to
   /// create copies for an [PigeonInstanceManager].
   @protected
-  ClientCertRequest.pigeon_detached({
-    super.pigeon_binaryMessenger,
-    super.pigeon_instanceManager,
-  });
+  ClientCertRequest.pigeon_detached({super.pigeon_binaryMessenger, super.pigeon_instanceManager});
 
-  late final _PigeonInternalProxyApiBaseCodec
-      _pigeonVar_codecClientCertRequest =
+  late final _PigeonInternalProxyApiBaseCodec _pigeonVar_codecClientCertRequest =
       _PigeonInternalProxyApiBaseCodec(pigeon_instanceManager);
 
   static void pigeon_setUpMessageHandlers({
@@ -6708,15 +6264,16 @@ class ClientCertRequest extends PigeonInternalProxyApiBaseClass {
     PigeonInstanceManager? pigeon_instanceManager,
     ClientCertRequest Function()? pigeon_newInstance,
   }) {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
-        _PigeonInternalProxyApiBaseCodec(
-            pigeon_instanceManager ?? PigeonInstanceManager.instance);
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _PigeonInternalProxyApiBaseCodec(
+      pigeon_instanceManager ?? PigeonInstanceManager.instance,
+    );
     final BinaryMessenger? binaryMessenger = pigeon_binaryMessenger;
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-          'dev.flutter.pigeon.webview_flutter_android.ClientCertRequest.pigeon_newInstance',
-          pigeonChannelCodec,
-          binaryMessenger: binaryMessenger);
+        'dev.flutter.pigeon.webview_flutter_android.ClientCertRequest.pigeon_newInstance',
+        pigeonChannelCodec,
+        binaryMessenger: binaryMessenger,
+      );
       if (pigeon_clearHandlers) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
@@ -6724,8 +6281,7 @@ class ClientCertRequest extends PigeonInternalProxyApiBaseClass {
           final List<Object?> args = message! as List<Object?>;
           final int arg_pigeon_instanceIdentifier = args[0]! as int;
           try {
-            (pigeon_instanceManager ?? PigeonInstanceManager.instance)
-                .addHostCreatedInstance(
+            (pigeon_instanceManager ?? PigeonInstanceManager.instance).addHostCreatedInstance(
               pigeon_newInstance?.call() ??
                   ClientCertRequest.pigeon_detached(
                     pigeon_binaryMessenger: pigeon_binaryMessenger,
@@ -6738,7 +6294,8 @@ class ClientCertRequest extends PigeonInternalProxyApiBaseClass {
             return wrapResponse(error: e);
           } catch (e) {
             return wrapResponse(
-                error: PlatformException(code: 'error', message: e.toString()));
+              error: PlatformException(code: 'error', message: e.toString()),
+            );
           }
         });
       }
@@ -6747,8 +6304,7 @@ class ClientCertRequest extends PigeonInternalProxyApiBaseClass {
 
   /// Cancel this request.
   Future<void> cancel() async {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
-        _pigeonVar_codecClientCertRequest;
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecClientCertRequest;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
     const pigeonVar_channelName =
         'dev.flutter.pigeon.webview_flutter_android.ClientCertRequest.cancel';
@@ -6757,21 +6313,15 @@ class ClientCertRequest extends PigeonInternalProxyApiBaseClass {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture =
-        pigeonVar_channel.send(<Object?>[this]);
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[this]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
-    _extractReplyValueOrThrow(
-      pigeonVar_replyList,
-      pigeonVar_channelName,
-      isNullValid: true,
-    );
+    _extractReplyValueOrThrow(pigeonVar_replyList, pigeonVar_channelName, isNullValid: true);
   }
 
   /// Ignore the request for now.
   Future<void> ignore() async {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
-        _pigeonVar_codecClientCertRequest;
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecClientCertRequest;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
     const pigeonVar_channelName =
         'dev.flutter.pigeon.webview_flutter_android.ClientCertRequest.ignore';
@@ -6780,24 +6330,15 @@ class ClientCertRequest extends PigeonInternalProxyApiBaseClass {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture =
-        pigeonVar_channel.send(<Object?>[this]);
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[this]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
-    _extractReplyValueOrThrow(
-      pigeonVar_replyList,
-      pigeonVar_channelName,
-      isNullValid: true,
-    );
+    _extractReplyValueOrThrow(pigeonVar_replyList, pigeonVar_channelName, isNullValid: true);
   }
 
   /// Proceed with the specified private key and client certificate chain.
-  Future<void> proceed(
-    PrivateKey privateKey,
-    List<X509Certificate> chain,
-  ) async {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
-        _pigeonVar_codecClientCertRequest;
+  Future<void> proceed(PrivateKey privateKey, List<X509Certificate> chain) async {
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecClientCertRequest;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
     const pigeonVar_channelName =
         'dev.flutter.pigeon.webview_flutter_android.ClientCertRequest.proceed';
@@ -6806,15 +6347,14 @@ class ClientCertRequest extends PigeonInternalProxyApiBaseClass {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture =
-        pigeonVar_channel.send(<Object?>[this, privateKey, chain]);
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[
+      this,
+      privateKey,
+      chain,
+    ]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
-    _extractReplyValueOrThrow(
-      pigeonVar_replyList,
-      pigeonVar_channelName,
-      isNullValid: true,
-    );
+    _extractReplyValueOrThrow(pigeonVar_replyList, pigeonVar_channelName, isNullValid: true);
   }
 
   @override
@@ -6838,10 +6378,7 @@ class PrivateKey extends PigeonInternalProxyApiBaseClass {
   /// This should only be used by subclasses created by this library or to
   /// create copies for an [PigeonInstanceManager].
   @protected
-  PrivateKey.pigeon_detached({
-    super.pigeon_binaryMessenger,
-    super.pigeon_instanceManager,
-  });
+  PrivateKey.pigeon_detached({super.pigeon_binaryMessenger, super.pigeon_instanceManager});
 
   static void pigeon_setUpMessageHandlers({
     bool pigeon_clearHandlers = false,
@@ -6849,15 +6386,16 @@ class PrivateKey extends PigeonInternalProxyApiBaseClass {
     PigeonInstanceManager? pigeon_instanceManager,
     PrivateKey Function()? pigeon_newInstance,
   }) {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
-        _PigeonInternalProxyApiBaseCodec(
-            pigeon_instanceManager ?? PigeonInstanceManager.instance);
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _PigeonInternalProxyApiBaseCodec(
+      pigeon_instanceManager ?? PigeonInstanceManager.instance,
+    );
     final BinaryMessenger? binaryMessenger = pigeon_binaryMessenger;
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-          'dev.flutter.pigeon.webview_flutter_android.PrivateKey.pigeon_newInstance',
-          pigeonChannelCodec,
-          binaryMessenger: binaryMessenger);
+        'dev.flutter.pigeon.webview_flutter_android.PrivateKey.pigeon_newInstance',
+        pigeonChannelCodec,
+        binaryMessenger: binaryMessenger,
+      );
       if (pigeon_clearHandlers) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
@@ -6865,8 +6403,7 @@ class PrivateKey extends PigeonInternalProxyApiBaseClass {
           final List<Object?> args = message! as List<Object?>;
           final int arg_pigeon_instanceIdentifier = args[0]! as int;
           try {
-            (pigeon_instanceManager ?? PigeonInstanceManager.instance)
-                .addHostCreatedInstance(
+            (pigeon_instanceManager ?? PigeonInstanceManager.instance).addHostCreatedInstance(
               pigeon_newInstance?.call() ??
                   PrivateKey.pigeon_detached(
                     pigeon_binaryMessenger: pigeon_binaryMessenger,
@@ -6879,7 +6416,8 @@ class PrivateKey extends PigeonInternalProxyApiBaseClass {
             return wrapResponse(error: e);
           } catch (e) {
             return wrapResponse(
-                error: PlatformException(code: 'error', message: e.toString()));
+              error: PlatformException(code: 'error', message: e.toString()),
+            );
           }
         });
       }
@@ -6907,10 +6445,8 @@ class X509Certificate extends Certificate {
   /// This should only be used by subclasses created by this library or to
   /// create copies for an [PigeonInstanceManager].
   @protected
-  X509Certificate.pigeon_detached({
-    super.pigeon_binaryMessenger,
-    super.pigeon_instanceManager,
-  }) : super.pigeon_detached();
+  X509Certificate.pigeon_detached({super.pigeon_binaryMessenger, super.pigeon_instanceManager})
+    : super.pigeon_detached();
 
   static void pigeon_setUpMessageHandlers({
     bool pigeon_clearHandlers = false,
@@ -6918,15 +6454,16 @@ class X509Certificate extends Certificate {
     PigeonInstanceManager? pigeon_instanceManager,
     X509Certificate Function()? pigeon_newInstance,
   }) {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
-        _PigeonInternalProxyApiBaseCodec(
-            pigeon_instanceManager ?? PigeonInstanceManager.instance);
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _PigeonInternalProxyApiBaseCodec(
+      pigeon_instanceManager ?? PigeonInstanceManager.instance,
+    );
     final BinaryMessenger? binaryMessenger = pigeon_binaryMessenger;
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-          'dev.flutter.pigeon.webview_flutter_android.X509Certificate.pigeon_newInstance',
-          pigeonChannelCodec,
-          binaryMessenger: binaryMessenger);
+        'dev.flutter.pigeon.webview_flutter_android.X509Certificate.pigeon_newInstance',
+        pigeonChannelCodec,
+        binaryMessenger: binaryMessenger,
+      );
       if (pigeon_clearHandlers) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
@@ -6934,8 +6471,7 @@ class X509Certificate extends Certificate {
           final List<Object?> args = message! as List<Object?>;
           final int arg_pigeon_instanceIdentifier = args[0]! as int;
           try {
-            (pigeon_instanceManager ?? PigeonInstanceManager.instance)
-                .addHostCreatedInstance(
+            (pigeon_instanceManager ?? PigeonInstanceManager.instance).addHostCreatedInstance(
               pigeon_newInstance?.call() ??
                   X509Certificate.pigeon_detached(
                     pigeon_binaryMessenger: pigeon_binaryMessenger,
@@ -6948,7 +6484,8 @@ class X509Certificate extends Certificate {
             return wrapResponse(error: e);
           } catch (e) {
             return wrapResponse(
-                error: PlatformException(code: 'error', message: e.toString()));
+              error: PlatformException(code: 'error', message: e.toString()),
+            );
           }
         });
       }
@@ -6973,10 +6510,7 @@ class SslErrorHandler extends PigeonInternalProxyApiBaseClass {
   /// This should only be used by subclasses created by this library or to
   /// create copies for an [PigeonInstanceManager].
   @protected
-  SslErrorHandler.pigeon_detached({
-    super.pigeon_binaryMessenger,
-    super.pigeon_instanceManager,
-  });
+  SslErrorHandler.pigeon_detached({super.pigeon_binaryMessenger, super.pigeon_instanceManager});
 
   late final _PigeonInternalProxyApiBaseCodec _pigeonVar_codecSslErrorHandler =
       _PigeonInternalProxyApiBaseCodec(pigeon_instanceManager);
@@ -6987,15 +6521,16 @@ class SslErrorHandler extends PigeonInternalProxyApiBaseClass {
     PigeonInstanceManager? pigeon_instanceManager,
     SslErrorHandler Function()? pigeon_newInstance,
   }) {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
-        _PigeonInternalProxyApiBaseCodec(
-            pigeon_instanceManager ?? PigeonInstanceManager.instance);
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _PigeonInternalProxyApiBaseCodec(
+      pigeon_instanceManager ?? PigeonInstanceManager.instance,
+    );
     final BinaryMessenger? binaryMessenger = pigeon_binaryMessenger;
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-          'dev.flutter.pigeon.webview_flutter_android.SslErrorHandler.pigeon_newInstance',
-          pigeonChannelCodec,
-          binaryMessenger: binaryMessenger);
+        'dev.flutter.pigeon.webview_flutter_android.SslErrorHandler.pigeon_newInstance',
+        pigeonChannelCodec,
+        binaryMessenger: binaryMessenger,
+      );
       if (pigeon_clearHandlers) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
@@ -7003,8 +6538,7 @@ class SslErrorHandler extends PigeonInternalProxyApiBaseClass {
           final List<Object?> args = message! as List<Object?>;
           final int arg_pigeon_instanceIdentifier = args[0]! as int;
           try {
-            (pigeon_instanceManager ?? PigeonInstanceManager.instance)
-                .addHostCreatedInstance(
+            (pigeon_instanceManager ?? PigeonInstanceManager.instance).addHostCreatedInstance(
               pigeon_newInstance?.call() ??
                   SslErrorHandler.pigeon_detached(
                     pigeon_binaryMessenger: pigeon_binaryMessenger,
@@ -7017,7 +6551,8 @@ class SslErrorHandler extends PigeonInternalProxyApiBaseClass {
             return wrapResponse(error: e);
           } catch (e) {
             return wrapResponse(
-                error: PlatformException(code: 'error', message: e.toString()));
+              error: PlatformException(code: 'error', message: e.toString()),
+            );
           }
         });
       }
@@ -7027,8 +6562,7 @@ class SslErrorHandler extends PigeonInternalProxyApiBaseClass {
   /// Instructs the WebView that encountered the SSL certificate error to
   /// terminate communication with the server.
   Future<void> cancel() async {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
-        _pigeonVar_codecSslErrorHandler;
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecSslErrorHandler;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
     const pigeonVar_channelName =
         'dev.flutter.pigeon.webview_flutter_android.SslErrorHandler.cancel';
@@ -7037,22 +6571,16 @@ class SslErrorHandler extends PigeonInternalProxyApiBaseClass {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture =
-        pigeonVar_channel.send(<Object?>[this]);
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[this]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
-    _extractReplyValueOrThrow(
-      pigeonVar_replyList,
-      pigeonVar_channelName,
-      isNullValid: true,
-    );
+    _extractReplyValueOrThrow(pigeonVar_replyList, pigeonVar_channelName, isNullValid: true);
   }
 
   /// Instructs the WebView that encountered the SSL certificate error to ignore
   /// the error and continue communicating with the server.
   Future<void> proceed() async {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
-        _pigeonVar_codecSslErrorHandler;
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecSslErrorHandler;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
     const pigeonVar_channelName =
         'dev.flutter.pigeon.webview_flutter_android.SslErrorHandler.proceed';
@@ -7061,15 +6589,10 @@ class SslErrorHandler extends PigeonInternalProxyApiBaseClass {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture =
-        pigeonVar_channel.send(<Object?>[this]);
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[this]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
-    _extractReplyValueOrThrow(
-      pigeonVar_replyList,
-      pigeonVar_channelName,
-      isNullValid: true,
-    );
+    _extractReplyValueOrThrow(pigeonVar_replyList, pigeonVar_channelName, isNullValid: true);
   }
 
   @override
@@ -7111,20 +6634,18 @@ class SslError extends PigeonInternalProxyApiBaseClass {
     bool pigeon_clearHandlers = false,
     BinaryMessenger? pigeon_binaryMessenger,
     PigeonInstanceManager? pigeon_instanceManager,
-    SslError Function(
-      SslCertificate certificate,
-      String url,
-    )? pigeon_newInstance,
+    SslError Function(SslCertificate certificate, String url)? pigeon_newInstance,
   }) {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
-        _PigeonInternalProxyApiBaseCodec(
-            pigeon_instanceManager ?? PigeonInstanceManager.instance);
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _PigeonInternalProxyApiBaseCodec(
+      pigeon_instanceManager ?? PigeonInstanceManager.instance,
+    );
     final BinaryMessenger? binaryMessenger = pigeon_binaryMessenger;
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-          'dev.flutter.pigeon.webview_flutter_android.SslError.pigeon_newInstance',
-          pigeonChannelCodec,
-          binaryMessenger: binaryMessenger);
+        'dev.flutter.pigeon.webview_flutter_android.SslError.pigeon_newInstance',
+        pigeonChannelCodec,
+        binaryMessenger: binaryMessenger,
+      );
       if (pigeon_clearHandlers) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
@@ -7134,8 +6655,7 @@ class SslError extends PigeonInternalProxyApiBaseClass {
           final SslCertificate arg_certificate = args[1]! as SslCertificate;
           final String arg_url = args[2]! as String;
           try {
-            (pigeon_instanceManager ?? PigeonInstanceManager.instance)
-                .addHostCreatedInstance(
+            (pigeon_instanceManager ?? PigeonInstanceManager.instance).addHostCreatedInstance(
               pigeon_newInstance?.call(arg_certificate, arg_url) ??
                   SslError.pigeon_detached(
                     pigeon_binaryMessenger: pigeon_binaryMessenger,
@@ -7150,7 +6670,8 @@ class SslError extends PigeonInternalProxyApiBaseClass {
             return wrapResponse(error: e);
           } catch (e) {
             return wrapResponse(
-                error: PlatformException(code: 'error', message: e.toString()));
+              error: PlatformException(code: 'error', message: e.toString()),
+            );
           }
         });
       }
@@ -7159,8 +6680,7 @@ class SslError extends PigeonInternalProxyApiBaseClass {
 
   /// Gets the most severe SSL error in this object's set of errors.
   Future<SslErrorType> getPrimaryError() async {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
-        _pigeonVar_codecSslError;
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecSslError;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
     const pigeonVar_channelName =
         'dev.flutter.pigeon.webview_flutter_android.SslError.getPrimaryError';
@@ -7169,8 +6689,7 @@ class SslError extends PigeonInternalProxyApiBaseClass {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture =
-        pigeonVar_channel.send(<Object?>[this]);
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[this]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
@@ -7183,18 +6702,15 @@ class SslError extends PigeonInternalProxyApiBaseClass {
 
   /// Determines whether this object includes the supplied error.
   Future<bool> hasError(SslErrorType error) async {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
-        _pigeonVar_codecSslError;
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecSslError;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
-    const pigeonVar_channelName =
-        'dev.flutter.pigeon.webview_flutter_android.SslError.hasError';
+    const pigeonVar_channelName = 'dev.flutter.pigeon.webview_flutter_android.SslError.hasError';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture =
-        pigeonVar_channel.send(<Object?>[this, error]);
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[this, error]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
@@ -7228,13 +6744,9 @@ class SslCertificateDName extends PigeonInternalProxyApiBaseClass {
   /// This should only be used by subclasses created by this library or to
   /// create copies for an [PigeonInstanceManager].
   @protected
-  SslCertificateDName.pigeon_detached({
-    super.pigeon_binaryMessenger,
-    super.pigeon_instanceManager,
-  });
+  SslCertificateDName.pigeon_detached({super.pigeon_binaryMessenger, super.pigeon_instanceManager});
 
-  late final _PigeonInternalProxyApiBaseCodec
-      _pigeonVar_codecSslCertificateDName =
+  late final _PigeonInternalProxyApiBaseCodec _pigeonVar_codecSslCertificateDName =
       _PigeonInternalProxyApiBaseCodec(pigeon_instanceManager);
 
   static void pigeon_setUpMessageHandlers({
@@ -7243,15 +6755,16 @@ class SslCertificateDName extends PigeonInternalProxyApiBaseClass {
     PigeonInstanceManager? pigeon_instanceManager,
     SslCertificateDName Function()? pigeon_newInstance,
   }) {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
-        _PigeonInternalProxyApiBaseCodec(
-            pigeon_instanceManager ?? PigeonInstanceManager.instance);
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _PigeonInternalProxyApiBaseCodec(
+      pigeon_instanceManager ?? PigeonInstanceManager.instance,
+    );
     final BinaryMessenger? binaryMessenger = pigeon_binaryMessenger;
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-          'dev.flutter.pigeon.webview_flutter_android.SslCertificateDName.pigeon_newInstance',
-          pigeonChannelCodec,
-          binaryMessenger: binaryMessenger);
+        'dev.flutter.pigeon.webview_flutter_android.SslCertificateDName.pigeon_newInstance',
+        pigeonChannelCodec,
+        binaryMessenger: binaryMessenger,
+      );
       if (pigeon_clearHandlers) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
@@ -7259,8 +6772,7 @@ class SslCertificateDName extends PigeonInternalProxyApiBaseClass {
           final List<Object?> args = message! as List<Object?>;
           final int arg_pigeon_instanceIdentifier = args[0]! as int;
           try {
-            (pigeon_instanceManager ?? PigeonInstanceManager.instance)
-                .addHostCreatedInstance(
+            (pigeon_instanceManager ?? PigeonInstanceManager.instance).addHostCreatedInstance(
               pigeon_newInstance?.call() ??
                   SslCertificateDName.pigeon_detached(
                     pigeon_binaryMessenger: pigeon_binaryMessenger,
@@ -7273,7 +6785,8 @@ class SslCertificateDName extends PigeonInternalProxyApiBaseClass {
             return wrapResponse(error: e);
           } catch (e) {
             return wrapResponse(
-                error: PlatformException(code: 'error', message: e.toString()));
+              error: PlatformException(code: 'error', message: e.toString()),
+            );
           }
         });
       }
@@ -7282,8 +6795,7 @@ class SslCertificateDName extends PigeonInternalProxyApiBaseClass {
 
   /// The most specific Common-name (CN) component of this name.
   Future<String> getCName() async {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
-        _pigeonVar_codecSslCertificateDName;
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecSslCertificateDName;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
     const pigeonVar_channelName =
         'dev.flutter.pigeon.webview_flutter_android.SslCertificateDName.getCName';
@@ -7292,8 +6804,7 @@ class SslCertificateDName extends PigeonInternalProxyApiBaseClass {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture =
-        pigeonVar_channel.send(<Object?>[this]);
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[this]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
@@ -7306,8 +6817,7 @@ class SslCertificateDName extends PigeonInternalProxyApiBaseClass {
 
   /// The distinguished name (normally includes CN, O, and OU names).
   Future<String> getDName() async {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
-        _pigeonVar_codecSslCertificateDName;
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecSslCertificateDName;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
     const pigeonVar_channelName =
         'dev.flutter.pigeon.webview_flutter_android.SslCertificateDName.getDName';
@@ -7316,8 +6826,7 @@ class SslCertificateDName extends PigeonInternalProxyApiBaseClass {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture =
-        pigeonVar_channel.send(<Object?>[this]);
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[this]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
@@ -7330,8 +6839,7 @@ class SslCertificateDName extends PigeonInternalProxyApiBaseClass {
 
   /// The most specific Organization (O) component of this name.
   Future<String> getOName() async {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
-        _pigeonVar_codecSslCertificateDName;
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecSslCertificateDName;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
     const pigeonVar_channelName =
         'dev.flutter.pigeon.webview_flutter_android.SslCertificateDName.getOName';
@@ -7340,8 +6848,7 @@ class SslCertificateDName extends PigeonInternalProxyApiBaseClass {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture =
-        pigeonVar_channel.send(<Object?>[this]);
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[this]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
@@ -7354,8 +6861,7 @@ class SslCertificateDName extends PigeonInternalProxyApiBaseClass {
 
   /// The most specific Organizational Unit (OU) component of this name.
   Future<String> getUName() async {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
-        _pigeonVar_codecSslCertificateDName;
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecSslCertificateDName;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
     const pigeonVar_channelName =
         'dev.flutter.pigeon.webview_flutter_android.SslCertificateDName.getUName';
@@ -7364,8 +6870,7 @@ class SslCertificateDName extends PigeonInternalProxyApiBaseClass {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture =
-        pigeonVar_channel.send(<Object?>[this]);
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[this]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
@@ -7394,10 +6899,7 @@ class SslCertificate extends PigeonInternalProxyApiBaseClass {
   /// This should only be used by subclasses created by this library or to
   /// create copies for an [PigeonInstanceManager].
   @protected
-  SslCertificate.pigeon_detached({
-    super.pigeon_binaryMessenger,
-    super.pigeon_instanceManager,
-  });
+  SslCertificate.pigeon_detached({super.pigeon_binaryMessenger, super.pigeon_instanceManager});
 
   late final _PigeonInternalProxyApiBaseCodec _pigeonVar_codecSslCertificate =
       _PigeonInternalProxyApiBaseCodec(pigeon_instanceManager);
@@ -7408,15 +6910,16 @@ class SslCertificate extends PigeonInternalProxyApiBaseClass {
     PigeonInstanceManager? pigeon_instanceManager,
     SslCertificate Function()? pigeon_newInstance,
   }) {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
-        _PigeonInternalProxyApiBaseCodec(
-            pigeon_instanceManager ?? PigeonInstanceManager.instance);
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _PigeonInternalProxyApiBaseCodec(
+      pigeon_instanceManager ?? PigeonInstanceManager.instance,
+    );
     final BinaryMessenger? binaryMessenger = pigeon_binaryMessenger;
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-          'dev.flutter.pigeon.webview_flutter_android.SslCertificate.pigeon_newInstance',
-          pigeonChannelCodec,
-          binaryMessenger: binaryMessenger);
+        'dev.flutter.pigeon.webview_flutter_android.SslCertificate.pigeon_newInstance',
+        pigeonChannelCodec,
+        binaryMessenger: binaryMessenger,
+      );
       if (pigeon_clearHandlers) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
@@ -7424,8 +6927,7 @@ class SslCertificate extends PigeonInternalProxyApiBaseClass {
           final List<Object?> args = message! as List<Object?>;
           final int arg_pigeon_instanceIdentifier = args[0]! as int;
           try {
-            (pigeon_instanceManager ?? PigeonInstanceManager.instance)
-                .addHostCreatedInstance(
+            (pigeon_instanceManager ?? PigeonInstanceManager.instance).addHostCreatedInstance(
               pigeon_newInstance?.call() ??
                   SslCertificate.pigeon_detached(
                     pigeon_binaryMessenger: pigeon_binaryMessenger,
@@ -7438,7 +6940,8 @@ class SslCertificate extends PigeonInternalProxyApiBaseClass {
             return wrapResponse(error: e);
           } catch (e) {
             return wrapResponse(
-                error: PlatformException(code: 'error', message: e.toString()));
+              error: PlatformException(code: 'error', message: e.toString()),
+            );
           }
         });
       }
@@ -7447,8 +6950,7 @@ class SslCertificate extends PigeonInternalProxyApiBaseClass {
 
   /// Issued-by distinguished name or null if none has been set.
   Future<SslCertificateDName?> getIssuedBy() async {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
-        _pigeonVar_codecSslCertificate;
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecSslCertificate;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
     const pigeonVar_channelName =
         'dev.flutter.pigeon.webview_flutter_android.SslCertificate.getIssuedBy';
@@ -7457,8 +6959,7 @@ class SslCertificate extends PigeonInternalProxyApiBaseClass {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture =
-        pigeonVar_channel.send(<Object?>[this]);
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[this]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
@@ -7471,8 +6972,7 @@ class SslCertificate extends PigeonInternalProxyApiBaseClass {
 
   /// Issued-to distinguished name or null if none has been set.
   Future<SslCertificateDName?> getIssuedTo() async {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
-        _pigeonVar_codecSslCertificate;
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecSslCertificate;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
     const pigeonVar_channelName =
         'dev.flutter.pigeon.webview_flutter_android.SslCertificate.getIssuedTo';
@@ -7481,8 +6981,7 @@ class SslCertificate extends PigeonInternalProxyApiBaseClass {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture =
-        pigeonVar_channel.send(<Object?>[this]);
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[this]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
@@ -7496,8 +6995,7 @@ class SslCertificate extends PigeonInternalProxyApiBaseClass {
   /// Not-after date from the certificate validity period or null if none has been
   /// set.
   Future<int?> getValidNotAfterMsSinceEpoch() async {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
-        _pigeonVar_codecSslCertificate;
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecSslCertificate;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
     const pigeonVar_channelName =
         'dev.flutter.pigeon.webview_flutter_android.SslCertificate.getValidNotAfterMsSinceEpoch';
@@ -7506,8 +7004,7 @@ class SslCertificate extends PigeonInternalProxyApiBaseClass {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture =
-        pigeonVar_channel.send(<Object?>[this]);
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[this]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
@@ -7521,8 +7018,7 @@ class SslCertificate extends PigeonInternalProxyApiBaseClass {
   /// Not-before date from the certificate validity period or null if none has
   /// been set.
   Future<int?> getValidNotBeforeMsSinceEpoch() async {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
-        _pigeonVar_codecSslCertificate;
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecSslCertificate;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
     const pigeonVar_channelName =
         'dev.flutter.pigeon.webview_flutter_android.SslCertificate.getValidNotBeforeMsSinceEpoch';
@@ -7531,8 +7027,7 @@ class SslCertificate extends PigeonInternalProxyApiBaseClass {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture =
-        pigeonVar_channel.send(<Object?>[this]);
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[this]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
@@ -7548,8 +7043,7 @@ class SslCertificate extends PigeonInternalProxyApiBaseClass {
   ///
   /// Always returns null on Android versions below Q.
   Future<X509Certificate?> getX509Certificate() async {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
-        _pigeonVar_codecSslCertificate;
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecSslCertificate;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
     const pigeonVar_channelName =
         'dev.flutter.pigeon.webview_flutter_android.SslCertificate.getX509Certificate';
@@ -7558,8 +7052,7 @@ class SslCertificate extends PigeonInternalProxyApiBaseClass {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture =
-        pigeonVar_channel.send(<Object?>[this]);
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[this]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
@@ -7588,10 +7081,7 @@ class Certificate extends PigeonInternalProxyApiBaseClass {
   /// This should only be used by subclasses created by this library or to
   /// create copies for an [PigeonInstanceManager].
   @protected
-  Certificate.pigeon_detached({
-    super.pigeon_binaryMessenger,
-    super.pigeon_instanceManager,
-  });
+  Certificate.pigeon_detached({super.pigeon_binaryMessenger, super.pigeon_instanceManager});
 
   late final _PigeonInternalProxyApiBaseCodec _pigeonVar_codecCertificate =
       _PigeonInternalProxyApiBaseCodec(pigeon_instanceManager);
@@ -7602,15 +7092,16 @@ class Certificate extends PigeonInternalProxyApiBaseClass {
     PigeonInstanceManager? pigeon_instanceManager,
     Certificate Function()? pigeon_newInstance,
   }) {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
-        _PigeonInternalProxyApiBaseCodec(
-            pigeon_instanceManager ?? PigeonInstanceManager.instance);
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _PigeonInternalProxyApiBaseCodec(
+      pigeon_instanceManager ?? PigeonInstanceManager.instance,
+    );
     final BinaryMessenger? binaryMessenger = pigeon_binaryMessenger;
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-          'dev.flutter.pigeon.webview_flutter_android.Certificate.pigeon_newInstance',
-          pigeonChannelCodec,
-          binaryMessenger: binaryMessenger);
+        'dev.flutter.pigeon.webview_flutter_android.Certificate.pigeon_newInstance',
+        pigeonChannelCodec,
+        binaryMessenger: binaryMessenger,
+      );
       if (pigeon_clearHandlers) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
@@ -7618,8 +7109,7 @@ class Certificate extends PigeonInternalProxyApiBaseClass {
           final List<Object?> args = message! as List<Object?>;
           final int arg_pigeon_instanceIdentifier = args[0]! as int;
           try {
-            (pigeon_instanceManager ?? PigeonInstanceManager.instance)
-                .addHostCreatedInstance(
+            (pigeon_instanceManager ?? PigeonInstanceManager.instance).addHostCreatedInstance(
               pigeon_newInstance?.call() ??
                   Certificate.pigeon_detached(
                     pigeon_binaryMessenger: pigeon_binaryMessenger,
@@ -7632,7 +7122,8 @@ class Certificate extends PigeonInternalProxyApiBaseClass {
             return wrapResponse(error: e);
           } catch (e) {
             return wrapResponse(
-                error: PlatformException(code: 'error', message: e.toString()));
+              error: PlatformException(code: 'error', message: e.toString()),
+            );
           }
         });
       }
@@ -7641,8 +7132,7 @@ class Certificate extends PigeonInternalProxyApiBaseClass {
 
   /// The encoded form of this certificate.
   Future<Uint8List> getEncoded() async {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
-        _pigeonVar_codecCertificate;
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecCertificate;
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
     const pigeonVar_channelName =
         'dev.flutter.pigeon.webview_flutter_android.Certificate.getEncoded';
@@ -7651,8 +7141,7 @@ class Certificate extends PigeonInternalProxyApiBaseClass {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture =
-        pigeonVar_channel.send(<Object?>[this]);
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[this]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
@@ -7681,13 +7170,9 @@ class WebSettingsCompat extends PigeonInternalProxyApiBaseClass {
   /// This should only be used by subclasses created by this library or to
   /// create copies for an [PigeonInstanceManager].
   @protected
-  WebSettingsCompat.pigeon_detached({
-    super.pigeon_binaryMessenger,
-    super.pigeon_instanceManager,
-  });
+  WebSettingsCompat.pigeon_detached({super.pigeon_binaryMessenger, super.pigeon_instanceManager});
 
-  late final _PigeonInternalProxyApiBaseCodec
-      _pigeonVar_codecWebSettingsCompat =
+  late final _PigeonInternalProxyApiBaseCodec _pigeonVar_codecWebSettingsCompat =
       _PigeonInternalProxyApiBaseCodec(pigeon_instanceManager);
 
   static void pigeon_setUpMessageHandlers({
@@ -7696,15 +7181,16 @@ class WebSettingsCompat extends PigeonInternalProxyApiBaseClass {
     PigeonInstanceManager? pigeon_instanceManager,
     WebSettingsCompat Function()? pigeon_newInstance,
   }) {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
-        _PigeonInternalProxyApiBaseCodec(
-            pigeon_instanceManager ?? PigeonInstanceManager.instance);
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _PigeonInternalProxyApiBaseCodec(
+      pigeon_instanceManager ?? PigeonInstanceManager.instance,
+    );
     final BinaryMessenger? binaryMessenger = pigeon_binaryMessenger;
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-          'dev.flutter.pigeon.webview_flutter_android.WebSettingsCompat.pigeon_newInstance',
-          pigeonChannelCodec,
-          binaryMessenger: binaryMessenger);
+        'dev.flutter.pigeon.webview_flutter_android.WebSettingsCompat.pigeon_newInstance',
+        pigeonChannelCodec,
+        binaryMessenger: binaryMessenger,
+      );
       if (pigeon_clearHandlers) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
@@ -7712,8 +7198,7 @@ class WebSettingsCompat extends PigeonInternalProxyApiBaseClass {
           final List<Object?> args = message! as List<Object?>;
           final int arg_pigeon_instanceIdentifier = args[0]! as int;
           try {
-            (pigeon_instanceManager ?? PigeonInstanceManager.instance)
-                .addHostCreatedInstance(
+            (pigeon_instanceManager ?? PigeonInstanceManager.instance).addHostCreatedInstance(
               pigeon_newInstance?.call() ??
                   WebSettingsCompat.pigeon_detached(
                     pigeon_binaryMessenger: pigeon_binaryMessenger,
@@ -7726,7 +7211,8 @@ class WebSettingsCompat extends PigeonInternalProxyApiBaseClass {
             return wrapResponse(error: e);
           } catch (e) {
             return wrapResponse(
-                error: PlatformException(code: 'error', message: e.toString()));
+              error: PlatformException(code: 'error', message: e.toString()),
+            );
           }
         });
       }
@@ -7740,14 +7226,11 @@ class WebSettingsCompat extends PigeonInternalProxyApiBaseClass {
     PigeonInstanceManager? pigeon_instanceManager,
   }) async {
     if (PigeonOverrides.webSettingsCompat_setPaymentRequestEnabled != null) {
-      return PigeonOverrides.webSettingsCompat_setPaymentRequestEnabled!(
-        webSettings,
-        enabled,
-      );
+      return PigeonOverrides.webSettingsCompat_setPaymentRequestEnabled!(webSettings, enabled);
     }
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
-        _PigeonInternalProxyApiBaseCodec(
-            pigeon_instanceManager ?? PigeonInstanceManager.instance);
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _PigeonInternalProxyApiBaseCodec(
+      pigeon_instanceManager ?? PigeonInstanceManager.instance,
+    );
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
     const pigeonVar_channelName =
         'dev.flutter.pigeon.webview_flutter_android.WebSettingsCompat.setPaymentRequestEnabled';
@@ -7756,15 +7239,13 @@ class WebSettingsCompat extends PigeonInternalProxyApiBaseClass {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture =
-        pigeonVar_channel.send(<Object?>[webSettings, enabled]);
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[
+      webSettings,
+      enabled,
+    ]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
-    _extractReplyValueOrThrow(
-      pigeonVar_replyList,
-      pigeonVar_channelName,
-      isNullValid: true,
-    );
+    _extractReplyValueOrThrow(pigeonVar_replyList, pigeonVar_channelName, isNullValid: true);
   }
 
   @override
@@ -7785,10 +7266,7 @@ class WebViewFeature extends PigeonInternalProxyApiBaseClass {
   /// This should only be used by subclasses created by this library or to
   /// create copies for an [PigeonInstanceManager].
   @protected
-  WebViewFeature.pigeon_detached({
-    super.pigeon_binaryMessenger,
-    super.pigeon_instanceManager,
-  });
+  WebViewFeature.pigeon_detached({super.pigeon_binaryMessenger, super.pigeon_instanceManager});
 
   late final _PigeonInternalProxyApiBaseCodec _pigeonVar_codecWebViewFeature =
       _PigeonInternalProxyApiBaseCodec(pigeon_instanceManager);
@@ -7799,15 +7277,16 @@ class WebViewFeature extends PigeonInternalProxyApiBaseClass {
     PigeonInstanceManager? pigeon_instanceManager,
     WebViewFeature Function()? pigeon_newInstance,
   }) {
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
-        _PigeonInternalProxyApiBaseCodec(
-            pigeon_instanceManager ?? PigeonInstanceManager.instance);
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _PigeonInternalProxyApiBaseCodec(
+      pigeon_instanceManager ?? PigeonInstanceManager.instance,
+    );
     final BinaryMessenger? binaryMessenger = pigeon_binaryMessenger;
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-          'dev.flutter.pigeon.webview_flutter_android.WebViewFeature.pigeon_newInstance',
-          pigeonChannelCodec,
-          binaryMessenger: binaryMessenger);
+        'dev.flutter.pigeon.webview_flutter_android.WebViewFeature.pigeon_newInstance',
+        pigeonChannelCodec,
+        binaryMessenger: binaryMessenger,
+      );
       if (pigeon_clearHandlers) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
@@ -7815,8 +7294,7 @@ class WebViewFeature extends PigeonInternalProxyApiBaseClass {
           final List<Object?> args = message! as List<Object?>;
           final int arg_pigeon_instanceIdentifier = args[0]! as int;
           try {
-            (pigeon_instanceManager ?? PigeonInstanceManager.instance)
-                .addHostCreatedInstance(
+            (pigeon_instanceManager ?? PigeonInstanceManager.instance).addHostCreatedInstance(
               pigeon_newInstance?.call() ??
                   WebViewFeature.pigeon_detached(
                     pigeon_binaryMessenger: pigeon_binaryMessenger,
@@ -7829,7 +7307,8 @@ class WebViewFeature extends PigeonInternalProxyApiBaseClass {
             return wrapResponse(error: e);
           } catch (e) {
             return wrapResponse(
-                error: PlatformException(code: 'error', message: e.toString()));
+              error: PlatformException(code: 'error', message: e.toString()),
+            );
           }
         });
       }
@@ -7844,9 +7323,9 @@ class WebViewFeature extends PigeonInternalProxyApiBaseClass {
     if (PigeonOverrides.webViewFeature_isFeatureSupported != null) {
       return PigeonOverrides.webViewFeature_isFeatureSupported!(feature);
     }
-    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec =
-        _PigeonInternalProxyApiBaseCodec(
-            pigeon_instanceManager ?? PigeonInstanceManager.instance);
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _PigeonInternalProxyApiBaseCodec(
+      pigeon_instanceManager ?? PigeonInstanceManager.instance,
+    );
     final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
     const pigeonVar_channelName =
         'dev.flutter.pigeon.webview_flutter_android.WebViewFeature.isFeatureSupported';
@@ -7855,8 +7334,7 @@ class WebViewFeature extends PigeonInternalProxyApiBaseClass {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture =
-        pigeonVar_channel.send(<Object?>[feature]);
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[feature]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
@@ -7875,4 +7353,3 @@ class WebViewFeature extends PigeonInternalProxyApiBaseClass {
     );
   }
 }
-

--- a/packages/webview_flutter/webview_flutter_android/lib/src/android_webview_controller.dart
+++ b/packages/webview_flutter/webview_flutter_android/lib/src/android_webview_controller.dart
@@ -1452,6 +1452,15 @@ class AndroidNavigationDelegate extends PlatformNavigationDelegate {
               isForMainFrame: request.isForMainFrame,
             );
           },
+      onCreateWindow: (_, String url) {
+        final CreateWindowCallback? callback = weakThis.target?._onCreateWindow;
+        if (callback != null) {
+          callback(url);
+        } else {
+          // Upstream default: load new-window URLs in the same WebView.
+          weakThis.target?._handleNavigation(url, isForMainFrame: true);
+        }
+      },
       urlLoading: (_, android_webview.WebView webView, String url) {
         weakThis.target?._handleNavigation(url, isForMainFrame: true);
       },
@@ -1560,6 +1569,7 @@ class AndroidNavigationDelegate extends PlatformNavigationDelegate {
   ProgressCallback? _onProgress;
   WebResourceErrorCallback? _onWebResourceError;
   NavigationRequestCallback? _onNavigationRequest;
+  CreateWindowCallback? _onCreateWindow;
   LoadRequestCallback? _onLoadRequest;
   UrlChangeCallback? _onUrlChange;
   HttpAuthRequestCallback? _onHttpAuthRequest;
@@ -1603,6 +1613,11 @@ class AndroidNavigationDelegate extends PlatformNavigationDelegate {
   Future<void> setOnNavigationRequest(NavigationRequestCallback onNavigationRequest) async {
     _onNavigationRequest = onNavigationRequest;
     return _webViewClient.setSynchronousReturnValueForShouldOverrideUrlLoading(true);
+  }
+
+  @override
+  Future<void> setOnCreateWindow(CreateWindowCallback onCreateWindow) async {
+    _onCreateWindow = onCreateWindow;
   }
 
   @override

--- a/packages/webview_flutter/webview_flutter_android/pigeons/android_webkit.dart
+++ b/packages/webview_flutter/webview_flutter_android/pigeons/android_webkit.dart
@@ -490,6 +490,10 @@ abstract class WebViewClient {
   /// be loaded in the current WebView.
   late void Function(WebView webView, String url)? urlLoading;
 
+  /// Notifies the host that the page requested a new window
+  /// (`target=_blank` / `window.open`).
+  late void Function(String url)? onCreateWindow;
+
   /// Notify the host application to update its visited links database.
   late void Function(WebView webView, String url, bool isReload)? doUpdateVisitedHistory;
 

--- a/packages/webview_flutter/webview_flutter_android/pubspec.yaml
+++ b/packages/webview_flutter/webview_flutter_android/pubspec.yaml
@@ -2,7 +2,7 @@ name: webview_flutter_android
 description: A Flutter plugin that provides a WebView widget on Android.
 repository: https://github.com/flutter/packages/tree/main/packages/webview_flutter/webview_flutter_android
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+webview%22
-version: 4.13.0
+version: 4.14.0
 
 environment:
   sdk: ^3.12.0

--- a/packages/webview_flutter/webview_flutter_android/pubspec.yaml
+++ b/packages/webview_flutter/webview_flutter_android/pubspec.yaml
@@ -21,8 +21,7 @@ dependencies:
   flutter:
     sdk: flutter
   meta: ^1.10.0
-  webview_flutter_platform_interface:
-    path: ../webview_flutter_platform_interface
+  webview_flutter_platform_interface: ^2.16.0
 
 dev_dependencies:
   build_runner: ^2.1.4
@@ -35,3 +34,7 @@ topics:
   - html
   - webview
   - webview-flutter
+# FOR TESTING AND INITIAL REVIEW ONLY. DO NOT MERGE.
+# See https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changing-federated-plugins
+dependency_overrides:
+  webview_flutter_platform_interface: {path: ../../../packages/webview_flutter/webview_flutter_platform_interface}

--- a/packages/webview_flutter/webview_flutter_android/pubspec.yaml
+++ b/packages/webview_flutter/webview_flutter_android/pubspec.yaml
@@ -21,7 +21,8 @@ dependencies:
   flutter:
     sdk: flutter
   meta: ^1.10.0
-  webview_flutter_platform_interface: ^2.15.1
+  webview_flutter_platform_interface:
+    path: ../webview_flutter_platform_interface
 
 dev_dependencies:
   build_runner: ^2.1.4

--- a/packages/webview_flutter/webview_flutter_android/test/android_navigation_delegate_test.dart
+++ b/packages/webview_flutter/webview_flutter_android/test/android_navigation_delegate_test.dart
@@ -42,6 +42,20 @@ void main() {
       expect(callbackUrl, 'https://www.google.com');
     });
 
+    test('onCreateWindow', () {
+      final androidNavigationDelegate = AndroidNavigationDelegate(_buildCreationParams());
+
+      late final String callbackUrl;
+      androidNavigationDelegate.setOnCreateWindow((String url) => callbackUrl = url);
+
+      CapturingWebViewClient.lastCreatedDelegate.onCreateWindow!(
+        CapturingWebViewClient(),
+        'https://www.google.com',
+      );
+
+      expect(callbackUrl, 'https://www.google.com');
+    });
+
     test('onPageStarted', () {
       final androidNavigationDelegate = AndroidNavigationDelegate(_buildCreationParams());
 
@@ -660,6 +674,7 @@ class CapturingWebViewClient extends android_webview.WebViewClient {
     super.onReceivedRequestError,
     super.requestLoading,
     super.urlLoading,
+    super.onCreateWindow,
     super.onFormResubmission,
     super.onLoadResource,
     super.onPageCommitVisible,

--- a/packages/webview_flutter/webview_flutter_android/test/android_webview_controller_test.dart
+++ b/packages/webview_flutter/webview_flutter_android/test/android_webview_controller_test.dart
@@ -198,6 +198,7 @@ void main() {
           )?
           requestLoading,
           void Function(android_webview.WebViewClient, android_webview.WebView, String)? urlLoading,
+          void Function(android_webview.WebViewClient, String)? onCreateWindow,
           void Function(android_webview.WebViewClient, android_webview.WebView, String, bool)?
           doUpdateVisitedHistory,
           void Function(
@@ -2295,6 +2296,7 @@ class TestWebViewClient extends android_webview.WebViewClient {
     super.onReceivedRequestErrorCompat,
     super.requestLoading,
     super.urlLoading,
+    super.onCreateWindow,
     super.doUpdateVisitedHistory,
     super.onReceivedHttpAuthRequest,
     super.onFormResubmission,

--- a/packages/webview_flutter/webview_flutter_platform_interface/CHANGELOG.md
+++ b/packages/webview_flutter/webview_flutter_platform_interface/CHANGELOG.md
@@ -1,5 +1,6 @@
-## NEXT
+## 2.16.0
 
+* Adds NavigationDelegate.onCreateWindow for target=_blank / window.open.
 * Updates minimum supported SDK version to Flutter 3.38/Dart 3.10.
 
 ## 2.15.1

--- a/packages/webview_flutter/webview_flutter_platform_interface/lib/src/platform_navigation_delegate.dart
+++ b/packages/webview_flutter/webview_flutter_platform_interface/lib/src/platform_navigation_delegate.dart
@@ -15,6 +15,14 @@ import 'webview_platform.dart' show WebViewPlatform;
 typedef NavigationRequestCallback =
     FutureOr<NavigationDecision> Function(NavigationRequest navigationRequest);
 
+/// Signature for callbacks when the page requests a new window
+/// (`target=_blank` / `window.open`).
+///
+/// Corresponds to platform APIs like iOS `WKUIDelegate.createWebViewWith` and
+/// Android `WebChromeClient.onCreateWindow`. The host should open [url]
+/// externally (or otherwise handle it); the WebView will not load it.
+typedef CreateWindowCallback = void Function(String url);
+
 /// Signature for callbacks that report page events triggered by the native web view.
 typedef PageEventCallback = void Function(String url);
 
@@ -80,6 +88,13 @@ abstract class PlatformNavigationDelegate extends PlatformInterface {
   /// See [PlatformWebViewController.setPlatformNavigationDelegate].
   Future<void> setOnNavigationRequest(NavigationRequestCallback onNavigationRequest) {
     throw UnimplementedError('setOnNavigationRequest is not implemented on the current platform.');
+  }
+
+  /// Invoked when the page requests a new window (`target=_blank` / `window.open`).
+  ///
+  /// See [PlatformWebViewController.setPlatformNavigationDelegate].
+  Future<void> setOnCreateWindow(CreateWindowCallback onCreateWindow) {
+    throw UnimplementedError('setOnCreateWindow is not implemented on the current platform.');
   }
 
   /// Invoked when a page has started loading.

--- a/packages/webview_flutter/webview_flutter_platform_interface/pubspec.yaml
+++ b/packages/webview_flutter/webview_flutter_platform_interface/pubspec.yaml
@@ -4,7 +4,7 @@ repository: https://github.com/flutter/packages/tree/main/packages/webview_flutt
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+webview_flutter%22
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 2.15.1
+version: 2.16.0
 
 environment:
   sdk: ^3.10.0

--- a/packages/webview_flutter/webview_flutter_platform_interface/test/platform_navigation_delegate_test.dart
+++ b/packages/webview_flutter/webview_flutter_platform_interface/test/platform_navigation_delegate_test.dart
@@ -63,6 +63,14 @@ void main() {
     );
   });
 
+  test('Default implementation of setOnCreateWindow should throw unimplemented error', () {
+    final PlatformNavigationDelegate callbackDelegate = ExtendsPlatformNavigationDelegate(
+      const PlatformNavigationDelegateCreationParams(),
+    );
+
+    expect(() => callbackDelegate.setOnCreateWindow((String url) {}), throwsUnimplementedError);
+  });
+
   test('Default implementation of setOnPageStarted should throw unimplemented error', () {
     final PlatformNavigationDelegate callbackDelegate = ExtendsPlatformNavigationDelegate(
       const PlatformNavigationDelegateCreationParams(),

--- a/packages/webview_flutter/webview_flutter_web/example/pubspec.yaml
+++ b/packages/webview_flutter/webview_flutter_web/example/pubspec.yaml
@@ -29,3 +29,7 @@ dev_dependencies:
 
 flutter:
   uses-material-design: true
+# FOR TESTING AND INITIAL REVIEW ONLY. DO NOT MERGE.
+# See https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changing-federated-plugins
+dependency_overrides:
+  webview_flutter_platform_interface: {path: ../../../../packages/webview_flutter/webview_flutter_platform_interface}

--- a/packages/webview_flutter/webview_flutter_web/pubspec.yaml
+++ b/packages/webview_flutter/webview_flutter_web/pubspec.yaml
@@ -34,3 +34,7 @@ topics:
   - html
   - webview
   - webview-flutter
+# FOR TESTING AND INITIAL REVIEW ONLY. DO NOT MERGE.
+# See https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changing-federated-plugins
+dependency_overrides:
+  webview_flutter_platform_interface: {path: ../../../packages/webview_flutter/webview_flutter_platform_interface}

--- a/packages/webview_flutter/webview_flutter_wkwebview/CHANGELOG.md
+++ b/packages/webview_flutter/webview_flutter_wkwebview/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.27.0
+
+* Adds NavigationDelegate.onCreateWindow for target=_blank / window.open.
+
 ## 3.26.0
 
 * Adds new method for accessing a native `WKWebView` from a `FlutterPluginRegistrar`.

--- a/packages/webview_flutter/webview_flutter_wkwebview/example/integration_test/legacy/webview_flutter_test.dart
+++ b/packages/webview_flutter/webview_flutter_wkwebview/example/integration_test/legacy/webview_flutter_test.dart
@@ -76,22 +76,24 @@ Future<void> main() async {
     expect(currentUrl, primaryUrl);
   });
 
-  testWidgets('withWeakRefenceTo allows encapsulating class to be garbage collected', (
-    WidgetTester tester,
-  ) async {
-    final gcCompleter = Completer<int>();
-    final instanceManager = PigeonInstanceManager(onWeakReferenceRemoved: gcCompleter.complete);
+  testWidgets(
+    'withWeakRefenceTo allows encapsulating class to be garbage collected',
+    (WidgetTester tester) async {
+      final gcCompleter = Completer<int>();
+      final instanceManager = PigeonInstanceManager(onWeakReferenceRemoved: gcCompleter.complete);
 
-    ClassWithCallbackClass? instance = ClassWithCallbackClass();
-    instanceManager.addDartCreatedInstance(instance.callbackClass);
-    instance = null;
+      ClassWithCallbackClass? instance = ClassWithCallbackClass();
+      instanceManager.addDartCreatedInstance(instance.callbackClass);
+      instance = null;
 
-    // Force garbage collection.
-    await forceGC();
+      // Force garbage collection.
+      await forceGC();
 
-    final int gcIdentifier = await gcCompleter.future;
-    expect(gcIdentifier, 0);
-  }, timeout: const Timeout(Duration(seconds: 10)));
+      final int gcIdentifier = await gcCompleter.future;
+      expect(gcIdentifier, 0);
+    },
+    timeout: const Timeout(Duration(seconds: 10)),
+  );
 
   testWidgets('loadUrl', (WidgetTester tester) async {
     final controllerCompleter = Completer<WebViewController>();
@@ -455,104 +457,112 @@ Future<void> main() async {
         skip: Platform.isIOS,
       );
 
-      testWidgets('Video plays inline when allowsInlineMediaPlayback is true', (
-        WidgetTester tester,
-      ) async {
-        final String videoTestBase64 = await getTestVideoBase64();
-        final controllerCompleter = Completer<WebViewController>();
-        final pageLoaded = Completer<void>();
-        final videoPlaying = Completer<void>();
+      testWidgets(
+        'Video plays inline when allowsInlineMediaPlayback is true',
+        (WidgetTester tester) async {
+          final String videoTestBase64 = await getTestVideoBase64();
+          final controllerCompleter = Completer<WebViewController>();
+          final pageLoaded = Completer<void>();
+          final videoPlaying = Completer<void>();
 
-        await tester.pumpWidget(
-          Directionality(
-            textDirection: TextDirection.ltr,
-            child: WebView(
-              initialUrl: 'data:text/html;charset=utf-8;base64,$videoTestBase64',
-              onWebViewCreated: (WebViewController controller) {
-                controllerCompleter.complete(controller);
-              },
-              javascriptMode: JavascriptMode.unrestricted,
-              javascriptChannels: <JavascriptChannel>{
-                JavascriptChannel(
-                  name: 'VideoTestTime',
-                  onMessageReceived: (JavascriptMessage message) {
-                    final double currentTime = double.parse(message.message);
-                    // Let it play for at least 1 second to make sure the related video's properties are set.
-                    if (currentTime > 1 && !videoPlaying.isCompleted) {
-                      videoPlaying.complete(null);
-                    }
-                  },
-                ),
-              },
-              onPageFinished: (String url) {
-                pageLoaded.complete(null);
-              },
-              initialMediaPlaybackPolicy: AutoMediaPlaybackPolicy.always_allow,
-              allowsInlineMediaPlayback: true,
+          await tester.pumpWidget(
+            Directionality(
+              textDirection: TextDirection.ltr,
+              child: WebView(
+                initialUrl: 'data:text/html;charset=utf-8;base64,$videoTestBase64',
+                onWebViewCreated: (WebViewController controller) {
+                  controllerCompleter.complete(controller);
+                },
+                javascriptMode: JavascriptMode.unrestricted,
+                javascriptChannels: <JavascriptChannel>{
+                  JavascriptChannel(
+                    name: 'VideoTestTime',
+                    onMessageReceived: (JavascriptMessage message) {
+                      final double currentTime = double.parse(message.message);
+                      // Let it play for at least 1 second to make sure the related video's properties are set.
+                      if (currentTime > 1 && !videoPlaying.isCompleted) {
+                        videoPlaying.complete(null);
+                      }
+                    },
+                  ),
+                },
+                onPageFinished: (String url) {
+                  pageLoaded.complete(null);
+                },
+                initialMediaPlaybackPolicy: AutoMediaPlaybackPolicy.always_allow,
+                allowsInlineMediaPlayback: true,
+              ),
             ),
-          ),
-        );
-        final WebViewController controller = await controllerCompleter.future;
-        await pageLoaded.future;
+          );
+          final WebViewController controller = await controllerCompleter.future;
+          await pageLoaded.future;
 
-        // Pump once to trigger the video play.
-        await tester.pump();
+          // Pump once to trigger the video play.
+          await tester.pump();
 
-        // Makes sure we get the correct event that indicates the video is actually playing.
-        await videoPlaying.future;
+          // Makes sure we get the correct event that indicates the video is actually playing.
+          await videoPlaying.future;
 
-        final String fullScreen = await controller.runJavascriptReturningResult('isFullScreen();');
-        expect(fullScreen, _webviewBool(false));
-      }, skip: Platform.isMacOS || skipOnIosFor154676);
+          final String fullScreen = await controller.runJavascriptReturningResult(
+            'isFullScreen();',
+          );
+          expect(fullScreen, _webviewBool(false));
+        },
+        skip: Platform.isMacOS || skipOnIosFor154676,
+      );
 
-      testWidgets('Video plays full screen when allowsInlineMediaPlayback is false', (
-        WidgetTester tester,
-      ) async {
-        final String videoTestBase64 = await getTestVideoBase64();
-        final controllerCompleter = Completer<WebViewController>();
-        final pageLoaded = Completer<void>();
-        final videoPlaying = Completer<void>();
+      testWidgets(
+        'Video plays full screen when allowsInlineMediaPlayback is false',
+        (WidgetTester tester) async {
+          final String videoTestBase64 = await getTestVideoBase64();
+          final controllerCompleter = Completer<WebViewController>();
+          final pageLoaded = Completer<void>();
+          final videoPlaying = Completer<void>();
 
-        await tester.pumpWidget(
-          Directionality(
-            textDirection: TextDirection.ltr,
-            child: WebView(
-              initialUrl: 'data:text/html;charset=utf-8;base64,$videoTestBase64',
-              onWebViewCreated: (WebViewController controller) {
-                controllerCompleter.complete(controller);
-              },
-              javascriptMode: JavascriptMode.unrestricted,
-              javascriptChannels: <JavascriptChannel>{
-                JavascriptChannel(
-                  name: 'VideoTestTime',
-                  onMessageReceived: (JavascriptMessage message) {
-                    final double currentTime = double.parse(message.message);
-                    // Let it play for at least 1 second to make sure the related video's properties are set.
-                    if (currentTime > 1 && !videoPlaying.isCompleted) {
-                      videoPlaying.complete(null);
-                    }
-                  },
-                ),
-              },
-              onPageFinished: (String url) {
-                pageLoaded.complete(null);
-              },
-              initialMediaPlaybackPolicy: AutoMediaPlaybackPolicy.always_allow,
+          await tester.pumpWidget(
+            Directionality(
+              textDirection: TextDirection.ltr,
+              child: WebView(
+                initialUrl: 'data:text/html;charset=utf-8;base64,$videoTestBase64',
+                onWebViewCreated: (WebViewController controller) {
+                  controllerCompleter.complete(controller);
+                },
+                javascriptMode: JavascriptMode.unrestricted,
+                javascriptChannels: <JavascriptChannel>{
+                  JavascriptChannel(
+                    name: 'VideoTestTime',
+                    onMessageReceived: (JavascriptMessage message) {
+                      final double currentTime = double.parse(message.message);
+                      // Let it play for at least 1 second to make sure the related video's properties are set.
+                      if (currentTime > 1 && !videoPlaying.isCompleted) {
+                        videoPlaying.complete(null);
+                      }
+                    },
+                  ),
+                },
+                onPageFinished: (String url) {
+                  pageLoaded.complete(null);
+                },
+                initialMediaPlaybackPolicy: AutoMediaPlaybackPolicy.always_allow,
+              ),
             ),
-          ),
-        );
-        final WebViewController controller = await controllerCompleter.future;
-        await pageLoaded.future;
+          );
+          final WebViewController controller = await controllerCompleter.future;
+          await pageLoaded.future;
 
-        // Pump once to trigger the video play.
-        await tester.pump();
+          // Pump once to trigger the video play.
+          await tester.pump();
 
-        // Makes sure we get the correct event that indicates the video is actually playing.
-        await videoPlaying.future;
+          // Makes sure we get the correct event that indicates the video is actually playing.
+          await videoPlaying.future;
 
-        final String fullScreen = await controller.runJavascriptReturningResult('isFullScreen();');
-        expect(fullScreen, _webviewBool(true));
-      }, skip: Platform.isMacOS || skipOnIosFor154676);
+          final String fullScreen = await controller.runJavascriptReturningResult(
+            'isFullScreen();',
+          );
+          expect(fullScreen, _webviewBool(true));
+        },
+        skip: Platform.isMacOS || skipOnIosFor154676,
+      );
     },
     // allowsInlineMediaPlayback has no effect on macOS.
     skip: Platform.isMacOS,

--- a/packages/webview_flutter/webview_flutter_wkwebview/example/pubspec.yaml
+++ b/packages/webview_flutter/webview_flutter_wkwebview/example/pubspec.yaml
@@ -35,3 +35,7 @@ flutter:
     - assets/www/styles/style.css
     # Test certificate used to create a test native `SecTrust`.
     - assets/test_cert.der
+# FOR TESTING AND INITIAL REVIEW ONLY. DO NOT MERGE.
+# See https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changing-federated-plugins
+dependency_overrides:
+  webview_flutter_platform_interface: {path: ../../../../packages/webview_flutter/webview_flutter_platform_interface}

--- a/packages/webview_flutter/webview_flutter_wkwebview/lib/src/webkit_webview_controller.dart
+++ b/packages/webview_flutter/webview_flutter_wkwebview/lib/src/webkit_webview_controller.dart
@@ -196,7 +196,7 @@ class WebKitWebViewController extends PlatformWebViewController {
             }
 
             // Upstream default when no host callback is registered.
-            PlatformWebView.fromNativeWebView(webView).load(navigationAction.request);
+            await PlatformWebView.fromNativeWebView(webView).load(navigationAction.request);
           },
       requestMediaCapturePermission:
           (

--- a/packages/webview_flutter/webview_flutter_wkwebview/lib/src/webkit_webview_controller.dart
+++ b/packages/webview_flutter/webview_flutter_wkwebview/lib/src/webkit_webview_controller.dart
@@ -175,11 +175,28 @@ class WebKitWebViewController extends PlatformWebViewController {
             WKWebView webView,
             WKWebViewConfiguration configuration,
             WKNavigationAction navigationAction,
-          ) {
+          ) async {
+            // New-window requests (`target=_blank` / `window.open`) map to
+            // onCreateWindow — same role as WKUIDelegate.createWebViewWith.
             final bool isForMainFrame = navigationAction.targetFrame?.isMainFrame ?? false;
-            if (!isForMainFrame) {
-              PlatformWebView.fromNativeWebView(webView).load(navigationAction.request);
+            if (isForMainFrame) {
+              return;
             }
+
+            final String url = await navigationAction.request.getUrl() ?? '';
+            if (url.isEmpty) {
+              return;
+            }
+
+            final CreateWindowCallback? onCreateWindow =
+                weakThis.target?._currentNavigationDelegate?._onCreateWindow;
+            if (onCreateWindow != null) {
+              onCreateWindow(url);
+              return;
+            }
+
+            // Upstream default when no host callback is registered.
+            PlatformWebView.fromNativeWebView(webView).load(navigationAction.request);
           },
       requestMediaCapturePermission:
           (
@@ -1232,6 +1249,7 @@ class WebKitNavigationDelegate extends PlatformNavigationDelegate {
   ProgressCallback? _onProgress;
   WebResourceErrorCallback? _onWebResourceError;
   NavigationRequestCallback? _onNavigationRequest;
+  CreateWindowCallback? _onCreateWindow;
   UrlChangeCallback? _onUrlChange;
   HttpAuthRequestCallback? _onHttpAuthRequest;
   SslAuthErrorCallback? _onSslAuthError;
@@ -1264,6 +1282,11 @@ class WebKitNavigationDelegate extends PlatformNavigationDelegate {
   @override
   Future<void> setOnNavigationRequest(NavigationRequestCallback onNavigationRequest) async {
     _onNavigationRequest = onNavigationRequest;
+  }
+
+  @override
+  Future<void> setOnCreateWindow(CreateWindowCallback onCreateWindow) async {
+    _onCreateWindow = onCreateWindow;
   }
 
   @override

--- a/packages/webview_flutter/webview_flutter_wkwebview/pubspec.yaml
+++ b/packages/webview_flutter/webview_flutter_wkwebview/pubspec.yaml
@@ -2,7 +2,7 @@ name: webview_flutter_wkwebview
 description: A Flutter plugin that provides a WebView widget based on Apple's WKWebView control.
 repository: https://github.com/flutter/packages/tree/main/packages/webview_flutter/webview_flutter_wkwebview
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+webview%22
-version: 3.26.0
+version: 3.27.0
 
 environment:
   sdk: ^3.12.0

--- a/packages/webview_flutter/webview_flutter_wkwebview/pubspec.yaml
+++ b/packages/webview_flutter/webview_flutter_wkwebview/pubspec.yaml
@@ -26,7 +26,8 @@ dependencies:
     sdk: flutter
   meta: ^1.10.0
   path: ^1.8.0
-  webview_flutter_platform_interface: ^2.15.1
+  webview_flutter_platform_interface:
+    path: ../webview_flutter_platform_interface
 
 dev_dependencies:
   build_runner: ^2.1.5

--- a/packages/webview_flutter/webview_flutter_wkwebview/pubspec.yaml
+++ b/packages/webview_flutter/webview_flutter_wkwebview/pubspec.yaml
@@ -26,8 +26,7 @@ dependencies:
     sdk: flutter
   meta: ^1.10.0
   path: ^1.8.0
-  webview_flutter_platform_interface:
-    path: ../webview_flutter_platform_interface
+  webview_flutter_platform_interface: ^2.16.0
 
 dev_dependencies:
   build_runner: ^2.1.5
@@ -40,3 +39,7 @@ topics:
   - html
   - webview
   - webview-flutter
+# FOR TESTING AND INITIAL REVIEW ONLY. DO NOT MERGE.
+# See https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changing-federated-plugins
+dependency_overrides:
+  webview_flutter_platform_interface: {path: ../../../packages/webview_flutter/webview_flutter_platform_interface}

--- a/packages/webview_flutter/webview_flutter_wkwebview/test/webkit_webview_controller_test.dart
+++ b/packages/webview_flutter/webview_flutter_wkwebview/test/webkit_webview_controller_test.dart
@@ -1140,7 +1140,7 @@ void main() {
       expect(callbackProgress, 0);
     });
 
-    test('Requests to open a new window loads request in same window', () {
+    test('Requests to open a new window loads request in same window', () async {
       // Reset last created delegate.
       CapturingUIDelegate.lastCreatedDelegate = CapturingUIDelegate(
         requestMediaCapturePermission: (_, _, _, _, _) async {
@@ -1157,6 +1157,7 @@ void main() {
 
       final mockWebView = MockUIViewWKWebView();
       final mockRequest = MockURLRequest();
+      when(mockRequest.getUrl()).thenAnswer((_) => Future<String>.value('https://www.google.com'));
 
       CapturingUIDelegate.lastCreatedDelegate.onCreateWebView!(
         CapturingUIDelegate.lastCreatedDelegate,
@@ -1168,8 +1169,50 @@ void main() {
           navigationType: NavigationType.linkActivated,
         ),
       );
+      await pumpEventQueue();
 
       verify(mockWebView.load(mockRequest));
+    });
+
+    test('Requests to open a new window call onCreateWindow when set', () async {
+      CapturingUIDelegate.lastCreatedDelegate = CapturingUIDelegate(
+        requestMediaCapturePermission: (_, _, _, _, _) async {
+          return PermissionDecision.deny;
+        },
+        runJavaScriptConfirmPanel: (_, _, _, _) async {
+          return false;
+        },
+      );
+
+      final WebKitWebViewController controller = createControllerWithMocks();
+
+      PigeonOverrides.wKNavigationDelegate_new = CapturingNavigationDelegate.new;
+      final navigationDelegate = WebKitNavigationDelegate(
+        const WebKitNavigationDelegateCreationParams(),
+      );
+
+      late final String callbackUrl;
+      await navigationDelegate.setOnCreateWindow((String url) => callbackUrl = url);
+      await controller.setPlatformNavigationDelegate(navigationDelegate);
+
+      final mockWebView = MockUIViewWKWebView();
+      final mockRequest = MockURLRequest();
+      when(mockRequest.getUrl()).thenAnswer((_) => Future<String>.value('https://www.google.com'));
+
+      CapturingUIDelegate.lastCreatedDelegate.onCreateWebView!(
+        CapturingUIDelegate.lastCreatedDelegate,
+        mockWebView,
+        MockWKWebViewConfiguration(),
+        WKNavigationAction.pigeon_detached(
+          request: mockRequest,
+          targetFrame: WKFrameInfo.pigeon_detached(isMainFrame: false, request: MockURLRequest()),
+          navigationType: NavigationType.linkActivated,
+        ),
+      );
+      await pumpEventQueue();
+
+      expect(callbackUrl, 'https://www.google.com');
+      verifyNever(mockWebView.load(any));
     });
 
     test(


### PR DESCRIPTION
Adds an optional `NavigationDelegate.onCreateWindow` callback so hosts can
handle `target=_blank` / `window.open` (e.g. open in an external browser)
instead of only loading in the same WebView.

**Behavior**
- If `onCreateWindow` is set: Android (`WebChromeClient.onCreateWindow` →
  pigeon) and iOS/macOS (`WKUIDelegate.createWebViewWith`) invoke the callback
  with the requested URL.
- If unset: preserves existing same-WebView load behavior.

**Packages (federated review PR)**
- `webview_flutter_platform_interface` 2.16.0
- `webview_flutter_android` 4.14.0
- `webview_flutter_wkwebview` 3.27.0
- `webview_flutter` 4.15.0

Path `dependency_overrides` are present for combined review only
(`make-deps-path-based`). This PR is **not intended to land as-is**; after
approval we will land/publish in the usual federated order (platform
interface → implementations → app-facing).

## Related issues

Related to:
- https://github.com/flutter/flutter/issues/95060
- https://github.com/flutter/flutter/issues/36052
- https://github.com/flutter/flutter/issues/93425

Background (prior same-window `_blank` handling):
- https://github.com/flutter/flutter/issues/28875
- https://github.com/flutter/flutter/issues/42448
- https://github.com/flutter/plugins/pull/2500

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under[^1].
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [x] All existing and new tests are passing.

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.