### PR TITLE
[quick_actions_android] Return null from getLaunchAction when no activity is attached

### DIFF
--- a/packages/quick_actions/quick_actions_android/CHANGELOG.md
+++ b/packages/quick_actions/quick_actions_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.33
+
+* Fixes `getLaunchAction` throwing when there is no attached activity.
+
 ## 1.0.32
 
 * Bumps the androidx group across 10 directories with 1 update.

--- a/packages/quick_actions/quick_actions_android/CHANGELOG.md
+++ b/packages/quick_actions/quick_actions_android/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 * Fixes `getLaunchAction` throwing when the plugin has no attached activity, which made
   `initialize` throw for engines that run without UI, such as a cached engine warmed up by a
-  background service. It now logs a warning and returns `null`.
+  background service. It now returns `null`.
 
 ## 1.0.32
 

--- a/packages/quick_actions/quick_actions_android/CHANGELOG.md
+++ b/packages/quick_actions/quick_actions_android/CHANGELOG.md
@@ -1,9 +1,3 @@
-## 1.0.33
-
-* Fixes `getLaunchAction` throwing when the plugin has no attached activity, which made
-  `initialize` throw for engines that run without UI, such as a cached engine warmed up by a
-  background service. It now returns `null`.
-
 ## 1.0.32
 
 * Bumps the androidx group across 10 directories with 1 update.

--- a/packages/quick_actions/quick_actions_android/CHANGELOG.md
+++ b/packages/quick_actions/quick_actions_android/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.0.33
+
+* Fixes `getLaunchAction` throwing when the plugin has no attached activity, which made
+  `initialize` throw for engines that run without UI, such as a cached engine warmed up by a
+  background service. It now logs a warning and returns `null`.
+
 ## 1.0.32
 
 * Bumps the androidx group across 10 directories with 1 update.

--- a/packages/quick_actions/quick_actions_android/android/src/main/java/io/flutter/plugins/quickactions/QuickActions.java
+++ b/packages/quick_actions/quick_actions_android/android/src/main/java/io/flutter/plugins/quickactions/QuickActions.java
@@ -108,7 +108,7 @@ final class QuickActions implements AndroidQuickActionsApi {
       // up by a background service. Nothing launched the app in that case, so there is no launch
       // action to report. Any action that arrives later is reported through the plugin's
       // onNewIntent listener once an activity attaches.
-      Log.w(TAG, "There is no activity available when getting the launch action.");
+      Log.d(TAG, "There is no activity available when getting the launch action.");
       return null;
     }
     final Intent intent = activity.getIntent();

--- a/packages/quick_actions/quick_actions_android/android/src/main/java/io/flutter/plugins/quickactions/QuickActions.java
+++ b/packages/quick_actions/quick_actions_android/android/src/main/java/io/flutter/plugins/quickactions/QuickActions.java
@@ -11,6 +11,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.res.Resources;
 import android.os.Build;
+import android.util.Log;
 import androidx.annotation.ChecksSdkIntAtLeast;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -28,6 +29,7 @@ import kotlin.jvm.functions.Function1;
 import org.jetbrains.annotations.NotNull;
 
 final class QuickActions implements AndroidQuickActionsApi {
+  private static final String TAG = "QuickActionsAndroid";
   static final String EXTRA_ACTION = "some unique action key";
 
   private final Context context;
@@ -102,10 +104,12 @@ final class QuickActions implements AndroidQuickActionsApi {
       return null;
     }
     if (activity == null) {
-      throw new FlutterError(
-          "quick_action_getlaunchaction_no_activity",
-          "There is no activity available when launching action",
-          null);
+      // The engine can run without an attached activity, for instance when it is cached and warmed
+      // up by a background service. Nothing launched the app in that case, so there is no launch
+      // action to report. Any action that arrives later is reported through the plugin's
+      // onNewIntent listener once an activity attaches.
+      Log.w(TAG, "There is no activity available when getting the launch action.");
+      return null;
     }
     final Intent intent = activity.getIntent();
     final String launchAction = intent.getStringExtra(EXTRA_ACTION);

--- a/packages/quick_actions/quick_actions_android/android/src/test/java/io/flutter/plugins/quickactions/QuickActionsTest.java
+++ b/packages/quick_actions/quick_actions_android/android/src/test/java/io/flutter/plugins/quickactions/QuickActionsTest.java
@@ -8,6 +8,7 @@ import static io.flutter.plugins.quickactions.QuickActions.EXTRA_ACTION;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
@@ -58,7 +59,7 @@ public class QuickActionsTest {
     // Build.VERSION.SDK_INT is 0 in unit tests, so the version check is stubbed to make sure the
     // null activity, and not the unsupported version, is what is being exercised here.
     final QuickActions quickActions = spy(new QuickActions(mock(Context.class)));
-    when(quickActions.isVersionAllowed()).thenReturn(true);
+    doReturn(true).when(quickActions).isVersionAllowed();
 
     // Act
     final String launchAction = quickActions.getLaunchAction();

--- a/packages/quick_actions/quick_actions_android/android/src/test/java/io/flutter/plugins/quickactions/QuickActionsTest.java
+++ b/packages/quick_actions/quick_actions_android/android/src/test/java/io/flutter/plugins/quickactions/QuickActionsTest.java
@@ -6,8 +6,10 @@ package io.flutter.plugins.quickactions;
 
 import static io.flutter.plugins.quickactions.QuickActions.EXTRA_ACTION;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
 import android.app.Activity;
@@ -49,6 +51,21 @@ public class QuickActionsTest {
   static final int SUPPORTED_BUILD = 25;
   static final int UNSUPPORTED_BUILD = 24;
   static final String SHORTCUT_TYPE = "action_one";
+
+  @Test
+  public void getLaunchAction_noActivity_returnsNull() {
+    // Arrange
+    // Build.VERSION.SDK_INT is 0 in unit tests, so the version check is stubbed to make sure the
+    // null activity, and not the unsupported version, is what is being exercised here.
+    final QuickActions quickActions = spy(new QuickActions(mock(Context.class)));
+    when(quickActions.isVersionAllowed()).thenReturn(true);
+
+    // Act
+    final String launchAction = quickActions.getLaunchAction();
+
+    // Assert
+    assertNull(launchAction);
+  }
 
   @Test
   public void canAttachToEngine() {

--- a/packages/quick_actions/quick_actions_android/pubspec.yaml
+++ b/packages/quick_actions/quick_actions_android/pubspec.yaml
@@ -2,7 +2,7 @@ name: quick_actions_android
 description: An implementation for the Android platform of the Flutter `quick_actions` plugin.
 repository: https://github.com/flutter/packages/tree/main/packages/quick_actions/quick_actions_android
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+in_app_purchase%22
-version: 1.0.32
+version: 1.0.33
 
 environment:
   sdk: ^3.12.0

--- a/packages/quick_actions/quick_actions_android/pubspec.yaml
+++ b/packages/quick_actions/quick_actions_android/pubspec.yaml
@@ -2,7 +2,7 @@ name: quick_actions_android
 description: An implementation for the Android platform of the Flutter `quick_actions` plugin.
 repository: https://github.com/flutter/packages/tree/main/packages/quick_actions/quick_actions_android
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+in_app_purchase%22
-version: 1.0.33
+version: 1.0.32
 
 environment:
   sdk: ^3.12.0


### PR DESCRIPTION
`getLaunchAction` threw `quick_action_getlaunchaction_no_activity` when the plugin had no attached activity. `QuickActionsAndroid.initialize` calls `getLaunchAction` unconditionally, so `initialize` threw a `PlatformException` that callers could not prevent.

An engine can legitimately run without an attached activity. A cached engine warmed up by a background service is the common case: `audio_service` supplies a cached engine to its activity and also warms up that same engine from `AudioService.onCreate`, so `main()` runs with no activity when a media button or Android Auto starts the service.

This returns `null` in that case instead, and logs at debug level. The throw provided no recovery value:

* `initialize` registers the Dart handler before it calls `getLaunchAction`, so the handler is already installed when the exception is thrown.
* When an activity does attach, `QuickActionsPlugin.onAttachedToActivity` calls `onNewIntent(activity.getIntent())`, which reports the shortcut through `AndroidQuickActionsFlutterApi.launchAction`.

`null` is also already the return value for the other "cannot answer" case in this method, on the line directly above (`if (!isVersionAllowed())`).

Verified on an Android 12 emulator by pointing an app at this branch and starting its audio service with no UI: no exception, and a shortcut tap afterwards still routed correctly. A cold start from a shortcut still returns the action, so the activity-present path is unchanged. The new unit test fails with `io.flutter.plugins.quickactions.FlutterError` against the unmodified file.

Fixes flutter/flutter#190348

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under[^1].
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [x] All existing and new tests are passing.

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[the version and CHANGELOG instructions]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version-and-changelog-updates
[semantic versioning]: https://dart.dev/tools/pub/versioning#semantic-versions
[repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
