### PR TITLE
[webview_flutter_android] Expose allowFileAccessFromFileURLs and allowUniversalAccessFromFileURLs

### DIFF
--- a/packages/webview_flutter/webview_flutter_android/CHANGELOG.md
+++ b/packages/webview_flutter/webview_flutter_android/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 4.15.0
+
+* Adds support for configuring file URL access permissions. See
+  `AndroidWebViewController.setAllowFileAccessFromFileURLs` and
+  `AndroidWebViewController.setAllowUniversalAccessFromFileURLs`.
+
 ## 4.14.0
 * Adds support for configuring Web Authentication in `AndroidWebViewController` with `setWebAuthenticationSupport` to enable Passkey and other related Authentication.
 

--- a/packages/webview_flutter/webview_flutter_android/CHANGELOG.md
+++ b/packages/webview_flutter/webview_flutter_android/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 4.14.0
+
+* Adds support for configuring file URL access permissions. See
+  `AndroidWebViewController.setAllowFileAccessFromFileURLs` and
+  `AndroidWebViewController.setAllowUniversalAccessFromFileURLs`.
+
 ## 4.13.0
 
 * Adds new method for accessing a native `WebView` from a `FlutterPluginBinding`.

--- a/packages/webview_flutter/webview_flutter_android/android/src/main/java/io/flutter/plugins/webviewflutter/AndroidWebkitLibrary.g.kt
+++ b/packages/webview_flutter/webview_flutter_android/android/src/main/java/io/flutter/plugins/webviewflutter/AndroidWebkitLibrary.g.kt
@@ -2584,6 +2584,18 @@ abstract class PigeonApiWebSettings(
   /** Enables or disables content URL access within WebView. */
   abstract fun setAllowContentAccess(pigeon_instance: android.webkit.WebSettings, enabled: Boolean)
 
+  /** Enables or disables universal cross-origin access from file URLs. */
+  abstract fun setAllowUniversalAccessFromFileURLs(
+      pigeon_instance: android.webkit.WebSettings,
+      enabled: Boolean
+  )
+
+  /** Enables or disables file URL access to other file URLs. */
+  abstract fun setAllowFileAccessFromFileURLs(
+      pigeon_instance: android.webkit.WebSettings,
+      enabled: Boolean
+  )
+
   /** Sets whether Geolocation is enabled within WebView. */
   abstract fun setGeolocationEnabled(pigeon_instance: android.webkit.WebSettings, enabled: Boolean)
 
@@ -2905,6 +2917,54 @@ abstract class PigeonApiWebSettings(
             val wrapped: List<Any?> =
                 try {
                   api.setAllowContentAccess(pigeon_instanceArg, enabledArg)
+                  listOf(null)
+                } catch (exception: Throwable) {
+                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+                }
+            reply.reply(wrapped)
+          }
+        } else {
+          channel.setMessageHandler(null)
+        }
+      }
+      run {
+        val channel =
+            BasicMessageChannel<Any?>(
+                binaryMessenger,
+                "dev.flutter.pigeon.webview_flutter_android.WebSettings.setAllowUniversalAccessFromFileURLs",
+                codec)
+        if (api != null) {
+          channel.setMessageHandler { message, reply ->
+            val args = message as List<Any?>
+            val pigeon_instanceArg = args[0] as android.webkit.WebSettings
+            val enabledArg = args[1] as Boolean
+            val wrapped: List<Any?> =
+                try {
+                  api.setAllowUniversalAccessFromFileURLs(pigeon_instanceArg, enabledArg)
+                  listOf(null)
+                } catch (exception: Throwable) {
+                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+                }
+            reply.reply(wrapped)
+          }
+        } else {
+          channel.setMessageHandler(null)
+        }
+      }
+      run {
+        val channel =
+            BasicMessageChannel<Any?>(
+                binaryMessenger,
+                "dev.flutter.pigeon.webview_flutter_android.WebSettings.setAllowFileAccessFromFileURLs",
+                codec)
+        if (api != null) {
+          channel.setMessageHandler { message, reply ->
+            val args = message as List<Any?>
+            val pigeon_instanceArg = args[0] as android.webkit.WebSettings
+            val enabledArg = args[1] as Boolean
+            val wrapped: List<Any?> =
+                try {
+                  api.setAllowFileAccessFromFileURLs(pigeon_instanceArg, enabledArg)
                   listOf(null)
                 } catch (exception: Throwable) {
                   AndroidWebkitLibraryPigeonUtils.wrapError(exception)

--- a/packages/webview_flutter/webview_flutter_android/android/src/main/java/io/flutter/plugins/webviewflutter/WebSettingsProxyApi.java
+++ b/packages/webview_flutter/webview_flutter_android/android/src/main/java/io/flutter/plugins/webviewflutter/WebSettingsProxyApi.java
@@ -87,6 +87,18 @@ public class WebSettingsProxyApi extends PigeonApiWebSettings {
   }
 
   @Override
+  public void setAllowFileAccessFromFileURLs(
+      @NonNull WebSettings pigeon_instance, boolean enabled) {
+    pigeon_instance.setAllowFileAccessFromFileURLs(enabled);
+  }
+
+  @Override
+  public void setAllowUniversalAccessFromFileURLs(
+      @NonNull WebSettings pigeon_instance, boolean enabled) {
+    pigeon_instance.setAllowUniversalAccessFromFileURLs(enabled);
+  }
+
+  @Override
   public void setGeolocationEnabled(@NonNull WebSettings pigeon_instance, boolean enabled) {
     pigeon_instance.setGeolocationEnabled(enabled);
   }

--- a/packages/webview_flutter/webview_flutter_android/android/src/test/java/io/flutter/plugins/webviewflutter/WebSettingsTest.java
+++ b/packages/webview_flutter/webview_flutter_android/android/src/test/java/io/flutter/plugins/webviewflutter/WebSettingsTest.java
@@ -176,4 +176,24 @@ public class WebSettingsTest {
 
     verify(instance).setMixedContentMode(WebSettings.MIXED_CONTENT_COMPATIBILITY_MODE);
   }
+
+  @Test
+  public void setAllowFileAccessFromFileURLs() {
+    final PigeonApiWebSettings api = new TestProxyApiRegistrar().getPigeonApiWebSettings();
+
+    final WebSettings instance = mock(WebSettings.class);
+    api.setAllowFileAccessFromFileURLs(instance, true);
+
+    verify(instance).setAllowFileAccessFromFileURLs(true);
+  }
+
+  @Test
+  public void setAllowUniversalAccessFromFileURLs() {
+    final PigeonApiWebSettings api = new TestProxyApiRegistrar().getPigeonApiWebSettings();
+
+    final WebSettings instance = mock(WebSettings.class);
+    api.setAllowUniversalAccessFromFileURLs(instance, true);
+
+    verify(instance).setAllowUniversalAccessFromFileURLs(true);
+  }
 }

--- a/packages/webview_flutter/webview_flutter_android/lib/src/android_webkit.g.dart
+++ b/packages/webview_flutter/webview_flutter_android/lib/src/android_webkit.g.dart
@@ -2462,6 +2462,40 @@ class WebSettings extends PigeonInternalProxyApiBaseClass {
     _extractReplyValueOrThrow(pigeonVar_replyList, pigeonVar_channelName, isNullValid: true);
   }
 
+  /// Enables or disables universal cross-origin access from file URLs.
+  Future<void> setAllowUniversalAccessFromFileURLs(bool enabled) async {
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecWebSettings;
+    final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
+    const pigeonVar_channelName =
+        'dev.flutter.pigeon.webview_flutter_android.WebSettings.setAllowUniversalAccessFromFileURLs';
+    final pigeonVar_channel = BasicMessageChannel<Object?>(
+      pigeonVar_channelName,
+      pigeonChannelCodec,
+      binaryMessenger: pigeonVar_binaryMessenger,
+    );
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[this, enabled]);
+    final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
+
+    _extractReplyValueOrThrow(pigeonVar_replyList, pigeonVar_channelName, isNullValid: true);
+  }
+
+  /// Enables or disables file URL access to other file URLs.
+  Future<void> setAllowFileAccessFromFileURLs(bool enabled) async {
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecWebSettings;
+    final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
+    const pigeonVar_channelName =
+        'dev.flutter.pigeon.webview_flutter_android.WebSettings.setAllowFileAccessFromFileURLs';
+    final pigeonVar_channel = BasicMessageChannel<Object?>(
+      pigeonVar_channelName,
+      pigeonChannelCodec,
+      binaryMessenger: pigeonVar_binaryMessenger,
+    );
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[this, enabled]);
+    final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
+
+    _extractReplyValueOrThrow(pigeonVar_replyList, pigeonVar_channelName, isNullValid: true);
+  }
+
   /// Sets whether Geolocation is enabled within WebView.
   Future<void> setGeolocationEnabled(bool enabled) async {
     final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecWebSettings;

--- a/packages/webview_flutter/webview_flutter_android/lib/src/android_webkit.g.dart
+++ b/packages/webview_flutter/webview_flutter_android/lib/src/android_webkit.g.dart
@@ -2458,6 +2458,40 @@ class WebSettings extends PigeonInternalProxyApiBaseClass {
     _extractReplyValueOrThrow(pigeonVar_replyList, pigeonVar_channelName, isNullValid: true);
   }
 
+  /// Enables or disables universal cross-origin access from file URLs.
+  Future<void> setAllowUniversalAccessFromFileURLs(bool enabled) async {
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecWebSettings;
+    final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
+    const pigeonVar_channelName =
+        'dev.flutter.pigeon.webview_flutter_android.WebSettings.setAllowUniversalAccessFromFileURLs';
+    final pigeonVar_channel = BasicMessageChannel<Object?>(
+      pigeonVar_channelName,
+      pigeonChannelCodec,
+      binaryMessenger: pigeonVar_binaryMessenger,
+    );
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[this, enabled]);
+    final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
+
+    _extractReplyValueOrThrow(pigeonVar_replyList, pigeonVar_channelName, isNullValid: true);
+  }
+
+  /// Enables or disables file URL access to other file URLs.
+  Future<void> setAllowFileAccessFromFileURLs(bool enabled) async {
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecWebSettings;
+    final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
+    const pigeonVar_channelName =
+        'dev.flutter.pigeon.webview_flutter_android.WebSettings.setAllowFileAccessFromFileURLs';
+    final pigeonVar_channel = BasicMessageChannel<Object?>(
+      pigeonVar_channelName,
+      pigeonChannelCodec,
+      binaryMessenger: pigeonVar_binaryMessenger,
+    );
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[this, enabled]);
+    final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
+
+    _extractReplyValueOrThrow(pigeonVar_replyList, pigeonVar_channelName, isNullValid: true);
+  }
+
   /// Sets whether Geolocation is enabled within WebView.
   Future<void> setGeolocationEnabled(bool enabled) async {
     final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecWebSettings;

--- a/packages/webview_flutter/webview_flutter_android/lib/src/android_webview_controller.dart
+++ b/packages/webview_flutter/webview_flutter_android/lib/src/android_webview_controller.dart
@@ -620,6 +620,20 @@ class AndroidWebViewController extends PlatformWebViewController {
   Future<void> setAllowContentAccess(bool enabled) =>
       _webView.settings.setAllowContentAccess(enabled);
 
+  /// Sets the file URL access to other file URLs permission for the web view.
+  ///
+  /// The default value is true for apps targeting API 15 and below, and false
+  /// when targeting API 16 and above.
+  Future<void> setAllowFileAccessFromFileURLs(bool enabled) =>
+      _webView.settings.setAllowFileAccessFromFileURLs(enabled);
+
+  /// Sets the universal cross-origin access from file URLs permission for the web view.
+  ///
+  /// The default value is true for apps targeting API 15 and below, and false
+  /// when targeting API 16 and above.
+  Future<void> setAllowUniversalAccessFromFileURLs(bool enabled) =>
+      _webView.settings.setAllowUniversalAccessFromFileURLs(enabled);
+
   /// Sets whether Geolocation is enabled.
   ///
   /// The default is true.

--- a/packages/webview_flutter/webview_flutter_android/pigeons/android_webkit.dart
+++ b/packages/webview_flutter/webview_flutter_android/pigeons/android_webkit.dart
@@ -428,6 +428,12 @@ abstract class WebSettings {
   /// Enables or disables content URL access within WebView.
   void setAllowContentAccess(bool enabled);
 
+  /// Enables or disables universal cross-origin access from file URLs.
+  void setAllowUniversalAccessFromFileURLs(bool enabled);
+
+  /// Enables or disables file URL access to other file URLs.
+  void setAllowFileAccessFromFileURLs(bool enabled);
+
   /// Sets whether Geolocation is enabled within WebView.
   void setGeolocationEnabled(bool enabled);
 

--- a/packages/webview_flutter/webview_flutter_android/pubspec.yaml
+++ b/packages/webview_flutter/webview_flutter_android/pubspec.yaml
@@ -2,7 +2,7 @@ name: webview_flutter_android
 description: A Flutter plugin that provides a WebView widget on Android.
 repository: https://github.com/flutter/packages/tree/main/packages/webview_flutter/webview_flutter_android
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+webview%22
-version: 4.13.0
+version: 4.14.0
 
 environment:
   sdk: ^3.12.0

--- a/packages/webview_flutter/webview_flutter_android/test/android_webview_controller_test.dart
+++ b/packages/webview_flutter/webview_flutter_android/test/android_webview_controller_test.dart
@@ -1756,6 +1756,38 @@ void main() {
     verify(mockSettings.setAllowContentAccess(false)).called(1);
   });
 
+  test('setAllowFileAccessFromFileURLs', () async {
+    final mockWebView = MockWebView();
+    final mockSettings = MockWebSettings();
+    final AndroidWebViewController controller = createControllerWithMocks(
+      mockWebView: mockWebView,
+      mockSettings: mockSettings,
+    );
+
+    clearInteractions(mockWebView);
+
+    await controller.setAllowFileAccessFromFileURLs(false);
+
+    verify(mockWebView.settings).called(1);
+    verify(mockSettings.setAllowFileAccessFromFileURLs(false)).called(1);
+  });
+
+  test('setAllowUniversalAccessFromFileURLs', () async {
+    final mockWebView = MockWebView();
+    final mockSettings = MockWebSettings();
+    final AndroidWebViewController controller = createControllerWithMocks(
+      mockWebView: mockWebView,
+      mockSettings: mockSettings,
+    );
+
+    clearInteractions(mockWebView);
+
+    await controller.setAllowUniversalAccessFromFileURLs(false);
+
+    verify(mockWebView.settings).called(1);
+    verify(mockSettings.setAllowUniversalAccessFromFileURLs(false)).called(1);
+  });
+
   test('setGeolocationEnabled', () async {
     final mockWebView = MockWebView();
     final mockSettings = MockWebSettings();

--- a/packages/webview_flutter/webview_flutter_android/test/android_webview_controller_test.dart
+++ b/packages/webview_flutter/webview_flutter_android/test/android_webview_controller_test.dart
@@ -1753,6 +1753,38 @@ void main() {
     verify(mockSettings.setAllowContentAccess(false)).called(1);
   });
 
+  test('setAllowFileAccessFromFileURLs', () async {
+    final mockWebView = MockWebView();
+    final mockSettings = MockWebSettings();
+    final AndroidWebViewController controller = createControllerWithMocks(
+      mockWebView: mockWebView,
+      mockSettings: mockSettings,
+    );
+
+    clearInteractions(mockWebView);
+
+    await controller.setAllowFileAccessFromFileURLs(false);
+
+    verify(mockWebView.settings).called(1);
+    verify(mockSettings.setAllowFileAccessFromFileURLs(false)).called(1);
+  });
+
+  test('setAllowUniversalAccessFromFileURLs', () async {
+    final mockWebView = MockWebView();
+    final mockSettings = MockWebSettings();
+    final AndroidWebViewController controller = createControllerWithMocks(
+      mockWebView: mockWebView,
+      mockSettings: mockSettings,
+    );
+
+    clearInteractions(mockWebView);
+
+    await controller.setAllowUniversalAccessFromFileURLs(false);
+
+    verify(mockWebView.settings).called(1);
+    verify(mockSettings.setAllowUniversalAccessFromFileURLs(false)).called(1);
+  });
+
   test('setGeolocationEnabled', () async {
     final mockWebView = MockWebView();
     final mockSettings = MockWebSettings();

--- a/packages/webview_flutter/webview_flutter_android/test/android_webview_controller_test.mocks.dart
+++ b/packages/webview_flutter/webview_flutter_android/test/android_webview_controller_test.mocks.dart
@@ -611,6 +611,24 @@ class MockAndroidWebViewController extends _i1.Mock implements _i7.AndroidWebVie
           as _i8.Future<void>);
 
   @override
+  _i8.Future<void> setAllowFileAccessFromFileURLs(bool? enabled) =>
+      (super.noSuchMethod(
+            Invocation.method(#setAllowFileAccessFromFileURLs, [enabled]),
+            returnValue: _i8.Future<void>.value(),
+            returnValueForMissingStub: _i8.Future<void>.value(),
+          )
+          as _i8.Future<void>);
+
+  @override
+  _i8.Future<void> setAllowUniversalAccessFromFileURLs(bool? enabled) =>
+      (super.noSuchMethod(
+            Invocation.method(#setAllowUniversalAccessFromFileURLs, [enabled]),
+            returnValue: _i8.Future<void>.value(),
+            returnValueForMissingStub: _i8.Future<void>.value(),
+          )
+          as _i8.Future<void>);
+
+  @override
   _i8.Future<void> setGeolocationEnabled(bool? enabled) =>
       (super.noSuchMethod(
             Invocation.method(#setGeolocationEnabled, [enabled]),
@@ -1731,6 +1749,24 @@ class MockWebSettings extends _i1.Mock implements _i2.WebSettings {
   _i8.Future<void> setAllowContentAccess(bool? enabled) =>
       (super.noSuchMethod(
             Invocation.method(#setAllowContentAccess, [enabled]),
+            returnValue: _i8.Future<void>.value(),
+            returnValueForMissingStub: _i8.Future<void>.value(),
+          )
+          as _i8.Future<void>);
+
+  @override
+  _i8.Future<void> setAllowUniversalAccessFromFileURLs(bool? enabled) =>
+      (super.noSuchMethod(
+            Invocation.method(#setAllowUniversalAccessFromFileURLs, [enabled]),
+            returnValue: _i8.Future<void>.value(),
+            returnValueForMissingStub: _i8.Future<void>.value(),
+          )
+          as _i8.Future<void>);
+
+  @override
+  _i8.Future<void> setAllowFileAccessFromFileURLs(bool? enabled) =>
+      (super.noSuchMethod(
+            Invocation.method(#setAllowFileAccessFromFileURLs, [enabled]),
             returnValue: _i8.Future<void>.value(),
             returnValueForMissingStub: _i8.Future<void>.value(),
           )

--- a/packages/webview_flutter/webview_flutter_android/test/android_webview_controller_test.mocks.dart
+++ b/packages/webview_flutter/webview_flutter_android/test/android_webview_controller_test.mocks.dart
@@ -611,6 +611,24 @@ class MockAndroidWebViewController extends _i1.Mock implements _i7.AndroidWebVie
           as _i8.Future<void>);
 
   @override
+  _i8.Future<void> setAllowFileAccessFromFileURLs(bool? enabled) =>
+      (super.noSuchMethod(
+            Invocation.method(#setAllowFileAccessFromFileURLs, [enabled]),
+            returnValue: _i8.Future<void>.value(),
+            returnValueForMissingStub: _i8.Future<void>.value(),
+          )
+          as _i8.Future<void>);
+
+  @override
+  _i8.Future<void> setAllowUniversalAccessFromFileURLs(bool? enabled) =>
+      (super.noSuchMethod(
+            Invocation.method(#setAllowUniversalAccessFromFileURLs, [enabled]),
+            returnValue: _i8.Future<void>.value(),
+            returnValueForMissingStub: _i8.Future<void>.value(),
+          )
+          as _i8.Future<void>);
+
+  @override
   _i8.Future<void> setGeolocationEnabled(bool? enabled) =>
       (super.noSuchMethod(
             Invocation.method(#setGeolocationEnabled, [enabled]),
@@ -782,6 +800,15 @@ class MockAndroidWebViewController extends _i1.Mock implements _i7.AndroidWebVie
   _i8.Future<void> setPaymentRequestEnabled(bool? enabled) =>
       (super.noSuchMethod(
             Invocation.method(#setPaymentRequestEnabled, [enabled]),
+            returnValue: _i8.Future<void>.value(),
+            returnValueForMissingStub: _i8.Future<void>.value(),
+          )
+          as _i8.Future<void>);
+
+  @override
+  _i8.Future<void> setInsetsForWebContentToIgnore(List<_i7.AndroidWebViewInsets>? insets) =>
+      (super.noSuchMethod(
+            Invocation.method(#setInsetsForWebContentToIgnore, [insets]),
             returnValue: _i8.Future<void>.value(),
             returnValueForMissingStub: _i8.Future<void>.value(),
           )
@@ -1713,6 +1740,24 @@ class MockWebSettings extends _i1.Mock implements _i2.WebSettings {
   _i8.Future<void> setAllowContentAccess(bool? enabled) =>
       (super.noSuchMethod(
             Invocation.method(#setAllowContentAccess, [enabled]),
+            returnValue: _i8.Future<void>.value(),
+            returnValueForMissingStub: _i8.Future<void>.value(),
+          )
+          as _i8.Future<void>);
+
+  @override
+  _i8.Future<void> setAllowUniversalAccessFromFileURLs(bool? enabled) =>
+      (super.noSuchMethod(
+            Invocation.method(#setAllowUniversalAccessFromFileURLs, [enabled]),
+            returnValue: _i8.Future<void>.value(),
+            returnValueForMissingStub: _i8.Future<void>.value(),
+          )
+          as _i8.Future<void>);
+
+  @override
+  _i8.Future<void> setAllowFileAccessFromFileURLs(bool? enabled) =>
+      (super.noSuchMethod(
+            Invocation.method(#setAllowFileAccessFromFileURLs, [enabled]),
             returnValue: _i8.Future<void>.value(),
             returnValueForMissingStub: _i8.Future<void>.value(),
           )

--- a/packages/webview_flutter/webview_flutter_android/test/android_webview_cookie_manager_test.mocks.dart
+++ b/packages/webview_flutter/webview_flutter_android/test/android_webview_cookie_manager_test.mocks.dart
@@ -424,6 +424,24 @@ class MockAndroidWebViewController extends _i1.Mock implements _i6.AndroidWebVie
           as _i5.Future<void>);
 
   @override
+  _i5.Future<void> setAllowFileAccessFromFileURLs(bool? enabled) =>
+      (super.noSuchMethod(
+            Invocation.method(#setAllowFileAccessFromFileURLs, [enabled]),
+            returnValue: _i5.Future<void>.value(),
+            returnValueForMissingStub: _i5.Future<void>.value(),
+          )
+          as _i5.Future<void>);
+
+  @override
+  _i5.Future<void> setAllowUniversalAccessFromFileURLs(bool? enabled) =>
+      (super.noSuchMethod(
+            Invocation.method(#setAllowUniversalAccessFromFileURLs, [enabled]),
+            returnValue: _i5.Future<void>.value(),
+            returnValueForMissingStub: _i5.Future<void>.value(),
+          )
+          as _i5.Future<void>);
+
+  @override
   _i5.Future<void> setGeolocationEnabled(bool? enabled) =>
       (super.noSuchMethod(
             Invocation.method(#setGeolocationEnabled, [enabled]),

--- a/packages/webview_flutter/webview_flutter_android/test/android_webview_cookie_manager_test.mocks.dart
+++ b/packages/webview_flutter/webview_flutter_android/test/android_webview_cookie_manager_test.mocks.dart
@@ -424,6 +424,24 @@ class MockAndroidWebViewController extends _i1.Mock implements _i6.AndroidWebVie
           as _i5.Future<void>);
 
   @override
+  _i5.Future<void> setAllowFileAccessFromFileURLs(bool? enabled) =>
+      (super.noSuchMethod(
+            Invocation.method(#setAllowFileAccessFromFileURLs, [enabled]),
+            returnValue: _i5.Future<void>.value(),
+            returnValueForMissingStub: _i5.Future<void>.value(),
+          )
+          as _i5.Future<void>);
+
+  @override
+  _i5.Future<void> setAllowUniversalAccessFromFileURLs(bool? enabled) =>
+      (super.noSuchMethod(
+            Invocation.method(#setAllowUniversalAccessFromFileURLs, [enabled]),
+            returnValue: _i5.Future<void>.value(),
+            returnValueForMissingStub: _i5.Future<void>.value(),
+          )
+          as _i5.Future<void>);
+
+  @override
   _i5.Future<void> setGeolocationEnabled(bool? enabled) =>
       (super.noSuchMethod(
             Invocation.method(#setGeolocationEnabled, [enabled]),
@@ -589,6 +607,15 @@ class MockAndroidWebViewController extends _i1.Mock implements _i6.AndroidWebVie
   _i5.Future<void> setPaymentRequestEnabled(bool? enabled) =>
       (super.noSuchMethod(
             Invocation.method(#setPaymentRequestEnabled, [enabled]),
+            returnValue: _i5.Future<void>.value(),
+            returnValueForMissingStub: _i5.Future<void>.value(),
+          )
+          as _i5.Future<void>);
+
+  @override
+  _i5.Future<void> setInsetsForWebContentToIgnore(List<_i6.AndroidWebViewInsets>? insets) =>
+      (super.noSuchMethod(
+            Invocation.method(#setInsetsForWebContentToIgnore, [insets]),
             returnValue: _i5.Future<void>.value(),
             returnValueForMissingStub: _i5.Future<void>.value(),
           )

--- a/packages/webview_flutter/webview_flutter_android/test/legacy/webview_android_widget_test.mocks.dart
+++ b/packages/webview_flutter/webview_flutter_android/test/legacy/webview_android_widget_test.mocks.dart
@@ -268,6 +268,24 @@ class MockWebSettings extends _i1.Mock implements _i2.WebSettings {
           as _i4.Future<void>);
 
   @override
+  _i4.Future<void> setAllowUniversalAccessFromFileURLs(bool? enabled) =>
+      (super.noSuchMethod(
+            Invocation.method(#setAllowUniversalAccessFromFileURLs, [enabled]),
+            returnValue: _i4.Future<void>.value(),
+            returnValueForMissingStub: _i4.Future<void>.value(),
+          )
+          as _i4.Future<void>);
+
+  @override
+  _i4.Future<void> setAllowFileAccessFromFileURLs(bool? enabled) =>
+      (super.noSuchMethod(
+            Invocation.method(#setAllowFileAccessFromFileURLs, [enabled]),
+            returnValue: _i4.Future<void>.value(),
+            returnValueForMissingStub: _i4.Future<void>.value(),
+          )
+          as _i4.Future<void>);
+
+  @override
   _i4.Future<void> setGeolocationEnabled(bool? enabled) =>
       (super.noSuchMethod(
             Invocation.method(#setGeolocationEnabled, [enabled]),


### PR DESCRIPTION
This PR exposes Android WebView file URL access settings through `AndroidWebViewController`.

The following Android `WebSettings` APIs are added:

- `setAllowFileAccessFromFileURLs`
- `setAllowUniversalAccessFromFileURLs`

These settings allow applications loading local web content using `file://` URLs to explicitly configure whether local resources and resources from other origins can be accessed.

This is useful for applications embedding local HTML assets that need to load additional local files or communicate with remote web services.

The APIs are only available on Android and do not affect other WebView implementations.

## Issues

N/A

This is an API enhancement request to expose existing Android WebSettings functionality.

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under[^1].
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[the version and CHANGELOG instructions]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version-and-changelog-updates
[semantic versioning]: https://dart.dev/tools/pub/versioning#semantic-versions
[repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
