### PR TITLE
[camera_android_camerax][tool] Migrate complexity checks to package:cognitive_complexity

### DIFF
--- a/.repo_tool_config.yaml
+++ b/.repo_tool_config.yaml
@@ -20,8 +20,8 @@ allowed_dependencies:
   # A pin can be either an exact version, or a range with an explicit, inclusive
   # max version, which must a version that already exists, not a future version.
   pinned:
-    # Cyclomatic complexity linter for camera_android_camerax
-    - dart_code_linter
+    # Cognitive complexity linter for camera_android_camerax
+    - cognitive_complexity
 
     # Test-only dependency, so does not impact package clients, and
     # has limited impact so could be easily removed if there are

--- a/packages/camera/camera_android_camerax/analysis_options.yaml
+++ b/packages/camera/camera_android_camerax/analysis_options.yaml
@@ -10,7 +10,6 @@ analyzer:
     - macos/**
     - linux/**
 
-dart_code_linter:
-  metrics:
-    cyclomatic-complexity: 15
+cognitive_complexity:
+  fail-threshold: 15
 

--- a/packages/camera/camera_android_camerax/pubspec.yaml
+++ b/packages/camera/camera_android_camerax/pubspec.yaml
@@ -27,7 +27,7 @@ dependencies:
 
 dev_dependencies:
   build_runner: ^2.2.0
-  cognitive_complexity: 0.2.0
+  cognitive_complexity: ^0.2.1
   dart_skills_lint:
     git:
       url: https://github.com/flutter/skills.git
@@ -40,11 +40,6 @@ dev_dependencies:
   mockito: ^5.4.4
   path: ^1.8.0
   pigeon: ^26.1.4
-
-dependency_overrides:
-  # Pigeon restricts analyzer to <13.0.0, but cognitive_complexity requires ^14.1.0.
-  analyzer: ^14.1.0
-  file: ^7.0.1
 
 topics:
   - camera

--- a/packages/camera/camera_android_camerax/pubspec.yaml
+++ b/packages/camera/camera_android_camerax/pubspec.yaml
@@ -27,7 +27,7 @@ dependencies:
 
 dev_dependencies:
   build_runner: ^2.2.0
-  dart_code_linter: 4.1.5
+  cognitive_complexity: 0.2.0
   dart_skills_lint:
     git:
       url: https://github.com/flutter/skills.git
@@ -40,6 +40,11 @@ dev_dependencies:
   mockito: ^5.4.4
   path: ^1.8.0
   pigeon: ^26.1.4
+
+dependency_overrides:
+  # Pigeon restricts analyzer to <13.0.0, but cognitive_complexity requires ^14.1.0.
+  analyzer: ^14.1.0
+  file: ^7.0.1
 
 topics:
   - camera

--- a/packages/camera/camera_android_camerax/pubspec.yaml
+++ b/packages/camera/camera_android_camerax/pubspec.yaml
@@ -27,7 +27,7 @@ dependencies:
 
 dev_dependencies:
   build_runner: ^2.2.0
-  cognitive_complexity: ^0.2.1
+  cognitive_complexity: 0.2.1
   dart_skills_lint:
     git:
       url: https://github.com/flutter/skills.git

--- a/script/tool/lib/src/analyze_command.dart
+++ b/script/tool/lib/src/analyze_command.dart
@@ -350,7 +350,7 @@ class AnalyzeCommand extends PackageLoopingCommand {
       if (yaml is YamlMap) {
         final Object? linter = yaml['cognitive_complexity'];
         if (linter is YamlMap) {
-          final Object? threshold = linter['fail-threshold'] ?? linter['fail_threshold'];
+          final Object? threshold = linter['fail-threshold'];
           if (threshold is int) {
             return threshold;
           }

--- a/script/tool/lib/src/analyze_command.dart
+++ b/script/tool/lib/src/analyze_command.dart
@@ -321,10 +321,7 @@ class AnalyzeCommand extends PackageLoopingCommand {
     ];
 
     final customCheckRunners = <_CustomLinter>[
-      _CustomLinter(
-        dependencyName: 'cognitive_complexity',
-        run: _runCognitiveComplexityForPackage,
-      ),
+      _CustomLinter(dependencyName: 'cognitive_complexity', run: _runCognitiveComplexityForPackage),
     ];
 
     // Skip custom linters during downgrade as metrics are redundant and vulnerable to dependency issues.
@@ -353,8 +350,7 @@ class AnalyzeCommand extends PackageLoopingCommand {
       if (yaml is YamlMap) {
         final Object? linter = yaml['cognitive_complexity'];
         if (linter is YamlMap) {
-          final Object? threshold =
-              linter['fail-threshold'] ?? linter['fail_threshold'];
+          final Object? threshold = linter['fail-threshold'] ?? linter['fail_threshold'];
           if (threshold is int) {
             return threshold;
           }
@@ -380,13 +376,9 @@ class AnalyzeCommand extends PackageLoopingCommand {
       return <String>[];
     }
     final filesToAnalyze = <String>[];
-    for (final FileSystemEntity entity
-        in package.libDirectory.listSync(recursive: true)) {
-      if (entity is File &&
-          entity.path.endsWith('.dart') &&
-          !_isGeneratedDartFile(entity.path)) {
-        final String relativePath =
-            path.relative(entity.path, from: package.directory.path);
+    for (final FileSystemEntity entity in package.libDirectory.listSync(recursive: true)) {
+      if (entity is File && entity.path.endsWith('.dart') && !_isGeneratedDartFile(entity.path)) {
+        final String relativePath = path.relative(entity.path, from: package.directory.path);
         filesToAnalyze.add(relativePath.replaceAll(r'\', '/'));
       }
     }
@@ -417,8 +409,7 @@ class AnalyzeCommand extends PackageLoopingCommand {
       workingDir: package.directory,
     );
     if (linterExitCode != 0) {
-      final thresholdMessage =
-          threshold != null ? ' (configured threshold: $threshold)' : '';
+      final thresholdMessage = threshold != null ? ' (configured threshold: $threshold)' : '';
       return <String>[
         'Metrics violations found$thresholdMessage. See the package\'s local "analysis_options.yaml" for configured thresholds.',
       ];

--- a/script/tool/lib/src/analyze_command.dart
+++ b/script/tool/lib/src/analyze_command.dart
@@ -368,7 +368,6 @@ class AnalyzeCommand extends PackageLoopingCommand {
 
   bool _isGeneratedDartFile(String filePath) {
     return filePath.endsWith('.g.dart') ||
-        filePath.endsWith('.freezed.dart') ||
         filePath.endsWith('.mocks.dart') ||
         filePath.endsWith('.gen.dart');
   }
@@ -402,6 +401,9 @@ class AnalyzeCommand extends PackageLoopingCommand {
       'run',
       'cognitive_complexity',
       if (threshold != null) ...<String>[
+        // Set display threshold 5 points below fail-threshold so developers
+        // can see functions approaching the limit without flooding the logs
+        // with low-complexity functions.
         '--threshold',
         (threshold > 5 ? threshold - 5 : 0).toString(),
         '--fail-threshold',

--- a/script/tool/lib/src/analyze_command.dart
+++ b/script/tool/lib/src/analyze_command.dart
@@ -401,6 +401,9 @@ class AnalyzeCommand extends PackageLoopingCommand {
       'run',
       'cognitive_complexity',
       if (threshold != null) ...<String>[
+        // --fail-threshold only controls the exit code, while --threshold
+        // controls which functions are printed in the output table (default 0).
+        // Pass both so that only failing functions are printed in CI logs.
         '--threshold',
         threshold.toString(),
         '--fail-threshold',

--- a/script/tool/lib/src/analyze_command.dart
+++ b/script/tool/lib/src/analyze_command.dart
@@ -321,7 +321,10 @@ class AnalyzeCommand extends PackageLoopingCommand {
     ];
 
     final customCheckRunners = <_CustomLinter>[
-      _CustomLinter(dependencyName: 'dart_code_linter', run: _runDartCodeLinterForPackage),
+      _CustomLinter(
+        dependencyName: 'cognitive_complexity',
+        run: _runCognitiveComplexityForPackage,
+      ),
     ];
 
     // Skip custom linters during downgrade as metrics are redundant and vulnerable to dependency issues.
@@ -338,7 +341,7 @@ class AnalyzeCommand extends PackageLoopingCommand {
     return errors.isEmpty ? PackageResult.success() : PackageResult.fail(errors);
   }
 
-  /// Retrieves the configured cyclomatic complexity threshold from the local
+  /// Retrieves the configured cognitive complexity threshold from the local
   /// `analysis_options.yaml` if it exists and is configured.
   int? _getLinterThreshold(RepositoryPackage package) {
     final File optionsFile = package.directory.childFile('analysis_options.yaml');
@@ -348,14 +351,12 @@ class AnalyzeCommand extends PackageLoopingCommand {
     try {
       final Object? yaml = loadYaml(optionsFile.readAsStringSync());
       if (yaml is YamlMap) {
-        final Object? linter = yaml['dart_code_linter'];
+        final Object? linter = yaml['cognitive_complexity'];
         if (linter is YamlMap) {
-          final Object? metrics = linter['metrics'];
-          if (metrics is YamlMap) {
-            final Object? complexity = metrics['cyclomatic-complexity'];
-            if (complexity is int) {
-              return complexity;
-            }
+          final Object? threshold =
+              linter['fail-threshold'] ?? linter['fail_threshold'];
+          if (threshold is int) {
+            return threshold;
           }
         }
       }
@@ -365,24 +366,57 @@ class AnalyzeCommand extends PackageLoopingCommand {
     return null;
   }
 
-  /// Runs the `dart_code_linter` metrics analyzer on the package.
+  bool _isGeneratedDartFile(String filePath) {
+    return filePath.endsWith('.g.dart') ||
+        filePath.endsWith('.freezed.dart') ||
+        filePath.endsWith('.mocks.dart') ||
+        filePath.endsWith('.gen.dart');
+  }
+
+  /// Runs the `cognitive_complexity` metrics analyzer on the package.
   ///
-  /// Assumes `dart_code_linter` is present in `dev_dependencies`.
-  Future<List<String>> _runDartCodeLinterForPackage(RepositoryPackage package) async {
+  /// Assumes `cognitive_complexity` is present in `dev_dependencies`.
+  Future<List<String>> _runCognitiveComplexityForPackage(RepositoryPackage package) async {
     if (!package.libDirectory.existsSync()) {
       return <String>[];
     }
-    print('Running dart_code_linter:metrics analysis...');
-    final int linterExitCode = await processRunner.runAndStream(_dartBinaryPath, <String>[
+    final filesToAnalyze = <String>[];
+    for (final FileSystemEntity entity
+        in package.libDirectory.listSync(recursive: true)) {
+      if (entity is File &&
+          entity.path.endsWith('.dart') &&
+          !_isGeneratedDartFile(entity.path)) {
+        final String relativePath =
+            path.relative(entity.path, from: package.directory.path);
+        filesToAnalyze.add(relativePath.replaceAll(r'\', '/'));
+      }
+    }
+    if (filesToAnalyze.isEmpty) {
+      return <String>[];
+    }
+    filesToAnalyze.sort();
+
+    print('Running cognitive_complexity analysis...');
+    final int? threshold = _getLinterThreshold(package);
+    final args = <String>[
       'run',
-      'dart_code_linter:metrics',
-      'analyze',
-      'lib',
-      '--set-exit-on-violation-level=warning',
-    ], workingDir: package.directory);
+      'cognitive_complexity',
+      if (threshold != null) ...<String>[
+        '--threshold',
+        (threshold > 5 ? threshold - 5 : 0).toString(),
+        '--fail-threshold',
+        threshold.toString(),
+      ],
+      ...filesToAnalyze,
+    ];
+    final int linterExitCode = await processRunner.runAndStream(
+      _dartBinaryPath,
+      args,
+      workingDir: package.directory,
+    );
     if (linterExitCode != 0) {
-      final int? threshold = _getLinterThreshold(package);
-      final thresholdMessage = threshold != null ? ' (configured threshold: $threshold)' : '';
+      final thresholdMessage =
+          threshold != null ? ' (configured threshold: $threshold)' : '';
       return <String>[
         'Metrics violations found$thresholdMessage. See the package\'s local "analysis_options.yaml" for configured thresholds.',
       ];

--- a/script/tool/lib/src/analyze_command.dart
+++ b/script/tool/lib/src/analyze_command.dart
@@ -401,11 +401,8 @@ class AnalyzeCommand extends PackageLoopingCommand {
       'run',
       'cognitive_complexity',
       if (threshold != null) ...<String>[
-        // Set display threshold 5 points below fail-threshold so developers
-        // can see functions approaching the limit without flooding the logs
-        // with low-complexity functions.
         '--threshold',
-        (threshold > 5 ? threshold - 5 : 0).toString(),
+        threshold.toString(),
         '--fail-threshold',
         threshold.toString(),
       ],

--- a/script/tool/test/analyze_command_test.dart
+++ b/script/tool/test/analyze_command_test.dart
@@ -675,7 +675,7 @@ cognitive_complexity:
               'run',
               'cognitive_complexity',
               '--threshold',
-              '10',
+              '15',
               '--fail-threshold',
               '15',
               'lib/lib.dart',

--- a/script/tool/test/analyze_command_test.dart
+++ b/script/tool/test/analyze_command_test.dart
@@ -407,19 +407,20 @@ void main() {
       });
     });
 
-    group('dart_code_linter', () {
-      test('runs dart_code_linter if present in dev_dependencies', () async {
+    group('cognitive_complexity', () {
+      test('runs cognitive_complexity if present in dev_dependencies', () async {
         final RepositoryPackage package = createFakePackage(
           'a_package',
           packagesDir,
           isFlutter: true,
         );
         _writeFakePubspecWithLinter(package, inDevDependencies: true);
+        package.libDirectory.childFile('lib.dart').createSync();
 
         _mockCallsForFlutterAnalyze(
           processRunner,
           extraDartCalls: [
-            FakeProcessInfo(MockProcess(), <String>['run', 'dart_code_linter:metrics']),
+            FakeProcessInfo(MockProcess(), <String>['run', 'cognitive_complexity']),
           ],
         );
 
@@ -432,23 +433,22 @@ void main() {
             ProcessCall('dart', const <String>['analyze', '--fatal-infos'], package.path),
             ProcessCall('dart', const <String>[
               'run',
-              'dart_code_linter:metrics',
-              'analyze',
-              'lib',
-              '--set-exit-on-violation-level=warning',
+              'cognitive_complexity',
+              'lib/lib.dart',
             ], package.path),
           ]),
         );
-        expect(output, contains('Running dart_code_linter:metrics analysis...'));
+        expect(output, contains('Running cognitive_complexity analysis...'));
       });
 
-      test('does not run dart_code_linter when --downgrade is specified', () async {
+      test('does not run cognitive_complexity when --downgrade is specified', () async {
         final RepositoryPackage package = createFakePackage(
           'a_package',
           packagesDir,
           isFlutter: true,
         );
         _writeFakePubspecWithLinter(package, inDevDependencies: true);
+        package.libDirectory.childFile('lib.dart').createSync();
 
         processRunner.mockProcessesForExecutable['flutter'] = <FakeProcessInfo>[
           FakeProcessInfo(MockProcess(), <String>['pub', 'downgrade']),
@@ -472,17 +472,17 @@ void main() {
           ]),
         );
         final String combinedOutput = output.join('\n').toLowerCase();
-        expect(combinedOutput, isNot(contains('dart_code_linter')));
-        expect(combinedOutput, isNot(contains('metrics')));
+        expect(combinedOutput, isNot(contains('cognitive_complexity')));
       });
 
-      test('does not run dart_code_linter if present in dependencies', () async {
+      test('does not run cognitive_complexity if present in dependencies', () async {
         final RepositoryPackage package = createFakePackage(
           'a_package',
           packagesDir,
           isFlutter: true,
         );
         _writeFakePubspecWithLinter(package, inDependencies: true);
+        package.libDirectory.childFile('lib.dart').createSync();
 
         _mockCallsForFlutterAnalyze(processRunner);
 
@@ -496,16 +496,16 @@ void main() {
           ]),
         );
         final String combinedOutput = output.join('\n').toLowerCase();
-        expect(combinedOutput, isNot(contains('dart_code_linter')));
-        expect(combinedOutput, isNot(contains('metrics')));
+        expect(combinedOutput, isNot(contains('cognitive_complexity')));
       });
 
-      test('does not run dart_code_linter if not present', () async {
+      test('does not run cognitive_complexity if not present', () async {
         final RepositoryPackage package = createFakePackage(
           'a_package',
           packagesDir,
           isFlutter: true,
         );
+        package.libDirectory.childFile('lib.dart').createSync();
 
         _mockCallsForFlutterAnalyze(processRunner);
 
@@ -519,18 +519,18 @@ void main() {
           ]),
         );
         final String combinedOutput = output.join('\n').toLowerCase();
-        expect(combinedOutput, isNot(contains('dart_code_linter')));
-        expect(combinedOutput, isNot(contains('metrics')));
+        expect(combinedOutput, isNot(contains('cognitive_complexity')));
       });
 
-      test('runs dart_code_linter using dart for pure Dart packages', () async {
+      test('runs cognitive_complexity using dart for pure Dart packages', () async {
         final RepositoryPackage package = createFakePackage('a_package', packagesDir);
         _writeFakePubspecWithLinter(package, inDevDependencies: true, includeFlutter: false);
+        package.libDirectory.childFile('lib.dart').createSync();
 
         processRunner.mockProcessesForExecutable['dart'] = <FakeProcessInfo>[
           FakeProcessInfo(MockProcess(), <String>['pub', 'get']),
           FakeProcessInfo(MockProcess(), <String>['analyze']),
-          FakeProcessInfo(MockProcess(), <String>['run', 'dart_code_linter:metrics']),
+          FakeProcessInfo(MockProcess(), <String>['run', 'cognitive_complexity']),
         ];
 
         final List<String> output = await runCapturingPrint(runner, <String>['analyze']);
@@ -542,17 +542,15 @@ void main() {
             ProcessCall('dart', const <String>['analyze', '--fatal-infos'], package.path),
             ProcessCall('dart', const <String>[
               'run',
-              'dart_code_linter:metrics',
-              'analyze',
-              'lib',
-              '--set-exit-on-violation-level=warning',
+              'cognitive_complexity',
+              'lib/lib.dart',
             ], package.path),
           ]),
         );
-        expect(output, contains('Running dart_code_linter:metrics analysis...'));
+        expect(output, contains('Running cognitive_complexity analysis...'));
       });
 
-      test('skips dart_code_linter if lib/ does not exist', () async {
+      test('skips cognitive_complexity if lib/ does not exist', () async {
         final RepositoryPackage package = createFakePackage(
           'a_package',
           packagesDir,
@@ -573,22 +571,47 @@ void main() {
           ]),
         );
         final String combinedOutput = output.join('\n').toLowerCase();
-        expect(combinedOutput, isNot(contains('dart_code_linter')));
-        expect(combinedOutput, isNot(contains('metrics')));
+        expect(combinedOutput, isNot(contains('cognitive_complexity')));
       });
 
-      test('fails if dart_code_linter analysis fails', () async {
+      test('skips cognitive_complexity if lib/ only contains generated files', () async {
         final RepositoryPackage package = createFakePackage(
           'a_package',
           packagesDir,
           isFlutter: true,
         );
         _writeFakePubspecWithLinter(package, inDevDependencies: true);
+        package.libDirectory.childFile('foo.g.dart').createSync();
+        package.libDirectory.childFile('bar.freezed.dart').createSync();
+
+        _mockCallsForFlutterAnalyze(processRunner);
+
+        final List<String> output = await runCapturingPrint(runner, <String>['analyze']);
+
+        expect(
+          processRunner.recordedCalls,
+          orderedEquals(<ProcessCall>[
+            ProcessCall('flutter', const <String>['pub', 'get'], package.path),
+            ProcessCall('dart', const <String>['analyze', '--fatal-infos'], package.path),
+          ]),
+        );
+        final String combinedOutput = output.join('\n').toLowerCase();
+        expect(combinedOutput, isNot(contains('cognitive_complexity')));
+      });
+
+      test('fails if cognitive_complexity analysis fails', () async {
+        final RepositoryPackage package = createFakePackage(
+          'a_package',
+          packagesDir,
+          isFlutter: true,
+        );
+        _writeFakePubspecWithLinter(package, inDevDependencies: true);
+        package.libDirectory.childFile('lib.dart').createSync();
 
         _mockCallsForFlutterAnalyze(
           processRunner,
           extraDartCalls: [
-            FakeProcessInfo(MockProcess(exitCode: 1), <String>['run', 'dart_code_linter:metrics']),
+            FakeProcessInfo(MockProcess(exitCode: 1), <String>['run', 'cognitive_complexity']),
           ],
         );
 
@@ -619,17 +642,17 @@ void main() {
           isFlutter: true,
         );
         _writeFakePubspecWithLinter(package, inDevDependencies: true);
+        package.libDirectory.childFile('lib.dart').createSync();
         package.ciConfigFile.writeAsStringSync('allow_custom_analysis_options: true');
         package.directory.childFile('analysis_options.yaml').writeAsStringSync('''
-dart_code_linter:
-  metrics:
-    cyclomatic-complexity: 15
+cognitive_complexity:
+  fail-threshold: 15
 ''');
 
         _mockCallsForFlutterAnalyze(
           processRunner,
           extraDartCalls: [
-            FakeProcessInfo(MockProcess(exitCode: 1), <String>['run', 'dart_code_linter:metrics']),
+            FakeProcessInfo(MockProcess(exitCode: 1), <String>['run', 'cognitive_complexity']),
           ],
         );
 
@@ -642,6 +665,22 @@ dart_code_linter:
           },
         );
 
+        expect(
+          processRunner.recordedCalls,
+          orderedEquals(<ProcessCall>[
+            ProcessCall('flutter', const <String>['pub', 'get'], package.path),
+            ProcessCall('dart', const <String>['analyze', '--fatal-infos'], package.path),
+            ProcessCall('dart', const <String>[
+              'run',
+              'cognitive_complexity',
+              '--threshold',
+              '10',
+              '--fail-threshold',
+              '15',
+              'lib/lib.dart',
+            ], package.path),
+          ]),
+        );
         expect(commandError, isA<ToolExit>());
         expect(
           output,
@@ -773,6 +812,7 @@ dart_code_linter:
             isFlutter: true,
           );
           _writeFakePubspecWithLinter(package, inDevDependencies: true);
+          package.libDirectory.childFile('lib.dart').createSync();
           package.ciConfigFile.writeAsStringSync('analyze_skills: true');
 
           package.directory
@@ -789,7 +829,7 @@ dart_code_linter:
             FakeProcessInfo(MockProcess(exitCode: 1), <String>['analyze']), // skills package
             FakeProcessInfo(MockProcess(exitCode: 1), <String>[
               'run',
-              'dart_code_linter:metrics',
+              'cognitive_complexity',
             ]), // custom linter
           ];
 
@@ -1914,8 +1954,8 @@ environment:
   ${includeFlutter ? 'flutter: ">=2.5.0"' : ''}
 dependencies:
   ${includeFlutter ? 'flutter:\n    sdk: flutter' : ''}
-${inDependencies ? '  dart_code_linter: 4.1.5' : ''}
-${inDevDependencies ? 'dev_dependencies:\n  dart_code_linter: 4.1.5' : ''}
+${inDependencies ? '  cognitive_complexity: 0.2.0' : ''}
+${inDevDependencies ? 'dev_dependencies:\n  cognitive_complexity: 0.2.0' : ''}
 ''');
 }
 

--- a/script/tool/test/analyze_command_test.dart
+++ b/script/tool/test/analyze_command_test.dart
@@ -582,7 +582,8 @@ void main() {
         );
         _writeFakePubspecWithLinter(package, inDevDependencies: true);
         package.libDirectory.childFile('foo.g.dart').createSync();
-        package.libDirectory.childFile('bar.freezed.dart').createSync();
+        package.libDirectory.childFile('bar.mocks.dart').createSync();
+        package.libDirectory.childFile('baz.gen.dart').createSync();
 
         _mockCallsForFlutterAnalyze(processRunner);
 


### PR DESCRIPTION
When we initially added cyclomatic complexity [we wanted cognitive complexity](https://github.com/flutter/packages/pull/11999). Now there is a mit licensed version that meets our dependency constraints maintained by a flutter contributor so let's migrate to that. 

- @reidbaker 

---
Agent authored pr description

Migrates codebase complexity enforcement for `camera_android_camerax` from `dart_code_linter` (cyclomatic complexity) to `package:cognitive_complexity` (cognitive complexity), matching the migration in https://github.com/flutter/agent-plugins/pull/211 and replacing https://github.com/flutter/packages/pull/11999.

## Summary
- Replaced `dart_code_linter` with `cognitive_complexity` under `pinned` allowed dependencies in `.repo_tool_config.yaml`.
- Updated `AnalyzeCommand` in `script/tool/lib/src/analyze_command.dart` to execute `cognitive_complexity` with configured fail thresholds from `analysis_options.yaml` while filtering out generated Dart files (`.g.dart`, `.mocks.dart`, `.gen.dart`).
- Replaced `dart_code_linter` with `cognitive_complexity: 0.2.1` in `packages/camera/camera_android_camerax/pubspec.yaml` and configured `fail-threshold: 15` in `analysis_options.yaml`.
- Updated repository tooling unit tests in `script/tool/test/analyze_command_test.dart` to test `cognitive_complexity` and verify generated file exclusion.

## Pre-Review Checklist
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under.
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under.
- [x] All existing and new tests are passing.