### PR TITLE
[in_app_purchase_storekit] Add show manage subscriptions path

### DIFF
--- a/packages/in_app_purchase/in_app_purchase_storekit/CHANGELOG.md
+++ b/packages/in_app_purchase/in_app_purchase_storekit/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.4.12
+
+* Adds `showManageSubscriptions` to `InAppPurchaseStoreKitPlatformAddition`, which presents the
+  App Store sheet for managing subscriptions. Requires StoreKit 2 and iOS 15+
+
 ## 0.4.11+1
 
 * Fixes StoreKit 2 restore transactions not grouping purchases into a single event.

--- a/packages/in_app_purchase/in_app_purchase_storekit/darwin/in_app_purchase_storekit/Sources/in_app_purchase_storekit/StoreKit2/InAppPurchasePlugin+StoreKit2.swift
+++ b/packages/in_app_purchase/in_app_purchase_storekit/darwin/in_app_purchase_storekit/Sources/in_app_purchase_storekit/StoreKit2/InAppPurchasePlugin+StoreKit2.swift
@@ -401,6 +401,51 @@ extension InAppPurchasePlugin: InAppPurchase2API {
     #endif
   }
 
+  /// Wrapper method around StoreKit2's showManageSubscriptions(in:) method
+  /// https://developer.apple.com/documentation/storekit/appstore/showmanagesubscriptions(in:)
+  /// Presents the App Store sheet that lets the user manage their subscriptions.
+  func showManageSubscriptions(completion: @escaping (Result<Void, Error>) -> Void) {
+    #if os(iOS)
+      if #available(iOS 15.0, *) {
+        guard let windowScene = self.registrar?.viewController?.view.window?.windowScene else {
+          let error = PigeonError(
+            code: "storekit2_missing_key_window_scene",
+            message: "Failed to fetch key window scene",
+            details: "registrar.viewController.view.window.windowScene returned nil."
+          )
+          completion(.failure(error))
+          return
+        }
+        Task { @MainActor in
+          do {
+            try await AppStore.showManageSubscriptions(in: windowScene)
+            completion(.success(()))
+          } catch {
+            completion(.failure(error))
+          }
+        }
+      } else {
+        completion(
+          .failure(
+            PigeonError(
+              code: "storekit2_unsupported_platform_version",
+              message: "Managing subscriptions requires iOS 15+",
+              details: nil
+            )))
+      }
+    #elseif os(macOS)
+      // StoreKit does not provide showManageSubscriptions on macOS. Subscriptions are
+      // managed through the App Store app instead.
+      completion(
+        .failure(
+          PigeonError(
+            code: "storekit2_unsupported_platform",
+            message: "Managing subscriptions is not supported on macOS",
+            details: nil
+          )))
+    #endif
+  }
+
   /// Wrapper method around StoreKit2's sync() method
   /// https://developer.apple.com/documentation/storekit/appstore/sync()
   /// When called, a system prompt will ask users to enter their authentication details

--- a/packages/in_app_purchase/in_app_purchase_storekit/darwin/in_app_purchase_storekit/Sources/in_app_purchase_storekit/StoreKit2/StoreKit2Messages.g.swift
+++ b/packages/in_app_purchase/in_app_purchase_storekit/darwin/in_app_purchase_storekit/Sources/in_app_purchase_storekit/StoreKit2/StoreKit2Messages.g.swift
@@ -760,6 +760,7 @@ protocol InAppPurchase2API {
   func countryCode(completion: @escaping (Result<String, Error>) -> Void)
   func sync(completion: @escaping (Result<Void, Error>) -> Void)
   func presentOfferCodeRedeemSheet(completion: @escaping (Result<Void, Error>) -> Void)
+  func showManageSubscriptions(completion: @escaping (Result<Void, Error>) -> Void)
 }
 
 /// Generated setup class from Pigeon to handle messages through the `binaryMessenger`.
@@ -1026,6 +1027,24 @@ class InAppPurchase2APISetup {
       }
     } else {
       presentOfferCodeRedeemSheetChannel.setMessageHandler(nil)
+    }
+    let showManageSubscriptionsChannel = FlutterBasicMessageChannel(
+      name:
+        "dev.flutter.pigeon.in_app_purchase_storekit.InAppPurchase2API.showManageSubscriptions\(channelSuffix)",
+      binaryMessenger: binaryMessenger, codec: codec)
+    if let api = api {
+      showManageSubscriptionsChannel.setMessageHandler { _, reply in
+        api.showManageSubscriptions { result in
+          switch result {
+          case .success:
+            reply(wrapResult(nil))
+          case .failure(let error):
+            reply(wrapError(error))
+          }
+        }
+      }
+    } else {
+      showManageSubscriptionsChannel.setMessageHandler(nil)
     }
   }
 }

--- a/packages/in_app_purchase/in_app_purchase_storekit/example/lib/main.dart
+++ b/packages/in_app_purchase/in_app_purchase_storekit/example/lib/main.dart
@@ -147,6 +147,7 @@ class _MyAppState extends State<_MyApp> {
             _buildProductList(),
             _buildConsumableBox(),
             _buildCodeRedemptionButton(),
+            _buildShowManageSubscriptionsButton(),
             _buildRestoreButton(),
           ],
         ),
@@ -413,6 +414,29 @@ class _MyAppState extends State<_MyApp> {
             ),
             onPressed: () => _iapStoreKitPlatformAddition.presentCodeRedemptionSheet(),
             child: const Text('Show code redemption sheet'),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildShowManageSubscriptionsButton() {
+    if (_loading) {
+      return Container();
+    }
+
+    return Padding(
+      padding: const EdgeInsets.all(4.0),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.end,
+        children: <Widget>[
+          TextButton(
+            style: TextButton.styleFrom(
+              backgroundColor: Theme.of(context).colorScheme.primary,
+              foregroundColor: Colors.white,
+            ),
+            onPressed: () => _iapStoreKitPlatformAddition.showManageSubscriptions(),
+            child: const Text('Manage subscriptions'),
           ),
         ],
       ),

--- a/packages/in_app_purchase/in_app_purchase_storekit/example/shared/RunnerTests/InAppPurchaseStoreKit2PluginTests.swift
+++ b/packages/in_app_purchase/in_app_purchase_storekit/example/shared/RunnerTests/InAppPurchaseStoreKit2PluginTests.swift
@@ -636,4 +636,19 @@ final class InAppPurchase2PluginTests: XCTestCase {
     waitForExpectations(timeout: 1.0)
   }
 
+  func testShowManageSubscriptionsFailsGracefullyWhenNoWindow() {
+    let expectation = self.expectation(
+      description: "Should fail gracefully when without key window")
+
+    plugin.registrar = nil
+
+    plugin.showManageSubscriptions { result in
+      if case .failure = result {
+        expectation.fulfill()
+      }
+    }
+
+    waitForExpectations(timeout: 1.0)
+  }
+
 }

--- a/packages/in_app_purchase/in_app_purchase_storekit/lib/src/in_app_purchase_storekit_platform_addition.dart
+++ b/packages/in_app_purchase/in_app_purchase_storekit/lib/src/in_app_purchase_storekit_platform_addition.dart
@@ -29,6 +29,16 @@ class InAppPurchaseStoreKitPlatformAddition extends InAppPurchasePlatformAdditio
     return SKPaymentQueueWrapper().presentCodeRedemptionSheet();
   }
 
+  /// Presents the App Store sheet that lets the user manage their
+  /// subscriptions.
+  ///
+  /// Available on devices running iOS 15 and iPadOS 15 and later.
+  /// StoreKit 2 only; StoreKit 1 has no equivalent API. Not supported on macOS,
+  /// where subscriptions are managed through the App Store app instead.
+  Future<void> showManageSubscriptions() {
+    return AppStore().showManageSubscriptions();
+  }
+
   /// Retry loading purchase data after an initial failure.
   ///
   /// If no results, a `null` value is returned.

--- a/packages/in_app_purchase/in_app_purchase_storekit/lib/src/sk2_pigeon.g.dart
+++ b/packages/in_app_purchase/in_app_purchase_storekit/lib/src/sk2_pigeon.g.dart
@@ -1023,6 +1023,20 @@ class InAppPurchase2API {
 
     _extractReplyValueOrThrow(pigeonVar_replyList, pigeonVar_channelName, isNullValid: true);
   }
+
+  Future<void> showManageSubscriptions() async {
+    final pigeonVar_channelName =
+        'dev.flutter.pigeon.in_app_purchase_storekit.InAppPurchase2API.showManageSubscriptions$pigeonVar_messageChannelSuffix';
+    final pigeonVar_channel = BasicMessageChannel<Object?>(
+      pigeonVar_channelName,
+      pigeonChannelCodec,
+      binaryMessenger: pigeonVar_binaryMessenger,
+    );
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(null);
+    final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
+
+    _extractReplyValueOrThrow(pigeonVar_replyList, pigeonVar_channelName, isNullValid: true);
+  }
 }
 
 abstract class InAppPurchase2CallbackAPI {

--- a/packages/in_app_purchase/in_app_purchase_storekit/lib/src/store_kit_2_wrappers/sk2_appstore_wrapper.dart
+++ b/packages/in_app_purchase/in_app_purchase_storekit/lib/src/store_kit_2_wrappers/sk2_appstore_wrapper.dart
@@ -26,4 +26,11 @@ final class AppStore {
   Future<void> presentOfferCodeRedeemSheet() {
     return hostApi2.presentOfferCodeRedeemSheet();
   }
+
+  /// Dart wrapper for StoreKit2's showManageSubscriptions(in:)
+  /// Presents the App Store sheet that lets users manage their subscriptions.
+  /// https://developer.apple.com/documentation/storekit/appstore/showmanagesubscriptions(in:)
+  Future<void> showManageSubscriptions() {
+    return hostApi2.showManageSubscriptions();
+  }
 }

--- a/packages/in_app_purchase/in_app_purchase_storekit/pigeons/sk2_pigeon.dart
+++ b/packages/in_app_purchase/in_app_purchase_storekit/pigeons/sk2_pigeon.dart
@@ -261,6 +261,9 @@ abstract class InAppPurchase2API {
 
   @async
   void presentOfferCodeRedeemSheet();
+
+  @async
+  void showManageSubscriptions();
 }
 
 @FlutterApi()

--- a/packages/in_app_purchase/in_app_purchase_storekit/pubspec.yaml
+++ b/packages/in_app_purchase/in_app_purchase_storekit/pubspec.yaml
@@ -2,7 +2,7 @@ name: in_app_purchase_storekit
 description: An implementation for the iOS and macOS platforms of the Flutter `in_app_purchase` plugin. This uses the StoreKit Framework.
 repository: https://github.com/flutter/packages/tree/main/packages/in_app_purchase/in_app_purchase_storekit
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+in_app_purchase%22
-version: 0.4.11+1
+version: 0.4.12
 
 environment:
   sdk: ^3.10.0

--- a/packages/in_app_purchase/in_app_purchase_storekit/test/fakes/fake_storekit_platform.dart
+++ b/packages/in_app_purchase/in_app_purchase_storekit/test/fakes/fake_storekit_platform.dart
@@ -327,6 +327,7 @@ class FakeStoreKit2Platform implements InAppPurchase2API {
   SK2ProductPurchaseOptionsMessage? lastPurchaseOptions;
   Map<String, Set<String>> eligibleWinBackOffers = <String, Set<String>>{};
   Map<String, bool> eligibleIntroductoryOffers = <String, bool>{};
+  int showManageSubscriptionsCallCount = 0;
 
   /// Simulates purchase result for testing non-success scenarios.
   /// Set to userCancelled, pending, or unverified to test those cases.
@@ -350,6 +351,7 @@ class FakeStoreKit2Platform implements InAppPurchase2API {
     eligibleWinBackOffers = <String, Set<String>>{};
     eligibleIntroductoryOffers = <String, bool>{};
     simulatedPurchaseResult = SK2ProductPurchaseResultMessage.success;
+    showManageSubscriptionsCallCount = 0;
     transactionsList = <SK2TransactionMessage>[
       SK2TransactionMessage(
         id: 123,
@@ -557,6 +559,11 @@ class FakeStoreKit2Platform implements InAppPurchase2API {
 
   @override
   Future<void> presentOfferCodeRedeemSheet() async {}
+
+  @override
+  Future<void> showManageSubscriptions() async {
+    showManageSubscriptionsCallCount++;
+  }
 }
 
 SK2TransactionMessage createPendingTransaction(String id, {int quantity = 1}) {

--- a/packages/in_app_purchase/in_app_purchase_storekit/test/in_app_purchase_storekit_2_platform_test.dart
+++ b/packages/in_app_purchase/in_app_purchase_storekit/test/in_app_purchase_storekit_2_platform_test.dart
@@ -403,6 +403,13 @@ void main() {
     });
   });
 
+  group('manage subscriptions', () {
+    test('forwards the call to the platform', () async {
+      await InAppPurchaseStoreKitPlatformAddition().showManageSubscriptions();
+      expect(fakeStoreKit2Platform.showManageSubscriptionsCallCount, 1);
+    });
+  });
+
   group('win back offers eligibility', () {
     late FakeStoreKit2Platform fakeStoreKit2Platform;
 


### PR DESCRIPTION
Adds a new `showManageSubscriptions` method which wraps around storekit's [showManageSubscriptions(in:)](https://developer.apple.com/documentation/storekit/appstore/showmanagesubscriptions(in:))

Fixes https://github.com/flutter/flutter/issues/159664


## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under[^1].
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[the version and CHANGELOG instructions]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version-and-changelog-updates
[semantic versioning]: https://dart.dev/tools/pub/versioning#semantic-versions
[repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
