### PR TITLE
[material_ui] Add SliverAppBar showOnScreen semantics test coverage

### DIFF
--- a/packages/material_ui/test/app_bar_sliver_test.dart
+++ b/packages/material_ui/test/app_bar_sliver_test.dart
@@ -2079,17 +2079,20 @@ void main() {
   ) async {
     final semantics = SemanticsTester(tester); // enables semantics tree generation
 
-    const kItemHeight = 100.0;
+    const kItemHeight = 72.0;
+    const kInitialScrollOffset = 250.0;
     const kExpandedAppBarHeight = 256.0;
 
     final children = <Widget>[];
     final slivers = List<Widget>.generate(30, (int i) {
-      final Widget child = MergeSemantics(child: SizedBox(height: 72.0, child: Text('Item $i')));
+      final Widget child = MergeSemantics(
+        child: SizedBox(height: kItemHeight, child: Text('Item $i')),
+      );
       children.add(child);
       return SliverToBoxAdapter(child: child);
     });
 
-    final scrollController = ScrollController(initialScrollOffset: 2.5 * kItemHeight);
+    final scrollController = ScrollController(initialScrollOffset: kInitialScrollOffset);
     addTearDown(scrollController.dispose);
 
     await tester.pumpWidget(
@@ -2124,7 +2127,7 @@ void main() {
       ),
     );
 
-    expect(scrollController.offset, 2.5 * kItemHeight);
+    expect(scrollController.offset, kInitialScrollOffset);
 
     final int id0 = tester.renderObject(find.byWidget(children[0])).debugSemantics!.id;
     tester.binding.pipelineOwner.semanticsOwner!.performAction(id0, SemanticsAction.showOnScreen);

--- a/packages/material_ui/test/app_bar_sliver_test.dart
+++ b/packages/material_ui/test/app_bar_sliver_test.dart
@@ -2074,6 +2074,67 @@ void main() {
     semantics.dispose();
   });
 
+  testWidgets('showOnScreen works with pinned SliverAppBar and individual slivers', (
+    WidgetTester tester,
+  ) async {
+    final semantics = SemanticsTester(tester); // enables semantics tree generation
+
+    const kItemHeight = 100.0;
+    const kExpandedAppBarHeight = 256.0;
+
+    final children = <Widget>[];
+    final slivers = List<Widget>.generate(30, (int i) {
+      final Widget child = MergeSemantics(child: SizedBox(height: 72.0, child: Text('Item $i')));
+      children.add(child);
+      return SliverToBoxAdapter(child: child);
+    });
+
+    final scrollController = ScrollController(initialScrollOffset: 2.5 * kItemHeight);
+    addTearDown(scrollController.dispose);
+
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: MediaQuery(
+          data: const MediaQueryData(),
+          child: Localizations(
+            locale: const Locale('en', 'us'),
+            delegates: const <LocalizationsDelegate<dynamic>>[
+              DefaultWidgetsLocalizations.delegate,
+              DefaultMaterialLocalizations.delegate,
+            ],
+            child: Scrollable(
+              controller: scrollController,
+              viewportBuilder: (BuildContext context, ViewportOffset offset) {
+                return Viewport(
+                  offset: offset,
+                  slivers: <Widget>[
+                    const SliverAppBar(
+                      pinned: true,
+                      expandedHeight: kExpandedAppBarHeight,
+                      flexibleSpace: FlexibleSpaceBar(title: Text('App Bar')),
+                    ),
+                    ...slivers,
+                  ],
+                );
+              },
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(scrollController.offset, 2.5 * kItemHeight);
+
+    final int id0 = tester.renderObject(find.byWidget(children[0])).debugSemantics!.id;
+    tester.binding.pipelineOwner.semanticsOwner!.performAction(id0, SemanticsAction.showOnScreen);
+    await tester.pump();
+    await tester.pump(const Duration(seconds: 5));
+    expect(tester.getTopLeft(find.byWidget(children[0])).dy, kToolbarHeight);
+
+    semantics.dispose();
+  });
+
   testWidgets('Changing SliverAppBar snap from true to false', (WidgetTester tester) async {
     // Regression test for https://github.com/flutter/flutter/issues/17598
     const appBarHeight = 256.0;

--- a/packages/material_ui/test/app_bar_sliver_test.dart
+++ b/packages/material_ui/test/app_bar_sliver_test.dart
@@ -2007,6 +2007,73 @@ void main() {
     semantics.dispose();
   });
 
+  testWidgets('showOnScreen works with pinned SliverAppBar and sliver list', (
+    WidgetTester tester,
+  ) async {
+    final semantics = SemanticsTester(tester); // enables semantics tree generation
+
+    const kItemHeight = 100.0;
+    const kExpandedAppBarHeight = 56.0;
+
+    final containers = List<Widget>.generate(
+      80,
+      (int i) => MergeSemantics(
+        child: SizedBox(height: kItemHeight, child: Text('container $i')),
+      ),
+    );
+
+    final scrollController = ScrollController(initialScrollOffset: kItemHeight / 2);
+    addTearDown(scrollController.dispose);
+
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: Localizations(
+          locale: const Locale('en', 'us'),
+          delegates: const <LocalizationsDelegate<dynamic>>[
+            DefaultWidgetsLocalizations.delegate,
+            DefaultMaterialLocalizations.delegate,
+          ],
+          child: MediaQuery(
+            data: const MediaQueryData(),
+            child: Scrollable(
+              controller: scrollController,
+              viewportBuilder: (BuildContext context, ViewportOffset offset) {
+                return Viewport(
+                  offset: offset,
+                  slivers: <Widget>[
+                    const SliverAppBar(
+                      pinned: true,
+                      expandedHeight: kExpandedAppBarHeight,
+                      flexibleSpace: FlexibleSpaceBar(title: Text('App Bar')),
+                    ),
+                    SliverList.list(children: containers),
+                  ],
+                );
+              },
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(scrollController.offset, kItemHeight / 2);
+
+    final int firstContainerId = tester
+        .renderObject(find.byWidget(containers.first))
+        .debugSemantics!
+        .id;
+    tester.binding.pipelineOwner.semanticsOwner!.performAction(
+      firstContainerId,
+      SemanticsAction.showOnScreen,
+    );
+    await tester.pump();
+    await tester.pump(const Duration(seconds: 5));
+    expect(tester.getTopLeft(find.byWidget(containers.first)).dy, kExpandedAppBarHeight);
+
+    semantics.dispose();
+  });
+
   testWidgets('Changing SliverAppBar snap from true to false', (WidgetTester tester) async {
     // Regression test for https://github.com/flutter/flutter/issues/17598
     const appBarHeight = 256.0;


### PR DESCRIPTION
In flutter/flutter#186611, `scrollable_semantics_test.dart` had its `material` import removed, which meant replacing `SliverAppBar` with a private `SliverPersistentHeader` delegate in two tests:

- `showOnScreen works with pinned app bar and sliver list`
- `showOnScreen works with pinned app bar and individual slivers`

Those were the only tests exercising `SemanticsAction.showOnScreen` against a pinned `SliverAppBar`, so that behavior lost its coverage. This PR restores both, in `packages/material_ui/test/app_bar_sliver_test.dart` — which already imports `semantics_tester.dart` and is where the other `SliverAppBar` semantics tests live.

The two cases are not redundant:

- **sliver list** — `expandedHeight` of 56.0, so the app bar never collapses; asserts the revealed item lands at `kExpandedAppBarHeight`.
- **individual slivers** — `expandedHeight` of 256.0 with the scroll offset already past the collapse point; asserts the revealed item lands at `kToolbarHeight`. This is the case that actually exercises `FlexibleSpaceBar` collapse behavior, which the `SliverPersistentHeader` stand-in does not reproduce.

The coverage is added here rather than in `flutter/flutter` because Material is frozen there (flutter/flutter#184093), and the TODO left behind by #186611 explicitly pointed at the `material_ui` package.

A note on scope: flutter/flutter#189117 mentions only the first test, and only that one got a TODO. The second `SliverAppBar` removal in #186611 was untracked, so restoring only the first would have left the collapsing-app-bar path uncovered with nothing pointing at it. Happy to split the second test out if you'd rather keep this scoped to the issue as filed.

Verification, in `packages/material_ui`:
- `flutter test test/app_bar_sliver_test.dart` — all tests pass.
- Both new assertions were confirmed load-bearing by flipping `pinned` to `false`, which fails them.

No version bump or CHANGELOG entry: this is a test-only change, which is a documented exemption.

Fixes flutter/flutter#189117

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under[^1].
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [x] All existing and new tests are passing.

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[the version and CHANGELOG instructions]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version-and-changelog-updates
[semantic versioning]: https://dart.dev/tools/pub/versioning#semantic-versions
[repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests

