### PR TITLE
[quick_actions_ios]unskip XCUITests

### DIFF
--- a/packages/quick_actions/quick_actions_ios/example/ios/RunnerUITests/RunnerUITests.swift
+++ b/packages/quick_actions/quick_actions_ios/example/ios/RunnerUITests/RunnerUITests.swift
@@ -38,7 +38,7 @@ class RunnerUITests: XCTestCase {
 
   func testQuickActionWithFreshStart() throws {
     let springboard = XCUIApplication(bundleIdentifier: "com.apple.springboard")
-    let quickActionsAppIcon = springboard.icons["quick_actions_example"]
+    let quickActionsAppIcon = springboard.icons["Quick Actions Example"]
 
     findAndTapQuickActionButton(
       buttonName: "Action two", quickActionsAppIcon: quickActionsAppIcon, springboard: springboard)
@@ -73,7 +73,7 @@ class RunnerUITests: XCTestCase {
     XCUIDevice.shared.press(.home)
 
     let springboard = XCUIApplication(bundleIdentifier: "com.apple.springboard")
-    let quickActionsAppIcon = springboard.icons["quick_actions_example"]
+    let quickActionsAppIcon = springboard.icons["Quick Actions Example"]
     if !quickActionsAppIcon.waitForExistence(timeout: elementWaitingTime) {
       XCTFail(
         "Failed due to not able to find the example app from springboard with \(elementWaitingTime) seconds. Springboard debug description: \(springboard.debugDescription)"

--- a/packages/quick_actions/quick_actions_ios/example/ios/RunnerUITests/RunnerUITests.swift
+++ b/packages/quick_actions/quick_actions_ios/example/ios/RunnerUITests/RunnerUITests.swift
@@ -37,9 +37,6 @@ class RunnerUITests: XCTestCase {
   }
 
   func testQuickActionWithFreshStart() throws {
-    // See https://github.com/flutter/flutter/issues/169928
-    throw XCTSkip("Temporarily disabled")
-
     let springboard = XCUIApplication(bundleIdentifier: "com.apple.springboard")
     let quickActionsAppIcon = springboard.icons["quick_actions_example"]
 
@@ -57,9 +54,6 @@ class RunnerUITests: XCTestCase {
   }
 
   func testQuickActionWhenAppIsInBackground() throws {
-    // See https://github.com/flutter/flutter/issues/169928
-    throw XCTSkip("Temporarily disabled")
-
     exampleApp.launch()
 
     let actionsReady = exampleApp.otherElements["actions ready"]

--- a/packages/quick_actions/quick_actions_ios/example/ios/RunnerUITests/RunnerUITests.swift
+++ b/packages/quick_actions/quick_actions_ios/example/ios/RunnerUITests/RunnerUITests.swift
@@ -43,7 +43,10 @@ class RunnerUITests: XCTestCase {
     findAndTapQuickActionButton(
       buttonName: "Action two", quickActionsAppIcon: quickActionsAppIcon, springboard: springboard)
 
-    let actionTwoConfirmation = exampleApp.otherElements["action_two"]
+    // The semantics type of this element changed between Flutter 3.44 and 3.47.
+    // Using descendants(matching: .any) allows finding it regardless of whether
+    // it is a staticText or otherElement.
+    let actionTwoConfirmation = exampleApp.descendants(matching: .any)["action_two"]
     if !actionTwoConfirmation.waitForExistence(timeout: elementWaitingTime) {
       XCTFail(
         "Failed due to not able to find the actionTwoConfirmation in the app with \(elementWaitingTime) seconds. Springboard debug description: \(springboard.debugDescription)"
@@ -56,7 +59,10 @@ class RunnerUITests: XCTestCase {
   func testQuickActionWhenAppIsInBackground() throws {
     exampleApp.launch()
 
-    let actionsReady = exampleApp.otherElements["actions ready"]
+    // The semantics type of this element changed between Flutter 3.44 and 3.47.
+    // Using descendants(matching: .any) allows finding it regardless of whether
+    // it is a staticText or otherElement.
+    let actionsReady = exampleApp.descendants(matching: .any)["actions ready"]
 
     if !actionsReady.waitForExistence(timeout: elementWaitingTime) {
       XCTFail(
@@ -78,7 +84,10 @@ class RunnerUITests: XCTestCase {
       buttonName: "Action one, Action one subtitle", quickActionsAppIcon: quickActionsAppIcon,
       springboard: springboard)
 
-    let actionOneConfirmation = exampleApp.otherElements["action_one"]
+    // The semantics type of this element changed between Flutter 3.44 and 3.47.
+    // Using descendants(matching: .any) allows finding it regardless of whether
+    // it is a staticText or otherElement.
+    let actionOneConfirmation = exampleApp.descendants(matching: .any)["action_one"]
     if !actionOneConfirmation.waitForExistence(timeout: elementWaitingTime) {
       XCTFail(
         "Failed due to not able to find the actionOneConfirmation in the app with \(elementWaitingTime) seconds. Springboard debug description: \(springboard.debugDescription)"


### PR DESCRIPTION
It looks like https://github.com/flutter/flutter/issues/169928 has been addressed, so the test should already been passing. 

See also: https://github.com/flutter/flutter/pull/170180#issuecomment-2950938497


*List which issues are fixed by this PR. You must list at least one issue.*

Fixes https://github.com/flutter/flutter/issues/190966


## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under[^1].
**Comment: only test change**
- [ ] I updated/added any relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[the version and CHANGELOG instructions]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version-and-changelog-updates
[semantic versioning]: https://dart.dev/tools/pub/versioning#semantic-versions
[repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
