### PR TITLE
[camera_web] Remove invalid @JS annotation on extension type constructors

### DIFF
--- a/packages/camera/camera_web/CHANGELOG.md
+++ b/packages/camera/camera_web/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.5+5
+
+* Removes invalid @JS annotation from extension type constructors.
+
 ## 0.3.5+4
 
 * Fixes a `TypeError` in `availableCameras()` caused by browsers (e.g. Firefox) returning

--- a/packages/camera/camera_web/lib/src/pkg_web_tweaks.dart
+++ b/packages/camera/camera_web/lib/src/pkg_web_tweaks.dart
@@ -43,7 +43,6 @@ extension NonStandardFieldsOnMediaTrackSettings on MediaTrackSettings {
 
 /// Brought over from package:web 1.0.0
 extension type WebTweakMediaSettingsRange._(JSObject _) implements JSObject {
-  @JS('MediaSettingsRange')
   external factory WebTweakMediaSettingsRange({num max, num min, num step});
 
   external double get max;
@@ -63,6 +62,5 @@ extension WebTweakMethodVersions on MediaStreamTrack {
 /// Allows creating the MediaTrackConstraints that are needed.
 /// Brought over from package:web 1.0.0
 extension type WebTweakMediaTrackConstraints._(JSObject _) implements JSObject {
-  @JS('MediaTrackConstraints')
   external factory WebTweakMediaTrackConstraints({JSAny zoom, ConstrainBoolean torch});
 }

--- a/packages/camera/camera_web/pubspec.yaml
+++ b/packages/camera/camera_web/pubspec.yaml
@@ -2,7 +2,7 @@ name: camera_web
 description: A Flutter plugin for getting information about and controlling the camera on Web.
 repository: https://github.com/flutter/packages/tree/main/packages/camera/camera_web
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+camera%22
-version: 0.3.5+4
+version: 0.3.5+5
 
 environment:
   sdk: ^3.10.0


### PR DESCRIPTION
Removes invalid `@JS()` annotations from extension type constructors in `packages/camera/camera_web`.

Fixes https://github.com/flutter/flutter/issues/190355

### Description
In newer Dart SDKs (following Dart SDK commit https://github.com/dart-lang/sdk/commit/cecd7ec2585f8330522c73c0c867c01a867532e5 rolled into Flutter in PR https://github.com/flutter/flutter/pull/190158), placing `@JS()` annotations on extension type constructors has no effect and is now flagged as an error (`invalid_js_annotation`).

Removing these annotations resolves the error without altering runtime behavior.