### PR TITLE
[url_launcher] Update dependency on url_launcher_android to resolve KGP warning

### DIFF
--- a/packages/url_launcher/url_launcher/CHANGELOG.md
+++ b/packages/url_launcher/url_launcher/CHANGELOG.md
@@ -5,7 +5,10 @@
   versions of the endorsed platform implementations.
   * Applications built with older versions of Flutter will continue to
     use compatible versions of the platform implementations.
-* `url_launcher_android` package version updated to resolve the KGP warning.
+
+## 6.3.3
+
+* Updates `url_launcher_android` package version to resolve the KGP warning.
 
 ## 6.3.2
 

--- a/packages/url_launcher/url_launcher/CHANGELOG.md
+++ b/packages/url_launcher/url_launcher/CHANGELOG.md
@@ -5,6 +5,7 @@
   versions of the endorsed platform implementations.
   * Applications built with older versions of Flutter will continue to
     use compatible versions of the platform implementations.
+* `url_launcher_android` package version updated to resolve the KGP warning.
 
 ## 6.3.2
 

--- a/packages/url_launcher/url_launcher/pubspec.yaml
+++ b/packages/url_launcher/url_launcher/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for launching a URL. Supports
   web, phone, SMS, and email schemes.
 repository: https://github.com/flutter/packages/tree/main/packages/url_launcher/url_launcher
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+url_launcher%22
-version: 6.3.2
+version: 6.3.3
 
 environment:
   sdk: ^3.10.0

--- a/packages/url_launcher/url_launcher/pubspec.yaml
+++ b/packages/url_launcher/url_launcher/pubspec.yaml
@@ -28,7 +28,7 @@ flutter:
 dependencies:
   flutter:
     sdk: flutter
-  url_launcher_android: ^6.3.0
+  url_launcher_android: ^6.3.32
   url_launcher_ios: ^6.2.4
   # Allow either the pure-native or Dart/native hybrid versions of the desktop
   # implementations, as both are compatible.


### PR DESCRIPTION
# [url_launcher] Update dependency on url_launcher_android to resolve KGP warning

## Description
This PR bumps the `url_launcher` package to 6.3.3.

- Update dependency on `url_launcher_android` to ^6.3.32
- Resolve the KGP warning already fixed in `url_launcher_android`
- No API changes, only dependency update

## Notes
This PR does not correspond to a tracked issue; it is a dependency bump to propagate an existing fix.

## Changelog
## 6.3.3

* Update `url_launcher_android` dependency to resolve the KGP warning.

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[url_launcher]`
- [ ] I linked to at least one issue that this PR fixes in the description above. *(Not applicable — explained in Notes)*
- [x] I followed the version and CHANGELOG instructions, using semantic versioning and the repository CHANGELOG style.
- [ ] I updated/added any relevant documentation (doc comments with `///`). *(Not needed for dependency bump)*
- [ ] I added new tests to check the change I am making, or I have commented below to indicate which test exemption this PR falls under. *(Not needed for dependency bump)*
- [x] All existing tests are passing.
