### PR TITLE
[material_ui] Fix MenuAnchor scrollbar safe-area padding

### DIFF
--- a/packages/material_ui/lib/src/menu_anchor.dart
+++ b/packages/material_ui/lib/src/menu_anchor.dart
@@ -3758,12 +3758,13 @@ class _MenuPanelState extends State<_MenuPanel> {
         ).copyWith(scrollbars: false, overscroll: false, physics: const ClampingScrollPhysics()),
         child: PrimaryScrollController(
           controller: scrollController,
-          child: MediaQuery.removePadding(
-            context: context,
-            removeLeft: true,
-            removeTop: true,
-            removeRight: true,
-            removeBottom: true,
+          child: MediaQuery(
+            data: mediaQuery.removePadding(
+              removeLeft: true,
+              removeTop: true,
+              removeRight: true,
+              removeBottom: true,
+            ),
             child: Scrollbar(
               thumbVisibility: displayScrollbar,
               child: MediaQuery(

--- a/packages/material_ui/lib/src/menu_anchor.dart
+++ b/packages/material_ui/lib/src/menu_anchor.dart
@@ -3697,6 +3697,7 @@ class _MenuPanelState extends State<_MenuPanel> {
     final EdgeInsetsGeometry padding =
         resolve<EdgeInsetsGeometry?>((MenuStyle? style) => style?.padding) ?? EdgeInsets.zero;
     final Offset densityAdjustment = visualDensity.baseSizeAdjustment;
+    final MediaQueryData mediaQuery = MediaQuery.of(context);
     // Per the Material Design team: don't allow the VisualDensity
     // adjustment to reduce the width of the left/right padding. If we
     // did, VisualDensity.compact, the default for desktop/web, would
@@ -3757,17 +3758,27 @@ class _MenuPanelState extends State<_MenuPanel> {
         ).copyWith(scrollbars: false, overscroll: false, physics: const ClampingScrollPhysics()),
         child: PrimaryScrollController(
           controller: scrollController,
-          child: Scrollbar(
-            thumbVisibility: displayScrollbar,
-            child: SingleChildScrollView(
-              controller: scrollController,
-              scrollDirection: widget.orientation,
-              child: Flex(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                textDirection: Directionality.of(context),
-                direction: widget.orientation,
-                mainAxisSize: MainAxisSize.min,
-                children: children,
+          child: MediaQuery.removePadding(
+            context: context,
+            removeLeft: true,
+            removeTop: true,
+            removeRight: true,
+            removeBottom: true,
+            child: Scrollbar(
+              thumbVisibility: displayScrollbar,
+              child: MediaQuery(
+                data: mediaQuery,
+                child: SingleChildScrollView(
+                  controller: scrollController,
+                  scrollDirection: widget.orientation,
+                  child: Flex(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    textDirection: Directionality.of(context),
+                    direction: widget.orientation,
+                    mainAxisSize: MainAxisSize.min,
+                    children: children,
+                  ),
+                ),
               ),
             ),
           ),

--- a/packages/material_ui/lib/src/menu_anchor.dart
+++ b/packages/material_ui/lib/src/menu_anchor.dart
@@ -3697,7 +3697,20 @@ class _MenuPanelState extends State<_MenuPanel> {
     final EdgeInsetsGeometry padding =
         resolve<EdgeInsetsGeometry?>((MenuStyle? style) => style?.padding) ?? EdgeInsets.zero;
     final Offset densityAdjustment = visualDensity.baseSizeAdjustment;
-    final MediaQueryData mediaQuery = MediaQuery.of(context);
+    // Material's Scrollbar uses the ambient MediaQuery padding as its painter
+    // padding when no explicit padding is given, so that the thumb clears
+    // system intrusions such as a gesture bar. The menu overlay is already
+    // positioned inside the safe area, so honoring that padding a second time
+    // shortens the scrollbar track and stops the thumb from reaching the end of
+    // the menu. The padding is therefore removed for the Scrollbar only and
+    // restored below it, so menu children keep observing the ambient values.
+    final MediaQueryData ambientMediaQuery = MediaQuery.of(context);
+    final MediaQueryData scrollbarMediaQuery = ambientMediaQuery.removePadding(
+      removeLeft: true,
+      removeTop: true,
+      removeRight: true,
+      removeBottom: true,
+    );
     // Per the Material Design team: don't allow the VisualDensity
     // adjustment to reduce the width of the left/right padding. If we
     // did, VisualDensity.compact, the default for desktop/web, would
@@ -3759,16 +3772,11 @@ class _MenuPanelState extends State<_MenuPanel> {
         child: PrimaryScrollController(
           controller: scrollController,
           child: MediaQuery(
-            data: mediaQuery.removePadding(
-              removeLeft: true,
-              removeTop: true,
-              removeRight: true,
-              removeBottom: true,
-            ),
+            data: scrollbarMediaQuery,
             child: Scrollbar(
               thumbVisibility: displayScrollbar,
               child: MediaQuery(
-                data: mediaQuery,
+                data: ambientMediaQuery,
                 child: SingleChildScrollView(
                   controller: scrollController,
                   scrollDirection: widget.orientation,

--- a/packages/material_ui/pending_changelogs/change_2026_08_14_menu_anchor_scrollbar.yaml
+++ b/packages/material_ui/pending_changelogs/change_2026_08_14_menu_anchor_scrollbar.yaml
@@ -1,0 +1,3 @@
+changelog: |
+  - Fixes `MenuAnchor` scrollbars inheriting system safe-area padding.
+version: patch

--- a/packages/material_ui/test/menu_anchor_test.dart
+++ b/packages/material_ui/test/menu_anchor_test.dart
@@ -570,7 +570,7 @@ void main() {
   testWidgets('Menu scrollbar does not inherit MediaQuery padding', (WidgetTester tester) async {
     addTearDown(tester.view.reset);
     tester.view.devicePixelRatio = 1.0;
-    tester.view.padding = const FakeViewPadding(bottom: 24.0);
+    tester.view.padding = const FakeViewPadding(left: 8.0, top: 16.0, right: 32.0, bottom: 24.0);
     EdgeInsets? menuItemPadding;
 
     await tester.pumpWidget(
@@ -609,9 +609,41 @@ void main() {
         ),
       ),
     );
+    // The scrollbar ignores the view padding, but the menu children still
+    // observe it.
     final scrollbarPainter = scrollbarPaint.foregroundPainter! as ScrollbarPainter;
     expect(scrollbarPainter.padding, EdgeInsets.zero);
-    expect(menuItemPadding, const EdgeInsets.only(bottom: 24.0));
+    expect(menuItemPadding, const EdgeInsets.fromLTRB(8.0, 16.0, 32.0, 24.0));
+
+    // The menu scrolls all the way to the bottom and the scrollbar thumb
+    // reaches the end of its track instead of stopping short of it.
+    final ScrollableState scrollable = tester.state<ScrollableState>(
+      find.descendant(of: find.byType(Scrollbar), matching: find.byType(Scrollable)),
+    );
+    expect(scrollable.position.maxScrollExtent, greaterThan(0.0));
+    await tester.drag(find.byType(Scrollbar), const Offset(0.0, -200.0));
+    await tester.pumpAndSettle();
+    expect(scrollable.position.pixels, scrollable.position.maxScrollExtent);
+
+    // The thumb is painted at the very end of the track rather than stopping
+    // short of it by the height of the removed bottom padding.
+    final double scrollbarExtent = tester.getSize(find.byType(Scrollbar)).height;
+    expect(
+      find.byType(Scrollbar),
+      paints..something((Symbol method, List<dynamic> arguments) {
+        // The thumb is a rect on Android and a rounded rect elsewhere. The
+        // track shares the same shape but always starts at the top, so only
+        // the thumb is considered here.
+        final Rect? shape = switch (method) {
+          #drawRect => arguments[0] as Rect,
+          #drawRRect => (arguments[0] as RRect).outerRect,
+          _ => null,
+        };
+        return shape != null &&
+            shape.top > 0.0 &&
+            (shape.bottom - scrollbarExtent).abs() < precisionErrorTolerance;
+      }),
+    );
   });
 
   testWidgets('Focus is returned to previous focus before invoking onPressed', (

--- a/packages/material_ui/test/menu_anchor_test.dart
+++ b/packages/material_ui/test/menu_anchor_test.dart
@@ -566,6 +566,54 @@ void main() {
     expect(find.byType(Scrollbar).last, paints..rrect(color: const Color(0xff00ff00)));
   }, variant: TargetPlatformVariant.desktop());
 
+  // Regression test for https://github.com/flutter/flutter/issues/188155.
+  testWidgets('Menu scrollbar does not inherit MediaQuery padding', (WidgetTester tester) async {
+    addTearDown(tester.view.reset);
+    tester.view.devicePixelRatio = 1.0;
+    tester.view.padding = const FakeViewPadding(bottom: 24.0);
+    EdgeInsets? menuItemPadding;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Material(
+          child: MenuAnchor(
+            controller: controller,
+            style: const MenuStyle(
+              maximumSize: WidgetStatePropertyAll<Size>(Size.fromHeight(100.0)),
+            ),
+            menuChildren: <Widget>[
+              Builder(
+                builder: (BuildContext context) {
+                  menuItemPadding = MediaQuery.paddingOf(context);
+                  return MenuItemButton(onPressed: () {}, child: const Text('Item 0'));
+                },
+              ),
+              for (int i = 1; i < 4; i++) MenuItemButton(onPressed: () {}, child: Text('Item $i')),
+            ],
+            builder: (BuildContext context, MenuController controller, Widget? child) {
+              return TextButton(onPressed: controller.open, child: const Text('Open menu'));
+            },
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('Open menu'));
+    await tester.pumpAndSettle();
+
+    final CustomPaint scrollbarPaint = tester.widget<CustomPaint>(
+      find.descendant(
+        of: find.byType(Scrollbar),
+        matching: find.byWidgetPredicate(
+          (Widget widget) => widget is CustomPaint && widget.foregroundPainter is ScrollbarPainter,
+        ),
+      ),
+    );
+    final scrollbarPainter = scrollbarPaint.foregroundPainter! as ScrollbarPainter;
+    expect(scrollbarPainter.padding, EdgeInsets.zero);
+    expect(menuItemPadding, const EdgeInsets.only(bottom: 24.0));
+  });
+
   testWidgets('Focus is returned to previous focus before invoking onPressed', (
     WidgetTester tester,
   ) async {


### PR DESCRIPTION
Material `Scrollbar` uses the surrounding `MediaQuery.padding` as painter padding when no explicit padding is provided. A `MenuAnchor` overlay is already positioned within the safe area, so inheriting the view padding again shortens the scrollbar track and prevents the thumb from reaching its visual end.

This change removes safe-area padding only for the menu's `Scrollbar`, then restores the original `MediaQueryData` below it so custom menu children continue to observe the same media query values as before. It also adds a regression test and a patch changelog entry.

Fixes flutter/flutter#188155.

This supersedes flutter/flutter#191085, which cannot land in `flutter/flutter` because Material framework changes have moved to `material_ui`.

Validation:

- The regression test failed before the source change with a 24 logical pixel bottom scrollbar padding and passes after the change.
- `flutter test test/menu_anchor_test.dart` (171 passed, 1 skipped)
- `flutter analyze --no-pub`
- `flutter_plugin_tools format --packages=material_ui`
- `flutter_plugin_tools validate --packages=material_ui --check-for-missing-changes`

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under[^1].
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[the version and CHANGELOG instructions]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version-and-changelog-updates
[semantic versioning]: https://dart.dev/tools/pub/versioning#semantic-versions
[repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
