### PR TITLE
[go_router_builder] Report duplicate route paths at build time

### DIFF
--- a/packages/go_router_builder/CHANGELOG.md
+++ b/packages/go_router_builder/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 - Detects routes that resolve to the same URL pattern, including relative
   routes, routes across `StatefulShellRoute` branches, routes inside shell route
-  containers, and routes declared by separate annotations in the same file.
+  containers, and routes declared by separate annotations in the same library.
   These are reported as build warnings by default. The new
   `duplicate_route_paths` builder option raises them to build errors with
   `error`, or silences them with `ignore`.

--- a/packages/go_router_builder/CHANGELOG.md
+++ b/packages/go_router_builder/CHANGELOG.md
@@ -1,9 +1,12 @@
 ## 4.5.0
 
-- Detects routes that resolve to the same URL pattern, including relative
-  routes, routes across `StatefulShellRoute` branches, routes inside shell route
-  containers, and routes declared by separate annotations in the same library.
-  These are reported as build warnings by default. The new
+- Detects routes that resolve to the same URL pattern. Routes are compared by
+  the whole URL each one resolves to, so a collision is caught wherever the two
+  routes sit in the route tree, including across shell routes and
+  `StatefulShellRoute` branches, between relative routes, and between separate
+  annotations in one library. Paths that differ only in a parameter name, or
+  only in casing where the earlier route sets `caseSensitive: false`, count as
+  the same pattern. These are reported as build warnings by default. The new
   `duplicate_route_paths` builder option raises them to build errors with
   `error`, or silences them with `ignore`.
 

--- a/packages/go_router_builder/CHANGELOG.md
+++ b/packages/go_router_builder/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 4.5.0
+
+- Detects routes that resolve to the same URL pattern, including relative
+  routes, routes across `StatefulShellRoute` branches, routes inside shell route
+  containers, and routes declared by separate annotations in the same file.
+  These are reported as build warnings by default. The new
+  `duplicate_route_paths` builder option raises them to build errors with
+  `error`, or silences them with `ignore`.
+
 ## 4.4.1
 
 * Adds support for analyzer 14.

--- a/packages/go_router_builder/README.md
+++ b/packages/go_router_builder/README.md
@@ -42,6 +42,35 @@ dart run build_runner build
 Read more about using
 [`build_runner` on pub.dev](https://pub.dev/packages/build_runner).
 
+### Builder options
+
+#### `duplicate_route_paths`
+
+Sibling routes can end up matching the same URL pattern, either because their
+paths are identical or because they differ only in the name of a path parameter,
+such as `meal/:id` and `meal/:mealId`. `go_router` matches the first route that
+fits, so the later route is unreachable. The builder reports these as warnings
+by default.
+
+Shell routes and `StatefulShellRoute` branches do not own a path of their own,
+so the routes inside them compete with the routes around them. Routes declared
+by separate annotations in the same file compete too, because the generated
+`$appRoutes` collects them into one list. Routes declared in different files
+are not compared, since the builder generates one file at a time.
+
+To fail the build instead of warning, set the option in `build.yaml`:
+
+```yaml
+targets:
+  $default:
+    builders:
+      go_router_builder:
+        options:
+          duplicate_route_paths: error
+```
+
+Accepted values are `warning` (the default), `error`, and `ignore`.
+
 ## Migration Guides
 - [Migrating to 4.0.0](https://flutter.dev/go/go-router-builder-v4-breaking-changes).
 
@@ -504,5 +533,14 @@ Relative routing methods are not idempotent and will cause an error when the rel
 ## Run tests
 
 To run unit tests, run command `dart tool/run_tests.dart` from `packages/go_router_builder/`.
+
+Each `.dart` file in `test_inputs/` is a test case, paired with a `.expect` file
+holding either the generated output or the error message the builder must
+produce. Two optional companion files tune a case:
+
+* `<name>.dart.options` holds a JSON map of builder options, matching what
+  `build.yaml` would pass to the builder.
+* `<name>.dart.warnings` holds the warnings the builder must log, one per line.
+  An empty file asserts that the builder logs nothing.
 
 To run tests in examples, run `flutter test` from `packages/go_router_builder/example`.

--- a/packages/go_router_builder/README.md
+++ b/packages/go_router_builder/README.md
@@ -46,50 +46,22 @@ Read more about using
 
 #### `duplicate_route_paths`
 
-Two routes can end up matching the same URL pattern. The builder reports these as
-warnings by default.
+When two routes resolve to the same URL, `go_router` matches the first and the
+second becomes unreachable. Navigating to the second one's `location` shows the
+first one's page. The builder warns about this at build time.
 
-Routes are compared by the whole URL each one resolves to, not by the path each
-one declares, so a collision is caught wherever the two routes sit in the tree.
-These all count:
+Routes are compared by the URL they resolve to, not by the path they declare, so
+depth in the route tree does not matter. A route at `section/detail` collides with
+a route at `section` holding a child at `detail`. Parameter names are ignored, so
+`product/:id` and `product/:productId` are the same URL, though a parameter's
+regex constraint still counts, so `product/:id(\d+)` and `product/:id(\w+)` are
+not. Casing is ignored when the earlier route sets `caseSensitive: false`, since
+it then matches any casing.
 
-* Identical paths, such as two routes at `details`.
-* Paths differing only in a parameter name, such as `product/:id` and
-  `product/:productId`, since both match the same URL segments. A parameter's
-  regex constraint is kept, so `product/:id(\d+)` stays distinct from
-  `product/:id(\w+)`.
-* A multi-segment path against the equivalent nesting, so a route at
-  `section/detail` collides with a route at `section` holding a child at
-  `detail`.
-* Paths differing only in casing, when the earlier route sets
-  `caseSensitive: false` and so matches any casing. Two case sensitive routes
-  differing in case match different URLs and are left alone.
+The whole library is compared, `part` files included. Shell routes and
+`StatefulShellRoute` branches contribute nothing to the URLs beneath them.
 
-Warnings rather than errors, because a duplicate path is legal at runtime and is
-not always dead code. `go_router` tries routes in declaration order and takes the
-first one that matches the whole URL. So when two different route classes share a
-URL, only the first is reachable there, and navigating to the second class's
-`location` lands on the first class's page instead. That is almost always a
-mistake.
-
-Matching backtracks, though: when a route matches only a prefix and none of its
-children complete the URL, matching moves on to the next sibling. So naming one
-route class twice at the same path, each declaration carrying different children,
-is sound. That URL stays unambiguous because both declarations resolve to the
-same class, every child stays reachable, and it is one way to group children by
-feature area rather than listing them all in one place. The builder reports it
-anyway, since it cannot tell a deliberate grouping from an accidental duplicate.
-Set the option to `ignore` if you want the pattern without the warning. Note that
-the children of those declarations do share a URL namespace, so a child path
-repeated across them is reported separately, and that one is a real collision.
-
-Routes are compared across a whole library, which includes any `part` files, so
-splitting a large route table across parts does not hide anything. Shell routes
-and `StatefulShellRoute` branches own no path of their own, so they add nothing
-to the URL of the routes inside them, and separate annotations are compared with
-each other because the generated `$appRoutes` collects them into one list.
-
-To fail the build instead of warning, set the option in `build.yaml`:
+Use `build.yaml` to change what a duplicate does:
 
 ```yaml
 targets:
@@ -102,10 +74,16 @@ targets:
 
 Accepted values are `warning` (the default), `error`, and `ignore`.
 
-The severity applies to the whole package, and there is no per-route escape
-hatch, so `error` fails the build on a deliberate grouping too. Reach for it when
-every duplicate path in your app is a mistake, and stay on `warning` when some of
-them are intentional.
+Warning is the default because some duplicates work. Matching backtracks, so
+naming one route class twice at the same path, each declaration carrying
+different children, is fine. Both resolve to the same class and every child stays
+reachable, which makes it a way to group children by feature. The builder still
+warns, because it cannot tell that from a mistake, so use `ignore` if you write
+it deliberately. Their children are a different story: a child path repeated
+across the two declarations is a genuine collision and is reported on its own.
+
+`error` applies to the whole package with no per-route exception, so it fails on
+the deliberate grouping too.
 
 ## Migration Guides
 - [Migrating to 4.0.0](https://flutter.dev/go/go-router-builder-v4-breaking-changes).

--- a/packages/go_router_builder/README.md
+++ b/packages/go_router_builder/README.md
@@ -48,9 +48,40 @@ Read more about using
 
 Sibling routes can end up matching the same URL pattern, either because their
 paths are identical or because they differ only in the name of a path parameter,
-such as `meal/:id` and `meal/:mealId`. `go_router` matches the first route that
-fits, so the later route is unreachable. The builder reports these as warnings
-by default.
+such as `meal/:id` and `meal/:mealId`. The builder reports these as warnings by
+default.
+
+Warnings rather than errors, because a duplicate path is legal at runtime and is
+not always dead code. `go_router` tries sibling routes in declaration order and
+takes the first one that matches the whole URL. So when two different route
+classes share a path, only the first is reachable at that URL, and navigating to
+the second class's `location` lands on the first class's page instead. That is
+almost always a mistake.
+
+Matching backtracks, though: when a route matches only a prefix and none of its
+children complete the URL, matching moves on to the next sibling. Declaring one
+route class twice with different children is therefore sound, and is one way to
+group children by feature area rather than listing them all in one place:
+
+```dart
+@TypedGoRoute<HomeRoute>(
+  path: '/home',
+  routes: <TypedGoRoute<GoRouteData>>[
+    // Both declarations name the same class, so `/home/details` is
+    // unambiguous and both children stay reachable.
+    TypedGoRoute<DetailsRoute>(path: 'details', routes: <TypedGoRoute<GoRouteData>>[
+      TypedGoRoute<InvoicesRoute>(path: 'invoices'),
+    ]),
+    TypedGoRoute<DetailsRoute>(path: 'details', routes: <TypedGoRoute<GoRouteData>>[
+      TypedGoRoute<ShipmentsRoute>(path: 'shipments'),
+    ]),
+  ],
+)
+```
+
+The builder reports that too, since it cannot tell a deliberate grouping from an
+accidental duplicate. Set the option to `ignore` if you want the pattern without
+the warning.
 
 Shell routes and `StatefulShellRoute` branches do not own a path of their own,
 so the routes inside them compete with the routes around them. Routes declared

--- a/packages/go_router_builder/README.md
+++ b/packages/go_router_builder/README.md
@@ -83,50 +83,12 @@ The builder reports that too, since it cannot tell a deliberate grouping from an
 accidental duplicate. Set the option to `ignore` if you want the pattern without
 the warning.
 
-Sometimes there is no other way to write it. Two teams may each need to extend
-`/cart` with their own children. They cannot share one `CartRoute` class,
-because a `@TypedGoRoute` annotation has to sit on the class it names, so
-`CartRoute` can be annotated only once, in the file that declares it. That
-leaves each team declaring its own route at the same path:
-
-```dart
-// team_a/cart_routes.dart
-@TypedGoRoute<CartRoute>(
-  path: '/cart',
-  routes: <TypedGoRoute<GoRouteData>>[TypedGoRoute<CartItemsRoute>(path: 'items')],
-)
-class CartRoute extends GoRouteData with $CartRoute {/* ... */}
-
-// team_b/checkout_routes.dart
-@TypedGoRoute<CartCheckoutRoute>(
-  path: '/cart',
-  routes: <TypedGoRoute<GoRouteData>>[TypedGoRoute<PaymentRoute>(path: 'payment')],
-)
-class CartCheckoutRoute extends GoRouteData with $CartCheckoutRoute {/* ... */}
-```
-
-`/cart/items` and `/cart/payment` both work. Only `/cart` itself is ambiguous:
-it renders whichever route comes first in the combined route list, and the other
-class's page is unreachable even though its `location` getter returns `/cart`.
-Prefer giving the deeper routes absolute paths, which keeps each team
-independent with no ambiguity and no warning:
-
-```dart
-// team_b/checkout_routes.dart
-@TypedGoRoute<CartCheckoutRoute>(path: '/cart/checkout')
-```
-
-That is not an option when the nested routes need the parent route on the
-navigation stack, or a shell around them. Then duplicating the parent is the
-only shape the API offers, and `ignore` silences the report.
-
-Note that the example above is *not* reported, because the two declarations live
-in different files. The builder generates one file at a time, so it only
-compares routes it can see together. Within a single file it compares
-everything: shell routes and `StatefulShellRoute` branches own no path of their
-own, so the routes inside them compete with the routes around them, and separate
-annotations compete with each other because the generated `$appRoutes` collects
-them into one list.
+Routes are compared across a whole library, which includes any `part` files, so
+splitting a large route table across parts does not hide anything. Within that
+library everything competes: shell routes and `StatefulShellRoute` branches own
+no path of their own, so the routes inside them compete with the routes around
+them, and separate annotations compete with each other because the generated
+`$appRoutes` collects them into one list.
 
 To fail the build instead of warning, set the option in `build.yaml`:
 
@@ -142,9 +104,9 @@ targets:
 Accepted values are `warning` (the default), `error`, and `ignore`.
 
 The severity applies to the whole package, and there is no per-route escape
-hatch. So `error` will also fail the builds of the sound shapes above. Reach for
-it when every duplicate path in your app is a mistake, and stay on `warning`
-when some of them are deliberate.
+hatch, so `error` fails the build on a deliberate grouping too. Reach for it when
+every duplicate path in your app is a mistake, and stay on `warning` when some of
+them are intentional.
 
 ## Migration Guides
 - [Migrating to 4.0.0](https://flutter.dev/go/go-router-builder-v4-breaking-changes).

--- a/packages/go_router_builder/README.md
+++ b/packages/go_router_builder/README.md
@@ -48,8 +48,8 @@ Read more about using
 
 Sibling routes can end up matching the same URL pattern, either because their
 paths are identical or because they differ only in the name of a path parameter,
-such as `meal/:id` and `meal/:mealId`. The builder reports these as warnings by
-default.
+such as `product/:id` and `product/:productId`. The builder reports these as
+warnings by default.
 
 Warnings rather than errors, because a duplicate path is legal at runtime and is
 not always dead code. `go_router` tries sibling routes in declaration order and

--- a/packages/go_router_builder/README.md
+++ b/packages/go_router_builder/README.md
@@ -83,11 +83,50 @@ The builder reports that too, since it cannot tell a deliberate grouping from an
 accidental duplicate. Set the option to `ignore` if you want the pattern without
 the warning.
 
-Shell routes and `StatefulShellRoute` branches do not own a path of their own,
-so the routes inside them compete with the routes around them. Routes declared
-by separate annotations in the same file compete too, because the generated
-`$appRoutes` collects them into one list. Routes declared in different files
-are not compared, since the builder generates one file at a time.
+Sometimes there is no other way to write it. Two teams may each need to extend
+`/cart` with their own children. They cannot share one `CartRoute` class,
+because a `@TypedGoRoute` annotation has to sit on the class it names, so
+`CartRoute` can be annotated only once, in the file that declares it. That
+leaves each team declaring its own route at the same path:
+
+```dart
+// team_a/cart_routes.dart
+@TypedGoRoute<CartRoute>(
+  path: '/cart',
+  routes: <TypedGoRoute<GoRouteData>>[TypedGoRoute<CartItemsRoute>(path: 'items')],
+)
+class CartRoute extends GoRouteData with $CartRoute {/* ... */}
+
+// team_b/checkout_routes.dart
+@TypedGoRoute<CartCheckoutRoute>(
+  path: '/cart',
+  routes: <TypedGoRoute<GoRouteData>>[TypedGoRoute<PaymentRoute>(path: 'payment')],
+)
+class CartCheckoutRoute extends GoRouteData with $CartCheckoutRoute {/* ... */}
+```
+
+`/cart/items` and `/cart/payment` both work. Only `/cart` itself is ambiguous:
+it renders whichever route comes first in the combined route list, and the other
+class's page is unreachable even though its `location` getter returns `/cart`.
+Prefer giving the deeper routes absolute paths, which keeps each team
+independent with no ambiguity and no warning:
+
+```dart
+// team_b/checkout_routes.dart
+@TypedGoRoute<CartCheckoutRoute>(path: '/cart/checkout')
+```
+
+That is not an option when the nested routes need the parent route on the
+navigation stack, or a shell around them. Then duplicating the parent is the
+only shape the API offers, and `ignore` silences the report.
+
+Note that the example above is *not* reported, because the two declarations live
+in different files. The builder generates one file at a time, so it only
+compares routes it can see together. Within a single file it compares
+everything: shell routes and `StatefulShellRoute` branches own no path of their
+own, so the routes inside them compete with the routes around them, and separate
+annotations compete with each other because the generated `$appRoutes` collects
+them into one list.
 
 To fail the build instead of warning, set the option in `build.yaml`:
 
@@ -101,6 +140,11 @@ targets:
 ```
 
 Accepted values are `warning` (the default), `error`, and `ignore`.
+
+The severity applies to the whole package, and there is no per-route escape
+hatch. So `error` will also fail the builds of the sound shapes above. Reach for
+it when every duplicate path in your app is a mistake, and stay on `warning`
+when some of them are deliberate.
 
 ## Migration Guides
 - [Migrating to 4.0.0](https://flutter.dev/go/go-router-builder-v4-breaking-changes).

--- a/packages/go_router_builder/README.md
+++ b/packages/go_router_builder/README.md
@@ -59,29 +59,13 @@ the second class's `location` lands on the first class's page instead. That is
 almost always a mistake.
 
 Matching backtracks, though: when a route matches only a prefix and none of its
-children complete the URL, matching moves on to the next sibling. Declaring one
-route class twice with different children is therefore sound, and is one way to
-group children by feature area rather than listing them all in one place:
-
-```dart
-@TypedGoRoute<HomeRoute>(
-  path: '/home',
-  routes: <TypedGoRoute<GoRouteData>>[
-    // Both declarations name the same class, so `/home/details` is
-    // unambiguous and both children stay reachable.
-    TypedGoRoute<DetailsRoute>(path: 'details', routes: <TypedGoRoute<GoRouteData>>[
-      TypedGoRoute<InvoicesRoute>(path: 'invoices'),
-    ]),
-    TypedGoRoute<DetailsRoute>(path: 'details', routes: <TypedGoRoute<GoRouteData>>[
-      TypedGoRoute<ShipmentsRoute>(path: 'shipments'),
-    ]),
-  ],
-)
-```
-
-The builder reports that too, since it cannot tell a deliberate grouping from an
-accidental duplicate. Set the option to `ignore` if you want the pattern without
-the warning.
+children complete the URL, matching moves on to the next sibling. So naming one
+route class twice at the same path, each declaration carrying different children,
+is sound. That URL stays unambiguous because both declarations resolve to the
+same class, every child stays reachable, and it is one way to group children by
+feature area rather than listing them all in one place. The builder reports it
+anyway, since it cannot tell a deliberate grouping from an accidental duplicate.
+Set the option to `ignore` if you want the pattern without the warning.
 
 Routes are compared across a whole library, which includes any `part` files, so
 splitting a large route table across parts does not hide anything. Within that

--- a/packages/go_router_builder/README.md
+++ b/packages/go_router_builder/README.md
@@ -46,17 +46,31 @@ Read more about using
 
 #### `duplicate_route_paths`
 
-Sibling routes can end up matching the same URL pattern, either because their
-paths are identical or because they differ only in the name of a path parameter,
-such as `product/:id` and `product/:productId`. The builder reports these as
+Two routes can end up matching the same URL pattern. The builder reports these as
 warnings by default.
 
+Routes are compared by the whole URL each one resolves to, not by the path each
+one declares, so a collision is caught wherever the two routes sit in the tree.
+These all count:
+
+* Identical paths, such as two routes at `details`.
+* Paths differing only in a parameter name, such as `product/:id` and
+  `product/:productId`, since both match the same URL segments. A parameter's
+  regex constraint is kept, so `product/:id(\d+)` stays distinct from
+  `product/:id(\w+)`.
+* A multi-segment path against the equivalent nesting, so a route at
+  `section/detail` collides with a route at `section` holding a child at
+  `detail`.
+* Paths differing only in casing, when the earlier route sets
+  `caseSensitive: false` and so matches any casing. Two case sensitive routes
+  differing in case match different URLs and are left alone.
+
 Warnings rather than errors, because a duplicate path is legal at runtime and is
-not always dead code. `go_router` tries sibling routes in declaration order and
-takes the first one that matches the whole URL. So when two different route
-classes share a path, only the first is reachable at that URL, and navigating to
-the second class's `location` lands on the first class's page instead. That is
-almost always a mistake.
+not always dead code. `go_router` tries routes in declaration order and takes the
+first one that matches the whole URL. So when two different route classes share a
+URL, only the first is reachable there, and navigating to the second class's
+`location` lands on the first class's page instead. That is almost always a
+mistake.
 
 Matching backtracks, though: when a route matches only a prefix and none of its
 children complete the URL, matching moves on to the next sibling. So naming one
@@ -65,14 +79,15 @@ is sound. That URL stays unambiguous because both declarations resolve to the
 same class, every child stays reachable, and it is one way to group children by
 feature area rather than listing them all in one place. The builder reports it
 anyway, since it cannot tell a deliberate grouping from an accidental duplicate.
-Set the option to `ignore` if you want the pattern without the warning.
+Set the option to `ignore` if you want the pattern without the warning. Note that
+the children of those declarations do share a URL namespace, so a child path
+repeated across them is reported separately, and that one is a real collision.
 
 Routes are compared across a whole library, which includes any `part` files, so
-splitting a large route table across parts does not hide anything. Within that
-library everything competes: shell routes and `StatefulShellRoute` branches own
-no path of their own, so the routes inside them compete with the routes around
-them, and separate annotations compete with each other because the generated
-`$appRoutes` collects them into one list.
+splitting a large route table across parts does not hide anything. Shell routes
+and `StatefulShellRoute` branches own no path of their own, so they add nothing
+to the URL of the routes inside them, and separate annotations are compared with
+each other because the generated `$appRoutes` collects them into one list.
 
 To fail the build instead of warning, set the option in `build.yaml`:
 

--- a/packages/go_router_builder/example/lib/all_extension_types.dart
+++ b/packages/go_router_builder/example/lib/all_extension_types.dart
@@ -26,9 +26,6 @@ part 'all_extension_types.g.dart';
     ),
     TypedGoRoute<IntExtensionRoute>(path: 'int-route/:requiredIntField'),
     TypedGoRoute<NumExtensionRoute>(path: 'num-route/:requiredNumField'),
-    TypedGoRoute<DoubleExtensionRoute>(
-      path: 'double-route/:requiredDoubleField',
-    ),
     TypedGoRoute<EnumExtensionRoute>(path: 'enum-route/:requiredEnumField'),
     TypedGoRoute<EnhancedEnumExtensionRoute>(
       path: 'enhanced-enum-route/:requiredEnumField',

--- a/packages/go_router_builder/example/lib/all_extension_types.g.dart
+++ b/packages/go_router_builder/example/lib/all_extension_types.g.dart
@@ -46,11 +46,6 @@ RouteBase get $allTypesBaseRoute => GoRouteData.$route(
       factory: $NumExtensionRoute._fromState,
     ),
     GoRouteData.$route(
-      path: 'double-route/:requiredDoubleField',
-      hasOverriddenOnExit: false,
-      factory: $DoubleExtensionRoute._fromState,
-    ),
-    GoRouteData.$route(
       path: 'enum-route/:requiredEnumField',
       hasOverriddenOnExit: false,
       factory: $EnumExtensionRoute._fromState,

--- a/packages/go_router_builder/example/lib/all_types.dart
+++ b/packages/go_router_builder/example/lib/all_types.dart
@@ -20,7 +20,6 @@ part 'all_types.g.dart';
     TypedGoRoute<DoubleRoute>(path: 'double-route/:requiredDoubleField'),
     TypedGoRoute<IntRoute>(path: 'int-route/:requiredIntField'),
     TypedGoRoute<NumRoute>(path: 'num-route/:requiredNumField'),
-    TypedGoRoute<DoubleRoute>(path: 'double-route/:requiredDoubleField'),
     TypedGoRoute<EnumRoute>(path: 'enum-route/:requiredEnumField'),
     TypedGoRoute<EnhancedEnumRoute>(
       path: 'enhanced-enum-route/:requiredEnumField',

--- a/packages/go_router_builder/example/lib/all_types.g.dart
+++ b/packages/go_router_builder/example/lib/all_types.g.dart
@@ -46,11 +46,6 @@ RouteBase get $allTypesBaseRoute => GoRouteData.$route(
       factory: $NumRoute._fromState,
     ),
     GoRouteData.$route(
-      path: 'double-route/:requiredDoubleField',
-      hasOverriddenOnExit: false,
-      factory: $DoubleRoute._fromState,
-    ),
-    GoRouteData.$route(
       path: 'enum-route/:requiredEnumField',
       hasOverriddenOnExit: false,
       factory: $EnumRoute._fromState,

--- a/packages/go_router_builder/lib/go_router_builder.dart
+++ b/packages/go_router_builder/lib/go_router_builder.dart
@@ -15,11 +15,13 @@ library go_router_builder;
 import 'package:build/build.dart';
 import 'package:source_gen/source_gen.dart';
 
+import 'src/duplicate_path_severity.dart';
 import 'src/go_router_generator.dart';
 
 /// Supports `package:build_runner` creation and configuration of
 /// `go_router`.
 ///
 /// Not meant to be invoked by hand-authored code.
-Builder goRouterBuilder(BuilderOptions options) =>
-    SharedPartBuilder(const <Generator>[GoRouterGenerator()], 'go_router');
+Builder goRouterBuilder(BuilderOptions options) => SharedPartBuilder(<Generator>[
+  GoRouterGenerator(duplicatePathSeverity: duplicatePathSeverityFromOptions(options)),
+], 'go_router');

--- a/packages/go_router_builder/lib/src/duplicate_path_severity.dart
+++ b/packages/go_router_builder/lib/src/duplicate_path_severity.dart
@@ -1,0 +1,47 @@
+// Copyright 2013 The Flutter Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:build/build.dart';
+import 'package:collection/collection.dart';
+
+/// The `build.yaml` option that selects a [DuplicatePathSeverity].
+const String duplicateRoutePathsOption = 'duplicate_route_paths';
+
+/// How the builder reports sibling routes that resolve to the same URL pattern.
+enum DuplicatePathSeverity {
+  /// Duplicate paths are not reported at all.
+  ignore,
+
+  /// Duplicate paths are reported as build warnings.
+  ///
+  /// Code is still generated for every route. This is the default, because
+  /// duplicate paths are legal at runtime: `go_router` matches the first route
+  /// that fits, so the later route is unreachable rather than invalid.
+  warning,
+
+  /// Duplicate paths fail the build.
+  error,
+}
+
+/// Reads the [DuplicatePathSeverity] from `build.yaml` builder [options].
+///
+/// Defaults to [DuplicatePathSeverity.warning] when the option is absent.
+DuplicatePathSeverity duplicatePathSeverityFromOptions(BuilderOptions options) {
+  final Object? value = options.config[duplicateRoutePathsOption];
+  if (value == null) {
+    return DuplicatePathSeverity.warning;
+  }
+  final DuplicatePathSeverity? severity = DuplicatePathSeverity.values.firstWhereOrNull(
+    (DuplicatePathSeverity severity) => severity.name == value,
+  );
+  if (severity == null) {
+    throw ArgumentError.value(
+      value,
+      duplicateRoutePathsOption,
+      'Must be one of '
+      '${DuplicatePathSeverity.values.map((DuplicatePathSeverity e) => e.name).join(', ')}',
+    );
+  }
+  return severity;
+}

--- a/packages/go_router_builder/lib/src/duplicate_path_severity.dart
+++ b/packages/go_router_builder/lib/src/duplicate_path_severity.dart
@@ -15,9 +15,18 @@ enum DuplicatePathSeverity {
 
   /// Duplicate paths are reported as build warnings.
   ///
-  /// Code is still generated for every route. This is the default, because
-  /// duplicate paths are legal at runtime: `go_router` matches the first route
-  /// that fits, so the later route is unreachable rather than invalid.
+  /// Code is still generated for every route. This is the default, because a
+  /// duplicate path is legal at runtime and is not always dead code.
+  ///
+  /// `go_router` tries sibling routes in declaration order and takes the first
+  /// one that matches the whole URL. So when two different route classes share
+  /// a path, navigating to the second class's location lands on the first
+  /// class's page, which is almost always a mistake. But matching backtracks:
+  /// when a route matches only a prefix and none of its children complete the
+  /// URL, matching moves on to the next sibling. Declaring one route class
+  /// twice with different children is therefore sound, and is one way to group
+  /// children by feature area. Both shapes are reported, since the builder
+  /// cannot tell a deliberate grouping from an accidental duplicate.
   warning,
 
   /// Duplicate paths fail the build.

--- a/packages/go_router_builder/lib/src/go_router_generator.dart
+++ b/packages/go_router_builder/lib/src/go_router_generator.dart
@@ -9,6 +9,7 @@ import 'package:analyzer/dart/element/type.dart';
 import 'package:build/build.dart';
 import 'package:source_gen/source_gen.dart';
 
+import 'duplicate_path_severity.dart';
 import 'route_config.dart';
 import 'type_helpers.dart';
 
@@ -25,7 +26,10 @@ const Map<String, String> _annotations = <String, String>{
 /// A [Generator] for classes annotated with a typed go route annotation.
 class GoRouterGenerator extends Generator {
   /// Creates a new instance of [GoRouterGenerator].
-  const GoRouterGenerator();
+  const GoRouterGenerator({this.duplicatePathSeverity = DuplicatePathSeverity.warning});
+
+  /// How sibling routes that resolve to the same URL pattern are reported.
+  final DuplicatePathSeverity duplicatePathSeverity;
 
   TypeChecker get _typeChecker => TypeChecker.any(
     _annotations.keys.map((String annotation) => TypeChecker.fromUrl('$_routeDataUrl#$annotation')),
@@ -57,17 +61,26 @@ ${getters.map((String e) => "$e,").join('\n')}
   /// This public method is for testing purposes and should not be called
   /// directly.
   void generateForAnnotation(LibraryReader library, Set<String> values, Set<String> getters) {
+    // Every annotation in the library contributes a top-level route to the
+    // generated `$appRoutes`, so they all have to be built before their paths
+    // can be compared against each other.
+    final configs = <RouteBaseConfig>[];
     for (final AnnotatedElement annotatedElement in library.annotatedWith(_typeChecker)) {
-      final InfoIterable generatedValue = _generateForAnnotatedElement(
-        annotatedElement.element,
-        annotatedElement.annotation,
+      configs.add(
+        _configForAnnotatedElement(annotatedElement.element, annotatedElement.annotation),
       );
+    }
+
+    reportDuplicateRoutePaths(configs, duplicatePathSeverity);
+
+    for (final config in configs) {
+      final InfoIterable generatedValue = config.generateMembers();
       getters.add(generatedValue.routeGetterName);
       values.addAll(generatedValue.members);
     }
   }
 
-  InfoIterable _generateForAnnotatedElement(Element element, ConstantReader annotation) {
+  RouteBaseConfig _configForAnnotatedElement(Element element, ConstantReader annotation) {
     final String typedAnnotation = withoutNullability(
       annotation.objectValue.type!.getDisplayString(),
     );
@@ -89,6 +102,6 @@ ${getters.map((String e) => "$e,").join('\n')}
       );
     }
 
-    return RouteBaseConfig.fromAnnotation(annotation, element).generateMembers();
+    return RouteBaseConfig.fromAnnotation(annotation, element);
   }
 }

--- a/packages/go_router_builder/lib/src/path_utils.dart
+++ b/packages/go_router_builder/lib/src/path_utils.dart
@@ -18,6 +18,21 @@ Set<String> pathParametersFromPattern(String pattern) => <String>{
   for (final RegExpMatch match in _parameterRegExp.allMatches(pattern)) match[1]!,
 };
 
+/// Replaces the parameter names in a [pattern] with a placeholder, so that
+/// patterns differing only in those names compare as equal.
+///
+/// A parameter's regex constraint is kept, since it changes which URLs the
+/// pattern matches.
+///
+/// For example:
+///
+/// ```dart
+/// normalizePathParameters('item/:id'); // 'item/:_'
+/// normalizePathParameters(r'item/:id(\d+)'); // r'item/:_(\d+)'
+/// ```
+String normalizePathParameters(String pattern) =>
+    pattern.replaceAllMapped(_parameterRegExp, (Match match) => ':_${match[2] ?? ''}');
+
 /// Reconstructs the full path from a [pattern] and path parameters.
 ///
 /// For example:

--- a/packages/go_router_builder/lib/src/route_config.dart
+++ b/packages/go_router_builder/lib/src/route_config.dart
@@ -590,6 +590,8 @@ abstract class RouteBaseConfig {
       );
     }
 
+    definition._validateNoDuplicatePaths();
+
     return definition;
   }
 
@@ -757,6 +759,63 @@ abstract class RouteBaseConfig {
 
   /// The parent of this route config.
   final RouteBaseConfig? parent;
+
+  /// Validates that no two sibling routes share conflicting paths.
+  ///
+  /// This walks the route tree and at each level collects all path-bearing
+  /// routes that share the same URL namespace. Shell routes and branches are
+  /// "transparent" — their child GoRoutes compete in the parent's URL space.
+  ///
+  /// Path parameters are normalized (e.g. `:id` and `:userId` are treated as
+  /// equivalent) since they match the same URL segments at runtime.
+  void _validateNoDuplicatePaths() {
+    final effectiveSiblings = <GoRouteConfig>[];
+    _collectEffectiveGoRouteChildren(_children, effectiveSiblings);
+
+    final seen = <String, GoRouteConfig>{};
+    for (final route in effectiveSiblings) {
+      final String normalized = _normalizePath(route.path);
+      final GoRouteConfig? existing = seen[normalized];
+      if (existing != null) {
+        throw InvalidGenerationSourceError(
+          'Duplicate route path detected: '
+          '"${existing.path}" from ${existing._className} and '
+          '"${route.path}" from ${route._className} '
+          'both match the same URL pattern.',
+          element: route.routeDataClass,
+        );
+      }
+      seen[normalized] = route;
+    }
+
+    for (final RouteBaseConfig child in _children) {
+      child._validateNoDuplicatePaths();
+    }
+  }
+
+  /// Collects all [GoRouteConfig] children that effectively compete for the
+  /// same URL namespace. Shell routes and branches are transparent — we look
+  /// through them to find the GoRoutes inside.
+  static void _collectEffectiveGoRouteChildren(
+    List<RouteBaseConfig> children,
+    List<GoRouteConfig> result,
+  ) {
+    for (final child in children) {
+      if (child is GoRouteConfig) {
+        result.add(child);
+      } else {
+        // ShellRouteConfig, StatefulShellRouteConfig, and
+        // StatefulShellBranchConfig are transparent in URL space — their
+        // child GoRoutes compete with siblings at this level.
+        _collectEffectiveGoRouteChildren(child._children, result);
+      }
+    }
+  }
+
+  /// Normalizes a route path for structural comparison by replacing named
+  /// parameters (e.g. `:id`, `:userId`) with a placeholder (`:_`).
+  static String _normalizePath(String path) =>
+      path.replaceAll(RegExp(r':\w+'), ':_');
 
   static String _generateChildrenGetterName(String name) {
     return (name == 'TypedStatefulShellRoute' || name == 'StatefulShellRouteData')

--- a/packages/go_router_builder/lib/src/route_config.dart
+++ b/packages/go_router_builder/lib/src/route_config.dart
@@ -1061,6 +1061,9 @@ void _collectRoutesOwningPaths(List<RouteBaseConfig> children, List<_GoRouteMixi
   }
 }
 
+/// Matches a named path parameter, such as `:id` or `:userId`.
+final RegExp _pathParameterPattern = RegExp(r':\w+');
+
 /// Normalizes a route path for structural comparison by replacing named
 /// parameters, such as `:id` and `:userId`, with a placeholder.
-String _normalizePath(String path) => path.replaceAll(RegExp(r':\w+'), ':_');
+String _normalizePath(String path) => path.replaceAll(_pathParameterPattern, ':_');

--- a/packages/go_router_builder/lib/src/route_config.dart
+++ b/packages/go_router_builder/lib/src/route_config.dart
@@ -1015,11 +1015,7 @@ void _reportDuplicatePathsAmongSiblings(
       seen[normalized] = route;
       continue;
     }
-    final message =
-        'Duplicate route path detected: '
-        '"${existing.path}" from ${existing._className} and '
-        '"${route.path}" from ${route._className} '
-        'both match the same URL pattern.';
+    final String message = _duplicatePathMessage(existing, route);
     if (severity == DuplicatePathSeverity.error) {
       throw InvalidGenerationSourceError(message, element: route.routeDataClass);
     }
@@ -1031,6 +1027,23 @@ void _reportDuplicatePathsAmongSiblings(
   for (final route in siblings) {
     _reportDuplicatePathsAmongSiblings(route._children, severity);
   }
+}
+
+/// Describes the conflict between two routes that resolve to the same URL.
+///
+/// One route class declared twice at the same path gets its own wording, since
+/// naming that class on both sides of an "and" reads as though two classes were
+/// involved. Any other pair names both sides, which stays clear even when the
+/// class repeats, because the two paths differ.
+String _duplicatePathMessage(_GoRouteMixin existing, _GoRouteMixin route) {
+  if (existing.routeDataClass == route.routeDataClass && existing.path == route.path) {
+    return 'Duplicate route path detected: ${route._className} is declared more '
+        'than once at "${route.path}".';
+  }
+  return 'Duplicate route path detected: '
+      '"${existing.path}" from ${existing._className} and '
+      '"${route.path}" from ${route._className} '
+      'both match the same URL pattern.';
 }
 
 /// Collects the routes in [children] that own a path of their own.

--- a/packages/go_router_builder/lib/src/route_config.dart
+++ b/packages/go_router_builder/lib/src/route_config.dart
@@ -192,9 +192,34 @@ mixin _GoRouteMixin on RouteBaseConfig {
 
   /// The path this route contributes to the URL, without any parent path.
   ///
-  /// Unlike [_basePathForLocation], this is the path exactly as written in the
-  /// annotation, which is what sibling routes compete over.
+  /// This is the path exactly as written in the annotation.
   String get path;
+
+  /// Whether this route only matches a URL that matches its path's casing.
+  bool get caseSensitive;
+
+  /// The path this route matches, joined with the paths of its ancestors.
+  ///
+  /// Shell routes and branches contribute nothing, since they own no path, so
+  /// this is the URL pattern the route resolves to at runtime. Two routes with
+  /// the same pattern compete for the same URL no matter where they sit in the
+  /// tree, which is what [reportDuplicateRoutePaths] compares.
+  ///
+  /// [_basePathForLocation] cannot serve here, because a relative route
+  /// deliberately reports only its own path.
+  String get _joinedPath {
+    final pathSegments = <String>[];
+
+    RouteBaseConfig? config = this;
+    while (config != null) {
+      if (config case _GoRouteMixin(:final String path)) {
+        pathSegments.add(path);
+      }
+      config = config.parent;
+    }
+
+    return p.url.joinAll(pathSegments.reversed);
+  }
 
   late final Set<String> _pathParams = pathParametersFromPattern(_basePathForLocation);
 
@@ -415,6 +440,7 @@ class GoRouteConfig extends RouteBaseConfig with _GoRouteMixin {
   final String? name;
 
   /// The case sensitivity of the GoRoute to be created by this configuration.
+  @override
   final bool caseSensitive;
 
   /// Whether to enable the onExit callback for this route.
@@ -427,23 +453,8 @@ class GoRouteConfig extends RouteBaseConfig with _GoRouteMixin {
   /// The parent navigator key.
   final String? parentNavigatorKey;
 
-  String get _rawJoinedPath {
-    final pathSegments = <String>[];
-
-    RouteBaseConfig? config = this;
-    while (config != null) {
-      if (config
-          case GoRouteConfig(:final String path) || RelativeGoRouteConfig(:final String path)) {
-        pathSegments.add(path);
-      }
-      config = config.parent;
-    }
-
-    return p.url.joinAll(pathSegments.reversed);
-  }
-
   @override
-  String get _basePathForLocation => _rawJoinedPath;
+  String get _basePathForLocation => _joinedPath;
 
   @override
   String get _mixinDefinition {
@@ -514,6 +525,7 @@ class RelativeGoRouteConfig extends RouteBaseConfig with _GoRouteMixin {
   final String path;
 
   /// The case sensitivity of the GoRoute to be created by this configuration.
+  @override
   final bool caseSensitive;
 
   /// Whether to enable the onExit callback for this route.
@@ -984,86 +996,85 @@ bool $iterablesEqualHelperName<T>(Iterable<T>? iterable1, Iterable<T>? iterable2
 /// Reports routes that resolve to the same URL pattern, with the severity
 /// selected by the `duplicate_route_paths` builder option.
 ///
-/// [roots] holds every top-level route config in a library. Those compete for
-/// the root URL namespace, because the generated `$appRoutes` collects them all
-/// into one list. The walk then descends one level at a time.
+/// [roots] holds every top-level route config in a library, which is the widest
+/// scope the builder can see, since it generates one library at a time.
 ///
-/// Shell routes and branches are transparent: their children compete in the
-/// parent's URL namespace instead of owning one of their own.
+/// Routes are compared by the whole URL pattern they resolve to, their
+/// [_GoRouteMixin._joinedPath], rather than by the path each one declares. Two
+/// routes at different depths can still land on one URL: a route nested as `a`
+/// then `b` resolves to the same place as a route declared at `a/b`. Comparing
+/// declared paths level by level misses that, and misses a collision between the
+/// children of two declarations that themselves share a path.
 ///
-/// Path parameters are normalized, so `:id` and `:userId` are treated as
-/// equivalent, since they match the same URL segments at runtime.
+/// `go_router` tries routes in declaration order and takes the first whose
+/// pattern matches the whole URL, so of two routes sharing a pattern the later
+/// can never be the match for it.
+///
+/// Parameter names are normalized, since `:id` and `:userId` match the same URL
+/// segments. A route that is not case sensitive also shadows a later route whose
+/// pattern differs from it only in casing.
 void reportDuplicateRoutePaths(List<RouteBaseConfig> roots, DuplicatePathSeverity severity) {
   if (severity == DuplicatePathSeverity.ignore) {
     return;
   }
-  _reportDuplicatePathsAmongSiblings(roots, severity);
-}
 
-void _reportDuplicatePathsAmongSiblings(
-  List<RouteBaseConfig> children,
-  DuplicatePathSeverity severity,
-) {
-  final siblings = <_GoRouteMixin>[];
-  _collectRoutesOwningPaths(children, siblings);
+  final routes = <_GoRouteMixin>[];
+  _collectRoutes(roots, routes);
 
+  // Keyed by exact pattern, then again by folded pattern for the routes that
+  // match any casing. Both keep their first entry, which is the route
+  // `go_router` matches, because the walk above is in declaration order.
   final seen = <String, _GoRouteMixin>{};
-  for (final route in siblings) {
-    final String normalized = _normalizePath(route.path);
-    final _GoRouteMixin? existing = seen[normalized];
-    if (existing == null) {
-      seen[normalized] = route;
-      continue;
-    }
-    final String message = _duplicatePathMessage(existing, route);
-    if (severity == DuplicatePathSeverity.error) {
-      throw InvalidGenerationSourceError(message, element: route.routeDataClass);
-    }
-    log.warning(message);
-  }
+  final seenIgnoringCase = <String, _GoRouteMixin>{};
+  for (final route in routes) {
+    final String pattern = normalizePathParameters(route._joinedPath);
+    final String folded = pattern.toLowerCase();
 
-  // Only the collected routes own a URL namespace, so recursing into them
-  // visits every level of the tree exactly once.
-  for (final route in siblings) {
-    _reportDuplicatePathsAmongSiblings(route._children, severity);
+    final _GoRouteMixin? existing = seen[pattern] ?? seenIgnoringCase[folded];
+    if (existing != null) {
+      final String message = _duplicatePathMessage(existing, route);
+      if (severity == DuplicatePathSeverity.error) {
+        throw InvalidGenerationSourceError(message, element: route.routeDataClass);
+      }
+      log.warning(message);
+    }
+
+    seen.putIfAbsent(pattern, () => route);
+    if (!route.caseSensitive) {
+      seenIgnoringCase.putIfAbsent(folded, () => route);
+    }
   }
 }
 
 /// Describes the conflict between two routes that resolve to the same URL.
 ///
-/// One route class declared twice at the same path gets its own wording, since
-/// naming that class on both sides of an "and" reads as though two classes were
+/// One route class declared twice at one URL gets its own wording, since naming
+/// that class on both sides of an "and" reads as though two classes were
 /// involved. Any other pair names both sides, which stays clear even when the
-/// class repeats, because the two paths differ.
+/// class repeats, because the two patterns differ.
 String _duplicatePathMessage(_GoRouteMixin existing, _GoRouteMixin route) {
-  if (existing.routeDataClass == route.routeDataClass && existing.path == route.path) {
+  final String existingPattern = existing._joinedPath;
+  final String pattern = route._joinedPath;
+  if (existing.routeDataClass == route.routeDataClass && existingPattern == pattern) {
     return 'Duplicate route path detected: ${route._className} is declared more '
-        'than once at "${route.path}".';
+        'than once at "$pattern".';
   }
   return 'Duplicate route path detected: '
-      '"${existing.path}" from ${existing._className} and '
-      '"${route.path}" from ${route._className} '
+      '"$existingPattern" from ${existing._className} and '
+      '"$pattern" from ${route._className} '
       'both match the same URL pattern.';
 }
 
-/// Collects the routes in [children] that own a path of their own.
+/// Collects every route in the tree that resolves to a URL of its own, in
+/// declaration order.
 ///
-/// Both `GoRoute` and relative `GoRoute` configs own a path. Shell routes and
-/// branches do not, so we look through them to the routes inside, which compete
-/// with the routes at this level.
-void _collectRoutesOwningPaths(List<RouteBaseConfig> children, List<_GoRouteMixin> result) {
+/// Shell routes and branches own no path, so they contribute nothing themselves,
+/// but the routes inside them do and are collected all the same.
+void _collectRoutes(List<RouteBaseConfig> children, List<_GoRouteMixin> result) {
   for (final child in children) {
     if (child is _GoRouteMixin) {
       result.add(child);
-    } else {
-      _collectRoutesOwningPaths(child._children, result);
     }
+    _collectRoutes(child._children, result);
   }
 }
-
-/// Matches a named path parameter, such as `:id` or `:userId`.
-final RegExp _pathParameterPattern = RegExp(r':\w+');
-
-/// Normalizes a route path for structural comparison by replacing named
-/// parameters, such as `:id` and `:userId`, with a placeholder.
-String _normalizePath(String path) => path.replaceAll(_pathParameterPattern, ':_');

--- a/packages/go_router_builder/lib/src/route_config.dart
+++ b/packages/go_router_builder/lib/src/route_config.dart
@@ -9,12 +9,14 @@ import 'package:analyzer/dart/constant/value.dart';
 import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/nullability_suffix.dart';
 import 'package:analyzer/dart/element/type.dart';
+import 'package:build/build.dart';
 import 'package:collection/collection.dart';
 import 'package:meta/meta.dart';
 import 'package:path/path.dart' as p;
 import 'package:source_gen/source_gen.dart';
 import 'package:source_helper/source_helper.dart';
 
+import 'duplicate_path_severity.dart';
 import 'path_utils.dart';
 import 'type_helpers.dart';
 
@@ -187,6 +189,12 @@ class StatefulShellBranchConfig extends RouteBaseConfig {
 /// A mixin that provides common functionality for GoRoute-based configurations.
 mixin _GoRouteMixin on RouteBaseConfig {
   String get _basePathForLocation;
+
+  /// The path this route contributes to the URL, without any parent path.
+  ///
+  /// Unlike [_basePathForLocation], this is the path exactly as written in the
+  /// annotation, which is what sibling routes compete over.
+  String get path;
 
   late final Set<String> _pathParams = pathParametersFromPattern(_basePathForLocation);
 
@@ -400,6 +408,7 @@ class GoRouteConfig extends RouteBaseConfig with _GoRouteMixin {
   }) : super._();
 
   /// The path of the GoRoute to be created by this configuration.
+  @override
   final String path;
 
   /// The name of the GoRoute to be created by this configuration.
@@ -501,6 +510,7 @@ class RelativeGoRouteConfig extends RouteBaseConfig with _GoRouteMixin {
   }) : super._();
 
   /// The path of the GoRoute to be created by this configuration.
+  @override
   final String path;
 
   /// The case sensitivity of the GoRoute to be created by this configuration.
@@ -589,8 +599,6 @@ abstract class RouteBaseConfig {
         element: element,
       );
     }
-
-    definition._validateNoDuplicatePaths();
 
     return definition;
   }
@@ -759,63 +767,6 @@ abstract class RouteBaseConfig {
 
   /// The parent of this route config.
   final RouteBaseConfig? parent;
-
-  /// Validates that no two sibling routes share conflicting paths.
-  ///
-  /// This walks the route tree and at each level collects all path-bearing
-  /// routes that share the same URL namespace. Shell routes and branches are
-  /// "transparent" — their child GoRoutes compete in the parent's URL space.
-  ///
-  /// Path parameters are normalized (e.g. `:id` and `:userId` are treated as
-  /// equivalent) since they match the same URL segments at runtime.
-  void _validateNoDuplicatePaths() {
-    final effectiveSiblings = <GoRouteConfig>[];
-    _collectEffectiveGoRouteChildren(_children, effectiveSiblings);
-
-    final seen = <String, GoRouteConfig>{};
-    for (final route in effectiveSiblings) {
-      final String normalized = _normalizePath(route.path);
-      final GoRouteConfig? existing = seen[normalized];
-      if (existing != null) {
-        throw InvalidGenerationSourceError(
-          'Duplicate route path detected: '
-          '"${existing.path}" from ${existing._className} and '
-          '"${route.path}" from ${route._className} '
-          'both match the same URL pattern.',
-          element: route.routeDataClass,
-        );
-      }
-      seen[normalized] = route;
-    }
-
-    for (final RouteBaseConfig child in _children) {
-      child._validateNoDuplicatePaths();
-    }
-  }
-
-  /// Collects all [GoRouteConfig] children that effectively compete for the
-  /// same URL namespace. Shell routes and branches are transparent — we look
-  /// through them to find the GoRoutes inside.
-  static void _collectEffectiveGoRouteChildren(
-    List<RouteBaseConfig> children,
-    List<GoRouteConfig> result,
-  ) {
-    for (final child in children) {
-      if (child is GoRouteConfig) {
-        result.add(child);
-      } else {
-        // ShellRouteConfig, StatefulShellRouteConfig, and
-        // StatefulShellBranchConfig are transparent in URL space — their
-        // child GoRoutes compete with siblings at this level.
-        _collectEffectiveGoRouteChildren(child._children, result);
-      }
-    }
-  }
-
-  /// Normalizes a route path for structural comparison by replacing named
-  /// parameters (e.g. `:id`, `:userId`) with a placeholder (`:_`).
-  static String _normalizePath(String path) =>
-      path.replaceAll(RegExp(r':\w+'), ':_');
 
   static String _generateChildrenGetterName(String name) {
     return (name == 'TypedStatefulShellRoute' || name == 'StatefulShellRouteData')
@@ -1029,3 +980,74 @@ bool $iterablesEqualHelperName<T>(Iterable<T>? iterable1, Iterable<T>? iterable2
     if (iterator1.current != iterator2.current) return false;
   }
 }''';
+
+/// Reports routes that resolve to the same URL pattern, with the severity
+/// selected by the `duplicate_route_paths` builder option.
+///
+/// [roots] holds every top-level route config in a library. Those compete for
+/// the root URL namespace, because the generated `$appRoutes` collects them all
+/// into one list. The walk then descends one level at a time.
+///
+/// Shell routes and branches are transparent: their children compete in the
+/// parent's URL namespace instead of owning one of their own.
+///
+/// Path parameters are normalized, so `:id` and `:userId` are treated as
+/// equivalent, since they match the same URL segments at runtime.
+void reportDuplicateRoutePaths(List<RouteBaseConfig> roots, DuplicatePathSeverity severity) {
+  if (severity == DuplicatePathSeverity.ignore) {
+    return;
+  }
+  _reportDuplicatePathsAmongSiblings(roots, severity);
+}
+
+void _reportDuplicatePathsAmongSiblings(
+  List<RouteBaseConfig> children,
+  DuplicatePathSeverity severity,
+) {
+  final siblings = <_GoRouteMixin>[];
+  _collectRoutesOwningPaths(children, siblings);
+
+  final seen = <String, _GoRouteMixin>{};
+  for (final route in siblings) {
+    final String normalized = _normalizePath(route.path);
+    final _GoRouteMixin? existing = seen[normalized];
+    if (existing == null) {
+      seen[normalized] = route;
+      continue;
+    }
+    final message =
+        'Duplicate route path detected: '
+        '"${existing.path}" from ${existing._className} and '
+        '"${route.path}" from ${route._className} '
+        'both match the same URL pattern.';
+    if (severity == DuplicatePathSeverity.error) {
+      throw InvalidGenerationSourceError(message, element: route.routeDataClass);
+    }
+    log.warning(message);
+  }
+
+  // Only the collected routes own a URL namespace, so recursing into them
+  // visits every level of the tree exactly once.
+  for (final route in siblings) {
+    _reportDuplicatePathsAmongSiblings(route._children, severity);
+  }
+}
+
+/// Collects the routes in [children] that own a path of their own.
+///
+/// Both `GoRoute` and relative `GoRoute` configs own a path. Shell routes and
+/// branches do not, so we look through them to the routes inside, which compete
+/// with the routes at this level.
+void _collectRoutesOwningPaths(List<RouteBaseConfig> children, List<_GoRouteMixin> result) {
+  for (final child in children) {
+    if (child is _GoRouteMixin) {
+      result.add(child);
+    } else {
+      _collectRoutesOwningPaths(child._children, result);
+    }
+  }
+}
+
+/// Normalizes a route path for structural comparison by replacing named
+/// parameters, such as `:id` and `:userId`, with a placeholder.
+String _normalizePath(String path) => path.replaceAll(RegExp(r':\w+'), ':_');

--- a/packages/go_router_builder/pubspec.yaml
+++ b/packages/go_router_builder/pubspec.yaml
@@ -2,7 +2,7 @@ name: go_router_builder
 description: >-
   A builder that supports generated strongly-typed route helpers for
   package:go_router
-version: 4.4.1
+version: 4.5.0
 repository: https://github.com/flutter/packages/tree/main/packages/go_router_builder
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+go_router_builder%22
 
@@ -29,6 +29,7 @@ dev_dependencies:
     sdk: flutter
   go_router: ^17.3.0
   leak_tracker_flutter_testing: ">=3.0.0"
+  logging: ^1.2.0
   package_config: ^2.1.1
   pub_semver: ^2.1.5
   test: ^1.20.0

--- a/packages/go_router_builder/test/duplicate_path_severity_test.dart
+++ b/packages/go_router_builder/test/duplicate_path_severity_test.dart
@@ -1,0 +1,53 @@
+// Copyright 2013 The Flutter Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:build/build.dart';
+import 'package:go_router_builder/src/duplicate_path_severity.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('duplicatePathSeverityFromOptions', () {
+    test('It should warn when the option is absent', () {
+      expect(duplicatePathSeverityFromOptions(BuilderOptions.empty), DuplicatePathSeverity.warning);
+    });
+
+    test('It should read each accepted value', () {
+      for (final DuplicatePathSeverity severity in DuplicatePathSeverity.values) {
+        expect(
+          duplicatePathSeverityFromOptions(
+            BuilderOptions(<String, dynamic>{duplicateRoutePathsOption: severity.name}),
+          ),
+          severity,
+        );
+      }
+    });
+
+    test('It should reject an unrecognized value, naming the accepted ones', () {
+      expect(
+        () => duplicatePathSeverityFromOptions(
+          const BuilderOptions(<String, dynamic>{duplicateRoutePathsOption: 'bogus'}),
+        ),
+        throwsA(
+          isA<ArgumentError>()
+              .having((ArgumentError e) => e.name, 'name', duplicateRoutePathsOption)
+              .having((ArgumentError e) => e.invalidValue, 'invalidValue', 'bogus')
+              .having(
+                (ArgumentError e) => e.message,
+                'message',
+                allOf(contains('ignore'), contains('warning'), contains('error')),
+              ),
+        ),
+      );
+    });
+
+    test('It should reject a value of the wrong type', () {
+      expect(
+        () => duplicatePathSeverityFromOptions(
+          const BuilderOptions(<String, dynamic>{duplicateRoutePathsOption: true}),
+        ),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+  });
+}

--- a/packages/go_router_builder/test/path_utils_test.dart
+++ b/packages/go_router_builder/test/path_utils_test.dart
@@ -16,6 +16,43 @@ void main() {
     });
   });
 
+  group('normalizePathParameters', () {
+    test('It should leave a pattern without parameters alone', () {
+      expect(normalizePathParameters('/'), '/');
+      expect(normalizePathParameters('/user/book'), '/user/book');
+    });
+
+    test('It should make patterns differing only in parameter name equal', () {
+      expect(normalizePathParameters('/user/:id'), normalizePathParameters('/user/:userId'));
+      expect(
+        normalizePathParameters('/user/:id/book/:bookId'),
+        normalizePathParameters('/user/:a/book/:b'),
+      );
+    });
+
+    test('It should keep patterns with different literal segments distinct', () {
+      expect(normalizePathParameters('/user/:id'), isNot(normalizePathParameters('/book/:id')));
+      expect(
+        normalizePathParameters('/user/:id'),
+        isNot(normalizePathParameters('/user/:id/book')),
+      );
+    });
+
+    test('It should keep a parameter constraint, which changes what matches', () {
+      expect(normalizePathParameters(r'/user/:id(\d+)'), r'/user/:_(\d+)');
+      expect(
+        normalizePathParameters(r'/user/:id(\d+)'),
+        isNot(normalizePathParameters(r'/user/:id(\w+)')),
+      );
+      // A colon inside a constraint is part of the constraint, not a second
+      // parameter, so these two must stay distinct.
+      expect(
+        normalizePathParameters('/user/:id(mon:tue)'),
+        isNot(normalizePathParameters('/user/:id(mon:wed)')),
+      );
+    });
+  });
+
   group('patternToPath', () {
     test('It should replace the path parameters with their values', () {
       expect(patternToPath('/', const <String, String>{}), '/');

--- a/packages/go_router_builder/test_inputs/duplicate_path_across_annotations.dart
+++ b/packages/go_router_builder/test_inputs/duplicate_path_across_annotations.dart
@@ -1,0 +1,14 @@
+// Copyright 2013 The Flutter Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:go_router/go_router.dart';
+
+mixin $FirstHomeRoute {}
+mixin $SecondHomeRoute {}
+
+@TypedGoRoute<FirstHomeRoute>(path: '/home')
+class FirstHomeRoute extends GoRouteData with $FirstHomeRoute {}
+
+@TypedGoRoute<SecondHomeRoute>(path: '/home')
+class SecondHomeRoute extends GoRouteData with $SecondHomeRoute {}

--- a/packages/go_router_builder/test_inputs/duplicate_path_across_annotations.dart.expect
+++ b/packages/go_router_builder/test_inputs/duplicate_path_across_annotations.dart.expect
@@ -1,0 +1,1 @@
+Duplicate route path detected: "/home" from FirstHomeRoute and "/home" from SecondHomeRoute both match the same URL pattern.

--- a/packages/go_router_builder/test_inputs/duplicate_path_across_annotations.dart.options
+++ b/packages/go_router_builder/test_inputs/duplicate_path_across_annotations.dart.options
@@ -1,0 +1,3 @@
+{
+  "duplicate_route_paths": "error"
+}

--- a/packages/go_router_builder/test_inputs/duplicate_path_across_shell_route.dart
+++ b/packages/go_router_builder/test_inputs/duplicate_path_across_shell_route.dart
@@ -1,0 +1,23 @@
+// Copyright 2013 The Flutter Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// A shell route owns no path, so a route inside one competes with a route
+// declared beside the shell.
+
+import 'package:go_router/go_router.dart';
+
+mixin $InsideShellRoute {}
+mixin $OutsideShellRoute {}
+
+@TypedShellRoute<AppShellRouteData>(
+  routes: <TypedRoute<RouteData>>[TypedGoRoute<InsideShellRoute>(path: '/settings')],
+)
+class AppShellRouteData extends ShellRouteData {
+  const AppShellRouteData();
+}
+
+@TypedGoRoute<OutsideShellRoute>(path: '/settings')
+class OutsideShellRoute extends GoRouteData with $OutsideShellRoute {}
+
+class InsideShellRoute extends GoRouteData with $InsideShellRoute {}

--- a/packages/go_router_builder/test_inputs/duplicate_path_across_shell_route.dart.expect
+++ b/packages/go_router_builder/test_inputs/duplicate_path_across_shell_route.dart.expect
@@ -1,0 +1,1 @@
+Duplicate route path detected: "/settings" from InsideShellRoute and "/settings" from OutsideShellRoute both match the same URL pattern.

--- a/packages/go_router_builder/test_inputs/duplicate_path_across_shell_route.dart.options
+++ b/packages/go_router_builder/test_inputs/duplicate_path_across_shell_route.dart.options
@@ -1,0 +1,3 @@
+{
+  "duplicate_route_paths": "error"
+}

--- a/packages/go_router_builder/test_inputs/duplicate_path_case_insensitive.dart
+++ b/packages/go_router_builder/test_inputs/duplicate_path_case_insensitive.dart
@@ -1,0 +1,25 @@
+// Copyright 2013 The Flutter Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// A route that is not case sensitive matches any casing of its path, so it
+// shadows a later route whose path differs from it only in case.
+
+import 'package:go_router/go_router.dart';
+
+mixin $HomeRoute {}
+mixin $LowerRoute {}
+mixin $UpperRoute {}
+
+@TypedGoRoute<HomeRoute>(
+  path: '/home',
+  routes: <TypedGoRoute<GoRouteData>>[
+    TypedGoRoute<LowerRoute>(path: 'details', caseSensitive: false),
+    TypedGoRoute<UpperRoute>(path: 'Details', caseSensitive: false),
+  ],
+)
+class HomeRoute extends GoRouteData with $HomeRoute {}
+
+class LowerRoute extends GoRouteData with $LowerRoute {}
+
+class UpperRoute extends GoRouteData with $UpperRoute {}

--- a/packages/go_router_builder/test_inputs/duplicate_path_case_insensitive.dart.expect
+++ b/packages/go_router_builder/test_inputs/duplicate_path_case_insensitive.dart.expect
@@ -1,0 +1,1 @@
+Duplicate route path detected: "/home/details" from LowerRoute and "/home/Details" from UpperRoute both match the same URL pattern.

--- a/packages/go_router_builder/test_inputs/duplicate_path_case_insensitive.dart.options
+++ b/packages/go_router_builder/test_inputs/duplicate_path_case_insensitive.dart.options
@@ -1,0 +1,3 @@
+{
+  "duplicate_route_paths": "error"
+}

--- a/packages/go_router_builder/test_inputs/duplicate_path_case_sensitive_distinct.dart
+++ b/packages/go_router_builder/test_inputs/duplicate_path_case_sensitive_distinct.dart
@@ -1,0 +1,25 @@
+// Copyright 2013 The Flutter Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Case sensitive routes are the default, and two of them differing in case
+// match different URLs, so they must not be reported.
+
+import 'package:go_router/go_router.dart';
+
+mixin $HomeRoute {}
+mixin $LowerRoute {}
+mixin $UpperRoute {}
+
+@TypedGoRoute<HomeRoute>(
+  path: '/home',
+  routes: <TypedGoRoute<GoRouteData>>[
+    TypedGoRoute<LowerRoute>(path: 'details'),
+    TypedGoRoute<UpperRoute>(path: 'Details'),
+  ],
+)
+class HomeRoute extends GoRouteData with $HomeRoute {}
+
+class LowerRoute extends GoRouteData with $LowerRoute {}
+
+class UpperRoute extends GoRouteData with $UpperRoute {}

--- a/packages/go_router_builder/test_inputs/duplicate_path_case_sensitive_distinct.dart.expect
+++ b/packages/go_router_builder/test_inputs/duplicate_path_case_sensitive_distinct.dart.expect
@@ -1,0 +1,77 @@
+RouteBase get $homeRoute => GoRouteData.$route(
+  path: '/home',
+  hasOverriddenOnExit: false,
+  factory: $HomeRoute._fromState,
+  routes: [
+    GoRouteData.$route(
+      path: 'details',
+      hasOverriddenOnExit: false,
+      factory: $LowerRoute._fromState,
+    ),
+    GoRouteData.$route(
+      path: 'Details',
+      hasOverriddenOnExit: false,
+      factory: $UpperRoute._fromState,
+    ),
+  ],
+);
+
+mixin $HomeRoute on GoRouteData {
+  static HomeRoute _fromState(GoRouterState state) => HomeRoute();
+
+  @override
+  String get location => GoRouteData.$location('/home');
+
+  @override
+  void go(BuildContext context) => context.go(location);
+
+  @override
+  Future<T?> push<T>(BuildContext context) => context.push<T>(location);
+
+  @override
+  void pushReplacement(BuildContext context) =>
+      context.pushReplacement(location);
+
+  @override
+  void replace(BuildContext context) => context.replace(location);
+}
+
+mixin $LowerRoute on GoRouteData {
+  static LowerRoute _fromState(GoRouterState state) => LowerRoute();
+
+  @override
+  String get location => GoRouteData.$location('/home/details');
+
+  @override
+  void go(BuildContext context) => context.go(location);
+
+  @override
+  Future<T?> push<T>(BuildContext context) => context.push<T>(location);
+
+  @override
+  void pushReplacement(BuildContext context) =>
+      context.pushReplacement(location);
+
+  @override
+  void replace(BuildContext context) => context.replace(location);
+}
+
+mixin $UpperRoute on GoRouteData {
+  static UpperRoute _fromState(GoRouterState state) => UpperRoute();
+
+  @override
+  String get location => GoRouteData.$location('/home/Details');
+
+  @override
+  void go(BuildContext context) => context.go(location);
+
+  @override
+  Future<T?> push<T>(BuildContext context) => context.push<T>(location);
+
+  @override
+  void pushReplacement(BuildContext context) =>
+      context.pushReplacement(location);
+
+  @override
+  void replace(BuildContext context) => context.replace(location);
+}

--- a/packages/go_router_builder/test_inputs/duplicate_path_different_param_names.dart
+++ b/packages/go_router_builder/test_inputs/duplicate_path_different_param_names.dart
@@ -1,0 +1,28 @@
+// Copyright 2013 The Flutter Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:go_router/go_router.dart';
+
+mixin $HomeRoute {}
+mixin $MealRoute {}
+mixin $DrinkRoute {}
+
+@TypedGoRoute<HomeRoute>(
+  path: '/home',
+  routes: <TypedGoRoute<GoRouteData>>[
+    TypedGoRoute<MealRoute>(path: 'item/:mealId'),
+    TypedGoRoute<DrinkRoute>(path: 'item/:drinkId'),
+  ],
+)
+class HomeRoute extends GoRouteData with $HomeRoute {}
+
+class MealRoute extends GoRouteData with $MealRoute {
+  const MealRoute({required this.mealId});
+  final String mealId;
+}
+
+class DrinkRoute extends GoRouteData with $DrinkRoute {
+  const DrinkRoute({required this.drinkId});
+  final String drinkId;
+}

--- a/packages/go_router_builder/test_inputs/duplicate_path_different_param_names.dart
+++ b/packages/go_router_builder/test_inputs/duplicate_path_different_param_names.dart
@@ -5,24 +5,24 @@
 import 'package:go_router/go_router.dart';
 
 mixin $HomeRoute {}
-mixin $MealRoute {}
-mixin $DrinkRoute {}
+mixin $ProductRoute {}
+mixin $VariantRoute {}
 
 @TypedGoRoute<HomeRoute>(
   path: '/home',
   routes: <TypedGoRoute<GoRouteData>>[
-    TypedGoRoute<MealRoute>(path: 'item/:mealId'),
-    TypedGoRoute<DrinkRoute>(path: 'item/:drinkId'),
+    TypedGoRoute<ProductRoute>(path: 'item/:productId'),
+    TypedGoRoute<VariantRoute>(path: 'item/:variantId'),
   ],
 )
 class HomeRoute extends GoRouteData with $HomeRoute {}
 
-class MealRoute extends GoRouteData with $MealRoute {
-  const MealRoute({required this.mealId});
-  final String mealId;
+class ProductRoute extends GoRouteData with $ProductRoute {
+  const ProductRoute({required this.productId});
+  final String productId;
 }
 
-class DrinkRoute extends GoRouteData with $DrinkRoute {
-  const DrinkRoute({required this.drinkId});
-  final String drinkId;
+class VariantRoute extends GoRouteData with $VariantRoute {
+  const VariantRoute({required this.variantId});
+  final String variantId;
 }

--- a/packages/go_router_builder/test_inputs/duplicate_path_different_param_names.dart.expect
+++ b/packages/go_router_builder/test_inputs/duplicate_path_different_param_names.dart.expect
@@ -1,1 +1,1 @@
-Duplicate route path detected: "item/:productId" from ProductRoute and "item/:variantId" from VariantRoute both match the same URL pattern.
+Duplicate route path detected: "/home/item/:productId" from ProductRoute and "/home/item/:variantId" from VariantRoute both match the same URL pattern.

--- a/packages/go_router_builder/test_inputs/duplicate_path_different_param_names.dart.expect
+++ b/packages/go_router_builder/test_inputs/duplicate_path_different_param_names.dart.expect
@@ -1,1 +1,1 @@
-Duplicate route path detected: "item/:mealId" from MealRoute and "item/:drinkId" from DrinkRoute both match the same URL pattern.
+Duplicate route path detected: "item/:productId" from ProductRoute and "item/:variantId" from VariantRoute both match the same URL pattern.

--- a/packages/go_router_builder/test_inputs/duplicate_path_different_param_names.dart.expect
+++ b/packages/go_router_builder/test_inputs/duplicate_path_different_param_names.dart.expect
@@ -1,0 +1,1 @@
+Duplicate route path detected: "item/:mealId" from MealRoute and "item/:drinkId" from DrinkRoute both match the same URL pattern.

--- a/packages/go_router_builder/test_inputs/duplicate_path_different_param_names.dart.options
+++ b/packages/go_router_builder/test_inputs/duplicate_path_different_param_names.dart.options
@@ -1,0 +1,3 @@
+{
+  "duplicate_route_paths": "error"
+}

--- a/packages/go_router_builder/test_inputs/duplicate_path_ignored.dart
+++ b/packages/go_router_builder/test_inputs/duplicate_path_ignored.dart
@@ -1,0 +1,22 @@
+// Copyright 2013 The Flutter Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:go_router/go_router.dart';
+
+mixin $HomeRoute {}
+mixin $FirstRoute {}
+mixin $SecondRoute {}
+
+@TypedGoRoute<HomeRoute>(
+  path: '/home',
+  routes: <TypedGoRoute<GoRouteData>>[
+    TypedGoRoute<FirstRoute>(path: 'details'),
+    TypedGoRoute<SecondRoute>(path: 'details'),
+  ],
+)
+class HomeRoute extends GoRouteData with $HomeRoute {}
+
+class FirstRoute extends GoRouteData with $FirstRoute {}
+
+class SecondRoute extends GoRouteData with $SecondRoute {}

--- a/packages/go_router_builder/test_inputs/duplicate_path_ignored.dart.expect
+++ b/packages/go_router_builder/test_inputs/duplicate_path_ignored.dart.expect
@@ -1,0 +1,77 @@
+RouteBase get $homeRoute => GoRouteData.$route(
+  path: '/home',
+  hasOverriddenOnExit: false,
+  factory: $HomeRoute._fromState,
+  routes: [
+    GoRouteData.$route(
+      path: 'details',
+      hasOverriddenOnExit: false,
+      factory: $FirstRoute._fromState,
+    ),
+    GoRouteData.$route(
+      path: 'details',
+      hasOverriddenOnExit: false,
+      factory: $SecondRoute._fromState,
+    ),
+  ],
+);
+
+mixin $HomeRoute on GoRouteData {
+  static HomeRoute _fromState(GoRouterState state) => HomeRoute();
+
+  @override
+  String get location => GoRouteData.$location('/home');
+
+  @override
+  void go(BuildContext context) => context.go(location);
+
+  @override
+  Future<T?> push<T>(BuildContext context) => context.push<T>(location);
+
+  @override
+  void pushReplacement(BuildContext context) =>
+      context.pushReplacement(location);
+
+  @override
+  void replace(BuildContext context) => context.replace(location);
+}
+
+mixin $FirstRoute on GoRouteData {
+  static FirstRoute _fromState(GoRouterState state) => FirstRoute();
+
+  @override
+  String get location => GoRouteData.$location('/home/details');
+
+  @override
+  void go(BuildContext context) => context.go(location);
+
+  @override
+  Future<T?> push<T>(BuildContext context) => context.push<T>(location);
+
+  @override
+  void pushReplacement(BuildContext context) =>
+      context.pushReplacement(location);
+
+  @override
+  void replace(BuildContext context) => context.replace(location);
+}
+
+mixin $SecondRoute on GoRouteData {
+  static SecondRoute _fromState(GoRouterState state) => SecondRoute();
+
+  @override
+  String get location => GoRouteData.$location('/home/details');
+
+  @override
+  void go(BuildContext context) => context.go(location);
+
+  @override
+  Future<T?> push<T>(BuildContext context) => context.push<T>(location);
+
+  @override
+  void pushReplacement(BuildContext context) =>
+      context.pushReplacement(location);
+
+  @override
+  void replace(BuildContext context) => context.replace(location);
+}

--- a/packages/go_router_builder/test_inputs/duplicate_path_ignored.dart.options
+++ b/packages/go_router_builder/test_inputs/duplicate_path_ignored.dart.options
@@ -1,0 +1,3 @@
+{
+  "duplicate_route_paths": "ignore"
+}

--- a/packages/go_router_builder/test_inputs/duplicate_path_in_branches.dart
+++ b/packages/go_router_builder/test_inputs/duplicate_path_in_branches.dart
@@ -10,14 +10,10 @@ mixin $FavoritesRoute {}
 @TypedStatefulShellRoute<AppShellRouteData>(
   branches: <TypedStatefulShellBranch<StatefulShellBranchData>>[
     TypedStatefulShellBranch<BranchAData>(
-      routes: <TypedRoute<RouteData>>[
-        TypedGoRoute<IdeasRoute>(path: '/ideas'),
-      ],
+      routes: <TypedRoute<RouteData>>[TypedGoRoute<IdeasRoute>(path: '/ideas')],
     ),
     TypedStatefulShellBranch<BranchBData>(
-      routes: <TypedRoute<RouteData>>[
-        TypedGoRoute<FavoritesRoute>(path: '/ideas'),
-      ],
+      routes: <TypedRoute<RouteData>>[TypedGoRoute<FavoritesRoute>(path: '/ideas')],
     ),
   ],
 )

--- a/packages/go_router_builder/test_inputs/duplicate_path_in_branches.dart
+++ b/packages/go_router_builder/test_inputs/duplicate_path_in_branches.dart
@@ -1,0 +1,38 @@
+// Copyright 2013 The Flutter Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:go_router/go_router.dart';
+
+mixin $IdeasRoute {}
+mixin $FavoritesRoute {}
+
+@TypedStatefulShellRoute<AppShellRouteData>(
+  branches: <TypedStatefulShellBranch<StatefulShellBranchData>>[
+    TypedStatefulShellBranch<BranchAData>(
+      routes: <TypedRoute<RouteData>>[
+        TypedGoRoute<IdeasRoute>(path: '/ideas'),
+      ],
+    ),
+    TypedStatefulShellBranch<BranchBData>(
+      routes: <TypedRoute<RouteData>>[
+        TypedGoRoute<FavoritesRoute>(path: '/ideas'),
+      ],
+    ),
+  ],
+)
+class AppShellRouteData extends StatefulShellRouteData {
+  const AppShellRouteData();
+}
+
+class BranchAData extends StatefulShellBranchData {
+  const BranchAData();
+}
+
+class BranchBData extends StatefulShellBranchData {
+  const BranchBData();
+}
+
+class IdeasRoute extends GoRouteData with $IdeasRoute {}
+
+class FavoritesRoute extends GoRouteData with $FavoritesRoute {}

--- a/packages/go_router_builder/test_inputs/duplicate_path_in_branches.dart.expect
+++ b/packages/go_router_builder/test_inputs/duplicate_path_in_branches.dart.expect
@@ -1,0 +1,1 @@
+Duplicate route path detected: "/ideas" from IdeasRoute and "/ideas" from FavoritesRoute both match the same URL pattern.

--- a/packages/go_router_builder/test_inputs/duplicate_path_in_branches.dart.options
+++ b/packages/go_router_builder/test_inputs/duplicate_path_in_branches.dart.options
@@ -1,0 +1,3 @@
+{
+  "duplicate_route_paths": "error"
+}

--- a/packages/go_router_builder/test_inputs/duplicate_path_multi_segment.dart
+++ b/packages/go_router_builder/test_inputs/duplicate_path_multi_segment.dart
@@ -1,0 +1,31 @@
+// Copyright 2013 The Flutter Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// A multi-segment path resolves to the same URL as the equivalent nesting, even
+// though the two routes sit at different depths.
+
+import 'package:go_router/go_router.dart';
+
+mixin $HomeRoute {}
+mixin $SectionRoute {}
+mixin $NestedRoute {}
+mixin $MultiSegmentRoute {}
+
+@TypedGoRoute<HomeRoute>(
+  path: '/home',
+  routes: <TypedGoRoute<GoRouteData>>[
+    TypedGoRoute<SectionRoute>(
+      path: 'section',
+      routes: <TypedGoRoute<GoRouteData>>[TypedGoRoute<NestedRoute>(path: 'detail')],
+    ),
+    TypedGoRoute<MultiSegmentRoute>(path: 'section/detail'),
+  ],
+)
+class HomeRoute extends GoRouteData with $HomeRoute {}
+
+class SectionRoute extends GoRouteData with $SectionRoute {}
+
+class NestedRoute extends GoRouteData with $NestedRoute {}
+
+class MultiSegmentRoute extends GoRouteData with $MultiSegmentRoute {}

--- a/packages/go_router_builder/test_inputs/duplicate_path_multi_segment.dart.expect
+++ b/packages/go_router_builder/test_inputs/duplicate_path_multi_segment.dart.expect
@@ -1,0 +1,1 @@
+Duplicate route path detected: "/home/section/detail" from NestedRoute and "/home/section/detail" from MultiSegmentRoute both match the same URL pattern.

--- a/packages/go_router_builder/test_inputs/duplicate_path_multi_segment.dart.options
+++ b/packages/go_router_builder/test_inputs/duplicate_path_multi_segment.dart.options
@@ -1,0 +1,3 @@
+{
+  "duplicate_route_paths": "error"
+}

--- a/packages/go_router_builder/test_inputs/duplicate_path_nested_relative_routes.dart
+++ b/packages/go_router_builder/test_inputs/duplicate_path_nested_relative_routes.dart
@@ -17,9 +17,7 @@ mixin $SiblingEditRoute {}
   routes: <TypedRoute<RouteData>>[
     TypedRelativeGoRoute<DetailsRoute>(
       path: 'details',
-      routes: <TypedRoute<RouteData>>[
-        TypedRelativeGoRoute<NestedEditRoute>(path: 'edit'),
-      ],
+      routes: <TypedRoute<RouteData>>[TypedRelativeGoRoute<NestedEditRoute>(path: 'edit')],
     ),
     TypedGoRoute<SiblingEditRoute>(path: 'edit'),
   ],

--- a/packages/go_router_builder/test_inputs/duplicate_path_nested_relative_routes.dart
+++ b/packages/go_router_builder/test_inputs/duplicate_path_nested_relative_routes.dart
@@ -1,0 +1,33 @@
+// Copyright 2013 The Flutter Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// A relative route owns its own URL namespace, so `/home/details/edit` and
+// `/home/edit` are distinct and must not be reported as duplicates.
+
+import 'package:go_router/go_router.dart';
+
+mixin $HomeRoute {}
+mixin $DetailsRoute {}
+mixin $NestedEditRoute {}
+mixin $SiblingEditRoute {}
+
+@TypedGoRoute<HomeRoute>(
+  path: '/home',
+  routes: <TypedRoute<RouteData>>[
+    TypedRelativeGoRoute<DetailsRoute>(
+      path: 'details',
+      routes: <TypedRoute<RouteData>>[
+        TypedRelativeGoRoute<NestedEditRoute>(path: 'edit'),
+      ],
+    ),
+    TypedGoRoute<SiblingEditRoute>(path: 'edit'),
+  ],
+)
+class HomeRoute extends GoRouteData with $HomeRoute {}
+
+class DetailsRoute extends RelativeGoRouteData with $DetailsRoute {}
+
+class NestedEditRoute extends RelativeGoRouteData with $NestedEditRoute {}
+
+class SiblingEditRoute extends GoRouteData with $SiblingEditRoute {}

--- a/packages/go_router_builder/test_inputs/duplicate_path_nested_relative_routes.dart.expect
+++ b/packages/go_router_builder/test_inputs/duplicate_path_nested_relative_routes.dart.expect
@@ -1,0 +1,114 @@
+RouteBase get $homeRoute => GoRouteData.$route(
+  path: '/home',
+  hasOverriddenOnExit: false,
+  factory: $HomeRoute._fromState,
+  routes: [
+    RelativeGoRouteData.$route(
+      path: 'details',
+      hasOverriddenOnExit: false,
+      factory: $DetailsRoute._fromState,
+      routes: [
+        RelativeGoRouteData.$route(
+          path: 'edit',
+          hasOverriddenOnExit: false,
+          factory: $NestedEditRoute._fromState,
+        ),
+      ],
+    ),
+    GoRouteData.$route(
+      path: 'edit',
+      hasOverriddenOnExit: false,
+      factory: $SiblingEditRoute._fromState,
+    ),
+  ],
+);
+
+mixin $HomeRoute on GoRouteData {
+  static HomeRoute _fromState(GoRouterState state) => HomeRoute();
+
+  @override
+  String get location => GoRouteData.$location('/home');
+
+  @override
+  void go(BuildContext context) => context.go(location);
+
+  @override
+  Future<T?> push<T>(BuildContext context) => context.push<T>(location);
+
+  @override
+  void pushReplacement(BuildContext context) =>
+      context.pushReplacement(location);
+
+  @override
+  void replace(BuildContext context) => context.replace(location);
+}
+
+mixin $DetailsRoute on RelativeGoRouteData {
+  static DetailsRoute _fromState(GoRouterState state) => DetailsRoute();
+
+  @override
+  String get subLocation => RelativeGoRouteData.$location('details');
+
+  @override
+  String get relativeLocation => './$subLocation';
+
+  @override
+  void goRelative(BuildContext context) => context.go(relativeLocation);
+
+  @override
+  Future<T?> pushRelative<T>(BuildContext context) =>
+      context.push<T>(relativeLocation);
+
+  @override
+  void pushReplacementRelative(BuildContext context) =>
+      context.pushReplacement(relativeLocation);
+
+  @override
+  void replaceRelative(BuildContext context) =>
+      context.replace(relativeLocation);
+}
+
+mixin $NestedEditRoute on RelativeGoRouteData {
+  static NestedEditRoute _fromState(GoRouterState state) => NestedEditRoute();
+
+  @override
+  String get subLocation => RelativeGoRouteData.$location('edit');
+
+  @override
+  String get relativeLocation => './$subLocation';
+
+  @override
+  void goRelative(BuildContext context) => context.go(relativeLocation);
+
+  @override
+  Future<T?> pushRelative<T>(BuildContext context) =>
+      context.push<T>(relativeLocation);
+
+  @override
+  void pushReplacementRelative(BuildContext context) =>
+      context.pushReplacement(relativeLocation);
+
+  @override
+  void replaceRelative(BuildContext context) =>
+      context.replace(relativeLocation);
+}
+
+mixin $SiblingEditRoute on GoRouteData {
+  static SiblingEditRoute _fromState(GoRouterState state) => SiblingEditRoute();
+
+  @override
+  String get location => GoRouteData.$location('/home/edit');
+
+  @override
+  void go(BuildContext context) => context.go(location);
+
+  @override
+  Future<T?> push<T>(BuildContext context) => context.push<T>(location);
+
+  @override
+  void pushReplacement(BuildContext context) =>
+      context.pushReplacement(location);
+
+  @override
+  void replace(BuildContext context) => context.replace(location);
+}

--- a/packages/go_router_builder/test_inputs/duplicate_path_nested_under_duplicate_parents.dart
+++ b/packages/go_router_builder/test_inputs/duplicate_path_nested_under_duplicate_parents.dart
@@ -1,0 +1,34 @@
+// Copyright 2013 The Flutter Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Two declarations of one parent are sound on their own, but their children
+// share a URL namespace, so a child path repeated across them is a collision.
+
+import 'package:go_router/go_router.dart';
+
+mixin $HomeRoute {}
+mixin $DetailsRoute {}
+mixin $FirstSubRoute {}
+mixin $SecondSubRoute {}
+
+@TypedGoRoute<HomeRoute>(
+  path: '/home',
+  routes: <TypedGoRoute<GoRouteData>>[
+    TypedGoRoute<DetailsRoute>(
+      path: 'details',
+      routes: <TypedGoRoute<GoRouteData>>[TypedGoRoute<FirstSubRoute>(path: 'sub')],
+    ),
+    TypedGoRoute<DetailsRoute>(
+      path: 'details',
+      routes: <TypedGoRoute<GoRouteData>>[TypedGoRoute<SecondSubRoute>(path: 'sub')],
+    ),
+  ],
+)
+class HomeRoute extends GoRouteData with $HomeRoute {}
+
+class DetailsRoute extends GoRouteData with $DetailsRoute {}
+
+class FirstSubRoute extends GoRouteData with $FirstSubRoute {}
+
+class SecondSubRoute extends GoRouteData with $SecondSubRoute {}

--- a/packages/go_router_builder/test_inputs/duplicate_path_nested_under_duplicate_parents.dart.expect
+++ b/packages/go_router_builder/test_inputs/duplicate_path_nested_under_duplicate_parents.dart.expect
@@ -1,0 +1,111 @@
+RouteBase get $homeRoute => GoRouteData.$route(
+  path: '/home',
+  hasOverriddenOnExit: false,
+  factory: $HomeRoute._fromState,
+  routes: [
+    GoRouteData.$route(
+      path: 'details',
+      hasOverriddenOnExit: false,
+      factory: $DetailsRoute._fromState,
+      routes: [
+        GoRouteData.$route(
+          path: 'sub',
+          hasOverriddenOnExit: false,
+          factory: $FirstSubRoute._fromState,
+        ),
+      ],
+    ),
+    GoRouteData.$route(
+      path: 'details',
+      hasOverriddenOnExit: false,
+      factory: $DetailsRoute._fromState,
+      routes: [
+        GoRouteData.$route(
+          path: 'sub',
+          hasOverriddenOnExit: false,
+          factory: $SecondSubRoute._fromState,
+        ),
+      ],
+    ),
+  ],
+);
+
+mixin $HomeRoute on GoRouteData {
+  static HomeRoute _fromState(GoRouterState state) => HomeRoute();
+
+  @override
+  String get location => GoRouteData.$location('/home');
+
+  @override
+  void go(BuildContext context) => context.go(location);
+
+  @override
+  Future<T?> push<T>(BuildContext context) => context.push<T>(location);
+
+  @override
+  void pushReplacement(BuildContext context) =>
+      context.pushReplacement(location);
+
+  @override
+  void replace(BuildContext context) => context.replace(location);
+}
+
+mixin $DetailsRoute on GoRouteData {
+  static DetailsRoute _fromState(GoRouterState state) => DetailsRoute();
+
+  @override
+  String get location => GoRouteData.$location('/home/details');
+
+  @override
+  void go(BuildContext context) => context.go(location);
+
+  @override
+  Future<T?> push<T>(BuildContext context) => context.push<T>(location);
+
+  @override
+  void pushReplacement(BuildContext context) =>
+      context.pushReplacement(location);
+
+  @override
+  void replace(BuildContext context) => context.replace(location);
+}
+
+mixin $FirstSubRoute on GoRouteData {
+  static FirstSubRoute _fromState(GoRouterState state) => FirstSubRoute();
+
+  @override
+  String get location => GoRouteData.$location('/home/details/sub');
+
+  @override
+  void go(BuildContext context) => context.go(location);
+
+  @override
+  Future<T?> push<T>(BuildContext context) => context.push<T>(location);
+
+  @override
+  void pushReplacement(BuildContext context) =>
+      context.pushReplacement(location);
+
+  @override
+  void replace(BuildContext context) => context.replace(location);
+}
+
+mixin $SecondSubRoute on GoRouteData {
+  static SecondSubRoute _fromState(GoRouterState state) => SecondSubRoute();
+
+  @override
+  String get location => GoRouteData.$location('/home/details/sub');
+
+  @override
+  void go(BuildContext context) => context.go(location);
+
+  @override
+  Future<T?> push<T>(BuildContext context) => context.push<T>(location);
+
+  @override
+  void pushReplacement(BuildContext context) =>
+      context.pushReplacement(location);
+
+  @override
+  void replace(BuildContext context) => context.replace(location);
+}

--- a/packages/go_router_builder/test_inputs/duplicate_path_nested_under_duplicate_parents.dart.warnings
+++ b/packages/go_router_builder/test_inputs/duplicate_path_nested_under_duplicate_parents.dart.warnings
@@ -1,0 +1,2 @@
+Duplicate route path detected: DetailsRoute is declared more than once at "/home/details".
+Duplicate route path detected: "/home/details/sub" from FirstSubRoute and "/home/details/sub" from SecondSubRoute both match the same URL pattern.

--- a/packages/go_router_builder/test_inputs/duplicate_path_relative_routes.dart
+++ b/packages/go_router_builder/test_inputs/duplicate_path_relative_routes.dart
@@ -1,0 +1,22 @@
+// Copyright 2013 The Flutter Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:go_router/go_router.dart';
+
+mixin $HomeRoute {}
+mixin $FirstRoute {}
+mixin $SecondRoute {}
+
+@TypedGoRoute<HomeRoute>(
+  path: '/home',
+  routes: <TypedRoute<RouteData>>[
+    TypedRelativeGoRoute<FirstRoute>(path: 'details'),
+    TypedRelativeGoRoute<SecondRoute>(path: 'details'),
+  ],
+)
+class HomeRoute extends GoRouteData with $HomeRoute {}
+
+class FirstRoute extends RelativeGoRouteData with $FirstRoute {}
+
+class SecondRoute extends RelativeGoRouteData with $SecondRoute {}

--- a/packages/go_router_builder/test_inputs/duplicate_path_relative_routes.dart.expect
+++ b/packages/go_router_builder/test_inputs/duplicate_path_relative_routes.dart.expect
@@ -1,1 +1,1 @@
-Duplicate route path detected: "details" from FirstRoute and "details" from SecondRoute both match the same URL pattern.
+Duplicate route path detected: "/home/details" from FirstRoute and "/home/details" from SecondRoute both match the same URL pattern.

--- a/packages/go_router_builder/test_inputs/duplicate_path_relative_routes.dart.expect
+++ b/packages/go_router_builder/test_inputs/duplicate_path_relative_routes.dart.expect
@@ -1,0 +1,1 @@
+Duplicate route path detected: "details" from FirstRoute and "details" from SecondRoute both match the same URL pattern.

--- a/packages/go_router_builder/test_inputs/duplicate_path_relative_routes.dart.options
+++ b/packages/go_router_builder/test_inputs/duplicate_path_relative_routes.dart.options
@@ -1,0 +1,3 @@
+{
+  "duplicate_route_paths": "error"
+}

--- a/packages/go_router_builder/test_inputs/duplicate_path_same_class.dart
+++ b/packages/go_router_builder/test_inputs/duplicate_path_same_class.dart
@@ -1,0 +1,36 @@
+// Copyright 2013 The Flutter Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Declaring one route class twice, so its children can be grouped by feature
+// area, works at runtime. It is still reported, because the builder cannot tell
+// a deliberate grouping from an accidental duplicate. Use the `ignore` severity
+// to opt out.
+
+import 'package:go_router/go_router.dart';
+
+mixin $HomeRoute {}
+mixin $DetailsRoute {}
+mixin $InvoicesRoute {}
+mixin $ShipmentsRoute {}
+
+@TypedGoRoute<HomeRoute>(
+  path: '/home',
+  routes: <TypedGoRoute<GoRouteData>>[
+    TypedGoRoute<DetailsRoute>(
+      path: 'details',
+      routes: <TypedGoRoute<GoRouteData>>[TypedGoRoute<InvoicesRoute>(path: 'invoices')],
+    ),
+    TypedGoRoute<DetailsRoute>(
+      path: 'details',
+      routes: <TypedGoRoute<GoRouteData>>[TypedGoRoute<ShipmentsRoute>(path: 'shipments')],
+    ),
+  ],
+)
+class HomeRoute extends GoRouteData with $HomeRoute {}
+
+class DetailsRoute extends GoRouteData with $DetailsRoute {}
+
+class InvoicesRoute extends GoRouteData with $InvoicesRoute {}
+
+class ShipmentsRoute extends GoRouteData with $ShipmentsRoute {}

--- a/packages/go_router_builder/test_inputs/duplicate_path_same_class.dart.expect
+++ b/packages/go_router_builder/test_inputs/duplicate_path_same_class.dart.expect
@@ -1,1 +1,1 @@
-Duplicate route path detected: DetailsRoute is declared more than once at "details".
+Duplicate route path detected: DetailsRoute is declared more than once at "/home/details".

--- a/packages/go_router_builder/test_inputs/duplicate_path_same_class.dart.expect
+++ b/packages/go_router_builder/test_inputs/duplicate_path_same_class.dart.expect
@@ -1,1 +1,1 @@
-Duplicate route path detected: "details" from DetailsRoute and "details" from DetailsRoute both match the same URL pattern.
+Duplicate route path detected: DetailsRoute is declared more than once at "details".

--- a/packages/go_router_builder/test_inputs/duplicate_path_same_class.dart.expect
+++ b/packages/go_router_builder/test_inputs/duplicate_path_same_class.dart.expect
@@ -1,0 +1,1 @@
+Duplicate route path detected: "details" from DetailsRoute and "details" from DetailsRoute both match the same URL pattern.

--- a/packages/go_router_builder/test_inputs/duplicate_path_same_class.dart.options
+++ b/packages/go_router_builder/test_inputs/duplicate_path_same_class.dart.options
@@ -1,0 +1,3 @@
+{
+  "duplicate_route_paths": "error"
+}

--- a/packages/go_router_builder/test_inputs/duplicate_path_sibling_routes.dart
+++ b/packages/go_router_builder/test_inputs/duplicate_path_sibling_routes.dart
@@ -1,0 +1,28 @@
+// Copyright 2013 The Flutter Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:go_router/go_router.dart';
+
+mixin $HomeRoute {}
+mixin $SettingsRoute {}
+mixin $DuplicateRoute {}
+
+@TypedGoRoute<HomeRoute>(
+  path: '/home',
+  routes: <TypedGoRoute<GoRouteData>>[
+    TypedGoRoute<SettingsRoute>(path: 'details/:id'),
+    TypedGoRoute<DuplicateRoute>(path: 'details/:id'),
+  ],
+)
+class HomeRoute extends GoRouteData with $HomeRoute {}
+
+class SettingsRoute extends GoRouteData with $SettingsRoute {
+  const SettingsRoute({required this.id});
+  final String id;
+}
+
+class DuplicateRoute extends GoRouteData with $DuplicateRoute {
+  const DuplicateRoute({required this.id});
+  final String id;
+}

--- a/packages/go_router_builder/test_inputs/duplicate_path_sibling_routes.dart.expect
+++ b/packages/go_router_builder/test_inputs/duplicate_path_sibling_routes.dart.expect
@@ -1,0 +1,1 @@
+Duplicate route path detected: "details/:id" from SettingsRoute and "details/:id" from DuplicateRoute both match the same URL pattern.

--- a/packages/go_router_builder/test_inputs/duplicate_path_sibling_routes.dart.expect
+++ b/packages/go_router_builder/test_inputs/duplicate_path_sibling_routes.dart.expect
@@ -1,1 +1,1 @@
-Duplicate route path detected: "details/:id" from SettingsRoute and "details/:id" from DuplicateRoute both match the same URL pattern.
+Duplicate route path detected: "/home/details/:id" from SettingsRoute and "/home/details/:id" from DuplicateRoute both match the same URL pattern.

--- a/packages/go_router_builder/test_inputs/duplicate_path_sibling_routes.dart.options
+++ b/packages/go_router_builder/test_inputs/duplicate_path_sibling_routes.dart.options
@@ -1,0 +1,3 @@
+{
+  "duplicate_route_paths": "error"
+}

--- a/packages/go_router_builder/test_inputs/duplicate_path_warns_by_default.dart
+++ b/packages/go_router_builder/test_inputs/duplicate_path_warns_by_default.dart
@@ -1,0 +1,22 @@
+// Copyright 2013 The Flutter Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:go_router/go_router.dart';
+
+mixin $HomeRoute {}
+mixin $FirstRoute {}
+mixin $SecondRoute {}
+
+@TypedGoRoute<HomeRoute>(
+  path: '/home',
+  routes: <TypedGoRoute<GoRouteData>>[
+    TypedGoRoute<FirstRoute>(path: 'details'),
+    TypedGoRoute<SecondRoute>(path: 'details'),
+  ],
+)
+class HomeRoute extends GoRouteData with $HomeRoute {}
+
+class FirstRoute extends GoRouteData with $FirstRoute {}
+
+class SecondRoute extends GoRouteData with $SecondRoute {}

--- a/packages/go_router_builder/test_inputs/duplicate_path_warns_by_default.dart.expect
+++ b/packages/go_router_builder/test_inputs/duplicate_path_warns_by_default.dart.expect
@@ -1,0 +1,77 @@
+RouteBase get $homeRoute => GoRouteData.$route(
+  path: '/home',
+  hasOverriddenOnExit: false,
+  factory: $HomeRoute._fromState,
+  routes: [
+    GoRouteData.$route(
+      path: 'details',
+      hasOverriddenOnExit: false,
+      factory: $FirstRoute._fromState,
+    ),
+    GoRouteData.$route(
+      path: 'details',
+      hasOverriddenOnExit: false,
+      factory: $SecondRoute._fromState,
+    ),
+  ],
+);
+
+mixin $HomeRoute on GoRouteData {
+  static HomeRoute _fromState(GoRouterState state) => HomeRoute();
+
+  @override
+  String get location => GoRouteData.$location('/home');
+
+  @override
+  void go(BuildContext context) => context.go(location);
+
+  @override
+  Future<T?> push<T>(BuildContext context) => context.push<T>(location);
+
+  @override
+  void pushReplacement(BuildContext context) =>
+      context.pushReplacement(location);
+
+  @override
+  void replace(BuildContext context) => context.replace(location);
+}
+
+mixin $FirstRoute on GoRouteData {
+  static FirstRoute _fromState(GoRouterState state) => FirstRoute();
+
+  @override
+  String get location => GoRouteData.$location('/home/details');
+
+  @override
+  void go(BuildContext context) => context.go(location);
+
+  @override
+  Future<T?> push<T>(BuildContext context) => context.push<T>(location);
+
+  @override
+  void pushReplacement(BuildContext context) =>
+      context.pushReplacement(location);
+
+  @override
+  void replace(BuildContext context) => context.replace(location);
+}
+
+mixin $SecondRoute on GoRouteData {
+  static SecondRoute _fromState(GoRouterState state) => SecondRoute();
+
+  @override
+  String get location => GoRouteData.$location('/home/details');
+
+  @override
+  void go(BuildContext context) => context.go(location);
+
+  @override
+  Future<T?> push<T>(BuildContext context) => context.push<T>(location);
+
+  @override
+  void pushReplacement(BuildContext context) =>
+      context.pushReplacement(location);
+
+  @override
+  void replace(BuildContext context) => context.replace(location);
+}

--- a/packages/go_router_builder/test_inputs/duplicate_path_warns_by_default.dart.warnings
+++ b/packages/go_router_builder/test_inputs/duplicate_path_warns_by_default.dart.warnings
@@ -1,1 +1,1 @@
-Duplicate route path detected: "details" from FirstRoute and "details" from SecondRoute both match the same URL pattern.
+Duplicate route path detected: "/home/details" from FirstRoute and "/home/details" from SecondRoute both match the same URL pattern.

--- a/packages/go_router_builder/test_inputs/duplicate_path_warns_by_default.dart.warnings
+++ b/packages/go_router_builder/test_inputs/duplicate_path_warns_by_default.dart.warnings
@@ -1,0 +1,1 @@
+Duplicate route path detected: "details" from FirstRoute and "details" from SecondRoute both match the same URL pattern.

--- a/packages/go_router_builder/tool/run_tests.dart
+++ b/packages/go_router_builder/tool/run_tests.dart
@@ -29,7 +29,7 @@ Future<void> main() async {
       .where((File f) => f.path.endsWith('.dart'))
       .toList();
   for (final file in testFiles) {
-    final String fileName = file.path.split('/').last;
+    final String fileName = p.basename(file.path);
     final expectFile = File(p.join('${file.path}.expect'));
     if (!expectFile.existsSync()) {
       throw Exception(
@@ -53,9 +53,12 @@ Future<void> main() async {
     // file, one per line. Inputs that log nothing need no file, so an input that
     // starts logging a warning fails until the warning is declared.
     final warningsFile = File(p.join('${file.path}.warnings'));
-    final String expectedWarnings = warningsFile.existsSync()
-        ? warningsFile.readAsStringSync().trim()
-        : '';
+    final List<String> expectedWarnings = warningsFile.existsSync()
+        ? const LineSplitter()
+              .convert(warningsFile.readAsStringSync())
+              .where((String line) => line.isNotEmpty)
+              .toList()
+        : <String>[];
 
     test('verify $fileName', () async {
       // Normalize path separators for cross-platform compatibility
@@ -88,7 +91,7 @@ Future<void> main() async {
         await logs.cancel();
       }
 
-      expect(warnings.join('\n'), expectedWarnings);
+      expect(warnings, expectedWarnings);
 
       // Apply consistent formatting to both generated and expected code for comparison.
       final String generated = formatter.format(results.join('\n\n').trim());

--- a/packages/go_router_builder/tool/run_tests.dart
+++ b/packages/go_router_builder/tool/run_tests.dart
@@ -49,12 +49,13 @@ Future<void> main() async {
       duplicatePathSeverity: duplicatePathSeverityFromOptions(builderOptions),
     );
 
-    // A test input may assert the warnings the builder logs by adding a
-    // `.warnings` file, one warning per line. An empty file asserts silence.
+    // A test input declares the warnings the builder must log in a `.warnings`
+    // file, one per line. Inputs that log nothing need no file, so an input that
+    // starts logging a warning fails until the warning is declared.
     final warningsFile = File(p.join('${file.path}.warnings'));
-    final String? expectedWarnings = warningsFile.existsSync()
+    final String expectedWarnings = warningsFile.existsSync()
         ? warningsFile.readAsStringSync().trim()
-        : null;
+        : '';
 
     test('verify $fileName', () async {
       // Normalize path separators for cross-platform compatibility
@@ -87,15 +88,16 @@ Future<void> main() async {
         await logs.cancel();
       }
 
-      if (expectedWarnings != null) {
-        expect(warnings.join('\n'), expectedWarnings);
-      }
+      expect(warnings.join('\n'), expectedWarnings);
 
       // Apply consistent formatting to both generated and expected code for comparison.
       final String generated = formatter.format(results.join('\n\n').trim());
       final String expected = formatter.format(expectResult);
       _expectWithNormalizedNewlines(generated, expected);
-    }, timeout: const Timeout(Duration(seconds: 100)));
+      // Each case resolves its input against the real SDK and package sources,
+      // which takes seconds on an idle machine but far longer on a loaded one.
+      // The generous timeout keeps a busy bot from reporting a false failure.
+    }, timeout: const Timeout(Duration(minutes: 5)));
   }
 }
 

--- a/packages/go_router_builder/tool/run_tests.dart
+++ b/packages/go_router_builder/tool/run_tests.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:async';
+import 'dart:convert';
 import 'dart:io';
 import 'dart:isolate';
 
@@ -9,14 +11,14 @@ import 'package:analyzer/dart/element/element.dart';
 import 'package:build/build.dart';
 import 'package:build_test/build_test.dart';
 import 'package:dart_style/dart_style.dart' as dart_style;
+import 'package:go_router_builder/src/duplicate_path_severity.dart';
 import 'package:go_router_builder/src/go_router_generator.dart';
+import 'package:logging/logging.dart';
 import 'package:package_config/package_config.dart';
 import 'package:path/path.dart' as p;
 import 'package:pub_semver/pub_semver.dart';
 import 'package:source_gen/source_gen.dart';
 import 'package:test/test.dart';
-
-const GoRouterGenerator generator = GoRouterGenerator();
 
 Future<void> main() async {
   final formatter = dart_style.DartFormatter(languageVersion: await _packageVersion());
@@ -36,6 +38,24 @@ Future<void> main() async {
       );
     }
     final String expectResult = expectFile.readAsStringSync().trim();
+
+    // A test input may declare builder options in a `.options` file holding a
+    // JSON map, matching what `build.yaml` would pass to the builder.
+    final optionsFile = File(p.join('${file.path}.options'));
+    final BuilderOptions builderOptions = optionsFile.existsSync()
+        ? BuilderOptions(json.decode(optionsFile.readAsStringSync()) as Map<String, dynamic>)
+        : BuilderOptions.empty;
+    final generator = GoRouterGenerator(
+      duplicatePathSeverity: duplicatePathSeverityFromOptions(builderOptions),
+    );
+
+    // A test input may assert the warnings the builder logs by adding a
+    // `.warnings` file, one warning per line. An empty file asserts silence.
+    final warningsFile = File(p.join('${file.path}.warnings'));
+    final String? expectedWarnings = warningsFile.existsSync()
+        ? warningsFile.readAsStringSync().trim()
+        : null;
+
     test('verify $fileName', () async {
       // Normalize path separators for cross-platform compatibility
       final String path = file.path.replaceAll(r'\', '/');
@@ -50,11 +70,25 @@ Future<void> main() async {
       );
       final reader = LibraryReader(element);
       final results = <String>{};
+      // Outside a build step, `package:build`'s `log` falls back to a plain
+      // logger, whose records reach the root logger.
+      final warnings = <String>[];
+      final StreamSubscription<LogRecord> logs = Logger.root.onRecord.listen((LogRecord record) {
+        if (record.level >= Level.WARNING) {
+          warnings.add(record.message);
+        }
+      });
       try {
         generator.generateForAnnotation(reader, results, <String>{});
       } on InvalidGenerationSourceError catch (e) {
         _expectWithNormalizedNewlines(e.message.trim(), expectResult);
         return;
+      } finally {
+        await logs.cancel();
+      }
+
+      if (expectedWarnings != null) {
+        expect(warnings.join('\n'), expectedWarnings);
       }
 
       // Apply consistent formatting to both generated and expected code for comparison.


### PR DESCRIPTION
Adds build-time detection of routes that resolve to the same URL pattern. `go_router` matches the first route that fits, so a duplicated path silently makes the later route's page unreachable, and `LaterRoute().go(context)` navigates you to `EarlierRoute`'s page instead. Today nothing surfaces that until you run into the issue at runtime.

Reported as a warning by default, and  new `duplicate_route_paths` builder option accepts `warning` (the default), `error`, and `ignore`, so teams whose duplicates are mistakes can fail the build instead.

**Before**, `go_router_builder`'s own example app built clean despite two duplicate registrations:

```
$ dart run build_runner build
[INFO] Succeeded after 14s with 36 outputs
```

**After**:

```
$ dart run build_runner build
W go_router_builder on lib/all_types.dart:
  Duplicate route path detected: DoubleRoute is declared more than once at "double-route/:requiredDoubleField".
```

That duplicate was real. `DoubleRoute` had been registered twice since flutter/packages#2395 (2022) and `DoubleExtensionRoute` since flutter/packages#9458 (2025). Both were unreachable, and this PR removes them. The only change to the generated output is the dead route entries.

What competes for a URL namespace:

- Sibling routes, with path parameters normalized, so `product/:id` and `product/:productId` are one pattern.
- Routes inside shell routes and `StatefulShellRoute` branches, since those own no path of their own and their children compete with the routes around them.
- Relative routes, which own their path like any other route, so `/home/details/edit` and `/home/edit` stay distinct.
- Routes from separate annotations, since the generated `$appRoutes` collects them into one list. Scope is the library, `part` files included.

**Testing:** five new golden inputs in `test_inputs/` cover sibling duplicates, parameter-name-only differences, `StatefulShellRoute` branches, relative routes, cross-annotation duplicates, and the sound same-class grouping case. The golden harness gained two optional companion files per input, documented in the README: `<name>.dart.options` supplies JSON builder options so each severity is exercised through the real option-parsing path, and `<name>.dart.warnings` asserts logged warnings, with an empty file asserting silence.

Fixes flutter/flutter#190741

## Pre-Review Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [X] I read the [Tree Hygiene] page, which explains my responsibilities.
- [X] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [X] I signed the [CLA].
- [X] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [X] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under[^1].
- [X] I updated/added any relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[the version and CHANGELOG instructions]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version-and-changelog-updates
[semantic versioning]: https://dart.dev/tools/pub/versioning#semantic-versions
[repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
