### PR TITLE
[cross_file] fixed `readAsString` decoding in-memory bytes as UTF-16

### DIFF
--- a/packages/cross_file/CHANGELOG.md
+++ b/packages/cross_file/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.3.5+5
+
+* Fixes native `readAsString` returning mojibake for `XFile.fromData`, which
+  decoded the bytes as UTF-16 code units instead of using the `encoding`
+  argument.
+
 ## 0.3.5+4
 
 * Adds a runnable `main` entry point and an additional `XFile.fromData`

--- a/packages/cross_file/lib/src/types/io.dart
+++ b/packages/cross_file/lib/src/types/io.dart
@@ -111,11 +111,9 @@ class XFile extends XFileBase {
   }
 
   @override
-  Future<String> readAsString({Encoding encoding = utf8}) {
+  Future<String> readAsString({Encoding encoding = utf8}) async {
     if (_bytes != null) {
-      // TODO(kevmoo): Remove ignore and fix when the MIN Dart SDK is 3.3
-      // ignore: unnecessary_non_null_assertion
-      return Future<String>.value(String.fromCharCodes(_bytes!));
+      return encoding.decode(_bytes);
     }
     return _file.readAsString(encoding: encoding);
   }

--- a/packages/cross_file/lib/src/types/io.dart
+++ b/packages/cross_file/lib/src/types/io.dart
@@ -111,9 +111,10 @@ class XFile extends XFileBase {
   }
 
   @override
-  Future<String> readAsString({Encoding encoding = utf8}) async {
-    if (_bytes != null) {
-      return encoding.decode(_bytes);
+  Future<String> readAsString({Encoding encoding = utf8}) {
+    final Uint8List? bytes = _bytes;
+    if (bytes != null) {
+      return Future<String>.sync(() => encoding.decode(bytes));
     }
     return _file.readAsString(encoding: encoding);
   }

--- a/packages/cross_file/pubspec.yaml
+++ b/packages/cross_file/pubspec.yaml
@@ -2,7 +2,7 @@ name: cross_file
 description: An abstraction to allow working with files across multiple platforms.
 repository: https://github.com/flutter/packages/tree/main/packages/cross_file
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+cross_file%22
-version: 0.3.5+4
+version: 0.3.5+5
 
 environment:
   sdk: ^3.10.0

--- a/packages/cross_file/test/x_file_io_test.dart
+++ b/packages/cross_file/test/x_file_io_test.dart
@@ -82,6 +82,24 @@ void main() {
     test('Can be read as a string', () async {
       expect(await file.readAsString(), equals(expectedStringContents));
     });
+
+    test('Can be read as a string with multi-byte characters', () async {
+      const contents = 'Hello, world! I ❤ ñ! 空手 😀';
+      final multiByteFile = XFile.fromData(utf8.encode(contents));
+      expect(await multiByteFile.readAsString(), equals(contents));
+    });
+
+    test('Can be read as a string with a non-default encoding', () async {
+      const contents = 'Une soirée à Genève';
+      final latin1File = XFile.fromData(latin1.encode(contents));
+      expect(await latin1File.readAsString(encoding: latin1), equals(contents));
+    });
+
+    test('Reading undecodable data fails the future', () async {
+      final malformedFile = XFile.fromData(Uint8List.fromList(<int>[0xc3, 0x28]));
+      await expectLater(malformedFile.readAsString(), throwsA(isA<FormatException>()));
+    });
+
     test('Can be read as bytes', () async {
       expect(await file.readAsBytes(), equals(bytes));
     });


### PR DESCRIPTION
`XFile.fromData(utf8.encode('😀')).readAsString()` hands back mojibake

The bytes branch uses `String.fromCharCodes` which just widens each byte into
its own UTF-16 code unit so anything outside ASCII comes out mangled and the
`encoding` parameter the method accepts never gets used at all. The file-backed
branch right below it passes `encoding` through fine, and web already does
`readAsBytes().then(encoding.decode)` so this is mostly just making native do
what web has been doing all along.

I made the method `async` while I was in there and that bit is deliberate
rather than cosmetic: `encoding.decode` can throw on bad input where
`fromCharCodes` never could and without `async` that would come out
synchronously instead of as a failed future, which isn't what you get from
either the web version or the `_file.readAsString` path.

fixes https://github.com/flutter/flutter/issues/165120

AI usgae: I used antigravity (with gemini 3.7 flash)
