### PR TITLE
[material_ui, cupertino_ui] Prepare to release 1.0.0

### DIFF
--- a/packages/cupertino_ui/pending_changelogs/change_2026_08_10_release.yaml
+++ b/packages/cupertino_ui/pending_changelogs/change_2026_08_10_release.yaml
@@ -1,0 +1,3 @@
+changelog: |
+  - Promotes the pre-release to 1.0.0.
+version: promote

--- a/packages/material_ui/pending_changelogs/change_2026_08_10_release.yaml
+++ b/packages/material_ui/pending_changelogs/change_2026_08_10_release.yaml
@@ -1,0 +1,3 @@
+changelog: |
+  - Promotes the pre-release to 1.0.0.
+version: promote


### PR DESCRIPTION
This PR adds the pending changelog for bumping material_ui and cupertino_ui to 1.0.0. It probably shouldn't be landed until Wednesday to avoid the chance that someone triggers a batch release early.