### PR TITLE
[CI] Update deps script

### DIFF
--- a/script/tool/lib/src/make_deps_path_based_command.dart
+++ b/script/tool/lib/src/make_deps_path_based_command.dart
@@ -157,7 +157,8 @@ class MakeDepsPathBasedCommand extends PackageCommand {
       return RepositoryPackage(thirdPartyCandidate);
     }
     for (final FileSystemEntity entity in packagesDir.listSync()) {
-      if (entity is Directory && packageName.startsWith(entity.basename)) {
+      if (entity is Directory &&
+          (packageName == entity.basename || packageName.startsWith('${entity.basename}_'))) {
         final Directory subPackageCandidate = entity.childDirectory(packageName);
         if (subPackageCandidate.childFile('pubspec.yaml').existsSync()) {
           return RepositoryPackage(subPackageCandidate);
@@ -294,10 +295,7 @@ ${newOverrideLines.join('\n')}
         example,
         localDependencies,
         versions,
-        additionalPackagesToOverride: <String>{
-          ...packagesToOverride,
-          package.directory.basename,
-        },
+        additionalPackagesToOverride: <String>{...packagesToOverride, package.parsePubspec().name},
       );
     }
 

--- a/script/tool/lib/src/make_deps_path_based_command.dart
+++ b/script/tool/lib/src/make_deps_path_based_command.dart
@@ -110,62 +110,43 @@ class MakeDepsPathBasedCommand extends PackageCommand {
 
   Map<String, RepositoryPackage> _findLocalPackages(Set<String> packageNames) {
     final targets = <String, RepositoryPackage>{};
-    final queue = List<String>.from(packageNames);
-
-    while (queue.isNotEmpty) {
-      final String packageName = queue.removeLast();
-      if (targets.containsKey(packageName)) {
+    for (final packageName in packageNames) {
+      final Directory topLevelCandidate = packagesDir.childDirectory(packageName);
+      // If packages/<packageName>/ exists, then either that directory is the
+      // package, or packages/<packageName>/<packageName>/ exists and is the
+      // package (in the case of a federated plugin).
+      if (topLevelCandidate.existsSync()) {
+        final Directory appFacingCandidate = topLevelCandidate.childDirectory(packageName);
+        targets[packageName] = RepositoryPackage(
+          appFacingCandidate.existsSync() ? appFacingCandidate : topLevelCandidate,
+        );
         continue;
       }
-      final RepositoryPackage? package = _findLocalPackage(packageName);
-      if (package == null) {
-        if (packageNames.contains(packageName)) {
-          printError('Unable to find package "$packageName"');
-          throw ToolExit(_exitPackageNotFound);
-        }
+      // Check for a match in the third-party packages directory.
+      final Directory thirdPartyCandidate = thirdPartyPackagesDir.childDirectory(packageName);
+      if (thirdPartyCandidate.existsSync()) {
+        targets[packageName] = RepositoryPackage(thirdPartyCandidate);
         continue;
       }
-      targets[packageName] = package;
-
-      // Expand to include local in-repo dependencies of target packages to prevent
-      // pub version solving conflicts when co-dependent packages are tested with path dependencies.
-      final Pubspec pubspec = package.parsePubspec();
-      for (final depName in <String>[
-        ...pubspec.dependencies.keys,
-        ...pubspec.devDependencies.keys,
-      ]) {
-        if (!targets.containsKey(depName)) {
-          queue.add(depName);
+      // If there is no packages/<packageName> directory, then either the
+      // packages doesn't exist, or it is a sub-package of a federated plugin.
+      // If it's the latter, it will be a directory whose name is a prefix.
+      for (final FileSystemEntity entity in packagesDir.listSync()) {
+        if (entity is Directory && packageName.startsWith(entity.basename)) {
+          final Directory subPackageCandidate = entity.childDirectory(packageName);
+          if (subPackageCandidate.existsSync()) {
+            targets[packageName] = RepositoryPackage(subPackageCandidate);
+            break;
+          }
         }
+      }
+
+      if (!targets.containsKey(packageName)) {
+        printError('Unable to find package "$packageName"');
+        throw ToolExit(_exitPackageNotFound);
       }
     }
     return targets;
-  }
-
-  RepositoryPackage? _findLocalPackage(String packageName) {
-    final Directory topLevelCandidate = packagesDir.childDirectory(packageName);
-    if (topLevelCandidate.childFile('pubspec.yaml').existsSync()) {
-      final Directory appFacingCandidate = topLevelCandidate.childDirectory(packageName);
-      return RepositoryPackage(
-        appFacingCandidate.childFile('pubspec.yaml').existsSync()
-            ? appFacingCandidate
-            : topLevelCandidate,
-      );
-    }
-    final Directory thirdPartyCandidate = thirdPartyPackagesDir.childDirectory(packageName);
-    if (thirdPartyCandidate.childFile('pubspec.yaml').existsSync()) {
-      return RepositoryPackage(thirdPartyCandidate);
-    }
-    for (final FileSystemEntity entity in packagesDir.listSync()) {
-      if (entity is Directory &&
-          (packageName == entity.basename || packageName.startsWith('${entity.basename}_'))) {
-        final Directory subPackageCandidate = entity.childDirectory(packageName);
-        if (subPackageCandidate.childFile('pubspec.yaml').existsSync()) {
-          return RepositoryPackage(subPackageCandidate);
-        }
-      }
-    }
-    return null;
   }
 
   /// If [pubspecFile] has any non-path dependencies on packages in
@@ -255,7 +236,10 @@ class MakeDepsPathBasedCommand extends PackageCommand {
 
         // Find the relative path from the common base to the local package.
         final List<String> repoRelativePathComponents = path.split(
-          path.relative(localDependencies[packageName]!.path, from: repoRootPath),
+          path.relative(
+            localDependencies[packageName]!.directory.absolute.path,
+            from: repoRootPath,
+          ),
         );
         final String pathValue = p.posix.joinAll(<String>[
           ...relativeBasePathComponents,
@@ -291,11 +275,12 @@ ${newOverrideLines.join('\n')}
     // example app doesn't. Since integration tests are run in the example app,
     // it needs the overrides in order for tests to pass.
     for (final RepositoryPackage example in package.getExamples()) {
+      final String parentPackageName = package.parsePubspec().name;
       await _addDependencyOverridesIfNecessary(
         example,
-        localDependencies,
+        <String, RepositoryPackage>{...localDependencies, parentPackageName: package},
         versions,
-        additionalPackagesToOverride: <String>{...packagesToOverride, package.parsePubspec().name},
+        additionalPackagesToOverride: <String>{...packagesToOverride, parentPackageName},
       );
     }
 

--- a/script/tool/lib/src/make_deps_path_based_command.dart
+++ b/script/tool/lib/src/make_deps_path_based_command.dart
@@ -280,6 +280,8 @@ ${newOverrideLines.join('\n')}
         example,
         <String, RepositoryPackage>{...localDependencies, parentPackageName: package},
         versions,
+        // Add an override to the parent package in case a transitive dependency has a dependency on it,
+        // since that (non-path) dependency would conflict with the path-based dependency in the example.
         additionalPackagesToOverride: <String>{...packagesToOverride, parentPackageName},
       );
     }

--- a/script/tool/lib/src/make_deps_path_based_command.dart
+++ b/script/tool/lib/src/make_deps_path_based_command.dart
@@ -113,7 +113,7 @@ class MakeDepsPathBasedCommand extends PackageCommand {
     final queue = List<String>.from(packageNames);
 
     while (queue.isNotEmpty) {
-      final packageName = queue.removeLast();
+      final String packageName = queue.removeLast();
       if (targets.containsKey(packageName)) {
         continue;
       }
@@ -130,7 +130,7 @@ class MakeDepsPathBasedCommand extends PackageCommand {
       // Expand to include local in-repo dependencies of target packages to prevent
       // pub version solving conflicts when co-dependent packages are tested with path dependencies.
       final Pubspec pubspec = package.parsePubspec();
-      for (final String depName in <String>[
+      for (final depName in <String>[
         ...pubspec.dependencies.keys,
         ...pubspec.devDependencies.keys,
       ]) {

--- a/script/tool/lib/src/make_deps_path_based_command.dart
+++ b/script/tool/lib/src/make_deps_path_based_command.dart
@@ -110,43 +110,61 @@ class MakeDepsPathBasedCommand extends PackageCommand {
 
   Map<String, RepositoryPackage> _findLocalPackages(Set<String> packageNames) {
     final targets = <String, RepositoryPackage>{};
-    for (final packageName in packageNames) {
-      final Directory topLevelCandidate = packagesDir.childDirectory(packageName);
-      // If packages/<packageName>/ exists, then either that directory is the
-      // package, or packages/<packageName>/<packageName>/ exists and is the
-      // package (in the case of a federated plugin).
-      if (topLevelCandidate.existsSync()) {
-        final Directory appFacingCandidate = topLevelCandidate.childDirectory(packageName);
-        targets[packageName] = RepositoryPackage(
-          appFacingCandidate.existsSync() ? appFacingCandidate : topLevelCandidate,
-        );
-        continue;
-      }
-      // Check for a match in the third-party packages directory.
-      final Directory thirdPartyCandidate = thirdPartyPackagesDir.childDirectory(packageName);
-      if (thirdPartyCandidate.existsSync()) {
-        targets[packageName] = RepositoryPackage(thirdPartyCandidate);
-        continue;
-      }
-      // If there is no packages/<packageName> directory, then either the
-      // packages doesn't exist, or it is a sub-package of a federated plugin.
-      // If it's the latter, it will be a directory whose name is a prefix.
-      for (final FileSystemEntity entity in packagesDir.listSync()) {
-        if (entity is Directory && packageName.startsWith(entity.basename)) {
-          final Directory subPackageCandidate = entity.childDirectory(packageName);
-          if (subPackageCandidate.existsSync()) {
-            targets[packageName] = RepositoryPackage(subPackageCandidate);
-            break;
-          }
-        }
-      }
+    final queue = List<String>.from(packageNames);
 
-      if (!targets.containsKey(packageName)) {
-        printError('Unable to find package "$packageName"');
-        throw ToolExit(_exitPackageNotFound);
+    while (queue.isNotEmpty) {
+      final packageName = queue.removeLast();
+      if (targets.containsKey(packageName)) {
+        continue;
+      }
+      final RepositoryPackage? package = _findLocalPackage(packageName);
+      if (package == null) {
+        if (packageNames.contains(packageName)) {
+          printError('Unable to find package "$packageName"');
+          throw ToolExit(_exitPackageNotFound);
+        }
+        continue;
+      }
+      targets[packageName] = package;
+
+      // Expand to include local in-repo dependencies of target packages to prevent
+      // pub version solving conflicts when co-dependent packages are tested with path dependencies.
+      final Pubspec pubspec = package.parsePubspec();
+      for (final String depName in <String>[
+        ...pubspec.dependencies.keys,
+        ...pubspec.devDependencies.keys,
+      ]) {
+        if (!targets.containsKey(depName)) {
+          queue.add(depName);
+        }
       }
     }
     return targets;
+  }
+
+  RepositoryPackage? _findLocalPackage(String packageName) {
+    final Directory topLevelCandidate = packagesDir.childDirectory(packageName);
+    if (topLevelCandidate.childFile('pubspec.yaml').existsSync()) {
+      final Directory appFacingCandidate = topLevelCandidate.childDirectory(packageName);
+      return RepositoryPackage(
+        appFacingCandidate.childFile('pubspec.yaml').existsSync()
+            ? appFacingCandidate
+            : topLevelCandidate,
+      );
+    }
+    final Directory thirdPartyCandidate = thirdPartyPackagesDir.childDirectory(packageName);
+    if (thirdPartyCandidate.childFile('pubspec.yaml').existsSync()) {
+      return RepositoryPackage(thirdPartyCandidate);
+    }
+    for (final FileSystemEntity entity in packagesDir.listSync()) {
+      if (entity is Directory && packageName.startsWith(entity.basename)) {
+        final Directory subPackageCandidate = entity.childDirectory(packageName);
+        if (subPackageCandidate.childFile('pubspec.yaml').existsSync()) {
+          return RepositoryPackage(subPackageCandidate);
+        }
+      }
+    }
+    return null;
   }
 
   /// If [pubspecFile] has any non-path dependencies on packages in
@@ -276,7 +294,10 @@ ${newOverrideLines.join('\n')}
         example,
         localDependencies,
         versions,
-        additionalPackagesToOverride: packagesToOverride,
+        additionalPackagesToOverride: <String>{
+          ...packagesToOverride,
+          package.directory.basename,
+        },
       );
     }
 

--- a/script/tool/test/make_deps_path_based_command_test.dart
+++ b/script/tool/test/make_deps_path_based_command_test.dart
@@ -170,21 +170,19 @@ ${overrides.map((String dep) => '  $dep:\n    path: $path').join('\n')}
     expect(output, isNot(contains('  Modified packages/bar/bar_platform_interface/pubspec.yaml')));
 
     final Map<String, String?> simplePackageOverrides = getDependencyOverrides(simplePackage);
-    expect(simplePackageOverrides.length, 3);
+    expect(simplePackageOverrides.length, 2);
     expect(simplePackageOverrides['bar'], '../../packages/bar/bar');
     expect(
       simplePackageOverrides['bar_platform_interface'],
       '../../packages/bar/bar_platform_interface',
     );
-    expect(simplePackageOverrides['bar_android'], '../../packages/bar/bar_android');
 
     final Map<String, String?> appFacingPackageOverrides = getDependencyOverrides(pluginAppFacing);
-    expect(appFacingPackageOverrides.length, 2);
+    expect(appFacingPackageOverrides.length, 1);
     expect(
       appFacingPackageOverrides['bar_platform_interface'],
       '../../../packages/bar/bar_platform_interface',
     );
-    expect(appFacingPackageOverrides['bar_android'], '../../../packages/bar/bar_android');
   });
 
   test('rewrites "dev_dependencies" references', () async {
@@ -229,11 +227,8 @@ ${overrides.map((String dep) => '  $dep:\n    path: $path').join('\n')}
       pluginAppFacing.getExamples().first,
     );
     expect(exampleOverrides.length, 2);
+    expect(exampleOverrides['bar'], '../../../../packages/bar/bar');
     expect(exampleOverrides['bar_android'], '../../../../packages/bar/bar_android');
-    expect(
-      exampleOverrides['bar_platform_interface'],
-      '../../../../packages/bar/bar_platform_interface',
-    );
   });
 
   test('example overrides include both local and main-package dependencies', () async {
@@ -254,8 +249,9 @@ ${overrides.map((String dep) => '  $dep:\n    path: $path').join('\n')}
     final Map<String, String?> exampleOverrides = getDependencyOverrides(
       pluginAppFacing.getExamples().first,
     );
-    expect(exampleOverrides.length, 2);
+    expect(exampleOverrides.length, 3);
     expect(exampleOverrides['another_package'], '../../../../packages/another_package');
+    expect(exampleOverrides['bar'], '../../../../packages/bar/bar');
     expect(exampleOverrides['bar_android'], '../../../../packages/bar/bar_android');
   });
 
@@ -271,12 +267,11 @@ ${overrides.map((String dep) => '  $dep:\n    path: $path').join('\n')}
   });
 
   test(
-    'overrides co-dependent packages when target dependencies depend on local packages',
+    'example overrides include parent package to resolve dependency overrides cleanly',
     () async {
-      final RepositoryPackage materialUi = createFakePackage('material_ui', packagesDir);
-      final RepositoryPackage cupertinoUi = createFakePackage('cupertino_ui', packagesDir);
+      createFakePackage('material_ui', packagesDir);
+      final RepositoryPackage cupertinoUi = createFakePlugin('cupertino_ui', packagesDir);
 
-      addDependencies(materialUi, <String>['cupertino_ui']);
       addDevDependenciesSection(cupertinoUi, <String>['material_ui']);
 
       await runCapturingPrint(runner, <String>[
@@ -284,11 +279,34 @@ ${overrides.map((String dep) => '  $dep:\n    path: $path').join('\n')}
         '--target-dependencies=material_ui',
       ]);
 
-      final Map<String, String?> materialOverrides = getDependencyOverrides(materialUi);
-      expect(materialOverrides['cupertino_ui'], '../../packages/cupertino_ui');
+      final Map<String, String?> exampleOverrides = getDependencyOverrides(
+        cupertinoUi.getExamples().first,
+      );
+      expect(exampleOverrides['material_ui'], '../../../packages/material_ui');
+      expect(exampleOverrides['cupertino_ui'], '../../../packages/cupertino_ui');
+    },
+  );
 
-      final Map<String, String?> cupertinoOverrides = getDependencyOverrides(cupertinoUi);
-      expect(cupertinoOverrides['material_ui'], '../../packages/material_ui');
+  test(
+    'does not recursively override dependencies of target packages to preserve safety net',
+    () async {
+      final RepositoryPackage clientPkg = createFakePackage('pkg_client', packagesDir);
+      final RepositoryPackage targetPkg = createFakePackage('pkg_target', packagesDir);
+      createFakePackage('pkg_dependency', packagesDir);
+
+      addDependencies(clientPkg, <String>['pkg_target', 'pkg_dependency']);
+      addDependencies(targetPkg, <String>['pkg_dependency']);
+
+      await runCapturingPrint(runner, <String>[
+        'make-deps-path-based',
+        '--target-dependencies=pkg_target',
+      ]);
+
+      final Map<String, String?> clientOverrides = getDependencyOverrides(clientPkg);
+      expect(clientOverrides['pkg_target'], '../../packages/pkg_target');
+      // Dependencies of target packages must not be recursively pathified,
+      // ensuring clients are tested against published versions to preserve safety.
+      expect(clientOverrides['pkg_dependency'], isNull);
     },
   );
 

--- a/script/tool/test/make_deps_path_based_command_test.dart
+++ b/script/tool/test/make_deps_path_based_command_test.dart
@@ -170,19 +170,21 @@ ${overrides.map((String dep) => '  $dep:\n    path: $path').join('\n')}
     expect(output, isNot(contains('  Modified packages/bar/bar_platform_interface/pubspec.yaml')));
 
     final Map<String, String?> simplePackageOverrides = getDependencyOverrides(simplePackage);
-    expect(simplePackageOverrides.length, 2);
+    expect(simplePackageOverrides.length, 3);
     expect(simplePackageOverrides['bar'], '../../packages/bar/bar');
     expect(
       simplePackageOverrides['bar_platform_interface'],
       '../../packages/bar/bar_platform_interface',
     );
+    expect(simplePackageOverrides['bar_android'], '../../packages/bar/bar_android');
 
     final Map<String, String?> appFacingPackageOverrides = getDependencyOverrides(pluginAppFacing);
-    expect(appFacingPackageOverrides.length, 1);
+    expect(appFacingPackageOverrides.length, 2);
     expect(
       appFacingPackageOverrides['bar_platform_interface'],
       '../../../packages/bar/bar_platform_interface',
     );
+    expect(appFacingPackageOverrides['bar_android'], '../../../packages/bar/bar_android');
   });
 
   test('rewrites "dev_dependencies" references', () async {
@@ -226,8 +228,12 @@ ${overrides.map((String dep) => '  $dep:\n    path: $path').join('\n')}
     final Map<String, String?> exampleOverrides = getDependencyOverrides(
       pluginAppFacing.getExamples().first,
     );
-    expect(exampleOverrides.length, 1);
+    expect(exampleOverrides.length, 2);
     expect(exampleOverrides['bar_android'], '../../../../packages/bar/bar_android');
+    expect(
+      exampleOverrides['bar_platform_interface'],
+      '../../../../packages/bar/bar_platform_interface',
+    );
   });
 
   test('example overrides include both local and main-package dependencies', () async {
@@ -263,6 +269,28 @@ ${overrides.map((String dep) => '  $dep:\n    path: $path').join('\n')}
     final Map<String, String?> exampleOverrides = getDependencyOverrides(example);
     expect(exampleOverrides.length, 0);
   });
+
+  test(
+    'overrides co-dependent packages when target dependencies depend on local packages',
+    () async {
+      final RepositoryPackage materialUi = createFakePackage('material_ui', packagesDir);
+      final RepositoryPackage cupertinoUi = createFakePackage('cupertino_ui', packagesDir);
+
+      addDependencies(materialUi, <String>['cupertino_ui']);
+      addDevDependenciesSection(cupertinoUi, <String>['material_ui']);
+
+      await runCapturingPrint(runner, <String>[
+        'make-deps-path-based',
+        '--target-dependencies=material_ui',
+      ]);
+
+      final Map<String, String?> materialOverrides = getDependencyOverrides(materialUi);
+      expect(materialOverrides['cupertino_ui'], '../../packages/cupertino_ui');
+
+      final Map<String, String?> cupertinoOverrides = getDependencyOverrides(cupertinoUi);
+      expect(cupertinoOverrides['material_ui'], '../../packages/material_ui');
+    },
+  );
 
   test(
     'alphabetizes overrides from different sections to avoid lint warnings in analysis',


### PR DESCRIPTION
- Unblocks https://github.com/flutter/packages/pull/12423

Fixes a Pub version solver failure during release PR testing (`make-deps-path-based`) for co-dependent packages (specifically `material_ui` and `cupertino_ui`).

When creating a release PR for `material_ui` (e.g., `release-material_ui-0.0.3+1`), the `make-deps-path-based` CI step failed during `flutter test` on `packages/cupertino_ui` with the following Pub version solver error:

```
Resolving dependencies in `./example`...
Because every version of material_ui from path depends on cupertino_ui from hosted and cupertino_ui_examples depends on cupertino_ui from path, material_ui from path is forbidden.
So, because cupertino_ui_examples depends on material_ui from path, version solving failed.
Failed to update packages.
```

`material_ui` and `cupertino_ui` share an asymmetric co-dependency in the repository:
- **`material_ui`** has a **direct dependency** on `cupertino_ui` (`dependencies: cupertino_ui: ^0.0.3`).
- **`cupertino_ui`** has a **dev dependency** on `material_ui` (`dev_dependencies: material_ui: ^0.0.2`).

When `make-deps-path-based --target-dependencies=material_ui` runs:
1. `make-deps-path-based` adds `dependency_overrides: material_ui: {path: ../material_ui}` to `cupertino_ui/pubspec.yaml` and `cupertino_ui/example/pubspec.yaml`.
2. `cupertino_ui/example` depends directly on `cupertino_ui` (`path: ..`).
3. `material_ui` (from `path`) depends on `cupertino_ui: ^0.0.3` (from hosted `pub.dev`).
4. Without `cupertino_ui` in `cupertino_ui/example`'s `dependency_overrides`, Pub detects `cupertino_ui` sourced from **`path`** (in `cupertino_ui_examples`) and **`hosted`** (in `material_ui`), causing Pub's version solver to reject the resolution graph.


Updated `make-deps-path-based` (`script/tool/lib/src/make_deps_path_based_command.dart`):

When `_addDependencyOverridesIfNecessary` recursively updates example apps of a package (`for (final RepositoryPackage example in package.getExamples())`), it now explicitly includes the parent `package` itself in the local package mapping and `additionalPackagesToOverride`.

This ensures `cupertino_ui/example/pubspec.yaml` receives a path override for its parent package (`dependency_overrides: cupertino_ui: {path: ...}`) alongside the target package override (`material_ui: {path: ...}`). Consequently, Pub solver resolves both local path dependencies cleanly without requiring recursive dependency expansion (thereby preserving the safety net of `--target-dependencies`).

---

#### Why `cupertino_ui` Has a `dev_dependency` on `material_ui`

`cupertino_ui` declares `material_ui` in its `dev_dependencies` because multiple files across `cupertino_ui/lib/src/` (e.g., `text_field.dart`, `dialog.dart`, `scrollbar.dart`, `theme.dart`) use Dart `@docImport` directives referencing Material design widgets in public API documentation:

```dart
/// @docImport 'package:material_ui/material_ui.dart';
```

Per Dart doc guidelines, packages referenced in `@docImport` must be declared in `dev_dependencies` so static analysis and `dartdoc` can resolve the cross-referenced symbols.

---

#### Didn't we fix this last week?

- **Aug 4, 09:06 AM (`material_ui 0.0.3` release #12352)**: Both packages still used Dart Workspaces (`resolution: workspace`). Under Dart Workspaces, Pub dependency resolution was handled at the top-level workspace root, hiding the Pub solver conflict.
- **Aug 4, 12:44 PM (PR #12351)**: PR #12351 landed to unblock `cupertino_ui 0.0.3` by removing Dart workspaces from `cupertino_ui` and `material_ui`.
  - When releasing **`cupertino_ui`** (`targetDependencies=cupertino_ui`), `material_ui` got path overrides for `cupertino_ui`. Since `cupertino_ui` didn't depend on a third package pulling hosted `cupertino_ui`, `cupertino_ui`'s release succeeded.
  - However, when releasing **`material_ui`** (`targetDependencies=material_ui`), `material_ui`'s direct dependency on `cupertino_ui` caused `cupertino_ui/example` to fail.
- **Aug 10 (`material_ui 0.0.3+1` release #12423)**: This was the first release attempt of `material_ui` since Dart workspaces were removed, exposing the non-workspace Pub solver requirement.

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under[^1].
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[the version and CHANGELOG instructions]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version-and-changelog-updates
[semantic versioning]: https://dart.dev/tools/pub/versioning#semantic-versions
[repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
