### PR TITLE
[material_ui] Prevent stale async suggestions in SearchAnchor

### DIFF
--- a/packages/material_ui/lib/src/search_anchor.dart
+++ b/packages/material_ui/lib/src/search_anchor.dart
@@ -974,6 +974,8 @@ class _ViewContentState extends State<_ViewContent> {
   Iterable<Widget> result = <Widget>[];
   String? searchValue;
   Timer? _timer;
+  // Identifies the latest call so that older async results cannot replace newer ones.
+  int _suggestionsCallId = 0;
 
   @override
   void initState() {
@@ -1010,14 +1012,9 @@ class _ViewContentState extends State<_ViewContent> {
       _timer?.cancel();
       _timer = Timer(Duration.zero, () async {
         searchValue = _controller.text;
-        final Iterable<Widget> suggestions = await widget.suggestionsBuilder(context, _controller);
+        await _buildSuggestions();
         _timer?.cancel();
         _timer = null;
-        if (mounted) {
-          setState(() {
-            result = suggestions;
-          });
-        }
       });
     }
   }
@@ -1058,13 +1055,19 @@ class _ViewContentState extends State<_ViewContent> {
   Future<void> updateSuggestions() async {
     if (searchValue != _controller.text) {
       searchValue = _controller.text;
-      final Iterable<Widget> suggestions = await widget.suggestionsBuilder(context, _controller);
-      if (mounted) {
-        setState(() {
-          result = suggestions;
-        });
-      }
+      await _buildSuggestions();
     }
+  }
+
+  Future<void> _buildSuggestions() async {
+    final int callId = ++_suggestionsCallId;
+    final Iterable<Widget> suggestions = await widget.suggestionsBuilder(context, _controller);
+    if (!mounted || callId != _suggestionsCallId) {
+      return;
+    }
+    setState(() {
+      result = suggestions;
+    });
   }
 
   @override

--- a/packages/material_ui/pending_changelogs/change_2026_08_16_search_anchor.yaml
+++ b/packages/material_ui/pending_changelogs/change_2026_08_16_search_anchor.yaml
@@ -1,0 +1,3 @@
+changelog: |
+  - Prevents stale asynchronous suggestions from replacing newer `SearchAnchor` results.
+version: patch

--- a/packages/material_ui/test/search_anchor_test.dart
+++ b/packages/material_ui/test/search_anchor_test.dart
@@ -2261,6 +2261,46 @@ void main() {
     expect(controller.value.text, suggestion);
   });
 
+  testWidgets('SearchAnchor ignores out-of-order async suggestions', (WidgetTester tester) async {
+    final requests = <String, Completer<Iterable<Widget>>>{};
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: SearchAnchor(
+          builder: (BuildContext context, SearchController controller) {
+            return const Icon(Icons.search);
+          },
+          suggestionsBuilder: (BuildContext context, SearchController controller) {
+            final String query = controller.text;
+            if (query.isEmpty) {
+              return <Widget>[];
+            }
+            final request = Completer<Iterable<Widget>>();
+            requests[query] = request;
+            return request.future;
+          },
+        ),
+      ),
+    );
+
+    await tester.tap(find.byIcon(Icons.search));
+    await tester.pumpAndSettle();
+
+    await tester.enterText(findTextField(), 'a');
+    await tester.pump();
+    await tester.enterText(findTextField(), 'ab');
+    await tester.pump();
+
+    requests['ab']!.complete(<Widget>[const Text('ab-result')]);
+    await tester.pumpAndSettle();
+    expect(find.text('ab-result'), findsOneWidget);
+
+    requests['a']!.complete(<Widget>[const Text('a-result')]);
+    await tester.pumpAndSettle();
+    expect(find.text('ab-result'), findsOneWidget);
+    expect(find.text('a-result'), findsNothing);
+  });
+
   testWidgets('SearchAnchor.bar has a default search bar as the anchor', (
     WidgetTester tester,
   ) async {


### PR DESCRIPTION
Ports flutter/flutter#190206 to `material_ui` following flutter/flutter#188444.

Fixes flutter/flutter#190205.

This change prevents an older asynchronous `SearchAnchor.suggestionsBuilder` request from replacing the results of a newer request.

It assigns an incrementing ID to each suggestions request and only applies the result when it still represents the latest request.



## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under[^1].
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[the version and CHANGELOG instructions]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version-and-changelog-updates
[semantic versioning]: https://dart.dev/tools/pub/versioning#semantic-versions
[repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
