### PR TITLE
[material_ui, cupertino_ui] Add migration bridge utilities

### DIFF
--- a/packages/cupertino_ui/lib/cupertino_ui.dart
+++ b/packages/cupertino_ui/lib/cupertino_ui.dart
@@ -55,6 +55,7 @@ export 'src/list_tile.dart';
 export 'src/localizations.dart';
 export 'src/magnifier.dart';
 export 'src/menu_anchor.dart';
+export 'src/migration_utility.dart';
 export 'src/nav_bar.dart';
 export 'src/page_scaffold.dart';
 export 'src/picker.dart';

--- a/packages/cupertino_ui/lib/src/migration_utility.dart
+++ b/packages/cupertino_ui/lib/src/migration_utility.dart
@@ -69,8 +69,18 @@ import 'package:flutter_localizations/flutter_localizations.dart';
 ///   }
 /// }
 /// ```
+@Deprecated(
+  'CupertinoUiCompatibilityBridge is a temporary migration utility intended for use only while '
+  'dependencies are being migrated to package:cupertino_ui. '
+  'This feature was deprecated to indicate it will be removed in a future release.',
+)
 class CupertinoUiCompatibilityBridge extends StatelessWidget {
   /// Creates a [CupertinoUiCompatibilityBridge].
+  @Deprecated(
+    'CupertinoUiCompatibilityBridge is a temporary migration utility intended for use only while '
+    'dependencies are being migrated to package:cupertino_ui. '
+    'This feature was deprecated to indicate it will be removed in a future release.',
+  )
   const CupertinoUiCompatibilityBridge({super.key, required this.child, this.delegates});
 
   /// The widget below this widget in the tree.

--- a/packages/cupertino_ui/lib/src/migration_utility.dart
+++ b/packages/cupertino_ui/lib/src/migration_utility.dart
@@ -1,0 +1,126 @@
+// Copyright 2013 The Flutter Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:cupertino_ui/cupertino_ui.dart' as modern; // ignore: prefer_relative_imports
+import 'package:flutter/cupertino.dart' as legacy;
+import 'package:flutter/widgets.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+
+/// A bridge widget for applications that have migrated to `package:cupertino_ui`
+/// but still contain subtrees or package dependencies using `package:flutter/cupertino.dart`.
+///
+/// This widget maps the parent [modern.CupertinoThemeData] from `package:cupertino_ui` into
+/// a legacy [legacy.CupertinoThemeData] and overrides [legacy.Localizations] with delegates
+/// so that legacy widgets in [child] can resolve `legacy.CupertinoTheme.of(context)` and
+/// `legacy.CupertinoLocalizations.of(context)`.
+///
+/// ## App-wide usage
+///
+/// The recommended way to use this bridge across an entire application is to
+/// wrap the app once using [modern.CupertinoApp.builder]:
+///
+/// ```dart
+/// import 'package:cupertino_ui/cupertino_ui.dart';
+///
+/// void main() {
+///   runApp(const MyApp());
+/// }
+///
+/// class MyApp extends StatelessWidget {
+///   const MyApp({super.key});
+///
+///   @override
+///   Widget build(BuildContext context) {
+///     return CupertinoApp(
+///       theme: const CupertinoThemeData(
+///         primaryColor: CupertinoColors.systemIndigo,
+///       ),
+///       builder: (BuildContext context, Widget? child) {
+///         return CupertinoUiCompatibilityBridge(child: child!);
+///       },
+///       home: const HomeScreen(),
+///     );
+///   }
+/// }
+/// ```
+///
+/// ## Subtree usage
+///
+/// Alternatively, wrap specific legacy package widgets or subtrees:
+///
+/// ```dart
+/// import 'package:cupertino_ui/cupertino_ui.dart';
+/// import 'package:some_legacy_package/some_legacy_package.dart';
+///
+/// class MyScreen extends StatelessWidget {
+///   const MyScreen({super.key});
+///
+///   @override
+///   Widget build(BuildContext context) {
+///     return CupertinoPageScaffold(
+///       navigationBar: const CupertinoNavigationBar(
+///         middle: Text('Migrated Screen'),
+///       ),
+///       child: CupertinoUiCompatibilityBridge(
+///         child: LegacyPackageWidget(),
+///       ),
+///     );
+///   }
+/// }
+/// ```
+class CupertinoUiCompatibilityBridge extends StatelessWidget {
+  /// Creates a [CupertinoUiCompatibilityBridge].
+  const CupertinoUiCompatibilityBridge({super.key, required this.child, this.delegates});
+
+  /// The widget below this widget in the tree.
+  final Widget child;
+
+  /// The localizations delegates for legacy widgets.
+  ///
+  /// Defaults to `[GlobalCupertinoLocalizations.delegate, GlobalWidgetsLocalizations.delegate]`.
+  final List<LocalizationsDelegate<dynamic>>? delegates;
+
+  @override
+  Widget build(BuildContext context) {
+    final modern.CupertinoThemeData modernTheme = modern.CupertinoTheme.of(context);
+
+    return legacy.CupertinoTheme(
+      data: _mapToLegacy(modernTheme),
+      child: legacy.Localizations.override(
+        context: context,
+        delegates:
+            delegates ??
+            const <LocalizationsDelegate<dynamic>>[
+              GlobalCupertinoLocalizations.delegate,
+              GlobalWidgetsLocalizations.delegate,
+            ],
+        child: child,
+      ),
+    );
+  }
+
+  legacy.CupertinoThemeData _mapToLegacy(modern.CupertinoThemeData modernTheme) {
+    return legacy.CupertinoThemeData(
+      brightness: modernTheme.brightness,
+      primaryColor: modernTheme.primaryColor,
+      primaryContrastingColor: modernTheme.primaryContrastingColor,
+      barBackgroundColor: modernTheme.barBackgroundColor,
+      scaffoldBackgroundColor: modernTheme.scaffoldBackgroundColor,
+      selectionHandleColor: modernTheme.selectionHandleColor,
+      applyThemeToAll: modernTheme.applyThemeToAll,
+      textTheme: legacy.CupertinoTextThemeData(
+        primaryColor: modernTheme.primaryColor,
+        textStyle: modernTheme.textTheme.textStyle,
+        actionTextStyle: modernTheme.textTheme.actionTextStyle,
+        actionSmallTextStyle: modernTheme.textTheme.actionSmallTextStyle,
+        tabLabelTextStyle: modernTheme.textTheme.tabLabelTextStyle,
+        navTitleTextStyle: modernTheme.textTheme.navTitleTextStyle,
+        navLargeTitleTextStyle: modernTheme.textTheme.navLargeTitleTextStyle,
+        navActionTextStyle: modernTheme.textTheme.navActionTextStyle,
+        pickerTextStyle: modernTheme.textTheme.pickerTextStyle,
+        dateTimePickerTextStyle: modernTheme.textTheme.dateTimePickerTextStyle,
+      ),
+    );
+  }
+}

--- a/packages/cupertino_ui/pending_changelogs/change_2026_07_29_compatibility_bridge.yaml
+++ b/packages/cupertino_ui/pending_changelogs/change_2026_07_29_compatibility_bridge.yaml
@@ -1,0 +1,3 @@
+changelog: |
+  - Adds CupertinoUiCompatibilityBridge for legacy flutter/cupertino.dart compatibility.
+version: minor

--- a/packages/cupertino_ui/test/migration_utility_test.dart
+++ b/packages/cupertino_ui/test/migration_utility_test.dart
@@ -39,11 +39,11 @@ void main() {
     );
 
     expect(capturedLegacyTheme, isNotNull);
-    expect(capturedLegacyTheme!.brightness, Brightness.dark);
-    expect(capturedLegacyTheme!.primaryColor, const Color(0xFF00FF00));
-    expect(capturedLegacyTheme!.primaryContrastingColor, const Color(0xFFFF0000));
-    expect(capturedLegacyTheme!.barBackgroundColor, const Color(0xFF111111));
-    expect(capturedLegacyTheme!.scaffoldBackgroundColor, const Color(0xFF222222));
+    expect(capturedLegacyTheme!.brightness, modernThemeData.brightness);
+    expect(capturedLegacyTheme!.primaryColor, modernThemeData.primaryColor);
+    expect(capturedLegacyTheme!.primaryContrastingColor, modernThemeData.primaryContrastingColor);
+    expect(capturedLegacyTheme!.barBackgroundColor, modernThemeData.barBackgroundColor);
+    expect(capturedLegacyTheme!.scaffoldBackgroundColor, modernThemeData.scaffoldBackgroundColor);
   });
 
   testWidgets('CupertinoUiCompatibilityBridge maps CupertinoTextThemeData properties', (
@@ -73,9 +73,18 @@ void main() {
     );
 
     expect(capturedLegacyTheme, isNotNull);
-    expect(capturedLegacyTheme!.textTheme.navTitleTextStyle.fontSize, 20.0);
-    expect(capturedLegacyTheme!.textTheme.navTitleTextStyle.fontWeight, FontWeight.bold);
-    expect(capturedLegacyTheme!.textTheme.actionTextStyle.color, const Color(0xFF123456));
+    expect(
+      capturedLegacyTheme!.textTheme.navTitleTextStyle.fontSize,
+      modernTextTheme.navTitleTextStyle.fontSize,
+    );
+    expect(
+      capturedLegacyTheme!.textTheme.navTitleTextStyle.fontWeight,
+      modernTextTheme.navTitleTextStyle.fontWeight,
+    );
+    expect(
+      capturedLegacyTheme!.textTheme.actionTextStyle.color,
+      modernTextTheme.actionTextStyle.color,
+    );
   });
 
   testWidgets('CupertinoUiCompatibilityBridge provides CupertinoLocalizations', (

--- a/packages/cupertino_ui/test/migration_utility_test.dart
+++ b/packages/cupertino_ui/test/migration_utility_test.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// ignore_for_file: deprecated_member_use
+
 import 'package:cupertino_ui/cupertino_ui.dart' as modern;
 import 'package:flutter/cupertino.dart' as legacy;
 import 'package:flutter/widgets.dart';

--- a/packages/cupertino_ui/test/migration_utility_test.dart
+++ b/packages/cupertino_ui/test/migration_utility_test.dart
@@ -1,0 +1,171 @@
+// Copyright 2013 The Flutter Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:cupertino_ui/cupertino_ui.dart' as modern;
+import 'package:flutter/cupertino.dart' as legacy;
+import 'package:flutter/widgets.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('CupertinoUiCompatibilityBridge provides mapped CupertinoThemeData properties', (
+    WidgetTester tester,
+  ) async {
+    legacy.CupertinoThemeData? capturedLegacyTheme;
+
+    const modernThemeData = modern.CupertinoThemeData(
+      brightness: Brightness.dark,
+      primaryColor: Color(0xFF00FF00),
+      primaryContrastingColor: Color(0xFFFF0000),
+      barBackgroundColor: Color(0xFF111111),
+      scaffoldBackgroundColor: Color(0xFF222222),
+    );
+
+    await tester.pumpWidget(
+      modern.CupertinoApp(
+        theme: modernThemeData,
+        home: modern.CupertinoUiCompatibilityBridge(
+          child: Builder(
+            builder: (BuildContext context) {
+              capturedLegacyTheme = legacy.CupertinoTheme.of(context);
+              return const SizedBox.shrink();
+            },
+          ),
+        ),
+      ),
+    );
+
+    expect(capturedLegacyTheme, isNotNull);
+    expect(capturedLegacyTheme!.brightness, Brightness.dark);
+    expect(capturedLegacyTheme!.primaryColor, const Color(0xFF00FF00));
+    expect(capturedLegacyTheme!.primaryContrastingColor, const Color(0xFFFF0000));
+    expect(capturedLegacyTheme!.barBackgroundColor, const Color(0xFF111111));
+    expect(capturedLegacyTheme!.scaffoldBackgroundColor, const Color(0xFF222222));
+  });
+
+  testWidgets('CupertinoUiCompatibilityBridge maps CupertinoTextThemeData properties', (
+    WidgetTester tester,
+  ) async {
+    legacy.CupertinoThemeData? capturedLegacyTheme;
+
+    const modernTextTheme = modern.CupertinoTextThemeData(
+      navTitleTextStyle: TextStyle(fontSize: 20.0, fontWeight: FontWeight.bold),
+      actionTextStyle: TextStyle(fontSize: 16.0, color: Color(0xFF123456)),
+    );
+
+    const modernThemeData = modern.CupertinoThemeData(textTheme: modernTextTheme);
+
+    await tester.pumpWidget(
+      modern.CupertinoApp(
+        theme: modernThemeData,
+        home: modern.CupertinoUiCompatibilityBridge(
+          child: Builder(
+            builder: (BuildContext context) {
+              capturedLegacyTheme = legacy.CupertinoTheme.of(context);
+              return const SizedBox.shrink();
+            },
+          ),
+        ),
+      ),
+    );
+
+    expect(capturedLegacyTheme, isNotNull);
+    expect(capturedLegacyTheme!.textTheme.navTitleTextStyle.fontSize, 20.0);
+    expect(capturedLegacyTheme!.textTheme.navTitleTextStyle.fontWeight, FontWeight.bold);
+    expect(capturedLegacyTheme!.textTheme.actionTextStyle.color, const Color(0xFF123456));
+  });
+
+  testWidgets('CupertinoUiCompatibilityBridge provides CupertinoLocalizations', (
+    WidgetTester tester,
+  ) async {
+    legacy.CupertinoLocalizations? capturedLegacyLocalizations;
+
+    await tester.pumpWidget(
+      modern.CupertinoApp(
+        home: modern.CupertinoUiCompatibilityBridge(
+          child: Builder(
+            builder: (BuildContext context) {
+              capturedLegacyLocalizations = legacy.CupertinoLocalizations.of(context);
+              return const SizedBox.shrink();
+            },
+          ),
+        ),
+      ),
+    );
+
+    expect(capturedLegacyLocalizations, isNotNull);
+    expect(capturedLegacyLocalizations!.datePickerDateOrder, isNotNull);
+    expect(capturedLegacyLocalizations!.modalBarrierDismissLabel, isNotEmpty);
+  });
+
+  testWidgets('CupertinoUiCompatibilityBridge allows rendering legacy Cupertino widgets', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(
+      modern.CupertinoApp(
+        home: modern.CupertinoUiCompatibilityBridge(
+          child: legacy.CupertinoPageScaffold(
+            navigationBar: const legacy.CupertinoNavigationBar(middle: Text('Legacy Title')),
+            child: Center(
+              child: legacy.CupertinoButton(onPressed: () {}, child: const Text('Legacy Button')),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text('Legacy Title'), findsOneWidget);
+    expect(find.text('Legacy Button'), findsOneWidget);
+    expect(find.byType(legacy.CupertinoButton), findsOneWidget);
+    expect(find.byType(legacy.CupertinoPageScaffold), findsOneWidget);
+  });
+
+  testWidgets('CupertinoUiCompatibilityBridge supports custom delegates', (
+    WidgetTester tester,
+  ) async {
+    legacy.CupertinoLocalizations? capturedLegacyLocalizations;
+
+    await tester.pumpWidget(
+      modern.CupertinoApp(
+        home: modern.CupertinoUiCompatibilityBridge(
+          delegates: const <LocalizationsDelegate<dynamic>>[GlobalCupertinoLocalizations.delegate],
+          child: Builder(
+            builder: (BuildContext context) {
+              capturedLegacyLocalizations = legacy.CupertinoLocalizations.of(context);
+              return const SizedBox.shrink();
+            },
+          ),
+        ),
+      ),
+    );
+
+    expect(capturedLegacyLocalizations, isNotNull);
+    expect(capturedLegacyLocalizations!.modalBarrierDismissLabel, isNotEmpty);
+  });
+
+  testWidgets('CupertinoUiCompatibilityBridge works at root in CupertinoApp.builder', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(
+      modern.CupertinoApp(
+        builder: (BuildContext context, Widget? child) {
+          return modern.CupertinoUiCompatibilityBridge(child: child!);
+        },
+        home: modern.CupertinoPageScaffold(
+          child: Column(
+            children: <Widget>[
+              modern.CupertinoButton(onPressed: () {}, child: const Text('Modern Button')),
+              legacy.CupertinoButton(onPressed: () {}, child: const Text('Legacy Button')),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text('Modern Button'), findsOneWidget);
+    expect(find.text('Legacy Button'), findsOneWidget);
+    expect(find.byType(modern.CupertinoButton), findsOneWidget);
+    expect(find.byType(legacy.CupertinoButton), findsOneWidget);
+  });
+}

--- a/packages/material_ui/lib/material_ui.dart
+++ b/packages/material_ui/lib/material_ui.dart
@@ -129,6 +129,7 @@ export 'src/menu_button_theme.dart';
 export 'src/menu_style.dart';
 export 'src/menu_theme.dart';
 export 'src/mergeable_material.dart';
+export 'src/migration_utility.dart';
 export 'src/motion.dart';
 export 'src/navigation_bar.dart';
 export 'src/navigation_bar_theme.dart';

--- a/packages/material_ui/lib/src/migration_utility.dart
+++ b/packages/material_ui/lib/src/migration_utility.dart
@@ -114,6 +114,11 @@ class MaterialUiCompatibilityBridge extends StatelessWidget {
     final modern.TextTheme textTheme = modernTheme.textTheme;
 
     return legacy.ThemeData(
+      platform: modernTheme.platform,
+      visualDensity: legacy.VisualDensity(
+        horizontal: modernTheme.visualDensity.horizontal,
+        vertical: modernTheme.visualDensity.vertical,
+      ),
       colorScheme: legacy.ColorScheme(
         brightness: scheme.brightness,
         primary: scheme.primary,

--- a/packages/material_ui/lib/src/migration_utility.dart
+++ b/packages/material_ui/lib/src/migration_utility.dart
@@ -1,0 +1,163 @@
+// Copyright 2013 The Flutter Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart' as legacy;
+import 'package:flutter/widgets.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:material_ui/material_ui.dart' as modern; // ignore: prefer_relative_imports
+
+/// A bridge widget for applications that have migrated to `package:material_ui`
+/// but still contain subtrees or package dependencies using `package:flutter/material.dart`.
+///
+/// This widget maps the parent [modern.ThemeData] from `package:material_ui` into
+/// a legacy [legacy.ThemeData] and overrides [legacy.Localizations] with delegates
+/// so that legacy widgets in [child] can resolve `legacy.Theme.of(context)` and
+/// `legacy.MaterialLocalizations.of(context)`.
+///
+/// ## App-wide usage
+///
+/// The recommended way to use this bridge across an entire application is to
+/// wrap the app once using [modern.MaterialApp.builder]:
+///
+/// ```dart
+/// import 'package:material_ui/material_ui.dart';
+///
+/// void main() {
+///   runApp(const MyApp());
+/// }
+///
+/// class MyApp extends StatelessWidget {
+///   const MyApp({super.key});
+///
+///   @override
+///   Widget build(BuildContext context) {
+///     return MaterialApp(
+///       theme: ThemeData(
+///         colorScheme: ColorScheme.fromSeed(seedColor: const Color(0xFF6750A4)),
+///       ),
+///       builder: (BuildContext context, Widget? child) {
+///         return MaterialUiCompatibilityBridge(child: child!);
+///       },
+///       home: const HomeScreen(),
+///     );
+///   }
+/// }
+/// ```
+///
+/// ## Subtree usage
+///
+/// Alternatively, wrap specific legacy package widgets or subtrees:
+///
+/// ```dart
+/// import 'package:material_ui/material_ui.dart';
+/// import 'package:some_legacy_package/some_legacy_package.dart';
+///
+/// class MyScreen extends StatelessWidget {
+///   const MyScreen({super.key});
+///
+///   @override
+///   Widget build(BuildContext context) {
+///     return Scaffold(
+///       appBar: AppBar(title: const Text('Migrated Screen')),
+///       body: MaterialUiCompatibilityBridge(
+///         child: LegacyPackageWidget(),
+///       ),
+///     );
+///   }
+/// }
+/// ```
+class MaterialUiCompatibilityBridge extends StatelessWidget {
+  /// Creates a [MaterialUiCompatibilityBridge].
+  const MaterialUiCompatibilityBridge({super.key, required this.child, this.delegates});
+
+  /// The widget below this widget in the tree.
+  final Widget child;
+
+  /// The localizations delegates for legacy widgets.
+  ///
+  /// Defaults to `[GlobalCupertinoLocalizations.delegate, GlobalMaterialLocalizations.delegate, GlobalWidgetsLocalizations.delegate]`.
+  final List<LocalizationsDelegate<dynamic>>? delegates;
+
+  @override
+  Widget build(BuildContext context) {
+    final modern.ThemeData modernTheme = modern.Theme.of(context);
+
+    return legacy.Theme(
+      data: _mapToLegacy(modernTheme),
+      child: legacy.Localizations.override(
+        context: context,
+        delegates:
+            delegates ??
+            const <LocalizationsDelegate<dynamic>>[
+              GlobalCupertinoLocalizations.delegate,
+              GlobalMaterialLocalizations.delegate,
+              GlobalWidgetsLocalizations.delegate,
+            ],
+        child: child,
+      ),
+    );
+  }
+
+  legacy.ThemeData _mapToLegacy(modern.ThemeData modernTheme) {
+    final modern.ColorScheme scheme = modernTheme.colorScheme;
+    final modern.TextTheme textTheme = modernTheme.textTheme;
+
+    return legacy.ThemeData(
+      colorScheme: legacy.ColorScheme(
+        brightness: scheme.brightness,
+        primary: scheme.primary,
+        onPrimary: scheme.onPrimary,
+        primaryContainer: scheme.primaryContainer,
+        onPrimaryContainer: scheme.onPrimaryContainer,
+        secondary: scheme.secondary,
+        onSecondary: scheme.onSecondary,
+        secondaryContainer: scheme.secondaryContainer,
+        onSecondaryContainer: scheme.onSecondaryContainer,
+        tertiary: scheme.tertiary,
+        onTertiary: scheme.onTertiary,
+        tertiaryContainer: scheme.tertiaryContainer,
+        onTertiaryContainer: scheme.onTertiaryContainer,
+        error: scheme.error,
+        onError: scheme.onError,
+        errorContainer: scheme.errorContainer,
+        onErrorContainer: scheme.onErrorContainer,
+        surface: scheme.surface,
+        onSurface: scheme.onSurface,
+        surfaceDim: scheme.surfaceDim,
+        surfaceBright: scheme.surfaceBright,
+        surfaceContainerLowest: scheme.surfaceContainerLowest,
+        surfaceContainerLow: scheme.surfaceContainerLow,
+        surfaceContainer: scheme.surfaceContainer,
+        surfaceContainerHigh: scheme.surfaceContainerHigh,
+        surfaceContainerHighest: scheme.surfaceContainerHighest,
+        onSurfaceVariant: scheme.onSurfaceVariant,
+        outline: scheme.outline,
+        outlineVariant: scheme.outlineVariant,
+        shadow: scheme.shadow,
+        scrim: scheme.scrim,
+        inverseSurface: scheme.inverseSurface,
+        onInverseSurface: scheme.onInverseSurface,
+        inversePrimary: scheme.inversePrimary,
+        surfaceTint: scheme.surfaceTint,
+      ),
+      textTheme: legacy.TextTheme(
+        displayLarge: textTheme.displayLarge,
+        displayMedium: textTheme.displayMedium,
+        displaySmall: textTheme.displaySmall,
+        headlineLarge: textTheme.headlineLarge,
+        headlineMedium: textTheme.headlineMedium,
+        headlineSmall: textTheme.headlineSmall,
+        titleLarge: textTheme.titleLarge,
+        titleMedium: textTheme.titleMedium,
+        titleSmall: textTheme.titleSmall,
+        bodyLarge: textTheme.bodyLarge,
+        bodyMedium: textTheme.bodyMedium,
+        bodySmall: textTheme.bodySmall,
+        labelLarge: textTheme.labelLarge,
+        labelMedium: textTheme.labelMedium,
+        labelSmall: textTheme.labelSmall,
+      ),
+    );
+  }
+}

--- a/packages/material_ui/lib/src/migration_utility.dart
+++ b/packages/material_ui/lib/src/migration_utility.dart
@@ -67,8 +67,18 @@ import 'package:material_ui/material_ui.dart' as modern; // ignore: prefer_relat
 ///   }
 /// }
 /// ```
+@Deprecated(
+  'MaterialUiCompatibilityBridge is a temporary migration utility intended for use only while '
+  'dependencies are being migrated to package:material_ui. '
+  'This feature was deprecated to indicate it will be removed in a future release.',
+)
 class MaterialUiCompatibilityBridge extends StatelessWidget {
   /// Creates a [MaterialUiCompatibilityBridge].
+  @Deprecated(
+    'MaterialUiCompatibilityBridge is a temporary migration utility intended for use only while '
+    'dependencies are being migrated to package:material_ui. '
+    'This feature was deprecated to indicate it will be removed in a future release.',
+  )
   const MaterialUiCompatibilityBridge({super.key, required this.child, this.delegates});
 
   /// The widget below this widget in the tree.

--- a/packages/material_ui/pending_changelogs/change_2026_07_29_compatibility_bridge.yaml
+++ b/packages/material_ui/pending_changelogs/change_2026_07_29_compatibility_bridge.yaml
@@ -1,0 +1,3 @@
+changelog: |
+  - Adds MaterialUiCompatibilityBridge for legacy flutter/material.dart compatibility.
+version: minor

--- a/packages/material_ui/test/migration_utility_test.dart
+++ b/packages/material_ui/test/migration_utility_test.dart
@@ -70,17 +70,47 @@ void main() {
     );
 
     expect(capturedLegacyTheme, isNotNull);
-    expect(capturedLegacyTheme!.colorScheme.brightness, Brightness.dark);
-    expect(capturedLegacyTheme!.colorScheme.primary, const Color(0xFF112233));
-    expect(capturedLegacyTheme!.colorScheme.onPrimary, const Color(0xFF445566));
-    expect(capturedLegacyTheme!.colorScheme.secondary, const Color(0xFFDDEEFF));
-    expect(capturedLegacyTheme!.colorScheme.tertiary, const Color(0xFF334455));
-    expect(capturedLegacyTheme!.colorScheme.error, const Color(0xFFFF0000));
-    expect(capturedLegacyTheme!.colorScheme.surface, const Color(0xFF101010));
-    expect(capturedLegacyTheme!.colorScheme.onSurface, const Color(0xFFEEEEEE));
-    expect(capturedLegacyTheme!.colorScheme.outline, const Color(0xFF777777));
-    expect(capturedLegacyTheme!.colorScheme.shadow, const Color(0xFF000001));
-    expect(capturedLegacyTheme!.colorScheme.scrim, const Color(0xFF000002));
+    expect(capturedLegacyTheme!.colorScheme.brightness, modernColorScheme.brightness);
+    expect(capturedLegacyTheme!.colorScheme.primary, modernColorScheme.primary);
+    expect(capturedLegacyTheme!.colorScheme.onPrimary, modernColorScheme.onPrimary);
+    expect(capturedLegacyTheme!.colorScheme.secondary, modernColorScheme.secondary);
+    expect(capturedLegacyTheme!.colorScheme.tertiary, modernColorScheme.tertiary);
+    expect(capturedLegacyTheme!.colorScheme.error, modernColorScheme.error);
+    expect(capturedLegacyTheme!.colorScheme.surface, modernColorScheme.surface);
+    expect(capturedLegacyTheme!.colorScheme.onSurface, modernColorScheme.onSurface);
+    expect(capturedLegacyTheme!.colorScheme.outline, modernColorScheme.outline);
+    expect(capturedLegacyTheme!.colorScheme.shadow, modernColorScheme.shadow);
+    expect(capturedLegacyTheme!.colorScheme.scrim, modernColorScheme.scrim);
+  });
+
+  testWidgets('MaterialUiCompatibilityBridge maps platform and visualDensity properties', (
+    WidgetTester tester,
+  ) async {
+    legacy.ThemeData? capturedLegacyTheme;
+
+    final modernThemeData = modern.ThemeData(
+      platform: TargetPlatform.iOS,
+      visualDensity: modern.VisualDensity.compact,
+    );
+
+    await tester.pumpWidget(
+      modern.MaterialApp(
+        theme: modernThemeData,
+        home: modern.MaterialUiCompatibilityBridge(
+          child: Builder(
+            builder: (BuildContext context) {
+              capturedLegacyTheme = legacy.Theme.of(context);
+              return const SizedBox.shrink();
+            },
+          ),
+        ),
+      ),
+    );
+
+    expect(capturedLegacyTheme, isNotNull);
+    expect(capturedLegacyTheme!.platform, modernThemeData.platform);
+    expect(capturedLegacyTheme!.visualDensity.horizontal, modernThemeData.visualDensity.horizontal);
+    expect(capturedLegacyTheme!.visualDensity.vertical, modernThemeData.visualDensity.vertical);
   });
 
   testWidgets('MaterialUiCompatibilityBridge maps TextTheme properties', (
@@ -113,12 +143,27 @@ void main() {
     );
 
     expect(capturedLegacyTheme, isNotNull);
-    expect(capturedLegacyTheme!.textTheme.displayLarge?.fontSize, 57.0);
-    expect(capturedLegacyTheme!.textTheme.headlineMedium?.fontSize, 28.0);
-    expect(capturedLegacyTheme!.textTheme.headlineMedium?.fontWeight, FontWeight.w600);
-    expect(capturedLegacyTheme!.textTheme.titleLarge?.fontSize, 22.0);
-    expect(capturedLegacyTheme!.textTheme.bodyLarge?.color, const Color(0xFF123456));
-    expect(capturedLegacyTheme!.textTheme.labelSmall?.fontSize, 11.0);
+    expect(
+      capturedLegacyTheme!.textTheme.displayLarge?.fontSize,
+      modernTextTheme.displayLarge?.fontSize,
+    );
+    expect(
+      capturedLegacyTheme!.textTheme.headlineMedium?.fontSize,
+      modernTextTheme.headlineMedium?.fontSize,
+    );
+    expect(
+      capturedLegacyTheme!.textTheme.headlineMedium?.fontWeight,
+      modernTextTheme.headlineMedium?.fontWeight,
+    );
+    expect(
+      capturedLegacyTheme!.textTheme.titleLarge?.fontSize,
+      modernTextTheme.titleLarge?.fontSize,
+    );
+    expect(capturedLegacyTheme!.textTheme.bodyLarge?.color, modernTextTheme.bodyLarge?.color);
+    expect(
+      capturedLegacyTheme!.textTheme.labelSmall?.fontSize,
+      modernTextTheme.labelSmall?.fontSize,
+    );
   });
 
   testWidgets('MaterialUiCompatibilityBridge provides MaterialLocalizations for custom locales', (

--- a/packages/material_ui/test/migration_utility_test.dart
+++ b/packages/material_ui/test/migration_utility_test.dart
@@ -1,0 +1,219 @@
+// Copyright 2013 The Flutter Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart' as legacy;
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:material_ui/material_ui.dart' as modern;
+
+void main() {
+  testWidgets('MaterialUiCompatibilityBridge provides mapped ColorScheme properties', (
+    WidgetTester tester,
+  ) async {
+    legacy.ThemeData? capturedLegacyTheme;
+
+    const modernColorScheme = modern.ColorScheme(
+      brightness: Brightness.dark,
+      primary: Color(0xFF112233),
+      onPrimary: Color(0xFF445566),
+      primaryContainer: Color(0xFF778899),
+      onPrimaryContainer: Color(0xFFAABBCC),
+      secondary: Color(0xFFDDEEFF),
+      onSecondary: Color(0xFF123456),
+      secondaryContainer: Color(0xFF654321),
+      onSecondaryContainer: Color(0xFF001122),
+      tertiary: Color(0xFF334455),
+      onTertiary: Color(0xFF667788),
+      tertiaryContainer: Color(0xFF99AABB),
+      onTertiaryContainer: Color(0xFFCCDDEE),
+      error: Color(0xFFFF0000),
+      onError: Color(0xFFFFFFFF),
+      errorContainer: Color(0xFF880000),
+      onErrorContainer: Color(0xFFFF8888),
+      surface: Color(0xFF101010),
+      onSurface: Color(0xFFEEEEEE),
+      surfaceDim: Color(0xFF050505),
+      surfaceBright: Color(0xFF202020),
+      surfaceContainerLowest: Color(0xFF000000),
+      surfaceContainerLow: Color(0xFF0A0A0A),
+      surfaceContainer: Color(0xFF151515),
+      surfaceContainerHigh: Color(0xFF1F1F1F),
+      surfaceContainerHighest: Color(0xFF282828),
+      onSurfaceVariant: Color(0xFFCCCCCC),
+      outline: Color(0xFF777777),
+      outlineVariant: Color(0xFF444444),
+      shadow: Color(0xFF000001),
+      scrim: Color(0xFF000002),
+      inverseSurface: Color(0xFFE0E0E0),
+      onInverseSurface: Color(0xFF1F1F1F),
+      inversePrimary: Color(0xFF90CAF9),
+      surfaceTint: Color(0xFF112233),
+    );
+
+    final modernThemeData = modern.ThemeData(colorScheme: modernColorScheme);
+
+    await tester.pumpWidget(
+      modern.MaterialApp(
+        theme: modernThemeData,
+        home: modern.MaterialUiCompatibilityBridge(
+          child: Builder(
+            builder: (BuildContext context) {
+              capturedLegacyTheme = legacy.Theme.of(context);
+              return const SizedBox.shrink();
+            },
+          ),
+        ),
+      ),
+    );
+
+    expect(capturedLegacyTheme, isNotNull);
+    expect(capturedLegacyTheme!.colorScheme.brightness, Brightness.dark);
+    expect(capturedLegacyTheme!.colorScheme.primary, const Color(0xFF112233));
+    expect(capturedLegacyTheme!.colorScheme.onPrimary, const Color(0xFF445566));
+    expect(capturedLegacyTheme!.colorScheme.secondary, const Color(0xFFDDEEFF));
+    expect(capturedLegacyTheme!.colorScheme.tertiary, const Color(0xFF334455));
+    expect(capturedLegacyTheme!.colorScheme.error, const Color(0xFFFF0000));
+    expect(capturedLegacyTheme!.colorScheme.surface, const Color(0xFF101010));
+    expect(capturedLegacyTheme!.colorScheme.onSurface, const Color(0xFFEEEEEE));
+    expect(capturedLegacyTheme!.colorScheme.outline, const Color(0xFF777777));
+    expect(capturedLegacyTheme!.colorScheme.shadow, const Color(0xFF000001));
+    expect(capturedLegacyTheme!.colorScheme.scrim, const Color(0xFF000002));
+  });
+
+  testWidgets('MaterialUiCompatibilityBridge maps TextTheme properties', (
+    WidgetTester tester,
+  ) async {
+    legacy.ThemeData? capturedLegacyTheme;
+
+    const modernTextTheme = modern.TextTheme(
+      displayLarge: TextStyle(fontSize: 57.0, fontWeight: FontWeight.w400),
+      headlineMedium: TextStyle(fontSize: 28.0, fontWeight: FontWeight.w600),
+      titleLarge: TextStyle(fontSize: 22.0, fontWeight: FontWeight.w500),
+      bodyLarge: TextStyle(fontSize: 16.0, color: Color(0xFF123456)),
+      labelSmall: TextStyle(fontSize: 11.0, letterSpacing: 0.5),
+    );
+
+    final modernThemeData = modern.ThemeData(textTheme: modernTextTheme);
+
+    await tester.pumpWidget(
+      modern.MaterialApp(
+        theme: modernThemeData,
+        home: modern.MaterialUiCompatibilityBridge(
+          child: Builder(
+            builder: (BuildContext context) {
+              capturedLegacyTheme = legacy.Theme.of(context);
+              return const SizedBox.shrink();
+            },
+          ),
+        ),
+      ),
+    );
+
+    expect(capturedLegacyTheme, isNotNull);
+    expect(capturedLegacyTheme!.textTheme.displayLarge?.fontSize, 57.0);
+    expect(capturedLegacyTheme!.textTheme.headlineMedium?.fontSize, 28.0);
+    expect(capturedLegacyTheme!.textTheme.headlineMedium?.fontWeight, FontWeight.w600);
+    expect(capturedLegacyTheme!.textTheme.titleLarge?.fontSize, 22.0);
+    expect(capturedLegacyTheme!.textTheme.bodyLarge?.color, const Color(0xFF123456));
+    expect(capturedLegacyTheme!.textTheme.labelSmall?.fontSize, 11.0);
+  });
+
+  testWidgets('MaterialUiCompatibilityBridge provides MaterialLocalizations for custom locales', (
+    WidgetTester tester,
+  ) async {
+    legacy.MaterialLocalizations? capturedLegacyLocalizations;
+
+    await tester.pumpWidget(
+      modern.MaterialApp(
+        locale: const Locale('es', 'ES'),
+        localizationsDelegates: modern.GlobalMaterialLocalizations.delegates,
+        supportedLocales: const <Locale>[Locale('en', 'US'), Locale('es', 'ES')],
+        home: modern.MaterialUiCompatibilityBridge(
+          child: Builder(
+            builder: (BuildContext context) {
+              capturedLegacyLocalizations = legacy.MaterialLocalizations.of(context);
+              return const SizedBox.shrink();
+            },
+          ),
+        ),
+      ),
+    );
+
+    expect(capturedLegacyLocalizations, isNotNull);
+    expect(capturedLegacyLocalizations!.okButtonLabel, 'ACEPTAR');
+    expect(capturedLegacyLocalizations!.cancelButtonLabel, 'Cancelar');
+  });
+
+  testWidgets('MaterialUiCompatibilityBridge allows rendering legacy Material widgets', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(
+      modern.MaterialApp(
+        home: modern.MaterialUiCompatibilityBridge(
+          child: legacy.Scaffold(
+            appBar: legacy.AppBar(title: const Text('Legacy Title')),
+            body: Center(
+              child: legacy.ElevatedButton(onPressed: () {}, child: const Text('Legacy Button')),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text('Legacy Title'), findsOneWidget);
+    expect(find.text('Legacy Button'), findsOneWidget);
+    expect(find.byType(legacy.ElevatedButton), findsOneWidget);
+    expect(find.byType(legacy.Scaffold), findsOneWidget);
+  });
+
+  testWidgets('MaterialUiCompatibilityBridge supports custom delegates', (
+    WidgetTester tester,
+  ) async {
+    legacy.MaterialLocalizations? capturedLegacyLocalizations;
+
+    await tester.pumpWidget(
+      modern.MaterialApp(
+        home: modern.MaterialUiCompatibilityBridge(
+          delegates: const <LocalizationsDelegate<dynamic>>[
+            legacy.DefaultMaterialLocalizations.delegate,
+          ],
+          child: Builder(
+            builder: (BuildContext context) {
+              capturedLegacyLocalizations = legacy.MaterialLocalizations.of(context);
+              return const SizedBox.shrink();
+            },
+          ),
+        ),
+      ),
+    );
+
+    expect(capturedLegacyLocalizations, isNotNull);
+    expect(capturedLegacyLocalizations!.okButtonLabel, isNotEmpty);
+  });
+
+  testWidgets('MaterialUiCompatibilityBridge works at root in MaterialApp.builder', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(
+      modern.MaterialApp(
+        builder: (BuildContext context, Widget? child) {
+          return modern.MaterialUiCompatibilityBridge(child: child!);
+        },
+        home: modern.Scaffold(
+          body: Column(
+            children: <Widget>[
+              modern.ElevatedButton(onPressed: () {}, child: const Text('Modern Button')),
+              legacy.ElevatedButton(onPressed: () {}, child: const Text('Legacy Button')),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text('Modern Button'), findsOneWidget);
+    expect(find.text('Legacy Button'), findsOneWidget);
+    expect(find.byType(modern.ElevatedButton), findsOneWidget);
+    expect(find.byType(legacy.ElevatedButton), findsOneWidget);
+  });
+}

--- a/packages/material_ui/test/migration_utility_test.dart
+++ b/packages/material_ui/test/migration_utility_test.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// ignore_for_file: deprecated_member_use
+
 import 'package:flutter/material.dart' as legacy;
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';


### PR DESCRIPTION
This adds utilities to the material_ui and cupertino_ui to help cover the gap during the ecosystem migration. Users who have migrated their applications can use these utilities to retain compatibility with packages that have not migrated yet.
These are marked deprecated as they will be removed in a future major release. 

Example:

```dart
import 'package:material_ui/material_ui.dart';

void main() {
  runApp(const MyApp());
}

class MyApp extends StatelessWidget {
  const MyApp({super.key});

  @override
  Widget build(BuildContext context) {
    return MaterialApp(
      theme: ThemeData(
        colorScheme: ColorScheme.fromSeed(seedColor: const Color(0xFF6750A4)),
      ),
      builder: (BuildContext context, Widget? child) {
        return MaterialUiCompatibilityBridge(child: child!);
      },
      home: const HomeScreen(),
    );
  }
}
```

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under[^1].
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[the version and CHANGELOG instructions]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version-and-changelog-updates
[semantic versioning]: https://dart.dev/tools/pub/versioning#semantic-versions
[repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
