### PR TITLE
[camera_android_camerax] Fix leaked thread per capture in `takePicture`

### DIFF
--- a/packages/camera/camera_android_camerax/CHANGELOG.md
+++ b/packages/camera/camera_android_camerax/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.7.4+5
+
+* Fixes a leaked thread per capture by dispatching the `takePicture` result callback on the main
+  executor.
+
 ## 0.7.4+4
 
 * Fix `NullPointerException` when disposing camera during active video recording.

--- a/packages/camera/camera_android_camerax/CHANGELOG.md
+++ b/packages/camera/camera_android_camerax/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.7.4+4
+
+* Fixes a leaked thread per capture by dispatching the `takePicture` result callback on the main
+  executor.
+
 ## 0.7.4+3
 
 * Updates `ResolutionPreset.max` to prefer higher resolution over capture rate

--- a/packages/camera/camera_android_camerax/android/src/main/java/io/flutter/plugins/camerax/ImageCaptureProxyApi.java
+++ b/packages/camera/camera_android_camerax/android/src/main/java/io/flutter/plugins/camerax/ImageCaptureProxyApi.java
@@ -9,9 +9,9 @@ import androidx.annotation.Nullable;
 import androidx.camera.core.ImageCapture;
 import androidx.camera.core.ImageCaptureException;
 import androidx.camera.core.resolutionselector.ResolutionSelector;
+import androidx.core.content.ContextCompat;
 import java.io.File;
 import java.io.IOException;
-import java.util.concurrent.Executors;
 import kotlin.Result;
 import kotlin.Unit;
 import kotlin.jvm.functions.Function1;
@@ -106,7 +106,9 @@ class ImageCaptureProxyApi extends PigeonApiImageCapture {
         createOnImageSavedCallback(temporaryCaptureFile, systemServicesManager, callback);
 
     pigeonInstance.takePicture(
-        outputFileOptions, Executors.newSingleThreadExecutor(), onImageSavedCallback);
+        outputFileOptions,
+        ContextCompat.getMainExecutor(getPigeonRegistrar().getContext()),
+        onImageSavedCallback);
   }
 
   @Override

--- a/packages/camera/camera_android_camerax/android/src/test/java/io/flutter/plugins/camerax/ImageCaptureTest.java
+++ b/packages/camera/camera_android_camerax/android/src/test/java/io/flutter/plugins/camerax/ImageCaptureTest.java
@@ -5,19 +5,23 @@
 package io.flutter.plugins.camerax;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
+import static org.robolectric.Shadows.shadowOf;
 
 import android.content.Context;
+import android.os.Looper;
 import android.view.Surface;
 import androidx.annotation.NonNull;
 import androidx.camera.core.ImageCapture;
 import androidx.camera.core.ImageCaptureException;
 import androidx.camera.core.resolutionselector.ResolutionSelector;
+import androidx.test.core.app.ApplicationProvider;
 import java.io.File;
 import java.io.IOException;
 import java.util.concurrent.Executor;
@@ -26,6 +30,7 @@ import kotlin.Unit;
 import kotlin.jvm.functions.Function1;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.MockedStatic;
 import org.robolectric.RobolectricTestRunner;
 
@@ -86,12 +91,40 @@ public class ImageCaptureTest {
   }
 
   @Test
+  public void takePicture_runsCallbackOnTheMainExecutor() {
+    final ProxyApiRegistrar apiRegistrar = new TestProxyApiRegistrar();
+    apiRegistrar.setContext(ApplicationProvider.getApplicationContext());
+
+    final PigeonApiImageCapture api = apiRegistrar.getPigeonApiImageCapture();
+    final ImageCapture instance = mock(ImageCapture.class);
+
+    api.takePicture(
+        instance, mock(SystemServicesManager.class), ResultCompat.asCompatCallback(reply -> null));
+
+    final ArgumentCaptor<Executor> executorCaptor = ArgumentCaptor.forClass(Executor.class);
+    verify(instance)
+        .takePicture(
+            any(ImageCapture.OutputFileOptions.class),
+            executorCaptor.capture(),
+            any(ImageCapture.OnImageSavedCallback.class));
+
+    final Thread[] callbackThread = {null};
+    executorCaptor.getValue().execute(() -> callbackThread[0] = Thread.currentThread());
+    assertNull(callbackThread[0]);
+
+    shadowOf(Looper.getMainLooper()).idle();
+    assertEquals(Looper.getMainLooper().getThread(), callbackThread[0]);
+  }
+
+  @Test
   public void
       takePicture_sendsRequestToTakePictureWithExpectedConfigurationWhenTemporaryFileCanBeCreated() {
     final ProxyApiRegistrar mockApiRegistrar = mock(ProxyApiRegistrar.class);
     final Context mockContext = mock(Context.class);
     final File mockOutputDir = mock(File.class);
     when(mockContext.getCacheDir()).thenReturn(mockOutputDir);
+    when(mockContext.getMainExecutor()).thenReturn(Runnable::run);
+    when(mockContext.getMainLooper()).thenReturn(Looper.getMainLooper());
     when(mockApiRegistrar.getContext()).thenReturn(mockContext);
 
     final String filename = "myFile.jpg";
@@ -194,6 +227,8 @@ public class ImageCaptureTest {
     final File mockOutputDir = mock(File.class);
     final SystemServicesManager mockSystemServicesManager = mock(SystemServicesManager.class);
     when(mockContext.getCacheDir()).thenReturn(mockOutputDir);
+    when(mockContext.getMainExecutor()).thenReturn(Runnable::run);
+    when(mockContext.getMainLooper()).thenReturn(Looper.getMainLooper());
     when(mockApiRegistrar.getContext()).thenReturn(mockContext);
 
     final ImageCaptureException captureException = mock(ImageCaptureException.class);

--- a/packages/camera/camera_android_camerax/pubspec.yaml
+++ b/packages/camera/camera_android_camerax/pubspec.yaml
@@ -2,7 +2,7 @@ name: camera_android_camerax
 description: Android implementation of the camera plugin using the CameraX library.
 repository: https://github.com/flutter/packages/tree/main/packages/camera/camera_android_camerax
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+camera%22
-version: 0.7.4+4
+version: 0.7.4+5
 
 environment:
   sdk: ^3.12.0

--- a/packages/camera/camera_android_camerax/pubspec.yaml
+++ b/packages/camera/camera_android_camerax/pubspec.yaml
@@ -2,7 +2,7 @@ name: camera_android_camerax
 description: Android implementation of the camera plugin using the CameraX library.
 repository: https://github.com/flutter/packages/tree/main/packages/camera/camera_android_camerax
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+camera%22
-version: 0.7.4+3
+version: 0.7.4+4
 
 environment:
   sdk: ^3.12.0


### PR DESCRIPTION

Fixes flutter/flutter#190523

## Problem

`ImageCaptureProxyApi.takePicture` creates a new single-thread executor on
every call and never shuts it down. The thread it owns is only reclaimed
once its `FinalizableDelegatedExecutorService` wrapper is finalized, at a
time the plugin does not control.

That executor only delivers an already finished result — it does no real
work:

- Encoding and file I/O run on CameraX's own IO executor.
- `TakePictureRequest.onResult` does nothing but hand the result to the
  executor the plugin passed in.

## Fix

Dispatch the result on the main executor instead, which is what this
plugin's other CameraX callbacks already use:

- `CameraControlProxyApi`
- `Camera2CameraControlProxyApi`
- `ImageAnalysisProxyApi`
- `ProcessCameraProviderProxyApi`
- `PendingRecordingProxyApi`

## Note

`PreviewProxyApi` uses the same per-request executor pattern for
`SurfaceRequest.provideSurface`. That callback releases a `Surface`, so it
is left for a separate change.

The two existing `takePicture` tests now stub the main executor on their
mock `Context`.


## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under.
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under.
- [x] All existing and new tests are passing.

[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[the version and CHANGELOG instructions]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version-and-changelog-updates
[semantic versioning]: https://dart.dev/tools/pub/versioning#semantic-versions
[repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
