### PR TITLE
[video_player_android] allow supplying a custom VideoAsset

### DIFF
--- a/packages/video_player/video_player_android/CHANGELOG.md
+++ b/packages/video_player/video_player_android/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 2.13.0
+
+* Adds `VideoAssetProvider` and `VideoPlayerPlugin.setVideoAssetProvider`, letting another
+  component supply the `VideoAsset` used for a URI. This is the extension point for playback
+  this plugin cannot express itself, such as reading from a download or HTTP cache, applying a
+  custom `DataSource.Factory`, or resolving an unknown scheme. Behavior is unchanged when no
+  provider is registered.
+
 ## 2.12.0
 
 * Fixes a [bug](https://github.com/flutter/flutter/issues/176575) where some videos report an incorrect duration when initialized without a video duration.

--- a/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/VideoAssetProvider.java
+++ b/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/VideoAssetProvider.java
@@ -1,0 +1,37 @@
+// Copyright 2013 The Flutter Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package io.flutter.plugins.videoplayer;
+
+import android.content.Context;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+/**
+ * Supplies a {@link VideoAsset} for a URI, overriding this plugin's default handling.
+ *
+ * <p>This is the extension point for playback that the plugin cannot express on its own, such as
+ * reading from a download or HTTP cache, applying a custom {@code DataSource.Factory}, or resolving
+ * a scheme this plugin does not know about. Because {@link VideoAsset} already exposes the media
+ * item and media source factory, an implementation has full control over how a URI is played
+ * without this plugin needing to know why.
+ *
+ * <p>Register with {@link VideoPlayerPlugin#setVideoAssetProvider}. At most one provider is active
+ * at a time; the last one registered wins.
+ */
+public interface VideoAssetProvider {
+  /**
+   * Returns the asset to play for {@code uri}, or null to use this plugin's default handling.
+   *
+   * <p>Called on the main thread each time a player is created, before the URI is inspected for a
+   * known scheme, so a provider may override any URI including {@code asset:} and {@code rtsp:}
+   * ones.
+   *
+   * @param context application context.
+   * @param uri the URI the player was created with.
+   * @return the asset to play, or null to fall through to the default.
+   */
+  @Nullable
+  VideoAsset getAsset(@NonNull Context context, @NonNull String uri);
+}

--- a/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayerPlugin.java
+++ b/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayerPlugin.java
@@ -27,6 +27,21 @@ public class VideoPlayerPlugin implements FlutterPlugin, AndroidVideoPlayerApi {
   private final VideoPlayerOptions sharedOptions = new VideoPlayerOptions();
   private long nextPlayerIdentifier = 1;
 
+  private static @Nullable VideoAssetProvider videoAssetProvider;
+
+  /**
+   * Sets the provider consulted before this plugin's own URI handling, or null to clear it.
+   *
+   * <p>Lets another component take over how a URI is played; see {@link VideoAssetProvider}. This
+   * is process-wide rather than per-plugin-instance because it is typically registered once at
+   * startup, before any player exists.
+   *
+   * @param provider the provider to consult, or null for default handling only.
+   */
+  public static void setVideoAssetProvider(@Nullable VideoAssetProvider provider) {
+    videoAssetProvider = provider;
+  }
+
   /** Register this with the v2 embedding for the plugin to respond to lifecycle callbacks. */
   public VideoPlayerPlugin() {}
 
@@ -126,6 +141,15 @@ public class VideoPlayerPlugin implements FlutterPlugin, AndroidVideoPlayerApi {
 
   private @NonNull VideoAsset videoAssetWithOptions(@NonNull CreationOptions options) {
     final @NonNull String uri = options.getUri();
+
+    VideoAssetProvider provider = videoAssetProvider;
+    if (provider != null) {
+      VideoAsset providedAsset = provider.getAsset(flutterState.applicationContext, uri);
+      if (providedAsset != null) {
+        return providedAsset;
+      }
+    }
+
     if (uri.startsWith("asset:")) {
       return VideoAsset.fromAssetUrl(uri);
     } else if (uri.startsWith("rtsp:")) {

--- a/packages/video_player/video_player_android/android/src/test/java/io/flutter/plugins/videoplayer/VideoPlayerPluginTest.java
+++ b/packages/video_player/video_player_android/android/src/test/java/io/flutter/plugins/videoplayer/VideoPlayerPluginTest.java
@@ -113,4 +113,55 @@ public class VideoPlayerPluginTest {
       assertTrue(videoPlayers.get(ids.getPlayerId()) instanceof TextureVideoPlayer);
     }
   }
+
+  @Test
+  public void videoAssetProviderOverridesDefaultAsset() throws Exception {
+    final VideoAsset providedAsset = mock(VideoAsset.class);
+    final String uri = "https://example.com/video.m3u8";
+    final String[] requestedUri = new String[1];
+
+    VideoPlayerPlugin.setVideoAssetProvider(
+        (context, requested) -> {
+          requestedUri[0] = requested;
+          return providedAsset;
+        });
+
+    try (MockedStatic<TextureVideoPlayer> mockedTextureVideoPlayerStatic =
+        mockStatic(TextureVideoPlayer.class)) {
+      mockedTextureVideoPlayerStatic
+          .when(() -> TextureVideoPlayer.create(any(), any(), any(), any(), any()))
+          .thenReturn(mock(TextureVideoPlayer.class));
+
+      plugin.createForTextureView(new CreationOptions(uri, null, new HashMap<>(), null, null));
+
+      assertEquals(uri, requestedUri[0]);
+      mockedTextureVideoPlayerStatic.verify(
+          () -> TextureVideoPlayer.create(any(), any(), any(), eq(providedAsset), any()));
+    } finally {
+      VideoPlayerPlugin.setVideoAssetProvider(null);
+    }
+  }
+
+  @Test
+  public void videoAssetProviderReturningNullFallsBackToDefault() throws Exception {
+    VideoPlayerPlugin.setVideoAssetProvider((context, requested) -> null);
+
+    try (MockedStatic<TextureVideoPlayer> mockedTextureVideoPlayerStatic =
+        mockStatic(TextureVideoPlayer.class)) {
+      mockedTextureVideoPlayerStatic
+          .when(() -> TextureVideoPlayer.create(any(), any(), any(), any(), any()))
+          .thenReturn(mock(TextureVideoPlayer.class));
+
+      final TexturePlayerIds ids =
+          plugin.createForTextureView(
+              new CreationOptions(
+                  "https://example.com/video.m3u8", null, new HashMap<>(), null, null));
+
+      // The default handling still produced a working player.
+      final LongSparseArray<VideoPlayer> videoPlayers = getVideoPlayers();
+      assertTrue(videoPlayers.get(ids.getPlayerId()) instanceof TextureVideoPlayer);
+    } finally {
+      VideoPlayerPlugin.setVideoAssetProvider(null);
+    }
+  }
 }

--- a/packages/video_player/video_player_android/pubspec.yaml
+++ b/packages/video_player/video_player_android/pubspec.yaml
@@ -2,7 +2,7 @@ name: video_player_android
 description: Android implementation of the video_player plugin.
 repository: https://github.com/flutter/packages/tree/main/packages/video_player/video_player_android
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+video_player%22
-version: 2.12.0
+version: 2.13.0
 
 environment:
   sdk: ^3.12.0


### PR DESCRIPTION
Adds VideoAssetProvider and VideoPlayerPlugin.setVideoAssetProvider, which is consulted before this plugin's own URI handling and may return null to fall through to it.

This is the extension point for playback the plugin cannot express itself: reading from a download or HTTP cache, applying a custom DataSource.Factory, or resolving a scheme the plugin does not know about. VideoAsset is already public and already exposes MediaItem and MediaSource.Factory, so this adds no new type surface; it only makes the existing one reachable.

Behavior is unchanged when no provider is registered, which the added tests cover alongside the override path.

This enables me to publish a companion package to allow downloading of HLS on Android and iOS.
Companion package source:
https://github.com/a1rwulf/video_player_offline

This is an attempt to upstream a fix for:
https://github.com/flutter/flutter/issues/59759

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under[^1].
- [ ] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[the version and CHANGELOG instructions]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version-and-changelog-updates
[semantic versioning]: https://dart.dev/tools/pub/versioning#semantic-versions
[repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
