### PR TITLE
[material_ui] Fix bottom sheet dismissal near minimum extent when shouldCloseOnMinExtent

### DIFF
--- a/packages/material_ui/CHANGELOG.md
+++ b/packages/material_ui/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.4
+
+- Fix bottom sheet dismissal when its extent is within floating-point precision of its minimum extent.
+
 ## 0.0.3
 
 - Fix API doc by clearing unsupported directives introduced by macros.

--- a/packages/material_ui/lib/src/bottom_sheet.dart
+++ b/packages/material_ui/lib/src/bottom_sheet.dart
@@ -323,7 +323,8 @@ class _BottomSheetState extends State<BottomSheet> {
   }
 
   bool extentChanged(DraggableScrollableNotification notification) {
-    if (notification.extent == notification.minExtent && notification.shouldCloseOnMinExtent) {
+    if ((notification.extent - notification.minExtent).abs() < precisionErrorTolerance &&
+        notification.shouldCloseOnMinExtent) {
       widget.onClosing();
     }
     return false;

--- a/packages/material_ui/lib/src/scaffold.dart
+++ b/packages/material_ui/lib/src/scaffold.dart
@@ -3507,7 +3507,7 @@ class _StandardBottomSheetState extends State<_StandardBottomSheet> {
       scaffold.showBodyScrim(false, 0.0);
     }
     // If the Scaffold.bottomSheet != null, we're a persistent bottom sheet.
-    if (notification.extent == notification.minExtent &&
+    if ((notification.extent - notification.minExtent).abs() < precisionErrorTolerance &&
         scaffold.widget.bottomSheet == null &&
         notification.shouldCloseOnMinExtent) {
       close();

--- a/packages/material_ui/pubspec.yaml
+++ b/packages/material_ui/pubspec.yaml
@@ -1,6 +1,6 @@
 name: material_ui
 description: The official Flutter Material UI Library, implementing Google's Material Design design system.
-version: 0.0.3
+version: 0.0.4
 repository: https://github.com/flutter/packages/tree/main/packages/material_ui
 issue_tracker:  https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A%20material%20design%22
 

--- a/packages/material_ui/test/bottom_sheet_test.dart
+++ b/packages/material_ui/test/bottom_sheet_test.dart
@@ -765,6 +765,43 @@ void main() {
     expect(find.text('BottomSheet'), findsNothing);
   });
 
+  testWidgets('Standard BottomSheet closes when its extent is nearly its minimum', (
+    WidgetTester tester,
+  ) async {
+    final scaffoldKey = GlobalKey<ScaffoldState>();
+    late BuildContext notificationContext;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          key: scaffoldKey,
+          body: const Center(child: Text('body')),
+        ),
+      ),
+    );
+
+    scaffoldKey.currentState!.showBottomSheet((BuildContext context) {
+      return Builder(
+        builder: (BuildContext context) {
+          notificationContext = context;
+          return const Text('BottomSheet');
+        },
+      );
+    });
+    await tester.pumpAndSettle();
+
+    DraggableScrollableNotification(
+      extent: 0.20000000001,
+      minExtent: 0.2,
+      maxExtent: 1.0,
+      initialExtent: 0.5,
+      context: notificationContext,
+    ).dispatch(notificationContext);
+    await tester.pumpAndSettle();
+
+    expect(find.text('BottomSheet'), findsNothing);
+  });
+
   testWidgets('modal BottomSheet has no top MediaQuery', (WidgetTester tester) async {
     late BuildContext outerContext;
     late BuildContext innerContext;
@@ -1076,6 +1113,46 @@ void main() {
       find.descendant(of: find.byType(BottomSheet), matching: find.byType(Material)),
     );
     expect(material.shadowColor, Colors.transparent);
+  });
+
+  testWidgets('Modal BottomSheet closes when its extent is nearly its minimum', (
+    WidgetTester tester,
+  ) async {
+    final scaffoldKey = GlobalKey<ScaffoldState>();
+    late BuildContext notificationContext;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          key: scaffoldKey,
+          body: const Center(child: Text('body')),
+        ),
+      ),
+    );
+
+    showModalBottomSheet<void>(
+      context: scaffoldKey.currentContext!,
+      builder: (BuildContext context) {
+        return Builder(
+          builder: (BuildContext context) {
+            notificationContext = context;
+            return const Text('BottomSheet');
+          },
+        );
+      },
+    );
+    await tester.pumpAndSettle();
+
+    DraggableScrollableNotification(
+      extent: 0.20000000001,
+      minExtent: 0.2,
+      maxExtent: 1.0,
+      initialExtent: 0.5,
+      context: notificationContext,
+    ).dispatch(notificationContext);
+    await tester.pumpAndSettle();
+
+    expect(find.text('BottomSheet'), findsNothing);
   });
 
   testWidgets('Material2 - Modal BottomSheet with ScrollController has semantics', (


### PR DESCRIPTION
Fixes bottom sheet dismissal when a `DraggableScrollableNotification` extent
is within floating-point precision of `minExtent`, instead of requiring exact
equality.

Updates both the modal `BottomSheet` and standard `Scaffold` bottom sheet
handlers. Adds regression tests for both paths using `extent: 0.20000000001`
and `minExtent: 0.2`.

Also bumps `material_ui` to `0.0.4` and updates its CHANGELOG.

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under[^1].
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [x] All existing and new tests are passing.
