### PR TITLE
[camera]fix test flake due to expectation fulfilled before flag is toggled

### DIFF
--- a/packages/camera/camera_avfoundation/darwin/Tests/CameraPluginDelegatingMethodTests.swift
+++ b/packages/camera/camera_avfoundation/darwin/Tests/CameraPluginDelegatingMethodTests.swift
@@ -319,8 +319,8 @@ final class CameraPluginDelegatingMethodTests: XCTestCase {
     var startVideoRecordingCalled = false
     mockCamera.startVideoRecordingStub = { completion, messenger in
       XCTAssertNotNil(messenger)
-      completion(.success(()))
       startVideoRecordingCalled = true
+      completion(.success(()))
     }
 
     cameraPlugin.startVideoRecording(enableStream: true) { result in
@@ -340,8 +340,8 @@ final class CameraPluginDelegatingMethodTests: XCTestCase {
     var startVideoRecordingCalled = false
     mockCamera.startVideoRecordingStub = { completion, messenger in
       XCTAssertNil(messenger)
-      completion(.success(()))
       startVideoRecordingCalled = true
+      completion(.success(()))
     }
 
     cameraPlugin.startVideoRecording(enableStream: false) { result in
@@ -362,8 +362,8 @@ final class CameraPluginDelegatingMethodTests: XCTestCase {
 
     var stopVideoRecordingCalled = false
     mockCamera.stopVideoRecordingStub = { completion in
-      completion(.success(targetPath))
       stopVideoRecordingCalled = true
+      completion(.success(targetPath))
     }
 
     cameraPlugin.stopVideoRecording { result in
@@ -409,8 +409,8 @@ final class CameraPluginDelegatingMethodTests: XCTestCase {
     var setExposurePointCalled = false
     mockCamera.setExposurePointStub = { point, completion in
       XCTAssertEqual(point, targetExposurePoint)
-      completion(.success(()))
       setExposurePointCalled = true
+      completion(.success(()))
     }
 
     cameraPlugin.setExposurePoint(point: targetExposurePoint) { result in
@@ -432,8 +432,8 @@ final class CameraPluginDelegatingMethodTests: XCTestCase {
     var setFlashModeCalled = false
     mockCamera.setFlashModeStub = { mode, completion in
       XCTAssertEqual(mode, targetFlashMode)
-      completion(.success(()))
       setFlashModeCalled = true
+      completion(.success(()))
     }
 
     cameraPlugin.setFlashMode(mode: targetFlashMode) { result in
@@ -455,8 +455,8 @@ final class CameraPluginDelegatingMethodTests: XCTestCase {
     var setFocusPointCalled = false
     mockCamera.setFocusPointStub = { point, completion in
       XCTAssertEqual(point, targetFocusPoint)
-      completion(.success(()))
       setFocusPointCalled = true
+      completion(.success(()))
     }
 
     cameraPlugin.setFocusPoint(point: targetFocusPoint) { result in
@@ -478,8 +478,8 @@ final class CameraPluginDelegatingMethodTests: XCTestCase {
     var setZoomLevelCalled = false
     mockCamera.setZoomLevelStub = { zoom, completion in
       XCTAssertEqual(zoom, targetZoomLevel)
-      completion(.success(()))
       setZoomLevelCalled = true
+      completion(.success(()))
     }
 
     cameraPlugin.setZoomLevel(zoom: targetZoomLevel) { result in
@@ -500,8 +500,8 @@ final class CameraPluginDelegatingMethodTests: XCTestCase {
 
     var captureToFileCalled = false
     mockCamera.captureToFileStub = { completion in
-      completion(.success(targetPath))
       captureToFileCalled = true
+      completion(.success(targetPath))
     }
 
     cameraPlugin.takePicture { result in
@@ -528,8 +528,8 @@ final class CameraPluginDelegatingMethodTests: XCTestCase {
     var setDescriptionWhileRecordingCalled = false
     mockCamera.setDescriptionWhileRecordingStub = { cameraName, completion in
       XCTAssertEqual(cameraName, targetCameraName)
-      completion(.success(()))
       setDescriptionWhileRecordingCalled = true
+      completion(.success(()))
     }
 
     cameraPlugin.updateDescriptionWhileRecording(cameraName: targetCameraName) { result in


### PR DESCRIPTION
The flake is due to `completion` block (which fulfills the expectation) being called too early, before the flag to test is actually toggled 

It flakes (rather than consistently fails) because we toggle the flag on capture session queue, while the test runs on main, resulting in a race.

Also audited all camera tests to check for similar bugs. 

*List which issues are fixed by this PR. You must list at least one issue.*

Fixes https://github.com/flutter/flutter/issues/189108

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under[^1].
**Comment: No version bump since it's test only**
- [ ] I updated/added any relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[the version and CHANGELOG instructions]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version-and-changelog-updates
[semantic versioning]: https://dart.dev/tools/pub/versioning#semantic-versions
[repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
