### PR TITLE
[video_player_avfoundation] Route video over AirPlay

### DIFF
--- a/packages/video_player/video_player_avfoundation/CHANGELOG.md
+++ b/packages/video_player/video_player_avfoundation/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 2.12.0
+
+* Routes video over AirPlay when an external screen is active, by setting
+  `usesExternalPlaybackWhileExternalScreenIsActive` on the `AVPlayer`. Selecting
+  an AirPlay route previously moved only the audio, leaving the video on the
+  device while the receiver showed a mirrored screen.
+
 ## 2.11.1
 
 * Updates pigeon dev_dependency to ^27.3.2 for analyzer 14 compatibility.

--- a/packages/video_player/video_player_avfoundation/darwin/RunnerTests/VideoPlayerTests.swift
+++ b/packages/video_player/video_player_avfoundation/darwin/RunnerTests/VideoPlayerTests.swift
@@ -396,6 +396,23 @@ private let hlsAudioTestURI =
     #expect(player.player.preventsDisplaySleepDuringVideoPlayback == true)
   }
 
+  #if os(iOS)
+    @Test func externalPlaybackIsEnabledForAirPlay() {
+      let stubAVFactory = StubFVPAVFactory(player: AVPlayer())
+      let player = FVPVideoPlayer(
+        playerItem: StubPlayerItem(),
+        avFactory: stubAVFactory,
+        viewProvider: StubViewProvider())
+
+      // usesExternalPlaybackWhileExternalScreenIsActive defaults to NO, which
+      // keeps the video on the device whenever an external screen is active. An
+      // AirPlay route then moves only the audio, and the receiver shows a
+      // mirrored screen rather than playing the stream itself.
+      #expect(player.player.allowsExternalPlayback == true)
+      #expect(player.player.usesExternalPlaybackWhileExternalScreenIsActive == true)
+    }
+  #endif
+
   /// Sanity checks a video player playing the given URL with the actual AVPlayer. This is essentially
   /// a mini integration test of the player component.
   ///

--- a/packages/video_player/video_player_avfoundation/darwin/video_player_avfoundation/Sources/video_player_avfoundation_objc/FVPVideoPlayer.m
+++ b/packages/video_player/video_player_avfoundation/darwin/video_player_avfoundation/Sources/video_player_avfoundation_objc/FVPVideoPlayer.m
@@ -145,6 +145,22 @@ static NSDictionary<NSString *, NSValue *> *FVPGetPlayerItemObservations(void) {
   _player = [avFactory playerWithPlayerItem:item];
   _player.actionAtItemEnd = AVPlayerActionAtItemEndNone;
 
+#if TARGET_OS_IOS
+  // Allow the video to follow an AirPlay route to an external device.
+  //
+  // allowsExternalPlayback already defaults to YES, but
+  // usesExternalPlaybackWhileExternalScreenIsActive defaults to NO, so the
+  // player deliberately keeps the picture on the device whenever an external
+  // screen is active. The result is that selecting an AirPlay route changes the
+  // audio route while the video stays on the phone and the TV only receives a
+  // mirrored copy of the screen.
+  //
+  // Verified on an Apple TV: with both set, the receiver plays the stream
+  // itself and the local surface is released.
+  _player.allowsExternalPlayback = YES;
+  _player.usesExternalPlaybackWhileExternalScreenIsActive = YES;
+#endif
+
   // Configure output. AVVideoColorPropertiesKey must be declared on the output settings (not on
   // pixel buffer attributes, where AVFoundation silently ignores it) so that HDR sources are
   // tone-mapped to BT.709 SDR for the Flutter texture.

--- a/packages/video_player/video_player_avfoundation/pubspec.yaml
+++ b/packages/video_player/video_player_avfoundation/pubspec.yaml
@@ -2,7 +2,7 @@ name: video_player_avfoundation
 description: iOS and macOS implementation of the video_player plugin.
 repository: https://github.com/flutter/packages/tree/main/packages/video_player/video_player_avfoundation
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+video_player%22
-version: 2.11.1
+version: 2.12.0
 
 environment:
   sdk: ^3.10.0


### PR DESCRIPTION
`usesExternalPlaybackWhileExternalScreenIsActive` defaults to NO, so an AVPlayer keeps the picture on the device whenever an external screen is active. Selecting an AirPlay route therefore moved only the audio, while the receiver showed a mirrored copy of the screen rather than playing the stream itself.

`allowsExternalPlayback` already defaults to YES, so the two together were incoherent: external playback was permitted but never used. AVKit's own AVPlayerViewController routes to AirPlay out of the box; this brings the plugin in line with it.

Verified on an Apple TV from iOS 26.6.

Fixes: https://github.com/flutter/flutter/issues/191227

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under[^1].
- [ ] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[the version and CHANGELOG instructions]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version-and-changelog-updates
[semantic versioning]: https://dart.dev/tools/pub/versioning#semantic-versions
[repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
