### PR TITLE
Add lazyLoadChildren to ExpansionTile in material_ui

### DIFF
--- a/packages/material_ui/lib/src/expansion_tile.dart
+++ b/packages/material_ui/lib/src/expansion_tile.dart
@@ -171,6 +171,7 @@ class ExpansionTile extends StatefulWidget {
     this.expansionAnimationStyle,
     this.internalAddSemanticForOnTap = false,
     this.statesController,
+    this.lazyLoadChildren = false,
   }) : assert(
          expandedCrossAxisAlignment != CrossAxisAlignment.baseline,
          'CrossAxisAlignment.baseline is not supported since the expanded children '
@@ -255,6 +256,13 @@ class ExpansionTile extends StatefulWidget {
   /// When false (default), the children are removed from the tree when the tile is
   /// collapsed and recreated upon expansion.
   final bool maintainState;
+
+  /// If [maintainState] is true, whether to delay building the children until
+  /// the tile is expanded for the first time.
+  ///
+  /// Defaults to false, meaning the children are built at the same time as the
+  /// header.
+  final bool lazyLoadChildren;
 
   /// Specifies padding for the [ListTile].
   ///
@@ -521,6 +529,15 @@ class ExpansionTile extends StatefulWidget {
 
   @override
   State<ExpansionTile> createState() => _ExpansionTileState();
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.add(FlagProperty('maintainState', value: maintainState, ifTrue: 'maintainState'));
+    properties.add(
+      FlagProperty('lazyLoadChildren', value: lazyLoadChildren, ifTrue: 'lazyLoadChildren'),
+    );
+  }
 }
 
 class _ExpansionTileState extends State<ExpansionTile> {
@@ -893,6 +910,7 @@ class _ExpansionTileState extends State<ExpansionTile> {
       duration: _duration,
       reverseCurve: _reverseCurve,
       maintainState: widget.maintainState,
+      lazyLoadChildren: widget.lazyLoadChildren,
       headerBuilder: _buildHeader,
       bodyBuilder: _buildBody,
       expansibleBuilder: _buildExpansible,

--- a/packages/material_ui/test/expansion_tile_test.dart
+++ b/packages/material_ui/test/expansion_tile_test.dart
@@ -279,6 +279,92 @@ void main() {
     expect(find.text('Discarding State'), findsNothing);
   });
 
+  testWidgets('ExpansionTile lazyLoadChildren defers child build until first expansion', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Material(
+          child: SingleChildScrollView(
+            child: ExpansionTile(
+              title: Text('Title'),
+              lazyLoadChildren: true,
+              maintainState: true,
+              children: <Widget>[Text('Lazy Child')],
+            ),
+          ),
+        ),
+      ),
+    );
+
+    // Child is not in the tree at all before first expansion, even with
+    // maintainState: true.
+    expect(find.text('Lazy Child', skipOffstage: false), findsNothing);
+
+    await tester.tap(find.text('Title'));
+    await tester.pumpAndSettle();
+    expect(find.text('Lazy Child'), findsOneWidget);
+
+    // After collapsing, the child remains in the tree (offstage) because
+    // maintainState is true and the tile has been expanded once.
+    await tester.tap(find.text('Title'));
+    await tester.pumpAndSettle();
+    expect(find.text('Lazy Child'), findsNothing);
+    expect(find.text('Lazy Child', skipOffstage: false), findsOneWidget);
+  });
+
+  testWidgets('ExpansionTile lazyLoadChildren builds children when initiallyExpanded is true', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Material(
+          child: SingleChildScrollView(
+            child: ExpansionTile(
+              title: Text('Title'),
+              lazyLoadChildren: true,
+              initiallyExpanded: true,
+              children: <Widget>[Text('Lazy Child')],
+            ),
+          ),
+        ),
+      ),
+    );
+
+    // Initially expanded, so the children are built right away.
+    expect(find.text('Lazy Child'), findsOneWidget);
+  });
+
+  testWidgets(
+    'ExpansionTile lazyLoadChildren with maintainState false still removes children when collapsed',
+    (WidgetTester tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Material(
+            child: SingleChildScrollView(
+              child: ExpansionTile(
+                title: Text('Title'),
+                lazyLoadChildren: true,
+                maintainState: false,
+                children: <Widget>[Text('Lazy Child')],
+              ),
+            ),
+          ),
+        ),
+      );
+
+      expect(find.text('Lazy Child', skipOffstage: false), findsNothing);
+
+      await tester.tap(find.text('Title'));
+      await tester.pumpAndSettle();
+      expect(find.text('Lazy Child'), findsOneWidget);
+
+      await tester.tap(find.text('Title'));
+      await tester.pumpAndSettle();
+      expect(find.text('Lazy Child', skipOffstage: false), findsNothing);
+    },
+  );
+
   testWidgets('ExpansionTile padding test', (WidgetTester tester) async {
     await tester.pumpWidget(
       const MaterialApp(


### PR DESCRIPTION
## Summary

This PR adds a `lazyLoadChildren` property to `ExpansionTile` in the `material_ui` package, enabling deferred construction of children until the tile is expanded for the first time.

This is the companion PR to `flutter/flutter` which adds `lazyLoadChildren` to the underlying `Expansible` widget (widget layer). The `ExpansionTile` change is submitted here instead of `flutter/flutter` due to the Material library code freeze introduced in [#184093](https://github.com/flutter/flutter/issues/184093).

### Changes
- Added `lazyLoadChildren` parameter to `ExpansionTile` constructor (defaults to `false`)
- Added `lazyLoadChildren` field documentation
- Passes `lazyLoadChildren` through to the underlying `Expansible` widget
- Added `debugFillProperties` support
- Added 3 tests covering:
  - Children deferred until first expansion (with `maintainState: true`)
  - Children built immediately when `initiallyExpanded: true`
  - Children removed on collapse when `maintainState: false`

### Motivation

When an `ExpansionTile` has expensive children (e.g. heavy widgets, network images), they are currently built eagerly on first frame even if the tile is collapsed. `lazyLoadChildren` defers this build until the user first expands the tile, reducing initial render overhead.

Fixes [flutter/flutter#184111](https://github.com/flutter/flutter/issues/184111)

## Pre-launch Checklist

- [x] I read the Contributor Guide and followed the process outlined there for submitting PRs.
- [x] I read the Tree Hygiene wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation.
- [x] All existing and new tests are passing.