### PR TITLE
[go_router] Fix pages dropped when switching to an unloaded branch

### DIFF
--- a/packages/go_router/lib/src/route.dart
+++ b/packages/go_router/lib/src/route.dart
@@ -1503,7 +1503,7 @@ class StatefulNavigationShellState extends State<StatefulNavigationShell> with R
       newShellMatch = match is ShellRouteMatch && match.route == route ? match : newShellMatch;
       return newShellMatch == null;
     });
-    if (newShellMatch == null || initialMatchList.error != null) {
+    if (newShellMatch == null) {
       return null;
     }
 

--- a/packages/go_router/lib/src/route.dart
+++ b/packages/go_router/lib/src/route.dart
@@ -1490,9 +1490,9 @@ class StatefulNavigationShellState extends State<StatefulNavigationShell> with R
   /// route.
   ///
   /// Switching to a branch without preserved state must not drop pages the
-  /// parent Navigators have below the shell route, so the shell match for the
-  /// initial branch location is grafted into the current match list instead
-  /// of navigating from scratch. See
+  /// parent Navigators have below the shell route. This grafts the shell match
+  /// for the initial branch location into the current match list instead of
+  /// navigating from scratch. See
   /// https://github.com/flutter/flutter/issues/188295.
   RouteMatchList? _initialMatchListForBranch(int index) {
     final RouteMatchList initialMatchList = _router.configuration.findMatch(
@@ -1527,7 +1527,7 @@ class StatefulNavigationShellState extends State<StatefulNavigationShell> with R
       matches: matches,
       uri: initialMatchList.uri,
       // The branch is navigated to as if by [GoRouter.go], which carries no
-      // extra, so the object the outer location was given must not leak into it.
+      // extra. The object the outer location was given must not leak into it.
       extra: initialMatchList.extra,
       pathParameters: <String, String>{
         ...currentMatchList.pathParameters,

--- a/packages/go_router/lib/src/route.dart
+++ b/packages/go_router/lib/src/route.dart
@@ -1500,8 +1500,11 @@ class StatefulNavigationShellState extends State<StatefulNavigationShell> with R
     );
     ShellRouteMatch? newShellMatch;
     initialMatchList.visitRouteMatches((RouteMatchBase match) {
-      newShellMatch = match is ShellRouteMatch && match.route == route ? match : newShellMatch;
-      return newShellMatch == null;
+      if (match is ShellRouteMatch && match.route == route) {
+        newShellMatch = match;
+        return false;
+      }
+      return true;
     });
     if (newShellMatch == null) {
       return null;

--- a/packages/go_router/lib/src/route.dart
+++ b/packages/go_router/lib/src/route.dart
@@ -1523,9 +1523,12 @@ class StatefulNavigationShellState extends State<StatefulNavigationShell> with R
       widget.shellRouteContext.routeMatchList,
     );
     final List<RouteMatchBase> matches = replaceShellMatch(currentMatchList.matches);
-    return currentMatchList.copyWith(
+    return RouteMatchList(
       matches: matches,
       uri: initialMatchList.uri,
+      // The branch is navigated to as if by [GoRouter.go], which carries no
+      // extra, so the object the outer location was given must not leak into it.
+      extra: initialMatchList.extra,
       pathParameters: <String, String>{
         ...currentMatchList.pathParameters,
         ...initialMatchList.pathParameters,

--- a/packages/go_router/lib/src/route.dart
+++ b/packages/go_router/lib/src/route.dart
@@ -1476,8 +1476,61 @@ class StatefulNavigationShellState extends State<StatefulNavigationShell> with R
     if (matchList != null && matchList.isNotEmpty) {
       _router.restore(matchList);
     } else {
-      _router.go(widget._effectiveInitialBranchLocation(index));
+      final RouteMatchList? initialMatchList = _initialMatchListForBranch(index);
+      if (initialMatchList != null) {
+        _router.restore(initialMatchList);
+      } else {
+        _router.go(widget._effectiveInitialBranchLocation(index));
+      }
     }
+  }
+
+  /// Builds the match list for the initial location of the branch at [index],
+  /// keeping the parts of the current match list that lie outside this shell
+  /// route.
+  ///
+  /// Switching to a branch without preserved state must not drop pages the
+  /// parent Navigators have below the shell route, so the shell match for the
+  /// initial branch location is grafted into the current match list instead
+  /// of navigating from scratch. See
+  /// https://github.com/flutter/flutter/issues/188295.
+  RouteMatchList? _initialMatchListForBranch(int index) {
+    final RouteMatchList initialMatchList = _router.configuration.findMatch(
+      Uri.parse(widget._effectiveInitialBranchLocation(index)),
+    );
+    ShellRouteMatch? newShellMatch;
+    initialMatchList.visitRouteMatches((RouteMatchBase match) {
+      newShellMatch = match is ShellRouteMatch && match.route == route ? match : newShellMatch;
+      return newShellMatch == null;
+    });
+    if (newShellMatch == null || initialMatchList.error != null) {
+      return null;
+    }
+
+    List<RouteMatchBase> replaceShellMatch(List<RouteMatchBase> matches) {
+      return matches.map((RouteMatchBase match) {
+        if (match is ShellRouteMatch) {
+          if (match.route == route) {
+            return newShellMatch!;
+          }
+          return match.copyWith(matches: replaceShellMatch(match.matches));
+        }
+        return match;
+      }).toList();
+    }
+
+    final RouteMatchList currentMatchList = _scopedMatchList(
+      widget.shellRouteContext.routeMatchList,
+    );
+    final List<RouteMatchBase> matches = replaceShellMatch(currentMatchList.matches);
+    return currentMatchList.copyWith(
+      matches: matches,
+      uri: initialMatchList.uri,
+      pathParameters: <String, String>{
+        ...currentMatchList.pathParameters,
+        ...initialMatchList.pathParameters,
+      },
+    );
   }
 
   @override

--- a/packages/go_router/pending_changelogs/change_2026_08_09_1786291908038.yaml
+++ b/packages/go_router/pending_changelogs/change_2026_08_09_1786291908038.yaml
@@ -1,0 +1,3 @@
+changelog: |
+  - Fixes pages on parent navigators being dropped when switching to a not yet loaded branch of a `StatefulShellRoute`.
+version: patch

--- a/packages/go_router/test/go_router_test.dart
+++ b/packages/go_router/test/go_router_test.dart
@@ -3211,6 +3211,61 @@ void main() {
       expect(matches.pathParameters['pid'], pid);
     });
 
+    testWidgets('StatefulShellRoute keeps parent navigator pages when switching '
+        'to an unloaded branch', (WidgetTester tester) async {
+      // Regression test for https://github.com/flutter/flutter/issues/188295
+      StatefulNavigationShell? routeState;
+      final routes = <RouteBase>[
+        GoRoute(
+          path: '/',
+          builder: (BuildContext context, GoRouterState state) => const Text('Home'),
+        ),
+        StatefulShellRoute.indexedStack(
+          builder:
+              (BuildContext context, GoRouterState state, StatefulNavigationShell navigationShell) {
+                routeState = navigationShell;
+                return navigationShell;
+              },
+          branches: <StatefulShellBranch>[
+            StatefulShellBranch(
+              routes: <RouteBase>[
+                GoRoute(
+                  path: '/a',
+                  builder: (BuildContext context, GoRouterState state) => const Text('Screen A'),
+                ),
+              ],
+            ),
+            StatefulShellBranch(
+              routes: <RouteBase>[
+                GoRoute(
+                  path: '/b',
+                  builder: (BuildContext context, GoRouterState state) => const Text('Screen B'),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ];
+
+      final GoRouter router = await createRouter(routes, tester);
+      expect(find.text('Home'), findsOneWidget);
+
+      router.push('/a');
+      await tester.pumpAndSettle();
+      expect(find.text('Screen A'), findsOneWidget);
+      expect(router.canPop(), isTrue);
+
+      routeState!.goBranch(1);
+      await tester.pumpAndSettle();
+      expect(find.text('Screen B'), findsOneWidget);
+      expect(router.routerDelegate.currentConfiguration.uri.toString(), '/b');
+      expect(router.canPop(), isTrue);
+
+      router.pop();
+      await tester.pumpAndSettle();
+      expect(find.text('Home'), findsOneWidget);
+    });
+
     testWidgets('StatefulShellRoute preserve extra when switching branch', (
       WidgetTester tester,
     ) async {

--- a/packages/go_router/test/go_router_test.dart
+++ b/packages/go_router/test/go_router_test.dart
@@ -3266,6 +3266,57 @@ void main() {
       expect(find.text('Home'), findsOneWidget);
     });
 
+    testWidgets('StatefulShellRoute does not carry extra into an unloaded branch', (
+      WidgetTester tester,
+    ) async {
+      StatefulNavigationShell? routeState;
+      Object? extraOnB;
+      final routes = <RouteBase>[
+        StatefulShellRoute.indexedStack(
+          builder:
+              (BuildContext context, GoRouterState state, StatefulNavigationShell navigationShell) {
+                routeState = navigationShell;
+                return navigationShell;
+              },
+          branches: <StatefulShellBranch>[
+            StatefulShellBranch(
+              routes: <RouteBase>[
+                GoRoute(
+                  path: '/a',
+                  builder: (BuildContext context, GoRouterState state) => const Text('Screen A'),
+                ),
+              ],
+            ),
+            StatefulShellBranch(
+              routes: <RouteBase>[
+                GoRoute(
+                  path: '/b',
+                  builder: (BuildContext context, GoRouterState state) {
+                    extraOnB = state.extra;
+                    return const Text('Screen B');
+                  },
+                ),
+              ],
+            ),
+          ],
+        ),
+      ];
+
+      final GoRouter router = await createRouter(
+        routes,
+        tester,
+        initialLocation: '/a',
+        initialExtra: Object(),
+      );
+      expect(find.text('Screen A'), findsOneWidget);
+
+      routeState!.goBranch(1);
+      await tester.pumpAndSettle();
+      expect(find.text('Screen B'), findsOneWidget);
+      expect(extraOnB, isNull);
+      expect(router.routerDelegate.currentConfiguration.uri.toString(), '/b');
+    });
+
     testWidgets('StatefulShellRoute preserve extra when switching branch', (
       WidgetTester tester,
     ) async {


### PR DESCRIPTION
Switching a `StatefulShellRoute` to a branch that has not been loaded yet drops the pages a parent Navigator holds below the shell, which is why the back button disappears in the issue's repro. `goBranch` with `initialLocation: true` takes the same path. Both call `_router.go` with the branch's initial location. `go` rebuilds the match list from that location alone.

This grafts the shell match for the initial location into the current match list so the parent's matches survive, and takes `extra` from that location's match list so the outer `extra` does not leak in. A location with no shell match still goes through `go`.

A branch initial location that redirects still loses the graft, since `restore` keeps the supplied list only when the URI is unchanged. The shell lookup also repeats the one in `_preloadBranches`. I raised both on the issue on 07-31 and took the smaller change here.

Fixes flutter/flutter#188295

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under[^1].
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [x] All existing and new tests are passing.

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[the version and CHANGELOG instructions]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version-and-changelog-updates
[semantic versioning]: https://dart.dev/tools/pub/versioning#semantic-versions
[repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests