### PR TITLE
[material_ui and cupertino_ui] Remove workspaces and fix CI

### DIFF
--- a/packages/cupertino_ui/example/lib/list_tile/cupertino_list_tile.0.dart
+++ b/packages/cupertino_ui/example/lib/list_tile/cupertino_list_tile.0.dart
@@ -4,7 +4,6 @@
 
 // #region body
 import 'package:cupertino_ui/cupertino_ui.dart';
-import 'package:material_ui/material_ui.dart';
 
 /// Flutter code sample for [CupertinoListTile].
 
@@ -37,25 +36,25 @@ class CupertinoListTileExample extends StatelessWidget {
           ),
           CupertinoListTile(
             title: Text('One-line with trailing widget'),
-            trailing: Icon(Icons.more_vert),
+            trailing: Icon(CupertinoIcons.ellipsis_vertical),
           ),
           CupertinoListTile(
             leading: FlutterLogo(),
             title: Text('One-line with both widgets'),
-            trailing: Icon(Icons.more_vert),
+            trailing: Icon(CupertinoIcons.ellipsis_vertical),
           ),
           CupertinoListTile(
             leading: FlutterLogo(size: 56.0),
             title: Text('Two-line CupertinoListTile'),
             subtitle: Text('Here is a subtitle'),
-            trailing: Icon(Icons.more_vert),
-            additionalInfo: Icon(Icons.info),
+            trailing: Icon(CupertinoIcons.ellipsis_vertical),
+            additionalInfo: Icon(CupertinoIcons.info),
           ),
           CupertinoListTile(
             key: Key('CupertinoListTile with background color'),
             leading: FlutterLogo(size: 56.0),
             title: Text('CupertinoListTile with background color'),
-            backgroundColor: Colors.lightBlue,
+            backgroundColor: CupertinoColors.activeBlue,
           ),
         ],
       ),

--- a/packages/cupertino_ui/example/lib/magnifier/text_magnifier.0.dart
+++ b/packages/cupertino_ui/example/lib/magnifier/text_magnifier.0.dart
@@ -3,8 +3,8 @@
 // found in the LICENSE file.
 
 // #region body
+import 'package:cupertino_ui/cupertino_ui.dart';
 import 'package:flutter/foundation.dart';
-import 'package:material_ui/material_ui.dart';
 
 void main() => runApp(const TextMagnifierExampleApp(text: 'Hello world!'));
 
@@ -20,12 +20,12 @@ class TextMagnifierExampleApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
-      home: Scaffold(
-        body: Padding(
+    return CupertinoApp(
+      home: CupertinoPageScaffold(
+        child: Padding(
           padding: const .symmetric(horizontal: 48.0),
           child: Center(
-            child: TextField(
+            child: CupertinoTextField(
               textDirection: textDirection,
               // Create a custom magnifier configuration that
               // this `TextField` will use to build a magnifier with.
@@ -96,7 +96,7 @@ class CustomMagnifier extends StatelessWidget {
             // Decorate it however we'd like!
             decoration: const MagnifierDecoration(
               shape: StarBorder(
-                side: BorderSide(color: Colors.green, width: 2),
+                side: BorderSide(color: CupertinoColors.activeGreen, width: 2),
               ),
             ),
             size: magnifierSize,

--- a/packages/cupertino_ui/example/pubspec.yaml
+++ b/packages/cupertino_ui/example/pubspec.yaml
@@ -7,8 +7,6 @@ version: 1.0.0
 environment:
   sdk: ^3.12.0
 
-resolution: workspace
-
 dependencies:
   flutter:
     sdk: flutter

--- a/packages/cupertino_ui/example/pubspec.yaml
+++ b/packages/cupertino_ui/example/pubspec.yaml
@@ -17,9 +17,7 @@ dependencies:
   web: ^1.1.1
   cupertino_ui:
     path: ..
-  material_ui:
-    # TODO(justinmc): Use the pub.dev package when published.
-    path: ../../material_ui
+  material_ui: ^0.0.2
 
 dev_dependencies:
   integration_test:

--- a/packages/cupertino_ui/example/pubspec.yaml
+++ b/packages/cupertino_ui/example/pubspec.yaml
@@ -19,6 +19,10 @@ dependencies:
     path: ..
   material_ui: ^0.0.2
 
+dependency_overrides:
+  cupertino_ui:
+    path: ..
+
 dev_dependencies:
   integration_test:
     sdk: flutter

--- a/packages/cupertino_ui/example/pubspec.yaml
+++ b/packages/cupertino_ui/example/pubspec.yaml
@@ -17,11 +17,6 @@ dependencies:
   web: ^1.1.1
   cupertino_ui:
     path: ..
-  material_ui: ^0.0.2
-
-dependency_overrides:
-  cupertino_ui:
-    path: ..
 
 dev_dependencies:
   integration_test:
@@ -37,6 +32,3 @@ dev_dependencies:
   flutter_web_plugins:
     sdk: flutter
   flutter_lints: ^6.0.0
-
-flutter:
-  uses-material-design: true

--- a/packages/cupertino_ui/example/test/context_menu/cupertino_context_menu.0_test.dart
+++ b/packages/cupertino_ui/example/test/context_menu/cupertino_context_menu.0_test.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:material_ui/material_ui.dart';
+import 'package:cupertino_ui/cupertino_ui.dart';
 import 'package:cupertino_ui_examples/context_menu/cupertino_context_menu.0.dart'
     as example;
 import 'package:flutter_test/flutter_test.dart';

--- a/packages/cupertino_ui/example/test/context_menu/cupertino_context_menu.0_test.dart
+++ b/packages/cupertino_ui/example/test/context_menu/cupertino_context_menu.0_test.dart
@@ -2,9 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:cupertino_ui/cupertino_ui.dart';
 import 'package:cupertino_ui_examples/context_menu/cupertino_context_menu.0.dart'
     as example;
+import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {

--- a/packages/cupertino_ui/example/test/context_menu/cupertino_context_menu.1_test.dart
+++ b/packages/cupertino_ui/example/test/context_menu/cupertino_context_menu.1_test.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:material_ui/material_ui.dart';
+import 'package:cupertino_ui/cupertino_ui.dart';
 import 'package:cupertino_ui_examples/context_menu/cupertino_context_menu.1.dart'
     as example;
 import 'package:flutter_test/flutter_test.dart';

--- a/packages/cupertino_ui/example/test/context_menu/cupertino_context_menu.1_test.dart
+++ b/packages/cupertino_ui/example/test/context_menu/cupertino_context_menu.1_test.dart
@@ -2,9 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:cupertino_ui/cupertino_ui.dart';
 import 'package:cupertino_ui_examples/context_menu/cupertino_context_menu.1.dart'
     as example;
+import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {

--- a/packages/cupertino_ui/example/test/list_tile/cupertino_list_tile.0_test.dart
+++ b/packages/cupertino_ui/example/test/list_tile/cupertino_list_tile.0_test.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 import 'package:cupertino_ui/cupertino_ui.dart';
-import 'package:material_ui/material_ui.dart';
 import 'package:cupertino_ui_examples/list_tile/cupertino_list_tile.0.dart'
     as example;
 import 'package:flutter_test/flutter_test.dart';
@@ -26,8 +25,8 @@ void main() {
     expect(find.text('Two-line CupertinoListTile'), findsOne);
     expect(find.text('Here is a subtitle'), findsOne);
     expect(find.text('CupertinoListTile with background color'), findsOne);
-    expect(find.byIcon(Icons.more_vert), findsNWidgets(3));
-    expect(find.byIcon(Icons.info), findsOne);
+    expect(find.byIcon(CupertinoIcons.ellipsis_vertical), findsNWidgets(3));
+    expect(find.byIcon(CupertinoIcons.info), findsOne);
 
     final Finder tileWithBackgroundFinder = find.byKey(
       const Key('CupertinoListTile with background color'),
@@ -36,7 +35,7 @@ void main() {
       tester
           .firstWidget<CupertinoListTile>(tileWithBackgroundFinder)
           .backgroundColor,
-      Colors.lightBlue,
+      CupertinoColors.activeBlue,
     );
   });
 }

--- a/packages/cupertino_ui/example/test/magnifier/text_magnifier.0_test.dart
+++ b/packages/cupertino_ui/example/test/magnifier/text_magnifier.0_test.dart
@@ -116,5 +116,5 @@ void main() {
     await showMagnifier(tester, text.indexOf(textToTapOn));
 
     expect(find.byType(example.CustomMagnifier), findsOneWidget);
-  });
+  }, variant: TargetPlatformVariant.only(TargetPlatform.iOS));
 }

--- a/packages/cupertino_ui/example/test/magnifier/text_magnifier.0_test.dart
+++ b/packages/cupertino_ui/example/test/magnifier/text_magnifier.0_test.dart
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:cupertino_ui/cupertino_ui.dart';
 import 'package:flutter/rendering.dart';
-import 'package:material_ui/material_ui.dart';
 import 'package:cupertino_ui_examples/magnifier/text_magnifier.0.dart'
     as example;
 import 'package:flutter_test/flutter_test.dart';
@@ -20,7 +20,7 @@ List<TextSelectionPoint> _globalize(
 RenderEditable _findRenderEditable<T extends State<StatefulWidget>>(
   WidgetTester tester,
 ) {
-  return (tester.state(find.byType(TextField))
+  return (tester.state(find.byType(CupertinoTextField))
           as TextSelectionGestureDetectorBuilderDelegate)
       .editableTextKey
       .currentState!
@@ -65,7 +65,7 @@ void main() {
     await tester.pumpAndSettle();
 
     final TextEditingController controller = tester
-        .firstWidget<TextField>(find.byType(TextField))
+        .firstWidget<CupertinoTextField>(find.byType(CupertinoTextField))
         .controller!;
 
     final TextSelection selection = controller.selection;

--- a/packages/cupertino_ui/example/test/magnifier/text_magnifier.0_test.dart
+++ b/packages/cupertino_ui/example/test/magnifier/text_magnifier.0_test.dart
@@ -48,13 +48,12 @@ Offset _textOffsetToPosition<T extends State<StatefulWidget>>(
 
 void main() {
   const Duration durationBetweenActions = Duration(milliseconds: 20);
-  const String defaultText = 'I am a magnifier, fear me!';
 
-  Future<void> showMagnifier(WidgetTester tester, int textOffset) async {
-    assert(textOffset >= 0);
-    final Offset tapOffset = _textOffsetToPosition(tester, textOffset);
+  Future<void> showMagnifier(WidgetTester tester, int textIndex) async {
+    assert(textIndex >= 0);
+    final Offset tapOffset = _textOffsetToPosition(tester, textIndex);
 
-    // Double tap 'Magnifier' word to show the selection handles.
+    // Double tap to show the selection handles.
     final TestGesture testGesture = await tester.startGesture(tapOffset);
     await tester.pump(durationBetweenActions);
     await testGesture.up();
@@ -75,17 +74,17 @@ void main() {
       renderEditable,
     );
 
-    final Offset handlePos = endpoints.last.point + const Offset(10.0, 10.0);
-
+    final Offset handlePos = endpoints.last.point;
     final TestGesture gesture = await tester.startGesture(handlePos);
 
-    await gesture.moveTo(_textOffsetToPosition(tester, defaultText.length - 2));
+    await gesture.moveTo(handlePos + Offset(50.0, 0.0));
     await tester.pump();
   }
 
   testWidgets(
     'should show custom magnifier on drag',
     (WidgetTester tester) async {
+      const String defaultText = 'I am a magnifier, fear me!';
       await tester.pumpWidget(
         const example.TextMagnifierExampleApp(text: defaultText),
       );
@@ -116,5 +115,5 @@ void main() {
     await showMagnifier(tester, text.indexOf(textToTapOn));
 
     expect(find.byType(example.CustomMagnifier), findsOneWidget);
-  }, variant: TargetPlatformVariant.only(TargetPlatform.iOS));
+  }, variant: TargetPlatformVariant.mobile());
 }

--- a/packages/cupertino_ui/pending_changelogs/change_2026_08_03_workspaces.yaml
+++ b/packages/cupertino_ui/pending_changelogs/change_2026_08_03_workspaces.yaml
@@ -1,0 +1,3 @@
+changelog: |
+  - Refactors examples to not cross-import material_ui.
+version: patch

--- a/packages/cupertino_ui/pubspec.yaml
+++ b/packages/cupertino_ui/pubspec.yaml
@@ -8,9 +8,6 @@ environment:
   sdk: ^3.12.0
   flutter: ">=3.44.0"
 
-workspace:
-  - example
-
 dependencies:
   collection: ^1.19.1
   flutter:

--- a/packages/cupertino_ui/pubspec.yaml
+++ b/packages/cupertino_ui/pubspec.yaml
@@ -24,9 +24,7 @@ dev_dependencies:
     sdk: flutter
   # To track memory leaks.
   leak_tracker_flutter_testing: ^3.0.10
-  material_ui:
-    # TODO(justinmc): Use the pub.dev package when published.
-    path: ../material_ui
+  material_ui: ^0.0.2
   path: ^1.9.1
 
 topics:

--- a/packages/material_ui/example/pubspec.yaml
+++ b/packages/material_ui/example/pubspec.yaml
@@ -7,8 +7,6 @@ version: 1.0.0
 environment:
   sdk: ^3.12.0
 
-resolution: workspace
-
 dependencies:
   flutter:
     sdk: flutter

--- a/packages/material_ui/example/pubspec.yaml
+++ b/packages/material_ui/example/pubspec.yaml
@@ -20,6 +20,10 @@ dependencies:
     path: ..
   cupertino_ui: ^0.0.2
 
+dependency_overrides:
+  material_ui:
+    path: ..
+
 dev_dependencies:
   integration_test:
     sdk: flutter

--- a/packages/material_ui/example/pubspec.yaml
+++ b/packages/material_ui/example/pubspec.yaml
@@ -20,10 +20,6 @@ dependencies:
     path: ..
   cupertino_ui: ^0.0.2
 
-dependency_overrides:
-  material_ui:
-    path: ..
-
 dev_dependencies:
   integration_test:
     sdk: flutter

--- a/packages/material_ui/pubspec.yaml
+++ b/packages/material_ui/pubspec.yaml
@@ -8,9 +8,6 @@ environment:
   sdk: ^3.12.0
   flutter: ">=3.44.0"
 
-workspace:
-  - example
-
 dependencies:
   collection: ^1.19.1
   cupertino_ui: ^0.0.2


### PR DESCRIPTION
It was discovered in the latest cupertino_ui batch release that CI is not set up to handle workspaces yet, causing CI failures. This PR attempts to solve the problem by:

 * Removing workspaces from material_ui_examples and cupertino_ui_examples.
 * Making cupertino_ui depend on material_ui via Pub instead of path.
 * Refactoring away all cross imports in cupertino_ui_examples and removing material_ui as its dependency.

See also https://github.com/flutter/flutter/issues/190453
https://github.com/flutter/flutter/issues/190305