### PR TITLE
[video_player] Build an empty view when the player is already disposed

### DIFF
--- a/packages/video_player/video_player_android/CHANGELOG.md
+++ b/packages/video_player/video_player_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.12.1
+
+* Fixes a [bug](https://github.com/flutter/flutter/issues/190739) where building the view for a disposed player threw a `StateError` instead of building an empty view.
+
 ## 2.12.0
 
 * Fixes a [bug](https://github.com/flutter/flutter/issues/176575) where some videos report an incorrect duration when initialized without a video duration.

--- a/packages/video_player/video_player_android/lib/src/android_video_player.dart
+++ b/packages/video_player/video_player_android/lib/src/android_video_player.dart
@@ -198,9 +198,16 @@ class AndroidVideoPlayer extends VideoPlayerPlatform {
   @override
   Widget buildViewWithOptions(VideoViewOptions options) {
     final int playerId = options.playerId;
-    final VideoPlayerViewState viewState = _playerWith(id: playerId).viewState;
+    // Disposal and the next frame are not synchronized: a widget holding this player can be rebuilt
+    // after the player is gone (an AnimatedSwitcher transition, or a rebuild triggered by a
+    // configuration change once the platform has reclaimed the player). Build an empty view rather
+    // than throwing, since a build method that throws leaves the widget permanently broken.
+    final _PlayerInstance? player = _players[playerId];
+    if (player == null) {
+      return const SizedBox.shrink();
+    }
 
-    return switch (viewState) {
+    return switch (player.viewState) {
       VideoPlayerTextureViewState(:final int textureId) => Texture(textureId: textureId),
       VideoPlayerPlatformViewState() => PlatformViewPlayer(playerId: playerId),
     };

--- a/packages/video_player/video_player_android/pubspec.yaml
+++ b/packages/video_player/video_player_android/pubspec.yaml
@@ -2,7 +2,7 @@ name: video_player_android
 description: Android implementation of the video_player plugin.
 repository: https://github.com/flutter/packages/tree/main/packages/video_player/video_player_android
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+video_player%22
-version: 2.12.0
+version: 2.12.1
 
 environment:
   sdk: ^3.12.0

--- a/packages/video_player/video_player_android/test/android_video_player_test.dart
+++ b/packages/video_player/video_player_android/test/android_video_player_test.dart
@@ -107,6 +107,16 @@ void main() {
       verify(api.dispose(1));
     });
 
+    test('buildViewWithOptions returns an empty widget after the player is disposed', () async {
+      final (AndroidVideoPlayer player, _, _) = setUpMockPlayer(playerId: 1, textureId: 100);
+      await player.dispose(1);
+
+      // A disposed player can still be built: the widget stays mounted through the frame that
+      // follows disposal (an AnimatedSwitcher transition, or a rebuild from a configuration
+      // change), so building must degrade to an empty view rather than throw.
+      expect(player.buildViewWithOptions(const VideoViewOptions(playerId: 1)), isA<SizedBox>());
+    });
+
     test('create with asset', () async {
       final (AndroidVideoPlayer player, MockAndroidVideoPlayerApi api, _) = setUpMockPlayer(
         playerId: 1,

--- a/packages/video_player/video_player_avfoundation/CHANGELOG.md
+++ b/packages/video_player/video_player_avfoundation/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.11.1
+
+* Fixes a [bug](https://github.com/flutter/flutter/issues/190739) where building the view for a disposed player threw a `StateError` instead of building an empty view.
+
 ## 2.11.0
 
 * Implements `setPreventsDisplaySleepDuringVideoPlayback` using

--- a/packages/video_player/video_player_avfoundation/lib/src/avfoundation_video_player.dart
+++ b/packages/video_player/video_player_avfoundation/lib/src/avfoundation_video_player.dart
@@ -301,9 +301,16 @@ class AVFoundationVideoPlayer extends VideoPlayerPlatform {
   @override
   Widget buildViewWithOptions(VideoViewOptions options) {
     final int playerId = options.playerId;
-    final VideoPlayerViewState viewState = _playerWith(id: playerId).viewState;
+    // Disposal and the next frame are not synchronized: a widget holding this player can be rebuilt
+    // after the player is gone (an AnimatedSwitcher transition, or a rebuild triggered by a
+    // configuration change once the platform has reclaimed the player). Build an empty view rather
+    // than throwing, since a build method that throws leaves the widget permanently broken.
+    final _PlayerInstance? player = _players[playerId];
+    if (player == null) {
+      return const SizedBox.shrink();
+    }
 
-    return switch (viewState) {
+    return switch (player.viewState) {
       VideoPlayerTextureViewState(:final int textureId) => Texture(textureId: textureId),
       VideoPlayerPlatformViewState() => _buildPlatformView(playerId),
     };

--- a/packages/video_player/video_player_avfoundation/pubspec.yaml
+++ b/packages/video_player/video_player_avfoundation/pubspec.yaml
@@ -2,7 +2,7 @@ name: video_player_avfoundation
 description: iOS and macOS implementation of the video_player plugin.
 repository: https://github.com/flutter/packages/tree/main/packages/video_player/video_player_avfoundation
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+video_player%22
-version: 2.11.0
+version: 2.11.1
 
 environment:
   sdk: ^3.10.0

--- a/packages/video_player/video_player_avfoundation/test/avfoundation_video_player_test.dart
+++ b/packages/video_player/video_player_avfoundation/test/avfoundation_video_player_test.dart
@@ -60,6 +60,16 @@ void main() {
       verify(playerApi.dispose());
     });
 
+    test('buildViewWithOptions returns an empty widget after the player is disposed', () async {
+      final (AVFoundationVideoPlayer player, _, _) = setUpMockPlayer(playerId: 1, textureId: 101);
+      await player.dispose(1);
+
+      // A disposed player can still be built: the widget stays mounted through the frame that
+      // follows disposal (an AnimatedSwitcher transition, or a rebuild from a configuration
+      // change), so building must degrade to an empty view rather than throw.
+      expect(player.buildViewWithOptions(const VideoViewOptions(playerId: 1)), isA<SizedBox>());
+    });
+
     test('create with asset', () async {
       final (AVFoundationVideoPlayer player, MockAVFoundationVideoPlayerApi api, _) =
           setUpMockPlayer(playerId: 1, textureId: 101);


### PR DESCRIPTION
`buildViewWithOptions` resolves the player through `_playerWith`, which throws a `StateError` when the id is no longer present in `_players`. Disposal and the next frame are not synchronized, so a widget still holding a disposed player can be rebuilt during an `AnimatedSwitcher` transition, or by a rebuild that a configuration change triggers once the platform has reclaimed the player. Because this runs inside `build`, the throw leaves the video view permanently broken rather than simply rendering nothing.

Both platform implementations now look the player up directly and build an empty view when it is gone.

Fixes https://github.com/flutter/flutter/issues/190739

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under[^1].
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [x] All existing and new tests are passing.

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[the version and CHANGELOG instructions]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version-and-changelog-updates
[semantic versioning]: https://dart.dev/tools/pub/versioning#semantic-versions
[repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
