### PR TITLE
[webview_flutter_wkwebview] Fix crash when JavaScript channel operations run concurrently

### DIFF
--- a/packages/webview_flutter/webview_flutter_wkwebview/CHANGELOG.md
+++ b/packages/webview_flutter/webview_flutter_wkwebview/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 3.26.1
+
+* Fixes a fatal crash caused by concurrent calls to `addJavaScriptChannel`,
+  `removeJavaScriptChannel`, or `enableZoom` attempting to register a script
+  message handler that is already registered.
+
 ## 3.26.0
 
 * Adds new method for accessing a native `WKWebView` from a `FlutterPluginRegistrar`.

--- a/packages/webview_flutter/webview_flutter_wkwebview/lib/src/webkit_webview_controller.dart
+++ b/packages/webview_flutter/webview_flutter_wkwebview/lib/src/webkit_webview_controller.dart
@@ -320,6 +320,11 @@ class WebKitWebViewController extends PlatformWebViewController {
   bool _zoomEnabled = true;
   WebKitNavigationDelegate? _currentNavigationDelegate;
 
+  // The last queued operation that modifies the user scripts or script
+  // message handlers of the user content controller. See
+  // [_enqueueUserContentOperation].
+  Future<void> _userContentOperations = Future<void>.value();
+
   void Function(bool)? _onCanGoBackChangeCallback;
   void Function(JavaScriptConsoleMessage)? _onConsoleMessageCallback;
   void Function(PlatformWebViewPermissionRequest)? _onPermissionRequestCallback;
@@ -417,12 +422,18 @@ class WebKitWebViewController extends PlatformWebViewController {
   }
 
   @override
-  Future<void> addJavaScriptChannel(JavaScriptChannelParams javaScriptChannelParams) async {
-    final String channelName = javaScriptChannelParams.name;
-    if (_javaScriptChannelParams.containsKey(channelName)) {
-      throw ArgumentError('A JavaScriptChannel with name `$channelName` already exists.');
-    }
+  Future<void> addJavaScriptChannel(JavaScriptChannelParams javaScriptChannelParams) {
+    return _enqueueUserContentOperation(() async {
+      final String channelName = javaScriptChannelParams.name;
+      if (_javaScriptChannelParams.containsKey(channelName)) {
+        throw ArgumentError('A JavaScriptChannel with name `$channelName` already exists.');
+      }
 
+      await _addJavaScriptChannel(javaScriptChannelParams);
+    });
+  }
+
+  Future<void> _addJavaScriptChannel(JavaScriptChannelParams javaScriptChannelParams) async {
     final WebKitJavaScriptChannelParams webKitParams =
         javaScriptChannelParams is WebKitJavaScriptChannelParams
         ? javaScriptChannelParams
@@ -448,12 +459,14 @@ class WebKitWebViewController extends PlatformWebViewController {
   }
 
   @override
-  Future<void> removeJavaScriptChannel(String javaScriptChannelName) async {
+  Future<void> removeJavaScriptChannel(String javaScriptChannelName) {
     assert(javaScriptChannelName.isNotEmpty);
-    if (!_javaScriptChannelParams.containsKey(javaScriptChannelName)) {
-      return;
-    }
-    await _resetUserScripts(removedJavaScriptChannel: javaScriptChannelName);
+    return _enqueueUserContentOperation(() async {
+      if (!_javaScriptChannelParams.containsKey(javaScriptChannelName)) {
+        return;
+      }
+      await _resetUserScripts(removedJavaScriptChannel: javaScriptChannelName);
+    });
   }
 
   @override
@@ -636,9 +649,9 @@ class WebKitWebViewController extends PlatformWebViewController {
 
     _zoomEnabled = enabled;
     if (enabled) {
-      await _resetUserScripts();
+      await _enqueueUserContentOperation(_resetUserScripts);
     } else {
-      await _disableZoom();
+      await _enqueueUserContentOperation(_disableZoom);
     }
   }
 
@@ -698,7 +711,7 @@ class WebKitWebViewController extends PlatformWebViewController {
     );
 
     await addJavaScriptChannel(channelParams);
-    return _injectConsoleOverride();
+    return _enqueueUserContentOperation(_injectConsoleOverride);
   }
 
   @override
@@ -787,11 +800,31 @@ class WebKitWebViewController extends PlatformWebViewController {
     _onJavaScriptTextInputDialog = onJavaScriptTextInputDialog;
   }
 
+  // Enqueues an operation that modifies the user scripts or script message
+  // handlers of the user content controller, ensuring it doesn't run until
+  // every previously enqueued operation has finished.
+  //
+  // Removing a JavaScript channel is implemented by removing every script
+  // message handler and re-adding the ones that should remain (see
+  // [_resetUserScripts]). Allowing these multistep operations to interleave
+  // can attempt to register a script message handler with a name that is
+  // already registered, which causes a fatal native exception. See
+  // https://github.com/flutter/flutter/issues/165287.
+  Future<void> _enqueueUserContentOperation(Future<void> Function() operation) {
+    final Future<void> result = _userContentOperations.then((_) => operation());
+    // Errors are exposed through `result`; ignore them here so a failed
+    // operation doesn't prevent later operations from running.
+    _userContentOperations = result.then<void>((_) {}, onError: (_) {});
+    return result;
+  }
+
   // WKWebView does not support removing a single user script, so all user
   // scripts and all message handlers are removed instead. And the JavaScript
   // channels that shouldn't be removed are re-registered. Note that this
   // workaround could interfere with exposing support for custom scripts from
   // applications.
+  //
+  // This must only be called through [_enqueueUserContentOperation].
   Future<void> _resetUserScripts({String? removedJavaScriptChannel}) async {
     final WKUserContentController controller = await _webView.configuration
         .getUserContentController();
@@ -808,7 +841,7 @@ class WebKitWebViewController extends PlatformWebViewController {
 
     await Future.wait(<Future<void>>[
       for (final JavaScriptChannelParams params in remainingChannelParams.values)
-        addJavaScriptChannel(params),
+        _addJavaScriptChannel(params),
       // Zoom is disabled with a WKUserScript, so this adds it back if it was
       // removed above.
       if (!_zoomEnabled) _disableZoom(),

--- a/packages/webview_flutter/webview_flutter_wkwebview/lib/src/webkit_webview_controller.dart
+++ b/packages/webview_flutter/webview_flutter_wkwebview/lib/src/webkit_webview_controller.dart
@@ -327,6 +327,12 @@ class WebKitWebViewController extends PlatformWebViewController {
 
   void Function(bool)? _onCanGoBackChangeCallback;
   void Function(JavaScriptConsoleMessage)? _onConsoleMessageCallback;
+
+  // Whether the console override script from [_injectConsoleOverride] is
+  // currently added to the user content controller. This prevents the script
+  // from being added more than once, which would cause console messages to be
+  // forwarded multiple times.
+  bool _isConsoleOverrideScriptInjected = false;
   void Function(PlatformWebViewPermissionRequest)? _onPermissionRequestCallback;
 
   Future<void> Function(JavaScriptAlertDialogRequest request)? _onJavaScriptAlertDialog;
@@ -710,8 +716,16 @@ class WebKitWebViewController extends PlatformWebViewController {
       },
     );
 
-    await addJavaScriptChannel(channelParams);
-    return _enqueueUserContentOperation(_injectConsoleOverride);
+    // Registering the channel and injecting the console override must run as
+    // a single queued operation. Otherwise another queued operation could run
+    // in between, call [_resetUserScripts], and inject the console override
+    // itself, resulting in the override script being added twice.
+    return _enqueueUserContentOperation(() async {
+      if (!_javaScriptChannelParams.containsKey(_onConsoleMessageChannelName)) {
+        await _addJavaScriptChannel(channelParams);
+      }
+      await _injectConsoleOverride();
+    });
   }
 
   @override
@@ -829,6 +843,7 @@ class WebKitWebViewController extends PlatformWebViewController {
     final WKUserContentController controller = await _webView.configuration
         .getUserContentController();
     unawaited(controller.removeAllUserScripts());
+    _isConsoleOverrideScriptInjected = false;
     // TODO(bparrishMines): This can be replaced with
     // `removeAllScriptMessageHandlers` once Dart supports runtime version
     // checking. (e.g. The equivalent to @availability in Objective-C.)
@@ -868,6 +883,11 @@ class WebKitWebViewController extends PlatformWebViewController {
   }
 
   Future<void> _injectConsoleOverride() async {
+    if (_isConsoleOverrideScriptInjected) {
+      return;
+    }
+    _isConsoleOverrideScriptInjected = true;
+
     // Within overrideScript, a series of console output methods such as
     // console.log will be rewritten to pass the output content to the Flutter
     // end.

--- a/packages/webview_flutter/webview_flutter_wkwebview/pubspec.yaml
+++ b/packages/webview_flutter/webview_flutter_wkwebview/pubspec.yaml
@@ -2,7 +2,7 @@ name: webview_flutter_wkwebview
 description: A Flutter plugin that provides a WebView widget based on Apple's WKWebView control.
 repository: https://github.com/flutter/packages/tree/main/packages/webview_flutter/webview_flutter_wkwebview
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+webview%22
-version: 3.26.0
+version: 3.26.1
 
 environment:
   sdk: ^3.12.0

--- a/packages/webview_flutter/webview_flutter_wkwebview/test/webkit_webview_controller_test.dart
+++ b/packages/webview_flutter/webview_flutter_wkwebview/test/webkit_webview_controller_test.dart
@@ -1108,6 +1108,64 @@ void main() {
       verify(mockUserContentController.removeScriptMessageHandler('name'));
     });
 
+    test('setOnConsoleMessage does not inject the console override script twice when '
+        'interleaved with removeJavaScriptChannel', () async {
+      PigeonOverrides.wKScriptMessageHandler_new =
+          ({
+            required void Function(WKScriptMessageHandler, WKUserContentController, WKScriptMessage)
+            didReceiveScriptMessage,
+            dynamic observeValue,
+          }) {
+            return WKScriptMessageHandler.pigeon_detached(
+              didReceiveScriptMessage: didReceiveScriptMessage,
+            );
+          };
+
+      final mockUserContentController = MockWKUserContentController();
+
+      // Track the user scripts currently added to the user content controller.
+      final addedScriptSources = <String>[];
+      when(mockUserContentController.addUserScript(any)).thenAnswer((Invocation invocation) async {
+        await Future<void>.delayed(Duration.zero);
+        addedScriptSources.add((invocation.positionalArguments[0] as WKUserScript).source);
+      });
+      when(mockUserContentController.removeAllUserScripts()).thenAnswer((
+        Invocation invocation,
+      ) async {
+        await Future<void>.delayed(Duration.zero);
+        addedScriptSources.clear();
+      });
+
+      final WebKitWebViewController controller = createControllerWithMocks(
+        mockUserContentController: mockUserContentController,
+      );
+
+      await controller.addJavaScriptChannel(
+        WebKitJavaScriptChannelParams(
+          name: 'channel1',
+          onMessageReceived: (JavaScriptMessage m) {},
+        ),
+      );
+
+      // Set the console callback and remove a channel without awaiting, so the
+      // reset from `removeJavaScriptChannel` runs between the operations
+      // queued by `setOnConsoleMessage`.
+      await Future.wait(<Future<void>>[
+        controller.setOnConsoleMessage((JavaScriptConsoleMessage message) {}),
+        controller.removeJavaScriptChannel('channel1'),
+      ]);
+
+      // Allow the unawaited calls made by the last reset to complete.
+      await Future<void>.delayed(Duration.zero);
+
+      expect(
+        addedScriptSources.where(
+          (String source) => source.contains('_flutter_webview_plugin_overrides'),
+        ),
+        hasLength(1),
+      );
+    });
+
     test('removeJavaScriptChannel with zoom disabled', () async {
       PigeonOverrides.wKScriptMessageHandler_new =
           ({

--- a/packages/webview_flutter/webview_flutter_wkwebview/test/webkit_webview_controller_test.dart
+++ b/packages/webview_flutter/webview_flutter_wkwebview/test/webkit_webview_controller_test.dart
@@ -1012,6 +1012,102 @@ void main() {
       verifyNoMoreInteractions(mockUserContentController);
     });
 
+    test('removeJavaScriptChannel calls do not interleave when not awaited', () async {
+      // Regression test for
+      // https://github.com/flutter/flutter/issues/165287.
+      PigeonOverrides.wKScriptMessageHandler_new =
+          ({
+            required void Function(WKScriptMessageHandler, WKUserContentController, WKScriptMessage)
+            didReceiveScriptMessage,
+            dynamic observeValue,
+          }) {
+            return WKScriptMessageHandler.pigeon_detached(
+              didReceiveScriptMessage: didReceiveScriptMessage,
+            );
+          };
+
+      final mockUserContentController = MockWKUserContentController();
+
+      // Simulate the native `WKUserContentController`, which raises a fatal
+      // exception when a script message handler is added with a name that is
+      // already registered.
+      final registeredHandlerNames = <String>{};
+      when(mockUserContentController.addScriptMessageHandler(any, any)).thenAnswer((
+        Invocation invocation,
+      ) async {
+        await Future<void>.delayed(Duration.zero);
+        final name = invocation.positionalArguments[1] as String;
+        if (!registeredHandlerNames.add(name)) {
+          throw StateError(
+            'Attempt to add script message handler with name `$name` when it already exists.',
+          );
+        }
+      });
+      when(mockUserContentController.removeScriptMessageHandler(any)).thenAnswer((
+        Invocation invocation,
+      ) async {
+        await Future<void>.delayed(Duration.zero);
+        registeredHandlerNames.remove(invocation.positionalArguments[0] as String);
+      });
+
+      final WebKitWebViewController controller = createControllerWithMocks(
+        mockUserContentController: mockUserContentController,
+      );
+
+      const channelNames = ['channel1', 'channel2', 'channel3', 'channel4'];
+      for (final name in channelNames) {
+        await controller.addJavaScriptChannel(
+          WebKitJavaScriptChannelParams(name: name, onMessageReceived: (JavaScriptMessage m) {}),
+        );
+      }
+
+      // Remove every channel without awaiting each call, as an app would when
+      // cleaning up from a synchronous method like `State.dispose`.
+      await Future.wait(<Future<void>>[
+        for (final name in channelNames) controller.removeJavaScriptChannel(name),
+      ]);
+
+      // Allow the unawaited `removeScriptMessageHandler` calls made by the
+      // last reset to complete.
+      await Future<void>.delayed(Duration.zero);
+
+      expect(registeredHandlerNames, isEmpty);
+    });
+
+    test('a failed JavaScript channel operation does not block later operations', () async {
+      PigeonOverrides.wKScriptMessageHandler_new =
+          ({
+            required void Function(WKScriptMessageHandler, WKUserContentController, WKScriptMessage)
+            didReceiveScriptMessage,
+            dynamic observeValue,
+          }) {
+            return WKScriptMessageHandler.pigeon_detached(
+              didReceiveScriptMessage: didReceiveScriptMessage,
+            );
+          };
+
+      final mockUserContentController = MockWKUserContentController();
+      final WebKitWebViewController controller = createControllerWithMocks(
+        mockUserContentController: mockUserContentController,
+      );
+
+      await controller.addJavaScriptChannel(
+        WebKitJavaScriptChannelParams(name: 'name', onMessageReceived: (JavaScriptMessage m) {}),
+      );
+
+      await expectLater(
+        controller.addJavaScriptChannel(
+          JavaScriptChannelParams(name: 'name', onMessageReceived: (_) {}),
+        ),
+        throwsArgumentError,
+      );
+
+      reset(mockUserContentController);
+
+      await controller.removeJavaScriptChannel('name');
+      verify(mockUserContentController.removeScriptMessageHandler('name'));
+    });
+
     test('removeJavaScriptChannel with zoom disabled', () async {
       PigeonOverrides.wKScriptMessageHandler_new =
           ({


### PR DESCRIPTION
On iOS, `removeJavaScriptChannel` is implemented by removing every script message handler and user script and re-adding the ones that should remain, because `WKWebView` does not support removing a single user script. This is a multistep async operation, so when an app calls `removeJavaScriptChannel` (or `addJavaScriptChannel`/`enableZoom`) multiple times without awaiting each call — for example when cleaning up from a synchronous method like `State.dispose` — the operations interleave. One in-flight reset can re-add a script message handler that a concurrent reset never removed, which makes `WKUserContentController.addScriptMessageHandler` raise a fatal `NSInvalidArgumentException` (`Attempt to add script message handler with name X when one already exists`). This matches the diagnosis in https://github.com/flutter/flutter/issues/165287#issuecomment-2733483573.

This PR fixes the crash by serializing every operation that modifies the user content controller's script message handlers or user scripts through an internal FIFO future chain (`_enqueueUserContentOperation`), so the operations can no longer interleave regardless of how the app calls them. Notes:

- `_resetUserScripts` re-registers remaining channels through a new private `_addJavaScriptChannel` (the previous method body without the duplicate-name check) instead of the public queued method, so a queued reset never waits on operations queued behind itself.
- The chain ignores errors from completed operations (each caller still receives its own operation's error through the returned `Future`), so one failed operation cannot block subsequent ones. This is covered by a new test.
- The duplicate-name `ArgumentError` from `addJavaScriptChannel` is still delivered through the returned `Future`, as before.

The new regression test simulates the native `WKUserContentController` behavior of throwing when a handler name is registered twice. Before this change it fails with exactly the crash mechanism from the issue:

```
Bad state: Attempt to add script message handler with name `channel3` when it already exists.
```

After this change it passes, along with all existing tests.

A `removeJavaScriptChannels(List<String>)` batch API (suggested in https://github.com/flutter/flutter/issues/165287#issuecomment-2733483573) could still be a useful ergonomic follow-up, but is not required for correctness after this change.

Fixes https://github.com/flutter/flutter/issues/165287

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under[^1].
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [x] All existing and new tests are passing.

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[the version and CHANGELOG instructions]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version-and-changelog-updates
[semantic versioning]: https://dart.dev/tools/pub/versioning#semantic-versions
[repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
