### PR TITLE
[material_ui] Fix ExpansionTile nested WidgetSpan semantics assertion

### DIFF
--- a/packages/material_ui/lib/src/expansion_tile.dart
+++ b/packages/material_ui/lib/src/expansion_tile.dart
@@ -693,7 +693,9 @@ class _ExpansionTileState extends State<ExpansionTile> {
       return Semantics(
         // Live region used to announce state changes (e.g., "expanded" or "collapsed")
         // without taking focus.
-        // blockNode prevents this node from being part of the focus traversal.
+        // The container ensures the live region forms the node that blockNode
+        // removes from focus traversal.
+        container: true,
         label: semanticsHint,
         liveRegion: true,
         accessibilityFocusBlockType: AccessibilityFocusBlockType.blockNode,

--- a/packages/material_ui/pending_changelogs/change_2026_08_06_expansion_tile_widget_span.yaml
+++ b/packages/material_ui/pending_changelogs/change_2026_08_06_expansion_tile_widget_span.yaml
@@ -1,0 +1,3 @@
+changelog: |
+  - Fixes an Android semantics assertion when an ExpansionTile title contains a nested WidgetSpan.
+version: patch

--- a/packages/material_ui/test/expansion_tile_test.dart
+++ b/packages/material_ui/test/expansion_tile_test.dart
@@ -2230,6 +2230,47 @@ void main() {
     );
   });
   group('Semantics tests for android platform', () {
+    // Regression test for https://github.com/flutter/flutter/issues/188298.
+    testWidgets('ExpansionTile supports a nested WidgetSpan title', (WidgetTester tester) async {
+      final SemanticsHandle handle = tester.ensureSemantics();
+
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: Text.rich(
+              TextSpan(
+                children: <InlineSpan>[
+                  WidgetSpan(
+                    child: SizedBox(
+                      width: 400,
+                      child: ExpansionTile(
+                        title: Text.rich(
+                          TextSpan(
+                            children: <InlineSpan>[
+                              WidgetSpan(
+                                child: Text.rich(
+                                  TextSpan(
+                                    style: TextStyle(fontSize: 32, fontWeight: FontWeight.bold),
+                                    text: 'Header',
+                                  ),
+                                ),
+                              ),
+                            ],
+                          ),
+                        ),
+                        children: <Widget>[Text('These are the details.')],
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      );
+      handle.dispose();
+    }, variant: const TargetPlatformVariant(<TargetPlatform>{TargetPlatform.android}));
+
     testWidgets('Semantics liveregion updates when expansion state changes', (
       WidgetTester tester,
     ) async {


### PR DESCRIPTION
Superseded by #12765, which contains the rebased fix and the simpler test requested in flutter/flutter#190639. This PR remains closed because GitHub cannot reopen it after the branch was rebased. The description and validation below refer to this PR's original diff.

On Android, `ExpansionTile` wraps its tile in a live-region `Semantics` node that uses `AccessibilityFocusBlockType.blockNode`. When the title contains a nested `WidgetSpan`, that live region can merge into the surrounding semantics tree and trigger a sibling-configuration conflict assertion.

This makes the live region a semantics container, so `blockNode` applies to an explicit node. It also adds an Android regression test using the reported nested `WidgetSpan` structure. The test fails with the original `!conflict` assertion when the production change is removed and passes with the fix.

Fixes flutter/flutter#188298.

This ports flutter/flutter#190639 to `material_ui`, where Material development is moving during the framework code freeze.

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under[^1].
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [x] All existing and new tests are passing.

Validation performed:

- `flutter test test/expansion_tile_test.dart`
- `flutter analyze lib/src/expansion_tile.dart test/expansion_tile_test.dart`

The release metadata uses `material_ui`'s batch-release convention: a pending changelog entry with `version: patch`.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[the version and CHANGELOG instructions]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version-and-changelog-updates
[semantic versioning]: https://dart.dev/tools/pub/versioning#semantic-versions
[repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests

