### PR TITLE
fix: add cooldown-period to Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    cooldown-period: 5
+    cooldown: 5 # days
     groups:
       all-github-actions:
         patterns: [ "*" ]
@@ -51,7 +51,6 @@ updates:
       - /packages/path_provider/path_provider/example/android/app
       - /packages/path_provider/path_provider_android/example/android/app
       - /packages/pigeon/example/app/android/app
-      - /packages/pigeon/example/native_interop_app/android/app
       - /packages/pigeon/platform_tests/test_plugin/example/android/app
       - /packages/pigeon/platform_tests/alternate_language_test_plugin/example/android/app
       - /packages/quick_actions/quick_actions_android/example/android/app
@@ -73,7 +72,7 @@ updates:
       prefix: "[dependabot]"
     schedule:
       interval: "weekly"
-    cooldown-period: 5
+    cooldown: 5 # days
     labels:
       - "autosubmit"
       - "triage-android"
@@ -108,7 +107,7 @@ updates:
       prefix: "[dependabot]"
     schedule:
       interval: "weekly"
-    cooldown-period: 5
+    cooldown: 5 # days
     open-pull-requests-limit: 10
     labels:
       - "autosubmit"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    cooldown: 5 # days
+    cooldown:
+      default-days: 5 # days
     groups:
       all-github-actions:
         patterns: [ "*" ]
@@ -72,7 +73,8 @@ updates:
       prefix: "[dependabot]"
     schedule:
       interval: "weekly"
-    cooldown: 5 # days
+    cooldown:
+      default-days: 5 # days
     labels:
       - "autosubmit"
       - "triage-android"
@@ -107,7 +109,8 @@ updates:
       prefix: "[dependabot]"
     schedule:
       interval: "weekly"
-    cooldown: 5 # days
+    cooldown:
+      default-days: 5 # days
     open-pull-requests-limit: 10
     labels:
       - "autosubmit"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown-period: 5
     groups:
       all-github-actions:
         patterns: [ "*" ]
@@ -50,6 +51,7 @@ updates:
       - /packages/path_provider/path_provider/example/android/app
       - /packages/path_provider/path_provider_android/example/android/app
       - /packages/pigeon/example/app/android/app
+      - /packages/pigeon/example/native_interop_app/android/app
       - /packages/pigeon/platform_tests/test_plugin/example/android/app
       - /packages/pigeon/platform_tests/alternate_language_test_plugin/example/android/app
       - /packages/quick_actions/quick_actions_android/example/android/app
@@ -71,6 +73,7 @@ updates:
       prefix: "[dependabot]"
     schedule:
       interval: "weekly"
+    cooldown-period: 5
     labels:
       - "autosubmit"
       - "triage-android"
@@ -105,6 +108,7 @@ updates:
       prefix: "[dependabot]"
     schedule:
       interval: "weekly"
+    cooldown-period: 5
     open-pull-requests-limit: 10
     labels:
       - "autosubmit"


### PR DESCRIPTION
Fix zizmor warnings found in https://github.com/flutter/packages/actions/runs/30682744926/job/91322900060?pr=11352#step:6:57

Cooldown period is measured in days. https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#cooldown-

Test Exemption: Modifying actions to comply with zizmor checks. 

Agent authored description 
Resolves Zizmor medium-severity findings about insufficient cooldown in Dependabot updates. Adds 5-day cooldown period to all three Dependabot update sections (github-actions and two gradle configurations) to prevent rapid consecutive PRs and improve workflow stability.

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [ ] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under[^1].
- [ ] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[the version and CHANGELOG instructions]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version-and-changelog-updates
[semantic versioning]: https://dart.dev/tools/pub/versioning#semantic-versions
[repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
