### PR TITLE
[go_router] Fix relative navigation after imperative navigation

### DIFF
--- a/packages/go_router/lib/src/router.dart
+++ b/packages/go_router/lib/src/router.dart
@@ -17,6 +17,7 @@ import 'misc/constants.dart';
 import 'misc/inherited_router.dart';
 import 'on_enter.dart';
 import 'parser.dart';
+import 'path_utils.dart';
 import 'route.dart';
 import 'state.dart';
 
@@ -402,11 +403,24 @@ class GoRouter implements RouterConfig<RouteMatchList> {
     fragment: fragment,
   );
 
+  String _resolveRelativeLocation(String location) {
+    if (!location.startsWith('./')) {
+      return location;
+    }
+
+    final RouteMatch? lastMatch = routerDelegate.currentConfiguration.lastOrNull;
+    if (lastMatch is! ImperativeRouteMatch) {
+      return location;
+    }
+
+    return concatenateUris(lastMatch.matches.uri, Uri.parse(location)).toString();
+  }
+
   /// Navigate to a URI location w/ optional query parameters, e.g.
   /// `/family/f2/person/p1?color=blue`
   void go(String location, {Object? extra}) {
     log('going to $location');
-    routeInformationProvider.go(location, extra: extra);
+    routeInformationProvider.go(_resolveRelativeLocation(location), extra: extra);
   }
 
   /// Restore the RouteMatchList
@@ -448,7 +462,7 @@ class GoRouter implements RouterConfig<RouteMatchList> {
   Future<T?> push<T extends Object?>(String location, {Object? extra}) async {
     log('pushing $location');
     return routeInformationProvider.push<T>(
-      location,
+      _resolveRelativeLocation(location),
       base: routerDelegate.currentConfiguration,
       extra: extra,
     );
@@ -478,7 +492,7 @@ class GoRouter implements RouterConfig<RouteMatchList> {
   Future<T?> pushReplacement<T extends Object?>(String location, {Object? extra}) {
     log('pushReplacement $location');
     return routeInformationProvider.pushReplacement<T>(
-      location,
+      _resolveRelativeLocation(location),
       base: routerDelegate.currentConfiguration,
       extra: extra,
     );
@@ -516,7 +530,7 @@ class GoRouter implements RouterConfig<RouteMatchList> {
   Future<T?> replace<T>(String location, {Object? extra}) {
     log('replace $location');
     return routeInformationProvider.replace<T>(
-      location,
+      _resolveRelativeLocation(location),
       base: routerDelegate.currentConfiguration,
       extra: extra,
     );

--- a/packages/go_router/pending_changelogs/change_2026_08_12_1786487000886.yaml
+++ b/packages/go_router/pending_changelogs/change_2026_08_12_1786487000886.yaml
@@ -1,0 +1,3 @@
+changelog: |
+  - Fixes relative navigation resolving against the underlying route instead of the imperatively-pushed route.
+version: patch

--- a/packages/go_router/test/imperative_api_test.dart
+++ b/packages/go_router/test/imperative_api_test.dart
@@ -286,4 +286,57 @@ void main() {
     expect(find.text('shell'), findsNothing);
     expect(find.byKey(e), findsOneWidget);
   });
+
+  for (final MapEntry<String, void Function(GoRouter, String)> operation
+      in <String, void Function(GoRouter, String)>{
+        'go': (GoRouter router, String location) => router.go(location),
+        'push': (GoRouter router, String location) => router.push<void>(location),
+        'pushReplacement': (GoRouter router, String location) =>
+            router.pushReplacement<void>(location),
+        'replace': (GoRouter router, String location) => router.replace<void>(location),
+      }.entries) {
+    testWidgets('${operation.key} resolves a relative route against the imperative top', (
+      WidgetTester tester,
+    ) async {
+      // Regression test for https://github.com/flutter/flutter/issues/182441.
+      final homeReviews = UniqueKey();
+      final productReviews = UniqueKey();
+      final routes = <RouteBase>[
+        GoRoute(
+          path: '/home',
+          builder: (_, _) => const DummyScreen(),
+          routes: <RouteBase>[
+            GoRoute(
+              path: 'reviews',
+              builder: (_, _) => DummyScreen(key: homeReviews),
+            ),
+          ],
+        ),
+        GoRoute(
+          path: '/products/:id',
+          builder: (_, _) => const DummyScreen(),
+          routes: <RouteBase>[
+            GoRoute(
+              path: 'reviews',
+              builder: (_, _) => DummyScreen(key: productReviews),
+            ),
+          ],
+        ),
+      ];
+      final GoRouter router = await createRouter(routes, tester, initialLocation: '/home');
+
+      router.push<void>('/products/9');
+      await tester.pumpAndSettle();
+      expect(router.state.uri.path, '/products/9');
+
+      operation.value(router, './reviews?sort=recent#top');
+      await tester.pumpAndSettle();
+
+      expect(router.state.uri.path, '/products/9/reviews');
+      expect(router.state.uri.queryParameters, <String, String>{'sort': 'recent'});
+      expect(router.state.uri.fragment, 'top');
+      expect(find.byKey(productReviews), findsOneWidget);
+      expect(find.byKey(homeReviews), findsNothing);
+    });
+  }
 }


### PR DESCRIPTION
Relative navigation after an imperative push currently resolves against the underlying route information instead of the visible imperative route. This updates `go`, `push`, `pushReplacement`, and `replace` to resolve `./` locations against the imperative top match, while preserving the existing behavior for other locations. Regression coverage includes query parameters and fragments.

This revisits and completes the fix proposed in #11726. Thank you @NadeemIqbal for the earlier investigation and implementation.

Fixes flutter/flutter#182441.

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under[^1].
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[the version and CHANGELOG instructions]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version-and-changelog-updates
[semantic versioning]: https://dart.dev/tools/pub/versioning#semantic-versions
[repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests