### PR TITLE
Update ci for + releases

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -7,9 +7,9 @@
 #  * https://github.com/flutter/cocoon/blob/main/CI_YAML.md
 enabled_branches:
   - main
-  - release-go_router-\d+\.\d+\.\d+
-  - release-cupertino_ui-\d+\.\d+\.\d+
-  - release-material_ui-\d+\.\d+\.\d+
+  - release-go_router-\d+\.\d+\.\d+(?:-[\w.]+)?(?:\+[\w.]+)?
+  - release-cupertino_ui-\d+\.\d+\.\d+(?:-[\w.]+)?(?:\+[\w.]+)?
+  - release-material_ui-\d+\.\d+\.\d+(?:-[\w.]+)?(?:\+[\w.]+)?
 
 platform_properties:
   linux:

--- a/script/tool/lib/src/validators/repo_info_validator.dart
+++ b/script/tool/lib/src/validators/repo_info_validator.dart
@@ -403,18 +403,20 @@ class RepoInfoValidator {
     final enabledBranches = yaml['enabled_branches'] as YamlList?;
     final bool hasBranchPattern =
         enabledBranches != null &&
-        enabledBranches.contains(r'release-' + packageName + r'-\d+\.\d+\.\d+');
+        enabledBranches.contains(
+          r'release-' + packageName + r'-\d+\.\d+\.\d+(?:-[\w.]+)?(?:\+[\w.]+)?',
+        );
 
     if (isBatchRelease && !hasBranchPattern) {
       printError(
-        '${_indentation}Missing release branch pattern release-$packageName-\\d+\\.\\d+\\.\\d+ '
+        '${_indentation}Missing release branch pattern release-$packageName-\\d+\\.\\d+\\.\\d+(?:-[\\w.]+)?(?:\\+[\\w.]+)? '
         'in enabled_branches in .ci.yaml\n'
         '${_indentation}See https://github.com/flutter/flutter/blob/master/docs/ecosystem/release/README.md#batch-release',
       );
       errors.add('Unexpected branch handling in .ci.yaml');
     } else if (!isBatchRelease && hasBranchPattern) {
       printError(
-        '${_indentation}Unexpected release branch pattern release-$packageName-\\d+\\.\\d+\\.\\d+ '
+        '${_indentation}Unexpected release branch pattern release-$packageName-\\d+\\.\\d+\\.\\d+(?:-[\\w.]+)?(?:\\+[\\w.]+)? '
         'in enabled_branches in .ci.yaml',
       );
       errors.add('Unexpected branch handling in .ci.yaml');

--- a/script/tool/test/validate_command_repo_info_test.dart
+++ b/script/tool/test/validate_command_repo_info_test.dart
@@ -696,7 +696,7 @@ release:
         root.childFile('.ci.yaml').writeAsStringSync(r'''
 enabled_branches:
   - main
-  - release-a_package-\d+\.\d+\.\d+
+  - release-a_package-\d+\.\d+\.\d+(?:-[\w.]+)?(?:\+[\w.]+)?
 ''');
       }
     }
@@ -991,7 +991,7 @@ enabled_branches:
           output,
           contains(
             contains(
-              r'Missing release branch pattern release-a_package-\d+\.\d+\.\d+ in enabled_branches in .ci.yaml',
+              r'Missing release branch pattern release-a_package-\d+\.\d+\.\d+(?:-[\w.]+)?(?:\+[\w.]+)? in enabled_branches in .ci.yaml',
             ),
           ),
         );
@@ -1006,7 +1006,7 @@ enabled_branches:
         root.childFile('.ci.yaml').writeAsStringSync(r'''
 enabled_branches:
   - main
-  - release-a_package-\d+\.\d+\.\d+
+  - release-a_package-\d+\.\d+\.\d+(?:-[\w.]+)?(?:\+[\w.]+)?
 ''');
 
         Error? commandError;
@@ -1023,7 +1023,7 @@ enabled_branches:
           output,
           contains(
             contains(
-              r'Unexpected release branch pattern release-a_package-\d+\.\d+\.\d+ in enabled_branches in .ci.yaml',
+              r'Unexpected release branch pattern release-a_package-\d+\.\d+\.\d+(?:-[\w.]+)?(?:\+[\w.]+)? in enabled_branches in .ci.yaml',
             ),
           ),
         );


### PR DESCRIPTION
Updates the `enabled_branches` regex patterns in `.ci.yaml` to support SemVer release branch names with optional pre-release tags (e.g., `-dev.1`) and build metadata suffixes (e.g., `+1`).

Previously, `enabled_branches` used the strict pattern `release-<package>-\d+\.\d+\.\d+`.
When release branches were created with build metadata suffixes (e.g., `release-material_ui-0.0.3+1`), Cocoon CI failed validation with:

> `release-material_ui-0.0.3+1 is not enabled for this .ci.yaml. Add it to run tests against this PR.`

Blocked PRs:
- https://github.com/flutter/packages/pull/12412
- https://github.com/flutter/packages/pull/12410

Updated the regex for release branches to `release-<package>-\d+\.\d+\.\d+(?:-[\w.]+)?(?:\+[\w.]+)?`, allowing valid SemVer pre-release and build metadata identifiers while maintaining strict matching against non-version branch names.

### Pattern Verification Examples

| Branch Name | Match Result | Status |
| --- | --- | --- |
| `release-material_ui-0.0.3` | **Match** | ✅ Standard SemVer |
| `release-material_ui-0.0.3+1` | **Match** | ✅ Build metadata suffix |
| `release-material_ui-0.0.3-dev.1+2` | **Match** | ✅ Pre-release & build metadata |
| `release-material_ui-invalid-branch` | **No Match** | ❌ Rejected |

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under[^1].
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[the version and CHANGELOG instructions]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version-and-changelog-updates
[semantic versioning]: https://dart.dev/tools/pub/versioning#semantic-versions
[repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
