### PR TITLE
[webview_flutter] Add document-start JavaScript API

### DIFF
--- a/packages/webview_flutter/webview_flutter/CHANGELOG.md
+++ b/packages/webview_flutter/webview_flutter/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 4.15.0
+
+* Adds `WebViewController.addDocumentStartJavaScript` for injecting JavaScript
+  that runs at the start of future document loads. It returns a
+  `DocumentStartJavaScriptRegistration` that can be used to stop injecting the JavaScript.
+
 ## 4.14.1
 
 * Adds documentation for `NavigationDelegate` callback parameters.

--- a/packages/webview_flutter/webview_flutter/README.md
+++ b/packages/webview_flutter/webview_flutter/README.md
@@ -61,6 +61,27 @@ See the Dartdocs for [WebViewController](https://pub.dev/documentation/webview_f
 and [WebViewWidget](https://pub.dev/documentation/webview_flutter/latest/webview_flutter/WebViewWidget-class.html)
 for more details.
 
+### Running JavaScript at document start
+
+`WebViewController.addDocumentStartJavaScript` registers JavaScript that runs at the start of every
+document loaded after the call, before the scripts of the loaded page run:
+
+<?code-excerpt "main.dart (document_start_javascript)"?>
+```dart
+final DocumentStartJavaScriptRegistration documentStartJavaScriptRegistration = await webViewController
+    .addDocumentStartJavaScript(
+      'window.exampleValue = "Hello from a document start script!";',
+    );
+```
+
+The script runs in every frame of the document, including cross-origin `<iframe>`s, so it should not
+contain sensitive data. Calling `remove()` on the returned registration deregisters it, stopping
+JavaScript injection into future document loads. The registration can be discarded if the script
+should be injected for the lifetime of the controller.
+
+This feature is not available on the web, or on Android devices whose WebView does not support the
+`DOCUMENT_START_SCRIPT` feature; an `UnsupportedError` is thrown in those cases.
+
 ### Platform-Specific Features
 
 Many classes have a subclass or an underlying implementation that provides access to platform-specific

--- a/packages/webview_flutter/webview_flutter/example/lib/main.dart
+++ b/packages/webview_flutter/webview_flutter/example/lib/main.dart
@@ -111,6 +111,27 @@ const String kLogExamplePage = '''
 </html>
 ''';
 
+const String kDocumentStartExamplePage = '''
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<title>Document start script example</title>
+</head>
+<body>
+
+<h1>Document start script demo page</h1>
+<p id="message">The document start script did not run.</p>
+
+<script>
+  document.getElementById('message').textContent =
+      'The document start script set window.exampleValue to: ' +
+      window.exampleValue;
+</script>
+
+</body>
+</html>
+''';
+
 class WebViewExample extends StatefulWidget {
   const WebViewExample({super.key});
 
@@ -303,6 +324,7 @@ enum MenuOptions {
   setCookie,
   logExample,
   basicAuthentication,
+  documentStartJavaScript,
 }
 
 class SampleMenu extends StatelessWidget {
@@ -310,6 +332,8 @@ class SampleMenu extends StatelessWidget {
 
   final WebViewController webViewController;
   late final WebViewCookieManager cookieManager = WebViewCookieManager();
+  final List<DocumentStartJavaScriptRegistration> _documentStartJavaScriptRegistrations =
+      <DocumentStartJavaScriptRegistration>[];
 
   @override
   Widget build(BuildContext context) {
@@ -347,6 +371,8 @@ class SampleMenu extends StatelessWidget {
             _onLogExample();
           case MenuOptions.basicAuthentication:
             _promptForUrl(context);
+          case MenuOptions.documentStartJavaScript:
+            _onDocumentStartJavaScriptExample(context);
         }
       },
       itemBuilder: (BuildContext context) => <PopupMenuItem<MenuOptions>>[
@@ -398,6 +424,10 @@ class SampleMenu extends StatelessWidget {
         const PopupMenuItem<MenuOptions>(
           value: MenuOptions.basicAuthentication,
           child: Text('Basic Authentication Example'),
+        ),
+        const PopupMenuItem<MenuOptions>(
+          value: MenuOptions.documentStartJavaScript,
+          child: Text('Document start JavaScript example'),
         ),
       ],
     );
@@ -509,6 +539,38 @@ class SampleMenu extends StatelessWidget {
 
   Future<void> _onTransparentBackground() {
     return webViewController.loadHtmlString(kTransparentBackgroundPage);
+  }
+
+  Future<void> _onDocumentStartJavaScriptExample(BuildContext context) async {
+    // Removing the previously added registration keeps this example from
+    // injecting the same JavaScript again every time it is run.
+    for (final DocumentStartJavaScriptRegistration registration
+        in _documentStartJavaScriptRegistrations) {
+      await registration.remove();
+    }
+    _documentStartJavaScriptRegistrations.clear();
+
+    try {
+      // #docregion document_start_javascript
+      final DocumentStartJavaScriptRegistration documentStartJavaScriptRegistration =
+          await webViewController.addDocumentStartJavaScript(
+            'window.exampleValue = "Hello from a document start script!";',
+          );
+      // #enddocregion document_start_javascript
+      _documentStartJavaScriptRegistrations.add(documentStartJavaScriptRegistration);
+    } on UnsupportedError {
+      if (context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(
+            content: Text('Document start JavaScript is not supported on this platform.'),
+          ),
+        );
+      }
+      return;
+    }
+
+    // The script only affects documents that are loaded after it is added.
+    await webViewController.loadHtmlString(kDocumentStartExamplePage);
   }
 
   Widget _getCookieList(List<WebViewCookie> cookies) {

--- a/packages/webview_flutter/webview_flutter/lib/src/webview_controller.dart
+++ b/packages/webview_flutter/webview_flutter/lib/src/webview_controller.dart
@@ -236,6 +236,30 @@ class WebViewController {
     return platform.runJavaScript(javaScript);
   }
 
+  /// Adds JavaScript that runs at the start of future document loads.
+  ///
+  /// This method should be called before loading a page if the script needs to
+  /// run for that page. It does not run JavaScript in the currently loaded
+  /// document. Scripts run in the order in which they were added.
+  ///
+  /// The script runs in every frame of a loaded document, regardless of its
+  /// origin, including cross-origin `<iframe>`s, so it should not contain
+  /// sensitive data.
+  ///
+  /// The returned [DocumentStartJavaScriptRegistration] can be used to stop injecting the
+  /// JavaScript into future document loads. It can be discarded if the
+  /// JavaScript should be injected for the lifetime of this controller.
+  ///
+  /// Throws an [UnsupportedError] if the current platform does not support
+  /// document-start JavaScript injection. This is currently the case on the
+  /// web, and on Android when the WebView installed on the device does not
+  /// support the `DOCUMENT_START_SCRIPT` feature.
+  Future<DocumentStartJavaScriptRegistration> addDocumentStartJavaScript(String javaScript) async {
+    return DocumentStartJavaScriptRegistration.fromPlatform(
+      await platform.addDocumentStartJavaScript(javaScript),
+    );
+  }
+
   /// Runs the given JavaScript in the context of the current page, and returns
   /// the result.
   ///
@@ -421,6 +445,22 @@ class WebViewController {
   Future<void> setOverScrollMode(WebViewOverScrollMode mode) async {
     return platform.setOverScrollMode(mode);
   }
+}
+
+/// A registration for JavaScript injected at the start of future document loads.
+///
+/// Returned by [WebViewController.addDocumentStartJavaScript].
+class DocumentStartJavaScriptRegistration {
+  /// Constructs a [DocumentStartJavaScriptRegistration] from a specific platform
+  /// implementation.
+  DocumentStartJavaScriptRegistration.fromPlatform(this.platform);
+
+  /// Implementation of [PlatformDocumentStartJavaScriptRegistration] for the current
+  /// platform.
+  final PlatformDocumentStartJavaScriptRegistration platform;
+
+  /// Deregisters this registration, stopping JavaScript injection into future document loads.
+  Future<void> remove() => platform.remove();
 }
 
 /// Permissions request when web content requests access to protected resources.

--- a/packages/webview_flutter/webview_flutter/lib/webview_flutter.dart
+++ b/packages/webview_flutter/webview_flutter/lib/webview_flutter.dart
@@ -19,6 +19,7 @@ export 'package:webview_flutter_platform_interface/webview_flutter_platform_inte
         NavigationRequest,
         NavigationRequestCallback,
         PageEventCallback,
+        PlatformDocumentStartJavaScriptRegistration,
         PlatformNavigationDelegateCreationParams,
         PlatformWebViewControllerCreationParams,
         PlatformWebViewCookieManagerCreationParams,

--- a/packages/webview_flutter/webview_flutter/pubspec.yaml
+++ b/packages/webview_flutter/webview_flutter/pubspec.yaml
@@ -2,7 +2,7 @@ name: webview_flutter
 description: A Flutter plugin that provides a WebView widget backed by the system webview.
 repository: https://github.com/flutter/packages/tree/main/packages/webview_flutter/webview_flutter
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+webview%22
-version: 4.14.1
+version: 4.15.0
 
 environment:
   sdk: ^3.10.0
@@ -21,9 +21,9 @@ flutter:
 dependencies:
   flutter:
     sdk: flutter
-  webview_flutter_android: ^4.12.0
-  webview_flutter_platform_interface: ^2.15.1
-  webview_flutter_wkwebview: ^3.25.1
+  webview_flutter_android: ^4.14.0
+  webview_flutter_platform_interface: ^2.16.0
+  webview_flutter_wkwebview: ^3.27.0
 
 dev_dependencies:
   build_runner: ^2.1.5

--- a/packages/webview_flutter/webview_flutter/test/webview_controller_test.dart
+++ b/packages/webview_flutter/webview_flutter/test/webview_controller_test.dart
@@ -13,7 +13,11 @@ import 'package:webview_flutter_platform_interface/webview_flutter_platform_inte
 
 import 'webview_controller_test.mocks.dart';
 
-@GenerateMocks(<Type>[PlatformWebViewController, PlatformNavigationDelegate])
+@GenerateMocks(<Type>[
+  PlatformWebViewController,
+  PlatformNavigationDelegate,
+  PlatformDocumentStartJavaScriptRegistration,
+])
 void main() {
   test('loadFile', () async {
     final mockPlatformWebViewController = MockPlatformWebViewController();
@@ -144,6 +148,40 @@ void main() {
 
     await webViewController.runJavaScript('1 + 1');
     verify(mockPlatformWebViewController.runJavaScript('1 + 1'));
+  });
+
+  test('addDocumentStartJavaScript', () async {
+    final mockPlatformWebViewController = MockPlatformWebViewController();
+    final mockPlatformDocumentStartJavaScriptRegistration =
+        MockPlatformDocumentStartJavaScriptRegistration();
+    when(
+      mockPlatformWebViewController.addDocumentStartJavaScript('window.test = true;'),
+    ).thenAnswer((_) async => mockPlatformDocumentStartJavaScriptRegistration);
+
+    final webViewController = WebViewController.fromPlatform(mockPlatformWebViewController);
+
+    final DocumentStartJavaScriptRegistration documentStartJavaScript = await webViewController
+        .addDocumentStartJavaScript('window.test = true;');
+
+    verify(mockPlatformWebViewController.addDocumentStartJavaScript('window.test = true;'));
+    expect(documentStartJavaScript.platform, mockPlatformDocumentStartJavaScriptRegistration);
+  });
+
+  test('DocumentStartJavaScriptRegistration.remove', () async {
+    final mockPlatformWebViewController = MockPlatformWebViewController();
+    final mockPlatformDocumentStartJavaScriptRegistration =
+        MockPlatformDocumentStartJavaScriptRegistration();
+    when(
+      mockPlatformWebViewController.addDocumentStartJavaScript('window.test = true;'),
+    ).thenAnswer((_) async => mockPlatformDocumentStartJavaScriptRegistration);
+
+    final webViewController = WebViewController.fromPlatform(mockPlatformWebViewController);
+
+    final DocumentStartJavaScriptRegistration documentStartJavaScript = await webViewController
+        .addDocumentStartJavaScript('window.test = true;');
+    await documentStartJavaScript.remove();
+
+    verify(mockPlatformDocumentStartJavaScriptRegistration.remove());
   });
 
   test('runJavaScriptReturningResult', () async {

--- a/packages/webview_flutter/webview_flutter/test/webview_controller_test.mocks.dart
+++ b/packages/webview_flutter/webview_flutter/test/webview_controller_test.mocks.dart
@@ -4,11 +4,11 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i5;
-import 'dart:ui' as _i3;
+import 'dart:ui' as _i4;
 
 import 'package:mockito/mockito.dart' as _i1;
 import 'package:webview_flutter_platform_interface/src/platform_navigation_delegate.dart' as _i6;
-import 'package:webview_flutter_platform_interface/src/platform_webview_controller.dart' as _i4;
+import 'package:webview_flutter_platform_interface/src/platform_webview_controller.dart' as _i3;
 import 'package:webview_flutter_platform_interface/src/types/types.dart' as _i2;
 
 // ignore_for_file: type=lint
@@ -32,24 +32,30 @@ class _FakePlatformWebViewControllerCreationParams_0 extends _i1.SmartFake
     : super(parent, parentInvocation);
 }
 
-class _FakeObject_1 extends _i1.SmartFake implements Object {
-  _FakeObject_1(Object parent, Invocation parentInvocation) : super(parent, parentInvocation);
+class _FakePlatformDocumentStartJavaScriptRegistration_1 extends _i1.SmartFake
+    implements _i3.PlatformDocumentStartJavaScriptRegistration {
+  _FakePlatformDocumentStartJavaScriptRegistration_1(Object parent, Invocation parentInvocation)
+    : super(parent, parentInvocation);
 }
 
-class _FakeOffset_2 extends _i1.SmartFake implements _i3.Offset {
-  _FakeOffset_2(Object parent, Invocation parentInvocation) : super(parent, parentInvocation);
+class _FakeObject_2 extends _i1.SmartFake implements Object {
+  _FakeObject_2(Object parent, Invocation parentInvocation) : super(parent, parentInvocation);
 }
 
-class _FakePlatformNavigationDelegateCreationParams_3 extends _i1.SmartFake
+class _FakeOffset_3 extends _i1.SmartFake implements _i4.Offset {
+  _FakeOffset_3(Object parent, Invocation parentInvocation) : super(parent, parentInvocation);
+}
+
+class _FakePlatformNavigationDelegateCreationParams_4 extends _i1.SmartFake
     implements _i2.PlatformNavigationDelegateCreationParams {
-  _FakePlatformNavigationDelegateCreationParams_3(Object parent, Invocation parentInvocation)
+  _FakePlatformNavigationDelegateCreationParams_4(Object parent, Invocation parentInvocation)
     : super(parent, parentInvocation);
 }
 
 /// A class which mocks [PlatformWebViewController].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockPlatformWebViewController extends _i1.Mock implements _i4.PlatformWebViewController {
+class MockPlatformWebViewController extends _i1.Mock implements _i3.PlatformWebViewController {
   MockPlatformWebViewController() {
     _i1.throwOnMissingStub(this);
   }
@@ -198,17 +204,32 @@ class MockPlatformWebViewController extends _i1.Mock implements _i4.PlatformWebV
           as _i5.Future<void>);
 
   @override
+  _i5.Future<_i3.PlatformDocumentStartJavaScriptRegistration> addDocumentStartJavaScript(
+    String? javaScript,
+  ) =>
+      (super.noSuchMethod(
+            Invocation.method(#addDocumentStartJavaScript, [javaScript]),
+            returnValue: _i5.Future<_i3.PlatformDocumentStartJavaScriptRegistration>.value(
+              _FakePlatformDocumentStartJavaScriptRegistration_1(
+                this,
+                Invocation.method(#addDocumentStartJavaScript, [javaScript]),
+              ),
+            ),
+          )
+          as _i5.Future<_i3.PlatformDocumentStartJavaScriptRegistration>);
+
+  @override
   _i5.Future<Object> runJavaScriptReturningResult(String? javaScript) =>
       (super.noSuchMethod(
             Invocation.method(#runJavaScriptReturningResult, [javaScript]),
             returnValue: _i5.Future<Object>.value(
-              _FakeObject_1(this, Invocation.method(#runJavaScriptReturningResult, [javaScript])),
+              _FakeObject_2(this, Invocation.method(#runJavaScriptReturningResult, [javaScript])),
             ),
           )
           as _i5.Future<Object>);
 
   @override
-  _i5.Future<void> addJavaScriptChannel(_i4.JavaScriptChannelParams? javaScriptChannelParams) =>
+  _i5.Future<void> addJavaScriptChannel(_i3.JavaScriptChannelParams? javaScriptChannelParams) =>
       (super.noSuchMethod(
             Invocation.method(#addJavaScriptChannel, [javaScriptChannelParams]),
             returnValue: _i5.Future<void>.value(),
@@ -275,14 +296,14 @@ class MockPlatformWebViewController extends _i1.Mock implements _i4.PlatformWebV
           as bool);
 
   @override
-  _i5.Future<_i3.Offset> getScrollPosition() =>
+  _i5.Future<_i4.Offset> getScrollPosition() =>
       (super.noSuchMethod(
             Invocation.method(#getScrollPosition, []),
-            returnValue: _i5.Future<_i3.Offset>.value(
-              _FakeOffset_2(this, Invocation.method(#getScrollPosition, [])),
+            returnValue: _i5.Future<_i4.Offset>.value(
+              _FakeOffset_3(this, Invocation.method(#getScrollPosition, [])),
             ),
           )
-          as _i5.Future<_i3.Offset>);
+          as _i5.Future<_i4.Offset>);
 
   @override
   _i5.Future<void> enableZoom(bool? enabled) =>
@@ -294,7 +315,7 @@ class MockPlatformWebViewController extends _i1.Mock implements _i4.PlatformWebV
           as _i5.Future<void>);
 
   @override
-  _i5.Future<void> setBackgroundColor(_i3.Color? color) =>
+  _i5.Future<void> setBackgroundColor(_i4.Color? color) =>
       (super.noSuchMethod(
             Invocation.method(#setBackgroundColor, [color]),
             returnValue: _i5.Future<void>.value(),
@@ -416,7 +437,7 @@ class MockPlatformNavigationDelegate extends _i1.Mock implements _i6.PlatformNav
   _i2.PlatformNavigationDelegateCreationParams get params =>
       (super.noSuchMethod(
             Invocation.getter(#params),
-            returnValue: _FakePlatformNavigationDelegateCreationParams_3(
+            returnValue: _FakePlatformNavigationDelegateCreationParams_4(
               this,
               Invocation.getter(#params),
             ),
@@ -499,6 +520,25 @@ class MockPlatformNavigationDelegate extends _i1.Mock implements _i6.PlatformNav
   _i5.Future<void> setOnSSlAuthError(_i6.SslAuthErrorCallback? onSslAuthError) =>
       (super.noSuchMethod(
             Invocation.method(#setOnSSlAuthError, [onSslAuthError]),
+            returnValue: _i5.Future<void>.value(),
+            returnValueForMissingStub: _i5.Future<void>.value(),
+          )
+          as _i5.Future<void>);
+}
+
+/// A class which mocks [PlatformDocumentStartJavaScriptRegistration].
+///
+/// See the documentation for Mockito's code generation for more information.
+class MockPlatformDocumentStartJavaScriptRegistration extends _i1.Mock
+    implements _i3.PlatformDocumentStartJavaScriptRegistration {
+  MockPlatformDocumentStartJavaScriptRegistration() {
+    _i1.throwOnMissingStub(this);
+  }
+
+  @override
+  _i5.Future<void> remove() =>
+      (super.noSuchMethod(
+            Invocation.method(#remove, []),
             returnValue: _i5.Future<void>.value(),
             returnValueForMissingStub: _i5.Future<void>.value(),
           )

--- a/packages/webview_flutter/webview_flutter/test/webview_widget_test.mocks.dart
+++ b/packages/webview_flutter/webview_flutter/test/webview_widget_test.mocks.dart
@@ -4,13 +4,13 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i7;
-import 'dart:ui' as _i3;
+import 'dart:ui' as _i4;
 
-import 'package:flutter/foundation.dart' as _i5;
-import 'package:flutter/widgets.dart' as _i4;
+import 'package:flutter/foundation.dart' as _i6;
+import 'package:flutter/widgets.dart' as _i5;
 import 'package:mockito/mockito.dart' as _i1;
 import 'package:webview_flutter_platform_interface/src/platform_navigation_delegate.dart' as _i8;
-import 'package:webview_flutter_platform_interface/src/platform_webview_controller.dart' as _i6;
+import 'package:webview_flutter_platform_interface/src/platform_webview_controller.dart' as _i3;
 import 'package:webview_flutter_platform_interface/src/platform_webview_widget.dart' as _i9;
 import 'package:webview_flutter_platform_interface/src/types/types.dart' as _i2;
 
@@ -35,31 +35,37 @@ class _FakePlatformWebViewControllerCreationParams_0 extends _i1.SmartFake
     : super(parent, parentInvocation);
 }
 
-class _FakeObject_1 extends _i1.SmartFake implements Object {
-  _FakeObject_1(Object parent, Invocation parentInvocation) : super(parent, parentInvocation);
-}
-
-class _FakeOffset_2 extends _i1.SmartFake implements _i3.Offset {
-  _FakeOffset_2(Object parent, Invocation parentInvocation) : super(parent, parentInvocation);
-}
-
-class _FakePlatformWebViewWidgetCreationParams_3 extends _i1.SmartFake
-    implements _i2.PlatformWebViewWidgetCreationParams {
-  _FakePlatformWebViewWidgetCreationParams_3(Object parent, Invocation parentInvocation)
+class _FakePlatformDocumentStartJavaScriptRegistration_1 extends _i1.SmartFake
+    implements _i3.PlatformDocumentStartJavaScriptRegistration {
+  _FakePlatformDocumentStartJavaScriptRegistration_1(Object parent, Invocation parentInvocation)
     : super(parent, parentInvocation);
 }
 
-class _FakeWidget_4 extends _i1.SmartFake implements _i4.Widget {
-  _FakeWidget_4(Object parent, Invocation parentInvocation) : super(parent, parentInvocation);
+class _FakeObject_2 extends _i1.SmartFake implements Object {
+  _FakeObject_2(Object parent, Invocation parentInvocation) : super(parent, parentInvocation);
+}
+
+class _FakeOffset_3 extends _i1.SmartFake implements _i4.Offset {
+  _FakeOffset_3(Object parent, Invocation parentInvocation) : super(parent, parentInvocation);
+}
+
+class _FakePlatformWebViewWidgetCreationParams_4 extends _i1.SmartFake
+    implements _i2.PlatformWebViewWidgetCreationParams {
+  _FakePlatformWebViewWidgetCreationParams_4(Object parent, Invocation parentInvocation)
+    : super(parent, parentInvocation);
+}
+
+class _FakeWidget_5 extends _i1.SmartFake implements _i5.Widget {
+  _FakeWidget_5(Object parent, Invocation parentInvocation) : super(parent, parentInvocation);
 
   @override
-  String toString({_i5.DiagnosticLevel? minLevel = _i5.DiagnosticLevel.info}) => super.toString();
+  String toString({_i6.DiagnosticLevel? minLevel = _i6.DiagnosticLevel.info}) => super.toString();
 }
 
 /// A class which mocks [PlatformWebViewController].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockPlatformWebViewController extends _i1.Mock implements _i6.PlatformWebViewController {
+class MockPlatformWebViewController extends _i1.Mock implements _i3.PlatformWebViewController {
   MockPlatformWebViewController() {
     _i1.throwOnMissingStub(this);
   }
@@ -208,17 +214,32 @@ class MockPlatformWebViewController extends _i1.Mock implements _i6.PlatformWebV
           as _i7.Future<void>);
 
   @override
+  _i7.Future<_i3.PlatformDocumentStartJavaScriptRegistration> addDocumentStartJavaScript(
+    String? javaScript,
+  ) =>
+      (super.noSuchMethod(
+            Invocation.method(#addDocumentStartJavaScript, [javaScript]),
+            returnValue: _i7.Future<_i3.PlatformDocumentStartJavaScriptRegistration>.value(
+              _FakePlatformDocumentStartJavaScriptRegistration_1(
+                this,
+                Invocation.method(#addDocumentStartJavaScript, [javaScript]),
+              ),
+            ),
+          )
+          as _i7.Future<_i3.PlatformDocumentStartJavaScriptRegistration>);
+
+  @override
   _i7.Future<Object> runJavaScriptReturningResult(String? javaScript) =>
       (super.noSuchMethod(
             Invocation.method(#runJavaScriptReturningResult, [javaScript]),
             returnValue: _i7.Future<Object>.value(
-              _FakeObject_1(this, Invocation.method(#runJavaScriptReturningResult, [javaScript])),
+              _FakeObject_2(this, Invocation.method(#runJavaScriptReturningResult, [javaScript])),
             ),
           )
           as _i7.Future<Object>);
 
   @override
-  _i7.Future<void> addJavaScriptChannel(_i6.JavaScriptChannelParams? javaScriptChannelParams) =>
+  _i7.Future<void> addJavaScriptChannel(_i3.JavaScriptChannelParams? javaScriptChannelParams) =>
       (super.noSuchMethod(
             Invocation.method(#addJavaScriptChannel, [javaScriptChannelParams]),
             returnValue: _i7.Future<void>.value(),
@@ -285,14 +306,14 @@ class MockPlatformWebViewController extends _i1.Mock implements _i6.PlatformWebV
           as bool);
 
   @override
-  _i7.Future<_i3.Offset> getScrollPosition() =>
+  _i7.Future<_i4.Offset> getScrollPosition() =>
       (super.noSuchMethod(
             Invocation.method(#getScrollPosition, []),
-            returnValue: _i7.Future<_i3.Offset>.value(
-              _FakeOffset_2(this, Invocation.method(#getScrollPosition, [])),
+            returnValue: _i7.Future<_i4.Offset>.value(
+              _FakeOffset_3(this, Invocation.method(#getScrollPosition, [])),
             ),
           )
-          as _i7.Future<_i3.Offset>);
+          as _i7.Future<_i4.Offset>);
 
   @override
   _i7.Future<void> enableZoom(bool? enabled) =>
@@ -304,7 +325,7 @@ class MockPlatformWebViewController extends _i1.Mock implements _i6.PlatformWebV
           as _i7.Future<void>);
 
   @override
-  _i7.Future<void> setBackgroundColor(_i3.Color? color) =>
+  _i7.Future<void> setBackgroundColor(_i4.Color? color) =>
       (super.noSuchMethod(
             Invocation.method(#setBackgroundColor, [color]),
             returnValue: _i7.Future<void>.value(),
@@ -426,7 +447,7 @@ class MockPlatformWebViewWidget extends _i1.Mock implements _i9.PlatformWebViewW
   _i2.PlatformWebViewWidgetCreationParams get params =>
       (super.noSuchMethod(
             Invocation.getter(#params),
-            returnValue: _FakePlatformWebViewWidgetCreationParams_3(
+            returnValue: _FakePlatformWebViewWidgetCreationParams_4(
               this,
               Invocation.getter(#params),
             ),
@@ -434,10 +455,10 @@ class MockPlatformWebViewWidget extends _i1.Mock implements _i9.PlatformWebViewW
           as _i2.PlatformWebViewWidgetCreationParams);
 
   @override
-  _i4.Widget build(_i4.BuildContext? context) =>
+  _i5.Widget build(_i5.BuildContext? context) =>
       (super.noSuchMethod(
             Invocation.method(#build, [context]),
-            returnValue: _FakeWidget_4(this, Invocation.method(#build, [context])),
+            returnValue: _FakeWidget_5(this, Invocation.method(#build, [context])),
           )
-          as _i4.Widget);
+          as _i5.Widget);
 }

--- a/packages/webview_flutter/webview_flutter_android/CHANGELOG.md
+++ b/packages/webview_flutter/webview_flutter_android/CHANGELOG.md
@@ -1,4 +1,9 @@
+## 4.15.0
+
+* Adds support for `addDocumentStartJavaScript`.
+
 ## 4.14.0
+
 * Adds support for configuring Web Authentication in `AndroidWebViewController` with `setWebAuthenticationSupport` to enable Passkey and other related Authentication.
 
 ## 4.13.0

--- a/packages/webview_flutter/webview_flutter_android/android/src/main/java/io/flutter/plugins/webviewflutter/AndroidWebkitLibrary.g.kt
+++ b/packages/webview_flutter/webview_flutter_android/android/src/main/java/io/flutter/plugins/webviewflutter/AndroidWebkitLibrary.g.kt
@@ -609,6 +609,12 @@ abstract class AndroidWebkitLibraryPigeonProxyApiRegistrar(val binaryMessenger: 
    */
   abstract fun getPigeonApiWebViewFeature(): PigeonApiWebViewFeature
 
+  /**
+   * An implementation of [PigeonApiScriptHandler] used to add a new Dart instance of
+   * `ScriptHandler` to the Dart `InstanceManager`.
+   */
+  abstract fun getPigeonApiScriptHandler(): PigeonApiScriptHandler
+
   fun setUp() {
     AndroidWebkitLibraryPigeonInstanceManagerApi.setUpMessageHandlers(
         binaryMessenger, instanceManager)
@@ -643,6 +649,7 @@ abstract class AndroidWebkitLibraryPigeonProxyApiRegistrar(val binaryMessenger: 
     PigeonApiWebSettingsCompat.setUpMessageHandlers(
         binaryMessenger, getPigeonApiWebSettingsCompat())
     PigeonApiWebViewFeature.setUpMessageHandlers(binaryMessenger, getPigeonApiWebViewFeature())
+    PigeonApiScriptHandler.setUpMessageHandlers(binaryMessenger, getPigeonApiScriptHandler())
   }
 
   fun tearDown() {
@@ -670,6 +677,7 @@ abstract class AndroidWebkitLibraryPigeonProxyApiRegistrar(val binaryMessenger: 
     PigeonApiCertificate.setUpMessageHandlers(binaryMessenger, null)
     PigeonApiWebSettingsCompat.setUpMessageHandlers(binaryMessenger, null)
     PigeonApiWebViewFeature.setUpMessageHandlers(binaryMessenger, null)
+    PigeonApiScriptHandler.setUpMessageHandlers(binaryMessenger, null)
   }
 }
 
@@ -911,6 +919,12 @@ private class AndroidWebkitLibraryPigeonProxyApiBaseCodec(
       registrar.getPigeonApiWebViewFeature().pigeon_newInstance(value) {
         if (it.isFailure) {
           logNewInstanceFailure("WebViewFeature", value, it.exceptionOrNull())
+        }
+      }
+    } else if (value is androidx.webkit.ScriptHandler) {
+      registrar.getPigeonApiScriptHandler().pigeon_newInstance(value) {
+        if (it.isFailure) {
+          logNewInstanceFailure("ScriptHandler", value, it.exceptionOrNull())
         }
       }
     }
@@ -1815,6 +1829,12 @@ abstract class PigeonApiWebView(
       callback: (Result<String?>) -> Unit
   )
 
+  /** Adds JavaScript that runs at the start of future document loads. */
+  abstract fun addDocumentStartJavaScript(
+      pigeon_instance: android.webkit.WebView,
+      javaScript: String
+  ): androidx.webkit.ScriptHandler
+
   /** Gets the title for the current page. */
   abstract fun getTitle(pigeon_instance: android.webkit.WebView): String?
 
@@ -2197,6 +2217,29 @@ abstract class PigeonApiWebView(
                 reply.reply(AndroidWebkitLibraryPigeonUtils.wrapResult(data))
               }
             }
+          }
+        } else {
+          channel.setMessageHandler(null)
+        }
+      }
+      run {
+        val channel =
+            BasicMessageChannel<Any?>(
+                binaryMessenger,
+                "dev.flutter.pigeon.webview_flutter_android.WebView.addDocumentStartJavaScript",
+                codec)
+        if (api != null) {
+          channel.setMessageHandler { message, reply ->
+            val args = message as List<Any?>
+            val pigeon_instanceArg = args[0] as android.webkit.WebView
+            val javaScriptArg = args[1] as String
+            val wrapped: List<Any?> =
+                try {
+                  listOf(api.addDocumentStartJavaScript(pigeon_instanceArg, javaScriptArg))
+                } catch (exception: Throwable) {
+                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+                }
+            reply.reply(wrapped)
           }
         } else {
           channel.setMessageHandler(null)
@@ -6979,6 +7022,85 @@ abstract class PigeonApiWebViewFeature(
       val codec = pigeonRegistrar.codec
       val channelName =
           "dev.flutter.pigeon.webview_flutter_android.WebViewFeature.pigeon_newInstance"
+      val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
+      channel.send(listOf(pigeon_identifierArg)) {
+        if (it is List<*>) {
+          if (it.size > 1) {
+            callback(
+                Result.failure(
+                    AndroidWebKitError(it[0] as String, it[1] as String, it[2] as String?)))
+          } else {
+            callback(Result.success(Unit))
+          }
+        } else {
+          callback(
+              Result.failure(AndroidWebkitLibraryPigeonUtils.createConnectionError(channelName)))
+        }
+      }
+    }
+  }
+}
+/**
+ * Handle to a document start JavaScript that was added with `WebView.addDocumentStartJavaScript`.
+ *
+ * See https://developer.android.com/reference/kotlin/androidx/webkit/ScriptHandler.
+ */
+@Suppress("UNCHECKED_CAST")
+abstract class PigeonApiScriptHandler(
+    open val pigeonRegistrar: AndroidWebkitLibraryPigeonProxyApiRegistrar
+) {
+  /** Removes the script from the WebView. */
+  abstract fun remove(pigeon_instance: androidx.webkit.ScriptHandler)
+
+  companion object {
+    @Suppress("LocalVariableName")
+    fun setUpMessageHandlers(binaryMessenger: BinaryMessenger, api: PigeonApiScriptHandler?) {
+      val codec = api?.pigeonRegistrar?.codec ?: AndroidWebkitLibraryPigeonCodec()
+      run {
+        val channel =
+            BasicMessageChannel<Any?>(
+                binaryMessenger,
+                "dev.flutter.pigeon.webview_flutter_android.ScriptHandler.remove",
+                codec)
+        if (api != null) {
+          channel.setMessageHandler { message, reply ->
+            val args = message as List<Any?>
+            val pigeon_instanceArg = args[0] as androidx.webkit.ScriptHandler
+            val wrapped: List<Any?> =
+                try {
+                  api.remove(pigeon_instanceArg)
+                  listOf(null)
+                } catch (exception: Throwable) {
+                  AndroidWebkitLibraryPigeonUtils.wrapError(exception)
+                }
+            reply.reply(wrapped)
+          }
+        } else {
+          channel.setMessageHandler(null)
+        }
+      }
+    }
+  }
+
+  @Suppress("LocalVariableName", "FunctionName")
+  /** Creates a Dart instance of ScriptHandler and attaches it to [pigeon_instanceArg]. */
+  fun pigeon_newInstance(
+      pigeon_instanceArg: androidx.webkit.ScriptHandler,
+      callback: (Result<Unit>) -> Unit
+  ) {
+    if (pigeonRegistrar.ignoreCallsToDart) {
+      callback(
+          Result.failure(
+              AndroidWebKitError("ignore-calls-error", "Calls to Dart are being ignored.", "")))
+    } else if (pigeonRegistrar.instanceManager.containsInstance(pigeon_instanceArg)) {
+      callback(Result.success(Unit))
+    } else {
+      val pigeon_identifierArg =
+          pigeonRegistrar.instanceManager.addHostCreatedInstance(pigeon_instanceArg)
+      val binaryMessenger = pigeonRegistrar.binaryMessenger
+      val codec = pigeonRegistrar.codec
+      val channelName =
+          "dev.flutter.pigeon.webview_flutter_android.ScriptHandler.pigeon_newInstance"
       val channel = BasicMessageChannel<Any?>(binaryMessenger, channelName, codec)
       channel.send(listOf(pigeon_identifierArg)) {
         if (it is List<*>) {

--- a/packages/webview_flutter/webview_flutter_android/android/src/main/java/io/flutter/plugins/webviewflutter/ProxyApiRegistrar.java
+++ b/packages/webview_flutter/webview_flutter_android/android/src/main/java/io/flutter/plugins/webviewflutter/ProxyApiRegistrar.java
@@ -261,4 +261,10 @@ public class ProxyApiRegistrar extends AndroidWebkitLibraryPigeonProxyApiRegistr
   public PigeonApiWebSettingsCompat getPigeonApiWebSettingsCompat() {
     return new WebSettingsCompatProxyApi(this);
   }
+
+  @NonNull
+  @Override
+  public PigeonApiScriptHandler getPigeonApiScriptHandler() {
+    return new ScriptHandlerProxyApi(this);
+  }
 }

--- a/packages/webview_flutter/webview_flutter_android/android/src/main/java/io/flutter/plugins/webviewflutter/ScriptHandlerProxyApi.java
+++ b/packages/webview_flutter/webview_flutter_android/android/src/main/java/io/flutter/plugins/webviewflutter/ScriptHandlerProxyApi.java
@@ -1,0 +1,25 @@
+// Copyright 2013 The Flutter Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package io.flutter.plugins.webviewflutter;
+
+import androidx.annotation.NonNull;
+import androidx.webkit.ScriptHandler;
+
+/**
+ * Proxy API implementation for {@link ScriptHandler}.
+ *
+ * <p>This class may handle instantiating and adding native object instances that are attached to a
+ * Dart instance or handle method calls on the associated native class or an instance of the class.
+ */
+public class ScriptHandlerProxyApi extends PigeonApiScriptHandler {
+  public ScriptHandlerProxyApi(@NonNull ProxyApiRegistrar pigeonRegistrar) {
+    super(pigeonRegistrar);
+  }
+
+  @Override
+  public void remove(@NonNull ScriptHandler pigeon_instance) {
+    pigeon_instance.remove();
+  }
+}

--- a/packages/webview_flutter/webview_flutter_android/android/src/main/java/io/flutter/plugins/webviewflutter/WebViewProxyApi.java
+++ b/packages/webview_flutter/webview_flutter_android/android/src/main/java/io/flutter/plugins/webviewflutter/WebViewProxyApi.java
@@ -17,8 +17,11 @@ import android.webkit.WebView;
 import android.webkit.WebViewClient;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.webkit.ScriptHandler;
+import androidx.webkit.WebViewCompat;
 import io.flutter.embedding.android.FlutterView;
 import io.flutter.plugin.platform.PlatformView;
+import java.util.Collections;
 import java.util.Map;
 import kotlin.Result;
 import kotlin.Unit;
@@ -224,6 +227,19 @@ public class WebViewProxyApi extends PigeonApiWebView {
       @NonNull Function1<? super Result<String>, Unit> callback) {
     pigeon_instance.evaluateJavascript(
         javascriptString, result -> ResultCompat.success(result, callback));
+  }
+
+  /**
+   * This method should only be called if {@link WebViewFeatureProxyApi#isFeatureSupported(String)}
+   * with DOCUMENT_START_SCRIPT returns true.
+   */
+  @SuppressLint("RequiresFeature")
+  @NonNull
+  @Override
+  public ScriptHandler addDocumentStartJavaScript(
+      @NonNull WebView pigeon_instance, @NonNull String javaScript) {
+    return WebViewCompat.addDocumentStartJavaScript(
+        pigeon_instance, javaScript, Collections.singleton("*"));
   }
 
   @Nullable

--- a/packages/webview_flutter/webview_flutter_android/android/src/test/java/io/flutter/plugins/webviewflutter/ScriptHandlerTest.java
+++ b/packages/webview_flutter/webview_flutter_android/android/src/test/java/io/flutter/plugins/webviewflutter/ScriptHandlerTest.java
@@ -1,0 +1,23 @@
+// Copyright 2013 The Flutter Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package io.flutter.plugins.webviewflutter;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import androidx.webkit.ScriptHandler;
+import org.junit.Test;
+
+public class ScriptHandlerTest {
+  @Test
+  public void remove() {
+    final PigeonApiScriptHandler api = new TestProxyApiRegistrar().getPigeonApiScriptHandler();
+
+    final ScriptHandler instance = mock(ScriptHandler.class);
+    api.remove(instance);
+
+    verify(instance).remove();
+  }
+}

--- a/packages/webview_flutter/webview_flutter_android/android/src/test/java/io/flutter/plugins/webviewflutter/WebViewTest.java
+++ b/packages/webview_flutter/webview_flutter_android/android/src/test/java/io/flutter/plugins/webviewflutter/WebViewTest.java
@@ -10,6 +10,7 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -19,11 +20,15 @@ import android.webkit.DownloadListener;
 import android.webkit.ValueCallback;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
+import androidx.webkit.ScriptHandler;
+import androidx.webkit.WebViewCompat;
 import io.flutter.embedding.android.FlutterView;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
+import org.mockito.MockedStatic;
 
 public class WebViewTest {
   @Test
@@ -216,6 +221,26 @@ public class WebViewTest {
     final String result = "resultValue";
     callbackCaptor.getValue().onReceiveValue(result);
     assertEquals(resultValue[0], result);
+  }
+
+  @Test
+  public void addDocumentStartJavaScript() {
+    final PigeonApiWebView api = new TestProxyApiRegistrar().getPigeonApiWebView();
+
+    final WebView instance = mock(WebView.class);
+    final String script = "window.test = true;";
+    final ScriptHandler scriptHandler = mock(ScriptHandler.class);
+
+    try (MockedStatic<WebViewCompat> mockedWebViewCompat = mockStatic(WebViewCompat.class)) {
+      mockedWebViewCompat
+          .when(
+              () ->
+                  WebViewCompat.addDocumentStartJavaScript(
+                      instance, script, Collections.singleton("*")))
+          .thenReturn(scriptHandler);
+
+      assertEquals(scriptHandler, api.addDocumentStartJavaScript(instance, script));
+    }
   }
 
   @Test

--- a/packages/webview_flutter/webview_flutter_android/example/integration_test/webview_flutter_test.dart
+++ b/packages/webview_flutter/webview_flutter_android/example/integration_test/webview_flutter_test.dart
@@ -36,6 +36,15 @@ Future<void> main() async {
         request.response.writeln('How are you today?');
       } else if (request.uri.path == '/headers') {
         request.response.writeln('${request.headers}');
+      } else if (request.uri.path == '/document-start.html') {
+        request.response.headers.contentType = ContentType.html;
+        // The inline script records the state of the window at parse time, so
+        // that a test can verify that injected scripts ran before it.
+        request.response.writeln(
+          '<!DOCTYPE html><html><head> '
+          '<script>window.recordedAtParseTime = String(window.injectedAtDocumentStart);</script> '
+          '</head><body>Document start test.</body></html>',
+        );
       } else if (request.uri.path == '/favicon.ico') {
         request.response.statusCode = HttpStatus.notFound;
       } else if (request.uri.path == '/http-basic-authentication') {
@@ -57,6 +66,7 @@ Future<void> main() async {
   final secondaryUrl = '$prefixUrl/secondary.txt';
   final headersUrl = '$prefixUrl/headers';
   final basicAuthUrl = '$prefixUrl/http-basic-authentication';
+  final documentStartUrl = '$prefixUrl/document-start.html';
 
   setUp(() {
     android_webkit.PigeonOverrides.pigeon_reset();
@@ -192,6 +202,44 @@ Future<void> main() async {
     await pageFinished.future;
 
     await expectLater(controller.runJavaScriptReturningResult('1 + 1'), completion(2));
+  });
+
+  testWidgets('addDocumentStartJavaScript', (WidgetTester tester) async {
+    final pageFinished = Completer<void>();
+    final messageReceived = Completer<String>();
+
+    final controller = PlatformWebViewController(const PlatformWebViewControllerCreationParams());
+    await controller.setJavaScriptMode(JavaScriptMode.unrestricted);
+    final delegate = PlatformNavigationDelegate(const PlatformNavigationDelegateCreationParams());
+    await delegate.setOnPageFinished((_) => pageFinished.complete());
+    await controller.setPlatformNavigationDelegate(delegate);
+    await controller.addJavaScriptChannel(
+      JavaScriptChannelParams(
+        name: 'Echo',
+        onMessageReceived: (JavaScriptMessage message) => messageReceived.complete(message.message),
+      ),
+    );
+
+    await controller.addDocumentStartJavaScript('window.injectedAtDocumentStart = "injected";');
+    await controller.loadRequest(LoadRequestParams(uri: Uri.parse(documentStartUrl)));
+
+    await tester.pumpWidget(
+      Builder(
+        builder: (BuildContext context) {
+          return PlatformWebViewWidget(
+            PlatformWebViewWidgetCreationParams(controller: controller),
+          ).build(context);
+        },
+      ),
+    );
+
+    await pageFinished.future;
+
+    // The page records this value while it is being parsed, so a match proves
+    // that the script ran before the document's own scripts.
+    await controller.runJavaScript('Echo.postMessage(window.recordedAtParseTime);');
+
+    await expectLater(messageReceived.future, completion('injected'));
   });
 
   testWidgets('loadRequest with headers', (WidgetTester tester) async {

--- a/packages/webview_flutter/webview_flutter_android/lib/src/android_webkit.g.dart
+++ b/packages/webview_flutter/webview_flutter_android/lib/src/android_webkit.g.dart
@@ -380,6 +380,7 @@ class PigeonInstanceManager {
     Certificate.pigeon_setUpMessageHandlers(pigeon_instanceManager: instanceManager);
     WebSettingsCompat.pigeon_setUpMessageHandlers(pigeon_instanceManager: instanceManager);
     WebViewFeature.pigeon_setUpMessageHandlers(pigeon_instanceManager: instanceManager);
+    ScriptHandler.pigeon_setUpMessageHandlers(pigeon_instanceManager: instanceManager);
     return instanceManager;
   }
 
@@ -1995,6 +1996,31 @@ class WebView extends View {
       isNullValid: true,
     );
     return pigeonVar_replyValue as String?;
+  }
+
+  /// Adds JavaScript that runs at the start of future document loads.
+  Future<ScriptHandler> addDocumentStartJavaScript(String javaScript) async {
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecWebView;
+    final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
+    const pigeonVar_channelName =
+        'dev.flutter.pigeon.webview_flutter_android.WebView.addDocumentStartJavaScript';
+    final pigeonVar_channel = BasicMessageChannel<Object?>(
+      pigeonVar_channelName,
+      pigeonChannelCodec,
+      binaryMessenger: pigeonVar_binaryMessenger,
+    );
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[
+      this,
+      javaScript,
+    ]);
+    final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
+
+    final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
+      pigeonVar_replyList,
+      pigeonVar_channelName,
+      isNullValid: false,
+    );
+    return pigeonVar_replyValue! as ScriptHandler;
   }
 
   /// Gets the title for the current page.
@@ -7321,6 +7347,90 @@ class WebViewFeature extends PigeonInternalProxyApiBaseClass {
   @override
   WebViewFeature pigeon_copy() {
     return WebViewFeature.pigeon_detached(
+      pigeon_binaryMessenger: pigeon_binaryMessenger,
+      pigeon_instanceManager: pigeon_instanceManager,
+    );
+  }
+}
+
+/// Handle to a document start JavaScript that was added with
+/// `WebView.addDocumentStartJavaScript`.
+///
+/// See https://developer.android.com/reference/kotlin/androidx/webkit/ScriptHandler.
+class ScriptHandler extends PigeonInternalProxyApiBaseClass {
+  /// Constructs [ScriptHandler] without creating the associated native object.
+  ///
+  /// This should only be used by subclasses created by this library or to
+  /// create copies for an [PigeonInstanceManager].
+  @protected
+  ScriptHandler.pigeon_detached({super.pigeon_binaryMessenger, super.pigeon_instanceManager});
+
+  late final _PigeonInternalProxyApiBaseCodec _pigeonVar_codecScriptHandler =
+      _PigeonInternalProxyApiBaseCodec(pigeon_instanceManager);
+
+  static void pigeon_setUpMessageHandlers({
+    bool pigeon_clearHandlers = false,
+    BinaryMessenger? pigeon_binaryMessenger,
+    PigeonInstanceManager? pigeon_instanceManager,
+    ScriptHandler Function()? pigeon_newInstance,
+  }) {
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _PigeonInternalProxyApiBaseCodec(
+      pigeon_instanceManager ?? PigeonInstanceManager.instance,
+    );
+    final BinaryMessenger? binaryMessenger = pigeon_binaryMessenger;
+    {
+      final pigeonVar_channel = BasicMessageChannel<Object?>(
+        'dev.flutter.pigeon.webview_flutter_android.ScriptHandler.pigeon_newInstance',
+        pigeonChannelCodec,
+        binaryMessenger: binaryMessenger,
+      );
+      if (pigeon_clearHandlers) {
+        pigeonVar_channel.setMessageHandler(null);
+      } else {
+        pigeonVar_channel.setMessageHandler((Object? message) async {
+          final List<Object?> args = message! as List<Object?>;
+          final int arg_pigeon_instanceIdentifier = args[0]! as int;
+          try {
+            (pigeon_instanceManager ?? PigeonInstanceManager.instance).addHostCreatedInstance(
+              pigeon_newInstance?.call() ??
+                  ScriptHandler.pigeon_detached(
+                    pigeon_binaryMessenger: pigeon_binaryMessenger,
+                    pigeon_instanceManager: pigeon_instanceManager,
+                  ),
+              arg_pigeon_instanceIdentifier,
+            );
+            return wrapResponse(empty: true);
+          } on PlatformException catch (e) {
+            return wrapResponse(error: e);
+          } catch (e) {
+            return wrapResponse(
+              error: PlatformException(code: 'error', message: e.toString()),
+            );
+          }
+        });
+      }
+    }
+  }
+
+  /// Removes the script from the WebView.
+  Future<void> remove() async {
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecScriptHandler;
+    final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
+    const pigeonVar_channelName = 'dev.flutter.pigeon.webview_flutter_android.ScriptHandler.remove';
+    final pigeonVar_channel = BasicMessageChannel<Object?>(
+      pigeonVar_channelName,
+      pigeonChannelCodec,
+      binaryMessenger: pigeonVar_binaryMessenger,
+    );
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[this]);
+    final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
+
+    _extractReplyValueOrThrow(pigeonVar_replyList, pigeonVar_channelName, isNullValid: true);
+  }
+
+  @override
+  ScriptHandler pigeon_copy() {
+    return ScriptHandler.pigeon_detached(
       pigeon_binaryMessenger: pigeon_binaryMessenger,
       pigeon_instanceManager: pigeon_instanceManager,
     );

--- a/packages/webview_flutter/webview_flutter_android/lib/src/android_webkit_constants.dart
+++ b/packages/webview_flutter/webview_flutter_android/lib/src/android_webkit_constants.dart
@@ -131,4 +131,9 @@ class WebViewFeatureConstants {
   ///
   /// See https://developer.android.com/reference/androidx/webkit/WebViewFeature#WEB_AUTHENTICATION.
   static const String webAuthentication = 'WEB_AUTHENTICATION';
+
+  /// This feature covers [WebView.addDocumentStartJavaScript].
+  ///
+  /// See https://developer.android.com/reference/androidx/webkit/WebViewFeature#DOCUMENT_START_SCRIPT.
+  static const String documentStartScript = 'DOCUMENT_START_SCRIPT';
 }

--- a/packages/webview_flutter/webview_flutter_android/lib/src/android_webview_controller.dart
+++ b/packages/webview_flutter/webview_flutter_android/lib/src/android_webview_controller.dart
@@ -518,6 +518,31 @@ class AndroidWebViewController extends PlatformWebViewController {
     return _webView.evaluateJavascript(javaScript);
   }
 
+  /// Adds JavaScript that runs at the start of future document loads.
+  ///
+  /// This requires the `DOCUMENT_START_SCRIPT` feature, which depends on the
+  /// version of the WebView installed on the device. Throws an
+  /// [UnsupportedError] if the feature is not available; support can be checked
+  /// ahead of time with [isWebViewFeatureSupported] and
+  /// [WebViewFeatureType.documentStartScript].
+  @override
+  Future<PlatformDocumentStartJavaScriptRegistration> addDocumentStartJavaScript(
+    String javaScript,
+  ) async {
+    final bool isSupported = await isWebViewFeatureSupported(
+      WebViewFeatureType.documentStartScript,
+    );
+    if (!isSupported) {
+      throw UnsupportedError(
+        'Document-start JavaScript injection is not supported by the WebView '
+        'installed on this device.',
+      );
+    }
+    return AndroidDocumentStartJavaScriptRegistration._(
+      await _webView.addDocumentStartJavaScript(javaScript),
+    );
+  }
+
   @override
   Future<Object> runJavaScriptReturningResult(String javaScript) async {
     final String? result = await _webView.evaluateJavascript(javaScript);
@@ -791,6 +816,7 @@ class AndroidWebViewController extends PlatformWebViewController {
     final String feature = switch (featureType) {
       WebViewFeatureType.paymentRequest => WebViewFeatureConstants.paymentRequest,
       WebViewFeatureType.webAuthentication => WebViewFeatureConstants.webAuthentication,
+      WebViewFeatureType.documentStartScript => WebViewFeatureConstants.documentStartScript,
     };
     return android_webview.WebViewFeature.isFeatureSupported(feature);
   }
@@ -997,6 +1023,9 @@ enum WebViewFeatureType {
   ///
   /// This feature covers [WebSettingsCompat.setWebAuthenticationSupport].
   webAuthentication,
+  /// This feature covers
+  /// [AndroidWebViewController.addDocumentStartJavaScript].
+  documentStartScript,
 }
 
 /// Support levels for [android_webview.WebSettingsCompat.setWebAuthenticationSupport].
@@ -1074,6 +1103,28 @@ class FileSelectorParams {
 
   /// Mode of how to select files for a file selector.
   final FileSelectorMode mode;
+}
+
+/// An implementation of [PlatformDocumentStartJavaScriptRegistration] with the Android
+/// WebView API.
+///
+/// See [AndroidWebViewController.addDocumentStartJavaScript].
+class AndroidDocumentStartJavaScriptRegistration
+    extends PlatformDocumentStartJavaScriptRegistration {
+  AndroidDocumentStartJavaScriptRegistration._(this._scriptHandler);
+
+  final android_webview.ScriptHandler _scriptHandler;
+
+  bool _removed = false;
+
+  @override
+  Future<void> remove() async {
+    if (_removed) {
+      return;
+    }
+    _removed = true;
+    await _scriptHandler.remove();
+  }
 }
 
 /// An implementation of [JavaScriptChannelParams] with the Android WebView API.

--- a/packages/webview_flutter/webview_flutter_android/pigeons/android_webkit.dart
+++ b/packages/webview_flutter/webview_flutter_android/pigeons/android_webkit.dart
@@ -347,6 +347,9 @@ abstract class WebView extends View {
   @async
   String? evaluateJavascript(String javascriptString);
 
+  /// Adds JavaScript that runs at the start of future document loads.
+  ScriptHandler addDocumentStartJavaScript(String javaScript);
+
   /// Gets the title for the current page.
   String? getTitle();
 
@@ -1016,4 +1019,14 @@ abstract class WebSettingsCompat {
 abstract class WebViewFeature {
   @static
   bool isFeatureSupported(String feature);
+}
+
+/// Handle to a document start JavaScript that was added with
+/// `WebView.addDocumentStartJavaScript`.
+///
+/// See https://developer.android.com/reference/kotlin/androidx/webkit/ScriptHandler.
+@ProxyApi(kotlinOptions: KotlinProxyApiOptions(fullClassName: 'androidx.webkit.ScriptHandler'))
+abstract class ScriptHandler {
+  /// Removes the script from the WebView.
+  void remove();
 }

--- a/packages/webview_flutter/webview_flutter_android/pubspec.yaml
+++ b/packages/webview_flutter/webview_flutter_android/pubspec.yaml
@@ -21,7 +21,7 @@ dependencies:
   flutter:
     sdk: flutter
   meta: ^1.10.0
-  webview_flutter_platform_interface: ^2.15.1
+  webview_flutter_platform_interface: ^2.16.0
 
 dev_dependencies:
   build_runner: ^2.1.4

--- a/packages/webview_flutter/webview_flutter_android/test/android_webview_controller_test.dart
+++ b/packages/webview_flutter/webview_flutter_android/test/android_webview_controller_test.dart
@@ -26,6 +26,7 @@ import 'android_webview_controller_test.mocks.dart';
   MockSpec<android_webview.JavaScriptChannel>(),
   MockSpec<android_webview.PermissionRequest>(),
   MockSpec<PlatformViewsServiceProxy>(),
+  MockSpec<android_webview.ScriptHandler>(),
   MockSpec<SurfaceAndroidViewController>(),
   MockSpec<android_webview.WebChromeClient>(),
   MockSpec<android_webview.WebSettings>(),
@@ -1404,6 +1405,68 @@ void main() {
       await controller.runJavaScript('alert("This is a test.");');
 
       verify(mockWebView.evaluateJavascript('alert("This is a test.");')).called(1);
+    });
+
+    test('addDocumentStartJavaScript', () async {
+      final mockWebView = MockWebView();
+      final mockScriptHandler = MockScriptHandler();
+      final AndroidWebViewController controller = createControllerWithMocks(
+        mockWebView: mockWebView,
+        isWebViewFeatureSupported: (_) async => true,
+      );
+      when(mockWebView.addDocumentStartJavaScript(any)).thenAnswer((_) async => mockScriptHandler);
+
+      await controller.addDocumentStartJavaScript('window.test = true;');
+
+      verify(mockWebView.addDocumentStartJavaScript('window.test = true;')).called(1);
+    });
+
+    test('addDocumentStartJavaScript throws if the feature is unsupported', () async {
+      final mockWebView = MockWebView();
+      final AndroidWebViewController controller = createControllerWithMocks(
+        mockWebView: mockWebView,
+        isWebViewFeatureSupported: (_) async => false,
+      );
+
+      await expectLater(
+        () => controller.addDocumentStartJavaScript('window.test = true;'),
+        throwsA(isA<UnsupportedError>()),
+      );
+
+      verifyNever(mockWebView.addDocumentStartJavaScript(any));
+    });
+
+    test('removing document start JavaScript removes the script handler', () async {
+      final mockWebView = MockWebView();
+      final mockScriptHandler = MockScriptHandler();
+      final AndroidWebViewController controller = createControllerWithMocks(
+        mockWebView: mockWebView,
+        isWebViewFeatureSupported: (_) async => true,
+      );
+      when(mockWebView.addDocumentStartJavaScript(any)).thenAnswer((_) async => mockScriptHandler);
+
+      final PlatformDocumentStartJavaScriptRegistration documentStartJavaScript = await controller
+          .addDocumentStartJavaScript('window.test = true;');
+      await documentStartJavaScript.remove();
+
+      verify(mockScriptHandler.remove()).called(1);
+    });
+
+    test('removing document start JavaScript more than once is a no-op', () async {
+      final mockWebView = MockWebView();
+      final mockScriptHandler = MockScriptHandler();
+      final AndroidWebViewController controller = createControllerWithMocks(
+        mockWebView: mockWebView,
+        isWebViewFeatureSupported: (_) async => true,
+      );
+      when(mockWebView.addDocumentStartJavaScript(any)).thenAnswer((_) async => mockScriptHandler);
+
+      final PlatformDocumentStartJavaScriptRegistration documentStartJavaScript = await controller
+          .addDocumentStartJavaScript('window.test = true;');
+      await documentStartJavaScript.remove();
+      await documentStartJavaScript.remove();
+
+      verify(mockScriptHandler.remove()).called(1);
     });
 
     test('runJavaScriptReturningResult with return value', () async {

--- a/packages/webview_flutter/webview_flutter_android/test/android_webview_controller_test.mocks.dart
+++ b/packages/webview_flutter/webview_flutter_android/test/android_webview_controller_test.mocks.dart
@@ -59,83 +59,94 @@ class _FakePlatformWebViewControllerCreationParams_4 extends _i1.SmartFake
     : super(parent, parentInvocation);
 }
 
-class _FakeObject_5 extends _i1.SmartFake implements Object {
-  _FakeObject_5(Object parent, Invocation parentInvocation) : super(parent, parentInvocation);
+class _FakePlatformDocumentStartJavaScript_5 extends _i1.SmartFake
+    implements _i3.PlatformDocumentStartJavaScriptRegistration {
+  _FakePlatformDocumentStartJavaScript_5(Object parent, Invocation parentInvocation)
+    : super(parent, parentInvocation);
 }
 
-class _FakeOffset_6 extends _i1.SmartFake implements _i4.Offset {
-  _FakeOffset_6(Object parent, Invocation parentInvocation) : super(parent, parentInvocation);
+class _FakeObject_6 extends _i1.SmartFake implements Object {
+  _FakeObject_6(Object parent, Invocation parentInvocation) : super(parent, parentInvocation);
 }
 
-class _FakePlatformViewsServiceProxy_7 extends _i1.SmartFake
+class _FakeOffset_7 extends _i1.SmartFake implements _i4.Offset {
+  _FakeOffset_7(Object parent, Invocation parentInvocation) : super(parent, parentInvocation);
+}
+
+class _FakePlatformViewsServiceProxy_8 extends _i1.SmartFake
     implements _i5.PlatformViewsServiceProxy {
-  _FakePlatformViewsServiceProxy_7(Object parent, Invocation parentInvocation)
+  _FakePlatformViewsServiceProxy_8(Object parent, Invocation parentInvocation)
     : super(parent, parentInvocation);
 }
 
-class _FakePlatformWebViewController_8 extends _i1.SmartFake
+class _FakePlatformWebViewController_9 extends _i1.SmartFake
     implements _i3.PlatformWebViewController {
-  _FakePlatformWebViewController_8(Object parent, Invocation parentInvocation)
+  _FakePlatformWebViewController_9(Object parent, Invocation parentInvocation)
     : super(parent, parentInvocation);
 }
 
-class _FakeSize_9 extends _i1.SmartFake implements _i4.Size {
-  _FakeSize_9(Object parent, Invocation parentInvocation) : super(parent, parentInvocation);
+class _FakeSize_10 extends _i1.SmartFake implements _i4.Size {
+  _FakeSize_10(Object parent, Invocation parentInvocation) : super(parent, parentInvocation);
 }
 
-class _FakePigeonInstanceManager_10 extends _i1.SmartFake implements _i2.PigeonInstanceManager {
-  _FakePigeonInstanceManager_10(Object parent, Invocation parentInvocation)
+class _FakePigeonInstanceManager_11 extends _i1.SmartFake implements _i2.PigeonInstanceManager {
+  _FakePigeonInstanceManager_11(Object parent, Invocation parentInvocation)
     : super(parent, parentInvocation);
 }
 
-class _FakeFlutterAssetManager_11 extends _i1.SmartFake implements _i2.FlutterAssetManager {
-  _FakeFlutterAssetManager_11(Object parent, Invocation parentInvocation)
+class _FakeFlutterAssetManager_12 extends _i1.SmartFake implements _i2.FlutterAssetManager {
+  _FakeFlutterAssetManager_12(Object parent, Invocation parentInvocation)
     : super(parent, parentInvocation);
 }
 
-class _FakeGeolocationPermissionsCallback_12 extends _i1.SmartFake
+class _FakeGeolocationPermissionsCallback_13 extends _i1.SmartFake
     implements _i2.GeolocationPermissionsCallback {
-  _FakeGeolocationPermissionsCallback_12(Object parent, Invocation parentInvocation)
+  _FakeGeolocationPermissionsCallback_13(Object parent, Invocation parentInvocation)
     : super(parent, parentInvocation);
 }
 
-class _FakeJavaScriptChannel_13 extends _i1.SmartFake implements _i2.JavaScriptChannel {
-  _FakeJavaScriptChannel_13(Object parent, Invocation parentInvocation)
+class _FakeJavaScriptChannel_14 extends _i1.SmartFake implements _i2.JavaScriptChannel {
+  _FakeJavaScriptChannel_14(Object parent, Invocation parentInvocation)
     : super(parent, parentInvocation);
 }
 
-class _FakePermissionRequest_14 extends _i1.SmartFake implements _i2.PermissionRequest {
-  _FakePermissionRequest_14(Object parent, Invocation parentInvocation)
+class _FakePermissionRequest_15 extends _i1.SmartFake implements _i2.PermissionRequest {
+  _FakePermissionRequest_15(Object parent, Invocation parentInvocation)
     : super(parent, parentInvocation);
 }
 
-class _FakeExpensiveAndroidViewController_15 extends _i1.SmartFake
+class _FakeExpensiveAndroidViewController_16 extends _i1.SmartFake
     implements _i6.ExpensiveAndroidViewController {
-  _FakeExpensiveAndroidViewController_15(Object parent, Invocation parentInvocation)
+  _FakeExpensiveAndroidViewController_16(Object parent, Invocation parentInvocation)
     : super(parent, parentInvocation);
 }
 
-class _FakeSurfaceAndroidViewController_16 extends _i1.SmartFake
+class _FakeSurfaceAndroidViewController_17 extends _i1.SmartFake
     implements _i6.SurfaceAndroidViewController {
-  _FakeSurfaceAndroidViewController_16(Object parent, Invocation parentInvocation)
+  _FakeSurfaceAndroidViewController_17(Object parent, Invocation parentInvocation)
     : super(parent, parentInvocation);
 }
 
-class _FakeWebSettings_17 extends _i1.SmartFake implements _i2.WebSettings {
-  _FakeWebSettings_17(Object parent, Invocation parentInvocation) : super(parent, parentInvocation);
-}
-
-class _FakeWebView_18 extends _i1.SmartFake implements _i2.WebView {
-  _FakeWebView_18(Object parent, Invocation parentInvocation) : super(parent, parentInvocation);
-}
-
-class _FakeWebViewPoint_19 extends _i1.SmartFake implements _i2.WebViewPoint {
-  _FakeWebViewPoint_19(Object parent, Invocation parentInvocation)
+class _FakeScriptHandler_18 extends _i1.SmartFake implements _i2.ScriptHandler {
+  _FakeScriptHandler_18(Object parent, Invocation parentInvocation)
     : super(parent, parentInvocation);
 }
 
-class _FakeWebStorage_20 extends _i1.SmartFake implements _i2.WebStorage {
-  _FakeWebStorage_20(Object parent, Invocation parentInvocation) : super(parent, parentInvocation);
+class _FakeWebSettings_19 extends _i1.SmartFake implements _i2.WebSettings {
+  _FakeWebSettings_19(Object parent, Invocation parentInvocation) : super(parent, parentInvocation);
+}
+
+class _FakeWebView_20 extends _i1.SmartFake implements _i2.WebView {
+  _FakeWebView_20(Object parent, Invocation parentInvocation) : super(parent, parentInvocation);
+}
+
+class _FakeWebViewPoint_21 extends _i1.SmartFake implements _i2.WebViewPoint {
+  _FakeWebViewPoint_21(Object parent, Invocation parentInvocation)
+    : super(parent, parentInvocation);
+}
+
+class _FakeWebStorage_22 extends _i1.SmartFake implements _i2.WebStorage {
+  _FakeWebStorage_22(Object parent, Invocation parentInvocation) : super(parent, parentInvocation);
 }
 
 /// A class which mocks [AndroidNavigationDelegate].
@@ -457,14 +468,36 @@ class MockAndroidWebViewController extends _i1.Mock implements _i7.AndroidWebVie
           as _i8.Future<void>);
 
   @override
+  _i8.Future<_i3.PlatformDocumentStartJavaScriptRegistration> addDocumentStartJavaScript(
+    String? javaScript,
+  ) =>
+      (super.noSuchMethod(
+            Invocation.method(#addDocumentStartJavaScript, [javaScript]),
+            returnValue: _i8.Future<_i3.PlatformDocumentStartJavaScriptRegistration>.value(
+              _FakePlatformDocumentStartJavaScript_5(
+                this,
+                Invocation.method(#addDocumentStartJavaScript, [javaScript]),
+              ),
+            ),
+            returnValueForMissingStub:
+                _i8.Future<_i3.PlatformDocumentStartJavaScriptRegistration>.value(
+                  _FakePlatformDocumentStartJavaScript_5(
+                    this,
+                    Invocation.method(#addDocumentStartJavaScript, [javaScript]),
+                  ),
+                ),
+          )
+          as _i8.Future<_i3.PlatformDocumentStartJavaScriptRegistration>);
+
+  @override
   _i8.Future<Object> runJavaScriptReturningResult(String? javaScript) =>
       (super.noSuchMethod(
             Invocation.method(#runJavaScriptReturningResult, [javaScript]),
             returnValue: _i8.Future<Object>.value(
-              _FakeObject_5(this, Invocation.method(#runJavaScriptReturningResult, [javaScript])),
+              _FakeObject_6(this, Invocation.method(#runJavaScriptReturningResult, [javaScript])),
             ),
             returnValueForMissingStub: _i8.Future<Object>.value(
-              _FakeObject_5(this, Invocation.method(#runJavaScriptReturningResult, [javaScript])),
+              _FakeObject_6(this, Invocation.method(#runJavaScriptReturningResult, [javaScript])),
             ),
           )
           as _i8.Future<Object>);
@@ -519,10 +552,10 @@ class MockAndroidWebViewController extends _i1.Mock implements _i7.AndroidWebVie
       (super.noSuchMethod(
             Invocation.method(#getScrollPosition, []),
             returnValue: _i8.Future<_i4.Offset>.value(
-              _FakeOffset_6(this, Invocation.method(#getScrollPosition, [])),
+              _FakeOffset_7(this, Invocation.method(#getScrollPosition, [])),
             ),
             returnValueForMissingStub: _i8.Future<_i4.Offset>.value(
-              _FakeOffset_6(this, Invocation.method(#getScrollPosition, [])),
+              _FakeOffset_7(this, Invocation.method(#getScrollPosition, [])),
             ),
           )
           as _i8.Future<_i4.Offset>);
@@ -816,11 +849,11 @@ class MockAndroidWebViewWidgetCreationParams extends _i1.Mock
   _i5.PlatformViewsServiceProxy get platformViewsServiceProxy =>
       (super.noSuchMethod(
             Invocation.getter(#platformViewsServiceProxy),
-            returnValue: _FakePlatformViewsServiceProxy_7(
+            returnValue: _FakePlatformViewsServiceProxy_8(
               this,
               Invocation.getter(#platformViewsServiceProxy),
             ),
-            returnValueForMissingStub: _FakePlatformViewsServiceProxy_7(
+            returnValueForMissingStub: _FakePlatformViewsServiceProxy_8(
               this,
               Invocation.getter(#platformViewsServiceProxy),
             ),
@@ -840,8 +873,8 @@ class MockAndroidWebViewWidgetCreationParams extends _i1.Mock
   _i3.PlatformWebViewController get controller =>
       (super.noSuchMethod(
             Invocation.getter(#controller),
-            returnValue: _FakePlatformWebViewController_8(this, Invocation.getter(#controller)),
-            returnValueForMissingStub: _FakePlatformWebViewController_8(
+            returnValue: _FakePlatformWebViewController_9(this, Invocation.getter(#controller)),
+            returnValueForMissingStub: _FakePlatformWebViewController_9(
               this,
               Invocation.getter(#controller),
             ),
@@ -900,9 +933,9 @@ class MockExpensiveAndroidViewController extends _i1.Mock
       (super.noSuchMethod(
             Invocation.getter(#pointTransformer),
             returnValue: (_i4.Offset position) =>
-                _FakeOffset_6(this, Invocation.getter(#pointTransformer)),
+                _FakeOffset_7(this, Invocation.getter(#pointTransformer)),
             returnValueForMissingStub: (_i4.Offset position) =>
-                _FakeOffset_6(this, Invocation.getter(#pointTransformer)),
+                _FakeOffset_7(this, Invocation.getter(#pointTransformer)),
           )
           as _i6.PointTransformer);
 
@@ -953,10 +986,10 @@ class MockExpensiveAndroidViewController extends _i1.Mock
       (super.noSuchMethod(
             Invocation.method(#setSize, [size]),
             returnValue: _i8.Future<_i4.Size>.value(
-              _FakeSize_9(this, Invocation.method(#setSize, [size])),
+              _FakeSize_10(this, Invocation.method(#setSize, [size])),
             ),
             returnValueForMissingStub: _i8.Future<_i4.Size>.value(
-              _FakeSize_9(this, Invocation.method(#setSize, [size])),
+              _FakeSize_10(this, Invocation.method(#setSize, [size])),
             ),
           )
           as _i8.Future<_i4.Size>);
@@ -1029,11 +1062,11 @@ class MockFlutterAssetManager extends _i1.Mock implements _i2.FlutterAssetManage
   _i2.PigeonInstanceManager get pigeon_instanceManager =>
       (super.noSuchMethod(
             Invocation.getter(#pigeon_instanceManager),
-            returnValue: _FakePigeonInstanceManager_10(
+            returnValue: _FakePigeonInstanceManager_11(
               this,
               Invocation.getter(#pigeon_instanceManager),
             ),
-            returnValueForMissingStub: _FakePigeonInstanceManager_10(
+            returnValueForMissingStub: _FakePigeonInstanceManager_11(
               this,
               Invocation.getter(#pigeon_instanceManager),
             ),
@@ -1066,8 +1099,8 @@ class MockFlutterAssetManager extends _i1.Mock implements _i2.FlutterAssetManage
   _i2.FlutterAssetManager pigeon_copy() =>
       (super.noSuchMethod(
             Invocation.method(#pigeon_copy, []),
-            returnValue: _FakeFlutterAssetManager_11(this, Invocation.method(#pigeon_copy, [])),
-            returnValueForMissingStub: _FakeFlutterAssetManager_11(
+            returnValue: _FakeFlutterAssetManager_12(this, Invocation.method(#pigeon_copy, [])),
+            returnValueForMissingStub: _FakeFlutterAssetManager_12(
               this,
               Invocation.method(#pigeon_copy, []),
             ),
@@ -1084,11 +1117,11 @@ class MockGeolocationPermissionsCallback extends _i1.Mock
   _i2.PigeonInstanceManager get pigeon_instanceManager =>
       (super.noSuchMethod(
             Invocation.getter(#pigeon_instanceManager),
-            returnValue: _FakePigeonInstanceManager_10(
+            returnValue: _FakePigeonInstanceManager_11(
               this,
               Invocation.getter(#pigeon_instanceManager),
             ),
-            returnValueForMissingStub: _FakePigeonInstanceManager_10(
+            returnValueForMissingStub: _FakePigeonInstanceManager_11(
               this,
               Invocation.getter(#pigeon_instanceManager),
             ),
@@ -1108,11 +1141,11 @@ class MockGeolocationPermissionsCallback extends _i1.Mock
   _i2.GeolocationPermissionsCallback pigeon_copy() =>
       (super.noSuchMethod(
             Invocation.method(#pigeon_copy, []),
-            returnValue: _FakeGeolocationPermissionsCallback_12(
+            returnValue: _FakeGeolocationPermissionsCallback_13(
               this,
               Invocation.method(#pigeon_copy, []),
             ),
-            returnValueForMissingStub: _FakeGeolocationPermissionsCallback_12(
+            returnValueForMissingStub: _FakeGeolocationPermissionsCallback_13(
               this,
               Invocation.method(#pigeon_copy, []),
             ),
@@ -1149,11 +1182,11 @@ class MockJavaScriptChannel extends _i1.Mock implements _i2.JavaScriptChannel {
   _i2.PigeonInstanceManager get pigeon_instanceManager =>
       (super.noSuchMethod(
             Invocation.getter(#pigeon_instanceManager),
-            returnValue: _FakePigeonInstanceManager_10(
+            returnValue: _FakePigeonInstanceManager_11(
               this,
               Invocation.getter(#pigeon_instanceManager),
             ),
-            returnValueForMissingStub: _FakePigeonInstanceManager_10(
+            returnValueForMissingStub: _FakePigeonInstanceManager_11(
               this,
               Invocation.getter(#pigeon_instanceManager),
             ),
@@ -1164,8 +1197,8 @@ class MockJavaScriptChannel extends _i1.Mock implements _i2.JavaScriptChannel {
   _i2.JavaScriptChannel pigeon_copy() =>
       (super.noSuchMethod(
             Invocation.method(#pigeon_copy, []),
-            returnValue: _FakeJavaScriptChannel_13(this, Invocation.method(#pigeon_copy, [])),
-            returnValueForMissingStub: _FakeJavaScriptChannel_13(
+            returnValue: _FakeJavaScriptChannel_14(this, Invocation.method(#pigeon_copy, [])),
+            returnValueForMissingStub: _FakeJavaScriptChannel_14(
               this,
               Invocation.method(#pigeon_copy, []),
             ),
@@ -1190,11 +1223,11 @@ class MockPermissionRequest extends _i1.Mock implements _i2.PermissionRequest {
   _i2.PigeonInstanceManager get pigeon_instanceManager =>
       (super.noSuchMethod(
             Invocation.getter(#pigeon_instanceManager),
-            returnValue: _FakePigeonInstanceManager_10(
+            returnValue: _FakePigeonInstanceManager_11(
               this,
               Invocation.getter(#pigeon_instanceManager),
             ),
-            returnValueForMissingStub: _FakePigeonInstanceManager_10(
+            returnValueForMissingStub: _FakePigeonInstanceManager_11(
               this,
               Invocation.getter(#pigeon_instanceManager),
             ),
@@ -1223,8 +1256,8 @@ class MockPermissionRequest extends _i1.Mock implements _i2.PermissionRequest {
   _i2.PermissionRequest pigeon_copy() =>
       (super.noSuchMethod(
             Invocation.method(#pigeon_copy, []),
-            returnValue: _FakePermissionRequest_14(this, Invocation.method(#pigeon_copy, [])),
-            returnValueForMissingStub: _FakePermissionRequest_14(
+            returnValue: _FakePermissionRequest_15(this, Invocation.method(#pigeon_copy, [])),
+            returnValueForMissingStub: _FakePermissionRequest_15(
               this,
               Invocation.method(#pigeon_copy, []),
             ),
@@ -1255,7 +1288,7 @@ class MockPlatformViewsServiceProxy extends _i1.Mock implements _i5.PlatformView
               #creationParamsCodec: creationParamsCodec,
               #onFocus: onFocus,
             }),
-            returnValue: _FakeExpensiveAndroidViewController_15(
+            returnValue: _FakeExpensiveAndroidViewController_16(
               this,
               Invocation.method(#initExpensiveAndroidView, [], {
                 #id: id,
@@ -1266,7 +1299,7 @@ class MockPlatformViewsServiceProxy extends _i1.Mock implements _i5.PlatformView
                 #onFocus: onFocus,
               }),
             ),
-            returnValueForMissingStub: _FakeExpensiveAndroidViewController_15(
+            returnValueForMissingStub: _FakeExpensiveAndroidViewController_16(
               this,
               Invocation.method(#initExpensiveAndroidView, [], {
                 #id: id,
@@ -1298,7 +1331,7 @@ class MockPlatformViewsServiceProxy extends _i1.Mock implements _i5.PlatformView
               #creationParamsCodec: creationParamsCodec,
               #onFocus: onFocus,
             }),
-            returnValue: _FakeSurfaceAndroidViewController_16(
+            returnValue: _FakeSurfaceAndroidViewController_17(
               this,
               Invocation.method(#initSurfaceAndroidView, [], {
                 #id: id,
@@ -1309,7 +1342,7 @@ class MockPlatformViewsServiceProxy extends _i1.Mock implements _i5.PlatformView
                 #onFocus: onFocus,
               }),
             ),
-            returnValueForMissingStub: _FakeSurfaceAndroidViewController_16(
+            returnValueForMissingStub: _FakeSurfaceAndroidViewController_17(
               this,
               Invocation.method(#initSurfaceAndroidView, [], {
                 #id: id,
@@ -1322,6 +1355,47 @@ class MockPlatformViewsServiceProxy extends _i1.Mock implements _i5.PlatformView
             ),
           )
           as _i6.SurfaceAndroidViewController);
+}
+
+/// A class which mocks [ScriptHandler].
+///
+/// See the documentation for Mockito's code generation for more information.
+class MockScriptHandler extends _i1.Mock implements _i2.ScriptHandler {
+  @override
+  _i2.PigeonInstanceManager get pigeon_instanceManager =>
+      (super.noSuchMethod(
+            Invocation.getter(#pigeon_instanceManager),
+            returnValue: _FakePigeonInstanceManager_11(
+              this,
+              Invocation.getter(#pigeon_instanceManager),
+            ),
+            returnValueForMissingStub: _FakePigeonInstanceManager_11(
+              this,
+              Invocation.getter(#pigeon_instanceManager),
+            ),
+          )
+          as _i2.PigeonInstanceManager);
+
+  @override
+  _i8.Future<void> remove() =>
+      (super.noSuchMethod(
+            Invocation.method(#remove, []),
+            returnValue: _i8.Future<void>.value(),
+            returnValueForMissingStub: _i8.Future<void>.value(),
+          )
+          as _i8.Future<void>);
+
+  @override
+  _i2.ScriptHandler pigeon_copy() =>
+      (super.noSuchMethod(
+            Invocation.method(#pigeon_copy, []),
+            returnValue: _FakeScriptHandler_18(this, Invocation.method(#pigeon_copy, [])),
+            returnValueForMissingStub: _FakeScriptHandler_18(
+              this,
+              Invocation.method(#pigeon_copy, []),
+            ),
+          )
+          as _i2.ScriptHandler);
 }
 
 /// A class which mocks [SurfaceAndroidViewController].
@@ -1357,9 +1431,9 @@ class MockSurfaceAndroidViewController extends _i1.Mock
       (super.noSuchMethod(
             Invocation.getter(#pointTransformer),
             returnValue: (_i4.Offset position) =>
-                _FakeOffset_6(this, Invocation.getter(#pointTransformer)),
+                _FakeOffset_7(this, Invocation.getter(#pointTransformer)),
             returnValueForMissingStub: (_i4.Offset position) =>
-                _FakeOffset_6(this, Invocation.getter(#pointTransformer)),
+                _FakeOffset_7(this, Invocation.getter(#pointTransformer)),
           )
           as _i6.PointTransformer);
 
@@ -1410,10 +1484,10 @@ class MockSurfaceAndroidViewController extends _i1.Mock
       (super.noSuchMethod(
             Invocation.method(#setSize, [size]),
             returnValue: _i8.Future<_i4.Size>.value(
-              _FakeSize_9(this, Invocation.method(#setSize, [size])),
+              _FakeSize_10(this, Invocation.method(#setSize, [size])),
             ),
             returnValueForMissingStub: _i8.Future<_i4.Size>.value(
-              _FakeSize_9(this, Invocation.method(#setSize, [size])),
+              _FakeSize_10(this, Invocation.method(#setSize, [size])),
             ),
           )
           as _i8.Future<_i4.Size>);
@@ -1531,11 +1605,11 @@ class MockWebChromeClient extends _i1.Mock implements _i2.WebChromeClient {
   _i2.PigeonInstanceManager get pigeon_instanceManager =>
       (super.noSuchMethod(
             Invocation.getter(#pigeon_instanceManager),
-            returnValue: _FakePigeonInstanceManager_10(
+            returnValue: _FakePigeonInstanceManager_11(
               this,
               Invocation.getter(#pigeon_instanceManager),
             ),
-            returnValueForMissingStub: _FakePigeonInstanceManager_10(
+            returnValueForMissingStub: _FakePigeonInstanceManager_11(
               this,
               Invocation.getter(#pigeon_instanceManager),
             ),
@@ -1608,11 +1682,11 @@ class MockWebSettings extends _i1.Mock implements _i2.WebSettings {
   _i2.PigeonInstanceManager get pigeon_instanceManager =>
       (super.noSuchMethod(
             Invocation.getter(#pigeon_instanceManager),
-            returnValue: _FakePigeonInstanceManager_10(
+            returnValue: _FakePigeonInstanceManager_11(
               this,
               Invocation.getter(#pigeon_instanceManager),
             ),
-            returnValueForMissingStub: _FakePigeonInstanceManager_10(
+            returnValueForMissingStub: _FakePigeonInstanceManager_11(
               this,
               Invocation.getter(#pigeon_instanceManager),
             ),
@@ -1780,8 +1854,8 @@ class MockWebSettings extends _i1.Mock implements _i2.WebSettings {
   _i2.WebSettings pigeon_copy() =>
       (super.noSuchMethod(
             Invocation.method(#pigeon_copy, []),
-            returnValue: _FakeWebSettings_17(this, Invocation.method(#pigeon_copy, [])),
-            returnValueForMissingStub: _FakeWebSettings_17(
+            returnValue: _FakeWebSettings_19(this, Invocation.method(#pigeon_copy, [])),
+            returnValueForMissingStub: _FakeWebSettings_19(
               this,
               Invocation.method(#pigeon_copy, []),
             ),
@@ -1797,8 +1871,8 @@ class MockWebView extends _i1.Mock implements _i2.WebView {
   _i2.WebSettings get settings =>
       (super.noSuchMethod(
             Invocation.getter(#settings),
-            returnValue: _FakeWebSettings_17(this, Invocation.getter(#settings)),
-            returnValueForMissingStub: _FakeWebSettings_17(this, Invocation.getter(#settings)),
+            returnValue: _FakeWebSettings_19(this, Invocation.getter(#settings)),
+            returnValueForMissingStub: _FakeWebSettings_19(this, Invocation.getter(#settings)),
           )
           as _i2.WebSettings);
 
@@ -1806,11 +1880,11 @@ class MockWebView extends _i1.Mock implements _i2.WebView {
   _i2.PigeonInstanceManager get pigeon_instanceManager =>
       (super.noSuchMethod(
             Invocation.getter(#pigeon_instanceManager),
-            returnValue: _FakePigeonInstanceManager_10(
+            returnValue: _FakePigeonInstanceManager_11(
               this,
               Invocation.getter(#pigeon_instanceManager),
             ),
-            returnValueForMissingStub: _FakePigeonInstanceManager_10(
+            returnValueForMissingStub: _FakePigeonInstanceManager_11(
               this,
               Invocation.getter(#pigeon_instanceManager),
             ),
@@ -1821,8 +1895,8 @@ class MockWebView extends _i1.Mock implements _i2.WebView {
   _i2.WebSettings pigeonVar_settings() =>
       (super.noSuchMethod(
             Invocation.method(#pigeonVar_settings, []),
-            returnValue: _FakeWebSettings_17(this, Invocation.method(#pigeonVar_settings, [])),
-            returnValueForMissingStub: _FakeWebSettings_17(
+            returnValue: _FakeWebSettings_19(this, Invocation.method(#pigeonVar_settings, [])),
+            returnValueForMissingStub: _FakeWebSettings_19(
               this,
               Invocation.method(#pigeonVar_settings, []),
             ),
@@ -1950,6 +2024,25 @@ class MockWebView extends _i1.Mock implements _i2.WebView {
           as _i8.Future<String?>);
 
   @override
+  _i8.Future<_i2.ScriptHandler> addDocumentStartJavaScript(String? javaScript) =>
+      (super.noSuchMethod(
+            Invocation.method(#addDocumentStartJavaScript, [javaScript]),
+            returnValue: _i8.Future<_i2.ScriptHandler>.value(
+              _FakeScriptHandler_18(
+                this,
+                Invocation.method(#addDocumentStartJavaScript, [javaScript]),
+              ),
+            ),
+            returnValueForMissingStub: _i8.Future<_i2.ScriptHandler>.value(
+              _FakeScriptHandler_18(
+                this,
+                Invocation.method(#addDocumentStartJavaScript, [javaScript]),
+              ),
+            ),
+          )
+          as _i8.Future<_i2.ScriptHandler>);
+
+  @override
   _i8.Future<String?> getTitle() =>
       (super.noSuchMethod(
             Invocation.method(#getTitle, []),
@@ -2025,8 +2118,8 @@ class MockWebView extends _i1.Mock implements _i2.WebView {
   _i2.WebView pigeon_copy() =>
       (super.noSuchMethod(
             Invocation.method(#pigeon_copy, []),
-            returnValue: _FakeWebView_18(this, Invocation.method(#pigeon_copy, [])),
-            returnValueForMissingStub: _FakeWebView_18(this, Invocation.method(#pigeon_copy, [])),
+            returnValue: _FakeWebView_20(this, Invocation.method(#pigeon_copy, [])),
+            returnValueForMissingStub: _FakeWebView_20(this, Invocation.method(#pigeon_copy, [])),
           )
           as _i2.WebView);
 
@@ -2053,10 +2146,10 @@ class MockWebView extends _i1.Mock implements _i2.WebView {
       (super.noSuchMethod(
             Invocation.method(#getScrollPosition, []),
             returnValue: _i8.Future<_i2.WebViewPoint>.value(
-              _FakeWebViewPoint_19(this, Invocation.method(#getScrollPosition, [])),
+              _FakeWebViewPoint_21(this, Invocation.method(#getScrollPosition, [])),
             ),
             returnValueForMissingStub: _i8.Future<_i2.WebViewPoint>.value(
-              _FakeWebViewPoint_19(this, Invocation.method(#getScrollPosition, [])),
+              _FakeWebViewPoint_21(this, Invocation.method(#getScrollPosition, [])),
             ),
           )
           as _i8.Future<_i2.WebViewPoint>);
@@ -2106,11 +2199,11 @@ class MockWebViewClient extends _i1.Mock implements _i2.WebViewClient {
   _i2.PigeonInstanceManager get pigeon_instanceManager =>
       (super.noSuchMethod(
             Invocation.getter(#pigeon_instanceManager),
-            returnValue: _FakePigeonInstanceManager_10(
+            returnValue: _FakePigeonInstanceManager_11(
               this,
               Invocation.getter(#pigeon_instanceManager),
             ),
-            returnValueForMissingStub: _FakePigeonInstanceManager_10(
+            returnValueForMissingStub: _FakePigeonInstanceManager_11(
               this,
               Invocation.getter(#pigeon_instanceManager),
             ),
@@ -2147,11 +2240,11 @@ class MockWebStorage extends _i1.Mock implements _i2.WebStorage {
   _i2.PigeonInstanceManager get pigeon_instanceManager =>
       (super.noSuchMethod(
             Invocation.getter(#pigeon_instanceManager),
-            returnValue: _FakePigeonInstanceManager_10(
+            returnValue: _FakePigeonInstanceManager_11(
               this,
               Invocation.getter(#pigeon_instanceManager),
             ),
-            returnValueForMissingStub: _FakePigeonInstanceManager_10(
+            returnValueForMissingStub: _FakePigeonInstanceManager_11(
               this,
               Invocation.getter(#pigeon_instanceManager),
             ),
@@ -2171,8 +2264,8 @@ class MockWebStorage extends _i1.Mock implements _i2.WebStorage {
   _i2.WebStorage pigeon_copy() =>
       (super.noSuchMethod(
             Invocation.method(#pigeon_copy, []),
-            returnValue: _FakeWebStorage_20(this, Invocation.method(#pigeon_copy, [])),
-            returnValueForMissingStub: _FakeWebStorage_20(
+            returnValue: _FakeWebStorage_22(this, Invocation.method(#pigeon_copy, [])),
+            returnValueForMissingStub: _FakeWebStorage_22(
               this,
               Invocation.method(#pigeon_copy, []),
             ),

--- a/packages/webview_flutter/webview_flutter_android/test/android_webview_cookie_manager_test.mocks.dart
+++ b/packages/webview_flutter/webview_flutter_android/test/android_webview_cookie_manager_test.mocks.dart
@@ -42,12 +42,18 @@ class _FakePlatformWebViewControllerCreationParams_2 extends _i1.SmartFake
     : super(parent, parentInvocation);
 }
 
-class _FakeObject_3 extends _i1.SmartFake implements Object {
-  _FakeObject_3(Object parent, Invocation parentInvocation) : super(parent, parentInvocation);
+class _FakePlatformDocumentStartJavaScript_3 extends _i1.SmartFake
+    implements _i3.PlatformDocumentStartJavaScriptRegistration {
+  _FakePlatformDocumentStartJavaScript_3(Object parent, Invocation parentInvocation)
+    : super(parent, parentInvocation);
 }
 
-class _FakeOffset_4 extends _i1.SmartFake implements _i4.Offset {
-  _FakeOffset_4(Object parent, Invocation parentInvocation) : super(parent, parentInvocation);
+class _FakeObject_4 extends _i1.SmartFake implements Object {
+  _FakeObject_4(Object parent, Invocation parentInvocation) : super(parent, parentInvocation);
+}
+
+class _FakeOffset_5 extends _i1.SmartFake implements _i4.Offset {
+  _FakeOffset_5(Object parent, Invocation parentInvocation) : super(parent, parentInvocation);
 }
 
 /// A class which mocks [CookieManager].
@@ -277,11 +283,26 @@ class MockAndroidWebViewController extends _i1.Mock implements _i6.AndroidWebVie
           as _i5.Future<void>);
 
   @override
+  _i5.Future<_i3.PlatformDocumentStartJavaScriptRegistration> addDocumentStartJavaScript(
+    String? javaScript,
+  ) =>
+      (super.noSuchMethod(
+            Invocation.method(#addDocumentStartJavaScript, [javaScript]),
+            returnValue: _i5.Future<_i3.PlatformDocumentStartJavaScriptRegistration>.value(
+              _FakePlatformDocumentStartJavaScript_3(
+                this,
+                Invocation.method(#addDocumentStartJavaScript, [javaScript]),
+              ),
+            ),
+          )
+          as _i5.Future<_i3.PlatformDocumentStartJavaScriptRegistration>);
+
+  @override
   _i5.Future<Object> runJavaScriptReturningResult(String? javaScript) =>
       (super.noSuchMethod(
             Invocation.method(#runJavaScriptReturningResult, [javaScript]),
             returnValue: _i5.Future<Object>.value(
-              _FakeObject_3(this, Invocation.method(#runJavaScriptReturningResult, [javaScript])),
+              _FakeObject_4(this, Invocation.method(#runJavaScriptReturningResult, [javaScript])),
             ),
           )
           as _i5.Future<Object>);
@@ -335,7 +356,7 @@ class MockAndroidWebViewController extends _i1.Mock implements _i6.AndroidWebVie
       (super.noSuchMethod(
             Invocation.method(#getScrollPosition, []),
             returnValue: _i5.Future<_i4.Offset>.value(
-              _FakeOffset_4(this, Invocation.method(#getScrollPosition, [])),
+              _FakeOffset_5(this, Invocation.method(#getScrollPosition, [])),
             ),
           )
           as _i5.Future<_i4.Offset>);

--- a/packages/webview_flutter/webview_flutter_android/test/legacy/webview_android_widget_test.mocks.dart
+++ b/packages/webview_flutter/webview_flutter_android/test/legacy/webview_android_widget_test.mocks.dart
@@ -46,42 +46,47 @@ class _FakeWebStorage_3 extends _i1.SmartFake implements _i2.WebStorage {
   _FakeWebStorage_3(Object parent, Invocation parentInvocation) : super(parent, parentInvocation);
 }
 
-class _FakeWebView_4 extends _i1.SmartFake implements _i2.WebView {
-  _FakeWebView_4(Object parent, Invocation parentInvocation) : super(parent, parentInvocation);
-}
-
-class _FakeWebViewPoint_5 extends _i1.SmartFake implements _i2.WebViewPoint {
-  _FakeWebViewPoint_5(Object parent, Invocation parentInvocation) : super(parent, parentInvocation);
-}
-
-class _FakeWebResourceRequest_6 extends _i1.SmartFake implements _i2.WebResourceRequest {
-  _FakeWebResourceRequest_6(Object parent, Invocation parentInvocation)
+class _FakeScriptHandler_4 extends _i1.SmartFake implements _i2.ScriptHandler {
+  _FakeScriptHandler_4(Object parent, Invocation parentInvocation)
     : super(parent, parentInvocation);
 }
 
-class _FakeDownloadListener_7 extends _i1.SmartFake implements _i2.DownloadListener {
-  _FakeDownloadListener_7(Object parent, Invocation parentInvocation)
+class _FakeWebView_5 extends _i1.SmartFake implements _i2.WebView {
+  _FakeWebView_5(Object parent, Invocation parentInvocation) : super(parent, parentInvocation);
+}
+
+class _FakeWebViewPoint_6 extends _i1.SmartFake implements _i2.WebViewPoint {
+  _FakeWebViewPoint_6(Object parent, Invocation parentInvocation) : super(parent, parentInvocation);
+}
+
+class _FakeWebResourceRequest_7 extends _i1.SmartFake implements _i2.WebResourceRequest {
+  _FakeWebResourceRequest_7(Object parent, Invocation parentInvocation)
     : super(parent, parentInvocation);
 }
 
-class _FakeJavascriptChannelRegistry_8 extends _i1.SmartFake
+class _FakeDownloadListener_8 extends _i1.SmartFake implements _i2.DownloadListener {
+  _FakeDownloadListener_8(Object parent, Invocation parentInvocation)
+    : super(parent, parentInvocation);
+}
+
+class _FakeJavascriptChannelRegistry_9 extends _i1.SmartFake
     implements _i3.JavascriptChannelRegistry {
-  _FakeJavascriptChannelRegistry_8(Object parent, Invocation parentInvocation)
+  _FakeJavascriptChannelRegistry_9(Object parent, Invocation parentInvocation)
     : super(parent, parentInvocation);
 }
 
-class _FakeJavaScriptChannel_9 extends _i1.SmartFake implements _i2.JavaScriptChannel {
-  _FakeJavaScriptChannel_9(Object parent, Invocation parentInvocation)
+class _FakeJavaScriptChannel_10 extends _i1.SmartFake implements _i2.JavaScriptChannel {
+  _FakeJavaScriptChannel_10(Object parent, Invocation parentInvocation)
     : super(parent, parentInvocation);
 }
 
-class _FakeWebChromeClient_10 extends _i1.SmartFake implements _i2.WebChromeClient {
-  _FakeWebChromeClient_10(Object parent, Invocation parentInvocation)
+class _FakeWebChromeClient_11 extends _i1.SmartFake implements _i2.WebChromeClient {
+  _FakeWebChromeClient_11(Object parent, Invocation parentInvocation)
     : super(parent, parentInvocation);
 }
 
-class _FakeWebViewClient_11 extends _i1.SmartFake implements _i2.WebViewClient {
-  _FakeWebViewClient_11(Object parent, Invocation parentInvocation)
+class _FakeWebViewClient_12 extends _i1.SmartFake implements _i2.WebViewClient {
+  _FakeWebViewClient_12(Object parent, Invocation parentInvocation)
     : super(parent, parentInvocation);
 }
 
@@ -499,6 +504,19 @@ class MockWebView extends _i1.Mock implements _i2.WebView {
           as _i4.Future<String?>);
 
   @override
+  _i4.Future<_i2.ScriptHandler> addDocumentStartJavaScript(String? javaScript) =>
+      (super.noSuchMethod(
+            Invocation.method(#addDocumentStartJavaScript, [javaScript]),
+            returnValue: _i4.Future<_i2.ScriptHandler>.value(
+              _FakeScriptHandler_4(
+                this,
+                Invocation.method(#addDocumentStartJavaScript, [javaScript]),
+              ),
+            ),
+          )
+          as _i4.Future<_i2.ScriptHandler>);
+
+  @override
   _i4.Future<String?> getTitle() =>
       (super.noSuchMethod(
             Invocation.method(#getTitle, []),
@@ -573,7 +591,7 @@ class MockWebView extends _i1.Mock implements _i2.WebView {
   _i2.WebView pigeon_copy() =>
       (super.noSuchMethod(
             Invocation.method(#pigeon_copy, []),
-            returnValue: _FakeWebView_4(this, Invocation.method(#pigeon_copy, [])),
+            returnValue: _FakeWebView_5(this, Invocation.method(#pigeon_copy, [])),
           )
           as _i2.WebView);
 
@@ -600,7 +618,7 @@ class MockWebView extends _i1.Mock implements _i2.WebView {
       (super.noSuchMethod(
             Invocation.method(#getScrollPosition, []),
             returnValue: _i4.Future<_i2.WebViewPoint>.value(
-              _FakeWebViewPoint_5(this, Invocation.method(#getScrollPosition, [])),
+              _FakeWebViewPoint_6(this, Invocation.method(#getScrollPosition, [])),
             ),
           )
           as _i4.Future<_i2.WebViewPoint>);
@@ -693,7 +711,7 @@ class MockWebResourceRequest extends _i1.Mock implements _i2.WebResourceRequest 
   _i2.WebResourceRequest pigeon_copy() =>
       (super.noSuchMethod(
             Invocation.method(#pigeon_copy, []),
-            returnValue: _FakeWebResourceRequest_6(this, Invocation.method(#pigeon_copy, [])),
+            returnValue: _FakeWebResourceRequest_7(this, Invocation.method(#pigeon_copy, [])),
           )
           as _i2.WebResourceRequest);
 }
@@ -737,7 +755,7 @@ class MockDownloadListener extends _i1.Mock implements _i2.DownloadListener {
   _i2.DownloadListener pigeon_copy() =>
       (super.noSuchMethod(
             Invocation.method(#pigeon_copy, []),
-            returnValue: _FakeDownloadListener_7(this, Invocation.method(#pigeon_copy, [])),
+            returnValue: _FakeDownloadListener_8(this, Invocation.method(#pigeon_copy, [])),
           )
           as _i2.DownloadListener);
 }
@@ -755,7 +773,7 @@ class MockWebViewAndroidJavaScriptChannel extends _i1.Mock
   _i3.JavascriptChannelRegistry get javascriptChannelRegistry =>
       (super.noSuchMethod(
             Invocation.getter(#javascriptChannelRegistry),
-            returnValue: _FakeJavascriptChannelRegistry_8(
+            returnValue: _FakeJavascriptChannelRegistry_9(
               this,
               Invocation.getter(#javascriptChannelRegistry),
             ),
@@ -793,7 +811,7 @@ class MockWebViewAndroidJavaScriptChannel extends _i1.Mock
   _i2.JavaScriptChannel pigeon_copy() =>
       (super.noSuchMethod(
             Invocation.method(#pigeon_copy, []),
-            returnValue: _FakeJavaScriptChannel_9(this, Invocation.method(#pigeon_copy, [])),
+            returnValue: _FakeJavaScriptChannel_10(this, Invocation.method(#pigeon_copy, [])),
           )
           as _i2.JavaScriptChannel);
 }
@@ -898,7 +916,7 @@ class MockWebChromeClient extends _i1.Mock implements _i2.WebChromeClient {
   _i2.WebChromeClient pigeon_copy() =>
       (super.noSuchMethod(
             Invocation.method(#pigeon_copy, []),
-            returnValue: _FakeWebChromeClient_10(this, Invocation.method(#pigeon_copy, [])),
+            returnValue: _FakeWebChromeClient_11(this, Invocation.method(#pigeon_copy, [])),
           )
           as _i2.WebChromeClient);
 }
@@ -935,7 +953,7 @@ class MockWebViewClient extends _i1.Mock implements _i2.WebViewClient {
   _i2.WebViewClient pigeon_copy() =>
       (super.noSuchMethod(
             Invocation.method(#pigeon_copy, []),
-            returnValue: _FakeWebViewClient_11(this, Invocation.method(#pigeon_copy, [])),
+            returnValue: _FakeWebViewClient_12(this, Invocation.method(#pigeon_copy, [])),
           )
           as _i2.WebViewClient);
 }
@@ -1024,7 +1042,7 @@ class MockWebViewProxy extends _i1.Mock implements _i7.WebViewProxy {
   _i2.WebView createWebView() =>
       (super.noSuchMethod(
             Invocation.method(#createWebView, []),
-            returnValue: _FakeWebView_4(this, Invocation.method(#createWebView, [])),
+            returnValue: _FakeWebView_5(this, Invocation.method(#createWebView, [])),
           )
           as _i2.WebView);
 
@@ -1054,7 +1072,7 @@ class MockWebViewProxy extends _i1.Mock implements _i7.WebViewProxy {
               #onReceivedSslError: onReceivedSslError,
               #urlLoading: urlLoading,
             }),
-            returnValue: _FakeWebViewClient_11(
+            returnValue: _FakeWebViewClient_12(
               this,
               Invocation.method(#createWebViewClient, [], {
                 #onPageStarted: onPageStarted,

--- a/packages/webview_flutter/webview_flutter_platform_interface/CHANGELOG.md
+++ b/packages/webview_flutter/webview_flutter_platform_interface/CHANGELOG.md
@@ -1,5 +1,7 @@
-## NEXT
+## 2.16.0
 
+* Adds `addDocumentStartJavaScript` to `PlatformWebViewController` and the
+  `PlatformDocumentStartJavaScriptRegistration` class that it returns.
 * Updates minimum supported SDK version to Flutter 3.38/Dart 3.10.
 
 ## 2.15.1

--- a/packages/webview_flutter/webview_flutter_platform_interface/lib/src/platform_webview_controller.dart
+++ b/packages/webview_flutter/webview_flutter_platform_interface/lib/src/platform_webview_controller.dart
@@ -168,6 +168,29 @@ abstract class PlatformWebViewController extends PlatformInterface {
     throw UnimplementedError('runJavaScript is not implemented on the current platform');
   }
 
+  /// Adds JavaScript that runs at the start of future document loads.
+  ///
+  /// This method should be called before loading a page if the script needs to
+  /// run for that page. It does not run JavaScript in the currently loaded
+  /// document. Implementations must run scripts in the order in which they were
+  /// added.
+  ///
+  /// The script runs in every frame of a loaded document, regardless of its
+  /// origin, including cross-origin `<iframe>`s.
+  ///
+  /// The returned [PlatformDocumentStartJavaScriptRegistration] can be used to stop
+  /// injecting the JavaScript into future document loads.
+  ///
+  /// Implementations that cannot support this feature should throw an
+  /// [UnsupportedError].
+  Future<PlatformDocumentStartJavaScriptRegistration> addDocumentStartJavaScript(
+    String javaScript,
+  ) {
+    throw UnimplementedError(
+      'addDocumentStartJavaScript is not implemented on the current platform',
+    );
+  }
+
   /// Runs the given JavaScript in the context of the current page, and returns the result.
   ///
   /// The Future completes with an error if a JavaScript error occurred, or if the
@@ -327,6 +350,18 @@ abstract class PlatformWebViewController extends PlatformInterface {
   Future<void> setOverScrollMode(WebViewOverScrollMode mode) async {
     throw UnimplementedError('setOverScrollMode is not implemented on the current platform');
   }
+}
+
+/// A registration for JavaScript injected at the start of future document loads.
+///
+/// Returned by [PlatformWebViewController.addDocumentStartJavaScript].
+abstract class PlatformDocumentStartJavaScriptRegistration {
+  /// Creates a [PlatformDocumentStartJavaScriptRegistration].
+  @protected
+  const PlatformDocumentStartJavaScriptRegistration();
+
+  /// Deregisters this registration, stopping JavaScript injection into future document loads.
+  Future<void> remove();
 }
 
 /// Describes the parameters necessary for registering a JavaScript channel.

--- a/packages/webview_flutter/webview_flutter_platform_interface/pubspec.yaml
+++ b/packages/webview_flutter/webview_flutter_platform_interface/pubspec.yaml
@@ -4,7 +4,7 @@ repository: https://github.com/flutter/packages/tree/main/packages/webview_flutt
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+webview_flutter%22
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 2.15.1
+version: 2.16.0
 
 environment:
   sdk: ^3.10.0

--- a/packages/webview_flutter/webview_flutter_platform_interface/test/platform_document_start_java_script_test.dart
+++ b/packages/webview_flutter/webview_flutter_platform_interface/test/platform_document_start_java_script_test.dart
@@ -1,0 +1,26 @@
+// Copyright 2013 The Flutter Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:webview_flutter_platform_interface/webview_flutter_platform_interface.dart';
+
+void main() {
+  test('remove is forwarded to the implementation', () async {
+    final documentStartJavaScript = ExtendsPlatformDocumentStartJavaScriptRegistration();
+
+    await documentStartJavaScript.remove();
+
+    expect(documentStartJavaScript.removeCallCount, 1);
+  });
+}
+
+class ExtendsPlatformDocumentStartJavaScriptRegistration
+    extends PlatformDocumentStartJavaScriptRegistration {
+  int removeCallCount = 0;
+
+  @override
+  Future<void> remove() async {
+    removeCallCount += 1;
+  }
+}

--- a/packages/webview_flutter/webview_flutter_platform_interface/test/platform_webview_controller_test.dart
+++ b/packages/webview_flutter/webview_flutter_platform_interface/test/platform_webview_controller_test.dart
@@ -180,6 +180,14 @@ void main() {
     expect(() => controller.runJavaScript('javaScript'), throwsUnimplementedError);
   });
 
+  test('Default implementation of addDocumentStartJavaScript should throw unimplemented error', () {
+    final PlatformWebViewController controller = ExtendsPlatformWebViewController(
+      const PlatformWebViewControllerCreationParams(),
+    );
+
+    expect(() => controller.addDocumentStartJavaScript('javaScript'), throwsUnimplementedError);
+  });
+
   test(
     'Default implementation of runJavaScriptReturningResult should throw unimplemented error',
     () {

--- a/packages/webview_flutter/webview_flutter_web/CHANGELOG.md
+++ b/packages/webview_flutter/webview_flutter_web/CHANGELOG.md
@@ -1,5 +1,7 @@
-## NEXT
+## 0.2.4
 
+* Adds `addDocumentStartJavaScript`, which throws an `UnsupportedError` since
+  document-start JavaScript injection is not supported on the web.
 * Updates minimum supported SDK version to Flutter 3.38/Dart 3.10.
 
 ## 0.2.3+4

--- a/packages/webview_flutter/webview_flutter_web/lib/src/web_webview_controller.dart
+++ b/packages/webview_flutter/webview_flutter_web/lib/src/web_webview_controller.dart
@@ -83,6 +83,17 @@ class WebWebViewController extends PlatformWebViewController {
     }
   }
 
+  /// Always throws an [UnsupportedError].
+  ///
+  /// Content is rendered in an `<iframe>`, which provides no way to inject a
+  /// script into a document before it loads.
+  @override
+  Future<PlatformDocumentStartJavaScriptRegistration> addDocumentStartJavaScript(
+    String javaScript,
+  ) async {
+    throw UnsupportedError('Document-start JavaScript injection is not supported on web.');
+  }
+
   /// Performs an AJAX request defined by [params].
   Future<void> _updateIFrameFromXhr(LoadRequestParams params) async {
     final response =

--- a/packages/webview_flutter/webview_flutter_web/pubspec.yaml
+++ b/packages/webview_flutter/webview_flutter_web/pubspec.yaml
@@ -2,7 +2,7 @@ name: webview_flutter_web
 description: A Flutter plugin that provides a WebView widget on web.
 repository: https://github.com/flutter/packages/tree/main/packages/webview_flutter/webview_flutter_web
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+webview%22
-version: 0.2.3+4
+version: 0.2.4
 
 environment:
   sdk: ^3.10.0
@@ -22,7 +22,7 @@ dependencies:
   flutter_web_plugins:
     sdk: flutter
   web: ">=0.5.1 <2.0.0"
-  webview_flutter_platform_interface: ^2.0.0
+  webview_flutter_platform_interface: ^2.16.0
 
 dev_dependencies:
   build_runner: ^2.1.5

--- a/packages/webview_flutter/webview_flutter_web/test/web_webview_controller_test.dart
+++ b/packages/webview_flutter/webview_flutter_web/test/web_webview_controller_test.dart
@@ -212,5 +212,14 @@ void main() {
         );
       });
     });
+
+    test('addDocumentStartJavaScript is unsupported', () async {
+      final controller = WebWebViewController(WebWebViewControllerCreationParams());
+
+      await expectLater(
+        () async => controller.addDocumentStartJavaScript('window.test = true;'),
+        throwsA(isA<UnsupportedError>()),
+      );
+    });
   });
 }

--- a/packages/webview_flutter/webview_flutter_wkwebview/CHANGELOG.md
+++ b/packages/webview_flutter/webview_flutter_wkwebview/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.27.0
+
+* Adds support for `addDocumentStartJavaScript`.
+
 ## 3.26.0
 
 * Adds new method for accessing a native `WKWebView` from a `FlutterPluginRegistrar`.

--- a/packages/webview_flutter/webview_flutter_wkwebview/example/integration_test/webview_flutter_test.dart
+++ b/packages/webview_flutter/webview_flutter_wkwebview/example/integration_test/webview_flutter_test.dart
@@ -33,6 +33,15 @@ Future<void> main() async {
         request.response.writeln('How are you today?');
       } else if (request.uri.path == '/headers') {
         request.response.writeln('${request.headers}');
+      } else if (request.uri.path == '/document-start.html') {
+        request.response.headers.contentType = ContentType.html;
+        // The inline script records the state of the window at parse time, so
+        // that a test can verify that injected scripts ran before it.
+        request.response.writeln(
+          '<!DOCTYPE html><html><head> '
+          '<script>window.recordedAtParseTime = String(window.injectedAtDocumentStart);</script> '
+          '</head><body>Document start test.</body></html>',
+        );
       } else if (request.uri.path == '/favicon.ico') {
         request.response.statusCode = HttpStatus.notFound;
       } else if (request.uri.path == '/http-basic-authentication') {
@@ -54,6 +63,7 @@ Future<void> main() async {
   final secondaryUrl = '$prefixUrl/secondary.txt';
   final headersUrl = '$prefixUrl/headers';
   final basicAuthUrl = '$prefixUrl/http-basic-authentication';
+  final documentStartUrl = '$prefixUrl/document-start.html';
 
   setUp(() {
     PigeonOverrides.pigeon_reset();
@@ -191,6 +201,44 @@ Future<void> main() async {
     await pageFinished.future;
 
     await expectLater(controller.runJavaScriptReturningResult('1 + 1'), completion(2));
+  });
+
+  testWidgets('addDocumentStartJavaScript', (WidgetTester tester) async {
+    final pageFinished = Completer<void>();
+    final messageReceived = Completer<String>();
+
+    final controller = PlatformWebViewController(const PlatformWebViewControllerCreationParams());
+    unawaited(controller.setJavaScriptMode(JavaScriptMode.unrestricted));
+    final delegate = PlatformNavigationDelegate(const PlatformNavigationDelegateCreationParams());
+    unawaited(delegate.setOnPageFinished((_) => pageFinished.complete()));
+    unawaited(controller.setPlatformNavigationDelegate(delegate));
+    await controller.addJavaScriptChannel(
+      JavaScriptChannelParams(
+        name: 'Echo',
+        onMessageReceived: (JavaScriptMessage message) => messageReceived.complete(message.message),
+      ),
+    );
+
+    await controller.addDocumentStartJavaScript('window.injectedAtDocumentStart = "injected";');
+    await controller.loadRequest(LoadRequestParams(uri: Uri.parse(documentStartUrl)));
+
+    await tester.pumpWidget(
+      Builder(
+        builder: (BuildContext context) {
+          return PlatformWebViewWidget(
+            PlatformWebViewWidgetCreationParams(controller: controller),
+          ).build(context);
+        },
+      ),
+    );
+
+    await pageFinished.future;
+
+    // The page records this value while it is being parsed, so a match proves
+    // that the script ran before the document's own scripts.
+    await controller.runJavaScript('Echo.postMessage(window.recordedAtParseTime);');
+
+    await expectLater(messageReceived.future, completion('injected'));
   });
 
   testWidgets('loadRequest with headers', (WidgetTester tester) async {

--- a/packages/webview_flutter/webview_flutter_wkwebview/lib/src/webkit_webview_controller.dart
+++ b/packages/webview_flutter/webview_flutter_wkwebview/lib/src/webkit_webview_controller.dart
@@ -317,6 +317,10 @@ class WebKitWebViewController extends PlatformWebViewController {
   final Map<String, WebKitJavaScriptChannelParams> _javaScriptChannelParams =
       <String, WebKitJavaScriptChannelParams>{};
 
+  /// Active document-start JavaScript registrations, in insertion order.
+  final List<WebKitDocumentStartJavaScriptRegistration> _documentStartJavaScriptRegistrations =
+      <WebKitDocumentStartJavaScriptRegistration>[];
+
   bool _zoomEnabled = true;
   WebKitNavigationDelegate? _currentNavigationDelegate;
 
@@ -445,6 +449,31 @@ class WebKitWebViewController extends PlatformWebViewController {
       contentController.addUserScript(wrapperScript),
       contentController.addScriptMessageHandler(webKitParams._messageHandler, webKitParams.name),
     ]);
+  }
+
+  /// Adds JavaScript that runs at the start of future document loads.
+  ///
+  /// The script is added as a `WKUserScript` that is injected into all frames
+  /// at [UserScriptInjectionTime.atDocumentStart].
+  @override
+  Future<PlatformDocumentStartJavaScriptRegistration> addDocumentStartJavaScript(
+    String javaScript,
+  ) async {
+    final registration = WebKitDocumentStartJavaScriptRegistration._(this, javaScript);
+    await _addDocumentStartJavaScript(javaScript);
+    _documentStartJavaScriptRegistrations.add(registration);
+    return registration;
+  }
+
+  Future<void> _removeDocumentStartJavaScriptRegistration(
+    WebKitDocumentStartJavaScriptRegistration registration,
+  ) async {
+    if (!_documentStartJavaScriptRegistrations.remove(registration)) {
+      return;
+    }
+    // WKWebView does not support removing a single user script, so all user
+    // scripts are removed and the remaining ones are re-added.
+    await _resetUserScripts();
   }
 
   @override
@@ -795,7 +824,9 @@ class WebKitWebViewController extends PlatformWebViewController {
   Future<void> _resetUserScripts({String? removedJavaScriptChannel}) async {
     final WKUserContentController controller = await _webView.configuration
         .getUserContentController();
-    unawaited(controller.removeAllUserScripts());
+    // This is awaited so that it cannot remove the scripts that are re-added
+    // below.
+    await controller.removeAllUserScripts();
     // TODO(bparrishMines): This can be replaced with
     // `removeAllScriptMessageHandlers` once Dart supports runtime version
     // checking. (e.g. The equivalent to @availability in Objective-C.)
@@ -807,6 +838,9 @@ class WebKitWebViewController extends PlatformWebViewController {
     _javaScriptChannelParams.clear();
 
     await Future.wait(<Future<void>>[
+      // These are added sequentially with each other, since user scripts are
+      // run in the order they were added.
+      _addAllDocumentStartJavaScriptRegistrations(),
       for (final JavaScriptChannelParams params in remainingChannelParams.values)
         addJavaScriptChannel(params),
       // Zoom is disabled with a WKUserScript, so this adds it back if it was
@@ -816,6 +850,26 @@ class WebKitWebViewController extends PlatformWebViewController {
       // if a console callback was registered with [setOnConsoleMessage].
       if (_onConsoleMessageCallback != null) _injectConsoleOverride(),
     ]);
+  }
+
+  Future<void> _addAllDocumentStartJavaScriptRegistrations() async {
+    final registrations = List<WebKitDocumentStartJavaScriptRegistration>.of(
+      _documentStartJavaScriptRegistrations,
+    );
+    for (final registration in registrations) {
+      await _addDocumentStartJavaScript(registration._javaScript);
+    }
+  }
+
+  Future<void> _addDocumentStartJavaScript(String javaScript) async {
+    final userScript = WKUserScript(
+      source: javaScript,
+      injectionTime: UserScriptInjectionTime.atDocumentStart,
+      isForMainFrameOnly: false,
+    );
+    final WKUserContentController controller = await _webView.configuration
+        .getUserContentController();
+    await controller.addUserScript(userScript);
   }
 
   Future<void> _disableZoom() async {
@@ -907,6 +961,23 @@ window.addEventListener("error", function(e) {
     final WKUserContentController controller = await _webView.configuration
         .getUserContentController();
     await controller.addUserScript(overrideScript);
+  }
+}
+
+/// An implementation of [PlatformDocumentStartJavaScriptRegistration] with the WebKit api.
+///
+/// See [WebKitWebViewController.addDocumentStartJavaScript].
+class WebKitDocumentStartJavaScriptRegistration
+    extends PlatformDocumentStartJavaScriptRegistration {
+  WebKitDocumentStartJavaScriptRegistration._(this._controller, this._javaScript);
+
+  final WebKitWebViewController _controller;
+
+  final String _javaScript;
+
+  @override
+  Future<void> remove() {
+    return _controller._removeDocumentStartJavaScriptRegistration(this);
   }
 }
 

--- a/packages/webview_flutter/webview_flutter_wkwebview/pubspec.yaml
+++ b/packages/webview_flutter/webview_flutter_wkwebview/pubspec.yaml
@@ -2,7 +2,7 @@ name: webview_flutter_wkwebview
 description: A Flutter plugin that provides a WebView widget based on Apple's WKWebView control.
 repository: https://github.com/flutter/packages/tree/main/packages/webview_flutter/webview_flutter_wkwebview
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+webview%22
-version: 3.26.0
+version: 3.27.0
 
 environment:
   sdk: ^3.12.0
@@ -26,7 +26,7 @@ dependencies:
     sdk: flutter
   meta: ^1.10.0
   path: ^1.8.0
-  webview_flutter_platform_interface: ^2.15.1
+  webview_flutter_platform_interface: ^2.16.0
 
 dev_dependencies:
   build_runner: ^2.1.5

--- a/packages/webview_flutter/webview_flutter_wkwebview/test/webkit_webview_controller_test.dart
+++ b/packages/webview_flutter/webview_flutter_wkwebview/test/webkit_webview_controller_test.dart
@@ -889,6 +889,170 @@ void main() {
       expect(userScript.injectionTime, UserScriptInjectionTime.atDocumentStart);
     });
 
+    test('addDocumentStartJavaScript', () async {
+      final mockUserContentController = MockWKUserContentController();
+      final WebKitWebViewController controller = createControllerWithMocks(
+        mockUserContentController: mockUserContentController,
+      );
+
+      await controller.addDocumentStartJavaScript('window.test = true;');
+
+      final userScript =
+          verify(mockUserContentController.addUserScript(captureAny)).captured.single
+              as WKUserScript;
+      expect(userScript.source, 'window.test = true;');
+      expect(userScript.injectionTime, UserScriptInjectionTime.atDocumentStart);
+      expect(userScript.isForMainFrameOnly, isFalse);
+    });
+
+    test('addDocumentStartJavaScript allows the same JavaScript twice', () async {
+      final mockUserContentController = MockWKUserContentController();
+      final WebKitWebViewController controller = createControllerWithMocks(
+        mockUserContentController: mockUserContentController,
+      );
+
+      final PlatformDocumentStartJavaScriptRegistration first = await controller
+          .addDocumentStartJavaScript('window.test = true;');
+      final PlatformDocumentStartJavaScriptRegistration second = await controller
+          .addDocumentStartJavaScript('window.test = true;');
+
+      expect(first, isNot(same(second)));
+      verify(mockUserContentController.addUserScript(any)).called(2);
+    });
+
+    test('removing document start JavaScript re-adds the remaining scripts', () async {
+      final mockUserContentController = MockWKUserContentController();
+      final WebKitWebViewController controller = createControllerWithMocks(
+        mockUserContentController: mockUserContentController,
+      );
+
+      final PlatformDocumentStartJavaScriptRegistration first = await controller
+          .addDocumentStartJavaScript('window.first = true;');
+      await controller.addDocumentStartJavaScript('window.second = true;');
+      reset(mockUserContentController);
+
+      await first.remove();
+
+      // WKWebView can only remove all user scripts, so the remaining script is
+      // re-added.
+      verify(mockUserContentController.removeAllUserScripts());
+      final userScript =
+          verify(mockUserContentController.addUserScript(captureAny)).captured.single
+              as WKUserScript;
+      expect(userScript.source, 'window.second = true;');
+    });
+
+    test('removing document start JavaScript more than once is a no-op', () async {
+      final mockUserContentController = MockWKUserContentController();
+      final WebKitWebViewController controller = createControllerWithMocks(
+        mockUserContentController: mockUserContentController,
+      );
+
+      final PlatformDocumentStartJavaScriptRegistration documentStartJavaScript = await controller
+          .addDocumentStartJavaScript('window.test = true;');
+      await documentStartJavaScript.remove();
+      reset(mockUserContentController);
+
+      await documentStartJavaScript.remove();
+
+      verifyNever(mockUserContentController.removeAllUserScripts());
+    });
+
+    test('removed document start JavaScript is not re-added', () async {
+      final mockUserContentController = MockWKUserContentController();
+      final WebKitWebViewController controller = createControllerWithMocks(
+        mockUserContentController: mockUserContentController,
+      );
+
+      final PlatformDocumentStartJavaScriptRegistration documentStartJavaScript = await controller
+          .addDocumentStartJavaScript('window.test = true;');
+      await documentStartJavaScript.remove();
+      reset(mockUserContentController);
+
+      await controller.enableZoom(false);
+      await controller.enableZoom(true);
+
+      final List<WKUserScript> userScripts = verify(
+        mockUserContentController.addUserScript(captureAny),
+      ).captured.cast<WKUserScript>();
+      expect(
+        userScripts.map((WKUserScript script) => script.source),
+        isNot(contains('window.test = true;')),
+      );
+    });
+
+    test('removeJavaScriptChannel preserves document start JavaScript', () async {
+      PigeonOverrides.wKScriptMessageHandler_new =
+          ({
+            required void Function(WKScriptMessageHandler, WKUserContentController, WKScriptMessage)
+            didReceiveScriptMessage,
+            dynamic observeValue,
+          }) {
+            return WKScriptMessageHandler.pigeon_detached(
+              didReceiveScriptMessage: didReceiveScriptMessage,
+            );
+          };
+
+      final javaScriptChannelParams = WebKitJavaScriptChannelParams(
+        name: 'name',
+        onMessageReceived: (JavaScriptMessage message) {},
+      );
+
+      final mockUserContentController = MockWKUserContentController();
+      final WebKitWebViewController controller = createControllerWithMocks(
+        mockUserContentController: mockUserContentController,
+      );
+
+      await controller.addDocumentStartJavaScript('window.test = true;');
+      await controller.addJavaScriptChannel(javaScriptChannelParams);
+      reset(mockUserContentController);
+
+      await controller.removeJavaScriptChannel('name');
+
+      verify(mockUserContentController.removeAllUserScripts());
+      verify(mockUserContentController.removeScriptMessageHandler('name'));
+      final userScript =
+          verify(mockUserContentController.addUserScript(captureAny)).captured.single
+              as WKUserScript;
+      expect(userScript.source, 'window.test = true;');
+      expect(userScript.injectionTime, UserScriptInjectionTime.atDocumentStart);
+      expect(userScript.isForMainFrameOnly, isFalse);
+    });
+
+    test('enableZoom re-adds document start JavaScript in order', () async {
+      final mockWebViewConfiguration = MockWKWebViewConfiguration();
+      final mockUserContentController = MockWKUserContentController();
+      final WebKitWebViewController controller = createControllerWithMocks(
+        mockWebViewConfiguration: mockWebViewConfiguration,
+        mockUserContentController: mockUserContentController,
+      );
+
+      await controller.addDocumentStartJavaScript('window.first = true;');
+      await controller.addDocumentStartJavaScript('window.second = true;');
+      await controller.enableZoom(false);
+      reset(mockUserContentController);
+
+      // Make each lookup faster than the previous one, so that the scripts
+      // would be added out of order if they were added in parallel.
+      var lookupCount = 0;
+      when(mockWebViewConfiguration.getUserContentController()).thenAnswer((_) async {
+        final int milliseconds = 40 - 10 * lookupCount++;
+        await Future<void>.delayed(Duration(milliseconds: milliseconds));
+        return mockUserContentController;
+      });
+
+      await controller.enableZoom(true);
+
+      verify(mockUserContentController.removeAllUserScripts());
+      final List<WKUserScript> userScripts = verify(
+        mockUserContentController.addUserScript(captureAny),
+      ).captured.cast<WKUserScript>();
+      expect(userScripts.map((WKUserScript script) => script.source), <String>[
+        'window.first = true;',
+        'window.second = true;',
+      ]);
+    });
+
     test('addJavaScriptChannel requires channel with a unique name', () async {
       PigeonOverrides.wKScriptMessageHandler_new =
           ({


### PR DESCRIPTION
Adds addDocumentStartJavaScript to WebViewController and the platform interface, returning a DocumentStartJavaScript handle that can be used to stop injecting the script into future document loads.

Implements support on Android and WKWebView, including Android feature gating and WKWebView re-registration when user scripts are reset.

Throws UnsupportedError on unsupported platforms (including web), and updates examples, documentation, changelogs, generated bindings, and tests

Example usage:

```dart
final WebViewController controller = WebViewController();

final DocumentStartJavaScriptRegistration registration =
    await controller.addDocumentStartJavaScript(
  'window.exampleValue = "Hello from a document start script!";',
);

await controller.loadRequest(Uri.parse('https://flutter.dev'));

// Later, if the script should no longer be injected into future document loads:
await registration.remove();
```

The registered script runs:
- at the start of each document loaded after `addDocumentStartJavaScript` is called;
- before the loaded page's own scripts run;
- in the order that document-start scripts were added;
- in every frame of the loaded document, including cross-origin `<iframe>`s.

The script does not run in the currently loaded document, so apps should call `addDocumentStartJavaScript` before loading the page where the script is needed. Because the script is injected into every frame, including cross-origin frames, it should not contain sensitive data.

The returned `DocumentStartJavaScriptRegistration` can be kept and used to call `remove()`, which stops injecting that specific script into future document loads. If the script should remain active for the lifetime of the controller, the registration can be discarded.

This PR includes:
- Adds `addDocumentStartJavaScript` to `WebViewController`.
- Adds `PlatformWebViewController.addDocumentStartJavaScript` and `PlatformDocumentStartJavaScriptRegistration` to the platform interface.
- Exposes the public `DocumentStartJavaScriptRegistration` handle from `webview_flutter`.
- Implements document-start JavaScript support for Android.
- Adds Android feature gating for the WebView `DOCUMENT_START_SCRIPT` feature.
- Implements document-start JavaScript support for WKWebView.
- Ensures WKWebView document-start scripts are re-registered when user scripts are reset.
- Throws `UnsupportedError` on unsupported platforms, including web and Android devices whose installed WebView does not support DOCUMENT_START_SCRIPT.
- Updates README documentation and example usage.
- Updates generated Android Pigeon bindings.
- Updates changelogs and package versions.
- Adds and updates tests for the platform interface, Android implementation, WKWebView implementation, web unsupported behavior, examples, and generated mocks.

Fixes flutter/flutter#36752, flutter/flutter#82682

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under[^1].
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[the version and CHANGELOG instructions]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version-and-changelog-updates
[semantic versioning]: https://dart.dev/tools/pub/versioning#semantic-versions
[repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
