### PR TITLE
Add `triage-design` label

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -243,6 +243,14 @@
       - packages/*/*_windows/**/*
       - packages/**/windows/**/*
 
+'triage-design':
+  - changed-files:
+    - any-glob-to-any-file:
+      - packages/cupertino_ui/**/*
+      - packages/google_fonts/**/*
+      - packages/material_ui/**/*
+      - third_party/packages/cupertino_icons/**/*
+
 'triage-engine':
   - changed-files:
     - any-glob-to-any-file:
@@ -256,11 +264,7 @@
   - changed-files:
     - any-glob-to-any-file:
       - packages/animations/**/*
-      - packages/cupertino_ui/**/*
       - packages/flutter_lints/**/*
       - packages/go_router/**/*
       - packages/go_router_builder/**/*
-      - packages/google_fonts/**/*
-      - packages/material_ui/**/*
       - packages/two_dimensional_scrollables/**/*
-      - third_party/packages/cupertino_icons/**/*


### PR DESCRIPTION
Adds the `triage-design` auto-labeler and changes `cupertino_ui`, `material_ui`, and related packages to be auto-labeled with `triage-design` instead of `triage-framework`. 

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [ ] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I [linked to at least one issue that this PR fixes] in the description above.
- [ ] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under[^1].
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [x] All existing and new tests are passing.

**Test and changelog exemption:** No changes to packages.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[the version and CHANGELOG instructions]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version-and-changelog-updates
[semantic versioning]: https://dart.dev/tools/pub/versioning#semantic-versions
[repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
