### PR TITLE
[camera_android_camerax] Add explicit concurrent-futures dependency

### DIFF
--- a/packages/camera/camera_android_camerax/CHANGELOG.md
+++ b/packages/camera/camera_android_camerax/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.7.4+5
 
-* Adds explicit `androidx.concurrent:concurrent-futures` dependency to fix
+* Adds explicit `androidx.concurrent:concurrent-futures:1.2.0` dependency to fix
   `compileDebugJavaWithJavac` failing with "class file for
   androidx.concurrent.futures.CallbackToFutureAdapter not found" when
   `camera-core`'s jspecify type annotations are resolved during compilation.

--- a/packages/camera/camera_android_camerax/CHANGELOG.md
+++ b/packages/camera/camera_android_camerax/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.7.4+5
+
+* Adds explicit `androidx.concurrent:concurrent-futures` dependency to fix
+  `compileDebugJavaWithJavac` failing with "class file for
+  androidx.concurrent.futures.CallbackToFutureAdapter not found" when
+  `camera-core`'s jspecify type annotations are resolved during compilation.
+
 ## 0.7.4+4
 
 * Fix `NullPointerException` when disposing camera during active video recording.

--- a/packages/camera/camera_android_camerax/android/build.gradle.kts
+++ b/packages/camera/camera_android_camerax/android/build.gradle.kts
@@ -84,7 +84,7 @@ dependencies {
     implementation("com.google.guava:guava:33.5.0-android")
     // camera-core's compiled classes reference CallbackToFutureAdapter type annotations;
     // without this explicit dependency, javac fails to resolve them during compilation.
-    implementation("androidx.concurrent:concurrent-futures:1.3.0")
+    implementation("androidx.concurrent:concurrent-futures:1.2.0")
     testImplementation("junit:junit:4.13.2")
     testImplementation("org.mockito:mockito-core:5.23.0")
     testImplementation("org.mockito:mockito-inline:5.2.0")

--- a/packages/camera/camera_android_camerax/android/build.gradle.kts
+++ b/packages/camera/camera_android_camerax/android/build.gradle.kts
@@ -82,6 +82,9 @@ dependencies {
     implementation("androidx.camera:camera-lifecycle:${cameraxVersion}")
     implementation("androidx.camera:camera-video:${cameraxVersion}")
     implementation("com.google.guava:guava:33.5.0-android")
+    // camera-core's compiled classes reference CallbackToFutureAdapter type annotations;
+    // without this explicit dependency, javac fails to resolve them during compilation.
+    implementation("androidx.concurrent:concurrent-futures:1.3.0")
     testImplementation("junit:junit:4.13.2")
     testImplementation("org.mockito:mockito-core:5.23.0")
     testImplementation("org.mockito:mockito-inline:5.2.0")

--- a/packages/camera/camera_android_camerax/android/src/test/java/io/flutter/plugins/camerax/ConcurrentFuturesDependencyTest.java
+++ b/packages/camera/camera_android_camerax/android/src/test/java/io/flutter/plugins/camerax/ConcurrentFuturesDependencyTest.java
@@ -1,0 +1,41 @@
+// Copyright 2013 The Flutter Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package io.flutter.plugins.camerax;
+
+import static org.junit.Assert.fail;
+
+import org.junit.Test;
+
+/**
+ * Regression test for https://github.com/flutter/flutter/issues/190505.
+ *
+ * <p>{@code camera-core}'s compiled classes carry jspecify {@code @NonNull} type annotations on
+ * members that reference {@code androidx.concurrent.futures.CallbackToFutureAdapter}. javac needs
+ * that class on the compile classpath to process those annotations, even though this plugin never
+ * calls the annotated members directly. Without an explicit {@code
+ * androidx.concurrent:concurrent-futures} dependency, resolution of that class can silently depend
+ * on transitive dependency behavior and fail with "class file for
+ * androidx.concurrent.futures.CallbackToFutureAdapter not found" during {@code
+ * compileDebugJavaWithJavac}.
+ *
+ * <p>This test asserts the class is present on the test classpath, so if the explicit dependency
+ * in {@code android/build.gradle.kts} is ever removed, this test fails instead of the break only
+ * surfacing as a build error for consumers.
+ */
+public class ConcurrentFuturesDependencyTest {
+  @Test
+  public void callbackToFutureAdapter_isOnClasspath() {
+    try {
+      Class.forName("androidx.concurrent.futures.CallbackToFutureAdapter");
+    } catch (ClassNotFoundException e) {
+      fail(
+          "androidx.concurrent.futures.CallbackToFutureAdapter is not on the classpath. "
+              + "This means the explicit androidx.concurrent:concurrent-futures dependency in "
+              + "android/build.gradle.kts was removed or is no longer being resolved, which will "
+              + "cause compileDebugJavaWithJavac to fail for consumers of this plugin. "
+              + "See https://github.com/flutter/flutter/issues/190505.");
+    }
+  }
+}

--- a/packages/camera/camera_android_camerax/android/src/test/java/io/flutter/plugins/camerax/ConcurrentFuturesDependencyTest.java
+++ b/packages/camera/camera_android_camerax/android/src/test/java/io/flutter/plugins/camerax/ConcurrentFuturesDependencyTest.java
@@ -4,38 +4,29 @@
 
 package io.flutter.plugins.camerax;
 
-import static org.junit.Assert.fail;
+import static org.junit.Assert.assertNotNull;
 
+import androidx.concurrent.futures.CallbackToFutureAdapter;
 import org.junit.Test;
 
 /**
  * Regression test for https://github.com/flutter/flutter/issues/190505.
  *
  * <p>{@code camera-core}'s compiled classes carry jspecify {@code @NonNull} type annotations on
- * members that reference {@code androidx.concurrent.futures.CallbackToFutureAdapter}. javac needs
- * that class on the compile classpath to process those annotations, even though this plugin never
- * calls the annotated members directly. Without an explicit {@code
- * androidx.concurrent:concurrent-futures} dependency, resolution of that class can silently depend
- * on transitive dependency behavior and fail with "class file for
- * androidx.concurrent.futures.CallbackToFutureAdapter not found" during {@code
+ * members that reference {@link CallbackToFutureAdapter}. javac needs that class on the compile
+ * classpath to process those annotations, even though this plugin never calls the annotated
+ * members directly. Without an explicit {@code androidx.concurrent:concurrent-futures} dependency,
+ * resolution of that class can silently depend on transitive dependency behavior and fail with
+ * "class file for androidx.concurrent.futures.CallbackToFutureAdapter not found" during {@code
  * compileDebugJavaWithJavac}.
  *
- * <p>This test asserts the class is present on the test classpath, so if the explicit dependency
- * in {@code android/build.gradle.kts} is ever removed, this test fails instead of the break only
- * surfacing as a build error for consumers.
+ * <p>The static reference to {@link CallbackToFutureAdapter} below means that if the explicit
+ * dependency in {@code android/build.gradle.kts} is ever removed, this test target fails to
+ * compile instead of the break only surfacing as a build error for consumers.
  */
 public class ConcurrentFuturesDependencyTest {
   @Test
   public void callbackToFutureAdapter_isOnClasspath() {
-    try {
-      Class.forName("androidx.concurrent.futures.CallbackToFutureAdapter");
-    } catch (ClassNotFoundException e) {
-      fail(
-          "androidx.concurrent.futures.CallbackToFutureAdapter is not on the classpath. "
-              + "This means the explicit androidx.concurrent:concurrent-futures dependency in "
-              + "android/build.gradle.kts was removed or is no longer being resolved, which will "
-              + "cause compileDebugJavaWithJavac to fail for consumers of this plugin. "
-              + "See https://github.com/flutter/flutter/issues/190505.");
-    }
+    assertNotNull(CallbackToFutureAdapter.class);
   }
 }

--- a/packages/camera/camera_android_camerax/pubspec.yaml
+++ b/packages/camera/camera_android_camerax/pubspec.yaml
@@ -2,7 +2,7 @@ name: camera_android_camerax
 description: Android implementation of the camera plugin using the CameraX library.
 repository: https://github.com/flutter/packages/tree/main/packages/camera/camera_android_camerax
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+camera%22
-version: 0.7.4+4
+version: 0.7.4+5
 
 environment:
   sdk: ^3.12.0


### PR DESCRIPTION
`camera_android_camerax`'s Gradle module does not explicitly declare a dependency on `androidx.concurrent:concurrent-futures`. Verified via `androidx.camera:camera-core:1.6.1`'s own Gradle module metadata (`.module` file): `camera-core` declares `androidx.concurrent:concurrent-futures` only on its **runtime** variant (`releaseVariantReleaseRuntimePublication`), not its **api/compile** variant (`releaseVariantReleaseApiPublication`). So when a consumer compiles against `camera-core`, Gradle correctly does not put `concurrent-futures` on the compile classpath — that's not a resolution bug, it's what `camera-core`'s own metadata declares.

However, `camera-core`'s compiled `SurfaceRequest.class` carries a compile-time-retained jspecify `@NonNull` type annotation on a member typed `androidx.concurrent.futures.CallbackToFutureAdapter`. javac needs that class on the compile classpath to fully process the annotation metadata during compilation — even though no `camera_android_camerax` (or `camera-core`) source calls it directly. This is a mismatch in `camera-core`'s own packaging (a type needed at compile time for annotation processing, but declared runtime-only), which the Flutter team can't fix upstream since `camera-core` is owned by the AndroidX/Jetpack team. Declaring the dependency explicitly in `camera_android_camerax` works around it.

Confirmed 100% reproducible on a completely stock, uncustomized `flutter create` app on current stable (3.44.8, default AGP 9.0.1, compileSdk 37):

```
flutter create camera_repro
cd camera_repro
flutter pub add camera
flutter build apk --debug
```

fails every time with:

```
error: Cannot attach type annotations @org.jspecify.annotations.NonNull to
SurfaceRequest.mSurfaceRecreationCompleter: class file for
androidx.concurrent.futures.CallbackToFutureAdapter not found
```

Minimal repro repo (steps + README with root cause): https://github.com/dhc-tech/camera-android-camerax-build-repro

List which issues are fixed by this PR:

Fixes https://github.com/flutter/flutter/issues/190505

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities. This PR was prepared with AI assistance (Claude Code); I reviewed the diagnosis and the diff, reproduced the failure myself on a clean project, and verified the root cause against `camera-core`'s published Gradle module metadata before submitting.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran the auto-formatter.
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[camera_android_camerax]`
- [x] I linked to at least one issue that this PR fixes in the description above.
- [x] I followed the version and CHANGELOG instructions, using semantic versioning and the repository CHANGELOG style (bumped to `0.7.4+5`, rebased to avoid colliding with the real `0.7.4+4` release).
- [x] I updated/added any relevant documentation (doc comments with `///`). N/A — no public API surface changed, only a build-file dependency.
- [x] I added new tests to check the change I am making: `ConcurrentFuturesDependencyTest.java` asserts `CallbackToFutureAdapter` resolves on the classpath, so it fails if the dependency is ever dropped again.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on Discord.

[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/