### PR TITLE
[material_ui] Migrate off of flutter_test's find.byTooltip and on to the local findByTooltip

### DIFF
--- a/packages/material_ui/example/test/bottom_app_bar/bottom_app_bar.2_test.dart
+++ b/packages/material_ui/example/test/bottom_app_bar/bottom_app_bar.2_test.dart
@@ -93,8 +93,6 @@ void main() {
 ///
 /// This was copied from flutter_test, which uses flutter/material.dart.
 ///
-// TODO(justinmc): Port flutter_test to material_ui, then delete this method and
-// use that one. See https://github.com/flutter/flutter/issues/186966
 Finder findByTooltip(Pattern message, {bool skipOffstage = true}) {
   return find.byWidgetPredicate((Widget widget) {
     // Compare RawTooltip's semantics tooltip with the given message.

--- a/packages/material_ui/example/test/bottom_app_bar/bottom_app_bar.2_test.dart
+++ b/packages/material_ui/example/test/bottom_app_bar/bottom_app_bar.2_test.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'package:flutter_test/flutter_test.dart';
+import '../../../test/finders.dart';
 import 'package:material_ui/material_ui.dart';
 import 'package:material_ui_examples/bottom_app_bar/bottom_app_bar.2.dart'
     as example;
@@ -70,7 +71,7 @@ void main() {
     await tester.pumpWidget(const example.BottomAppBarDemo());
 
     // Trigger the SnackBar.
-    await tester.tap(find.byTooltip('Open popup menu'));
+    await tester.tap(findByTooltip('Open popup menu'));
     await tester.pump();
 
     expect(find.text('Yay! A SnackBar!'), findsOneWidget);

--- a/packages/material_ui/example/test/bottom_app_bar/bottom_app_bar.2_test.dart
+++ b/packages/material_ui/example/test/bottom_app_bar/bottom_app_bar.2_test.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 import 'package:flutter_test/flutter_test.dart';
-import '../../../test/finders.dart';
 import 'package:material_ui/material_ui.dart';
 import 'package:material_ui_examples/bottom_app_bar/bottom_app_bar.2.dart'
     as example;
@@ -78,4 +77,44 @@ void main() {
 
     expect(find.text('Undo'), findsOneWidget);
   });
+}
+
+/// Finds [RawTooltip] or [Tooltip] widgets with the given `message`.
+///
+/// ## Sample code
+///
+/// ```dart
+/// expect(findByTooltip('Back'), findsOneWidget);
+/// expect(findByTooltip(RegExp('Back.*')), findsNWidgets(2));
+/// ```
+///
+/// If the `skipOffstage` argument is true (the default), then this skips
+/// nodes that are [Offstage] or that are from inactive [Route]s.
+///
+/// This was copied from flutter_test, which uses flutter/material.dart.
+///
+// TODO(justinmc): Port flutter_test to material_ui, then delete this method and
+// use that one. See https://github.com/flutter/flutter/issues/186966
+Finder findByTooltip(Pattern message, {bool skipOffstage = true}) {
+  return find.byWidgetPredicate((Widget widget) {
+    // Compare RawTooltip's semantics tooltip with the given message.
+    // However, Tooltip's message needs to be checked directly if:
+    // 1. Tooltip.excludeFromSemantics is true, since in this case Tooltip
+    //    provides no semantics tooltip to the underlying RawTooltip.
+    // 2. Tooltip.message and Tooltip.richMessage are empty, since in this
+    //    case no RawTooltip is created.
+    if (widget is Tooltip) {
+      final String tooltipMessage =
+          widget.message ?? widget.richMessage!.toPlainText();
+      if ((widget.excludeFromSemantics ?? false) || tooltipMessage.isEmpty) {
+        return message is RegExp
+            ? message.hasMatch(tooltipMessage)
+            : tooltipMessage == message;
+      }
+    }
+    return widget is RawTooltip &&
+        (message is RegExp
+            ? message.hasMatch(widget.semanticsTooltip ?? '')
+            : widget.semanticsTooltip == message);
+  }, skipOffstage: skipOffstage);
 }

--- a/packages/material_ui/example/test/tooltip/tooltip.3_test.dart
+++ b/packages/material_ui/example/test/tooltip/tooltip.3_test.dart
@@ -41,8 +41,6 @@ void main() {
 ///
 /// This was copied from flutter_test, which uses flutter/material.dart.
 ///
-// TODO(justinmc): Port flutter_test to material_ui, then delete this method and
-// use that one. See https://github.com/flutter/flutter/issues/186966
 Finder findByTooltip(Pattern message, {bool skipOffstage = true}) {
   return find.byWidgetPredicate((Widget widget) {
     // Compare RawTooltip's semantics tooltip with the given message.

--- a/packages/material_ui/example/test/tooltip/tooltip.3_test.dart
+++ b/packages/material_ui/example/test/tooltip/tooltip.3_test.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'package:flutter_test/flutter_test.dart';
+import '../../../test/finders.dart';
 import 'package:material_ui/material_ui.dart';
 import 'package:material_ui_examples/tooltip/tooltip.3.dart' as example;
 
@@ -21,7 +22,7 @@ void main() {
     await tester.pump(const Duration(milliseconds: 10));
     expect(find.text(tooltipText), findsOneWidget);
     // Tap on the tooltip and wait for the tooltip to disappear.
-    await tester.tap(find.byTooltip(tooltipText));
+    await tester.tap(findByTooltip(tooltipText));
     await tester.pump(const Duration(seconds: 1));
     expect(find.text(tooltipText), findsNothing);
   });

--- a/packages/material_ui/example/test/tooltip/tooltip.3_test.dart
+++ b/packages/material_ui/example/test/tooltip/tooltip.3_test.dart
@@ -52,9 +52,12 @@ Finder findByTooltip(Pattern message, {bool skipOffstage = true}) {
     // 2. Tooltip.message and Tooltip.richMessage are empty, since in this
     //    case no RawTooltip is created.
     if (widget is Tooltip) {
-      final String tooltipMessage = widget.message ?? widget.richMessage!.toPlainText();
+      final String tooltipMessage =
+          widget.message ?? widget.richMessage!.toPlainText();
       if ((widget.excludeFromSemantics ?? false) || tooltipMessage.isEmpty) {
-        return message is RegExp ? message.hasMatch(tooltipMessage) : tooltipMessage == message;
+        return message is RegExp
+            ? message.hasMatch(tooltipMessage)
+            : tooltipMessage == message;
       }
     }
     return widget is RawTooltip &&

--- a/packages/material_ui/example/test/tooltip/tooltip.3_test.dart
+++ b/packages/material_ui/example/test/tooltip/tooltip.3_test.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 import 'package:flutter_test/flutter_test.dart';
-import '../../../test/finders.dart';
 import 'package:material_ui/material_ui.dart';
 import 'package:material_ui_examples/tooltip/tooltip.3.dart' as example;
 
@@ -26,4 +25,41 @@ void main() {
     await tester.pump(const Duration(seconds: 1));
     expect(find.text(tooltipText), findsNothing);
   });
+}
+
+/// Finds [RawTooltip] or [Tooltip] widgets with the given `message`.
+///
+/// ## Sample code
+///
+/// ```dart
+/// expect(findByTooltip('Back'), findsOneWidget);
+/// expect(findByTooltip(RegExp('Back.*')), findsNWidgets(2));
+/// ```
+///
+/// If the `skipOffstage` argument is true (the default), then this skips
+/// nodes that are [Offstage] or that are from inactive [Route]s.
+///
+/// This was copied from flutter_test, which uses flutter/material.dart.
+///
+// TODO(justinmc): Port flutter_test to material_ui, then delete this method and
+// use that one. See https://github.com/flutter/flutter/issues/186966
+Finder findByTooltip(Pattern message, {bool skipOffstage = true}) {
+  return find.byWidgetPredicate((Widget widget) {
+    // Compare RawTooltip's semantics tooltip with the given message.
+    // However, Tooltip's message needs to be checked directly if:
+    // 1. Tooltip.excludeFromSemantics is true, since in this case Tooltip
+    //    provides no semantics tooltip to the underlying RawTooltip.
+    // 2. Tooltip.message and Tooltip.richMessage are empty, since in this
+    //    case no RawTooltip is created.
+    if (widget is Tooltip) {
+      final String tooltipMessage = widget.message ?? widget.richMessage!.toPlainText();
+      if ((widget.excludeFromSemantics ?? false) || tooltipMessage.isEmpty) {
+        return message is RegExp ? message.hasMatch(tooltipMessage) : tooltipMessage == message;
+      }
+    }
+    return widget is RawTooltip &&
+        (message is RegExp
+            ? message.hasMatch(widget.semanticsTooltip ?? '')
+            : widget.semanticsTooltip == message);
+  }, skipOffstage: skipOffstage);
 }

--- a/packages/material_ui/test/app_bar_test.dart
+++ b/packages/material_ui/test/app_bar_test.dart
@@ -9,6 +9,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:material_ui/material_ui.dart';
 
 import 'app_bar_utils.dart';
+import 'finders.dart';
 import 'semantics_tester.dart';
 
 TextStyle? _iconStyle(WidgetTester tester, IconData icon) {
@@ -1956,7 +1957,7 @@ void main() {
       ),
     );
 
-    final Finder endDrawerFinder = find.byTooltip('Open navigation menu');
+    final Finder endDrawerFinder = findByTooltip('Open navigation menu');
     await tester.tap(endDrawerFinder);
     await tester.pump();
 

--- a/packages/material_ui/test/chip_test.dart
+++ b/packages/material_ui/test/chip_test.dart
@@ -16,6 +16,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:material_ui/material_ui.dart';
 
 import 'feedback_tester.dart';
+import 'finders.dart';
 import 'semantics_tester.dart';
 
 Finder findRenderChipElement() {
@@ -327,19 +328,19 @@ void main() {
       ),
     );
 
-    expect(tester.widget(find.byTooltip('Delete chip A')), isNotNull);
-    expect(tester.widget(find.byTooltip('Delete chip B')), isNotNull);
+    expect(tester.widget(findByTooltip('Delete chip A')), isNotNull);
+    expect(tester.widget(findByTooltip('Delete chip B')), isNotNull);
 
     expect(feedback.clickSoundCount, 0);
 
     expect(deletedChipLabels, isEmpty);
-    await tester.tap(find.byTooltip('Delete chip A'));
+    await tester.tap(findByTooltip('Delete chip A'));
     expect(deletedChipLabels, equals(<String>['A']));
 
     await tester.pumpAndSettle(const Duration(seconds: 1));
     expect(feedback.clickSoundCount, 1);
 
-    await tester.tap(find.byTooltip('Delete chip B'));
+    await tester.tap(findByTooltip('Delete chip B'));
     expect(deletedChipLabels, equals(<String>['A', 'B']));
 
     await tester.pumpAndSettle(const Duration(seconds: 1));

--- a/packages/material_ui/test/finders.dart
+++ b/packages/material_ui/test/finders.dart
@@ -10,8 +10,8 @@ import 'package:material_ui/material_ui.dart';
 /// ## Sample code
 ///
 /// ```dart
-/// expect(find.byTooltip('Back'), findsOneWidget);
-/// expect(find.byTooltip(RegExp('Back.*')), findsNWidgets(2));
+/// expect(findByTooltip('Back'), findsOneWidget);
+/// expect(findByTooltip(RegExp('Back.*')), findsNWidgets(2));
 /// ```
 ///
 /// If the `skipOffstage` argument is true (the default), then this skips

--- a/packages/material_ui/test/floating_action_button_test.dart
+++ b/packages/material_ui/test/floating_action_button_test.dart
@@ -17,6 +17,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:material_ui/material_ui.dart';
 
 import 'feedback_tester.dart';
+import 'finders.dart';
 import 'semantics_tester.dart';
 
 void main() {
@@ -58,7 +59,7 @@ void main() {
     );
 
     await tester.tap(find.byType(Icon));
-    expect(find.byTooltip('Add'), findsOneWidget);
+    expect(findByTooltip('Add'), findsOneWidget);
   });
 
   // Regression test for: https://github.com/flutter/flutter/pull/21084

--- a/packages/material_ui/test/icon_button_test.dart
+++ b/packages/material_ui/test/icon_button_test.dart
@@ -16,6 +16,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:material_ui/material_ui.dart';
 
 import 'feedback_tester.dart';
+import 'finders.dart';
 import 'semantics_tester.dart';
 
 class MockOnPressedFunction {
@@ -437,9 +438,9 @@ void main() {
     await tester.pumpWidget(buildIconButton(tooltip: tooltipText));
 
     expect(find.byType(Tooltip), findsOneWidget);
-    expect(find.byTooltip(tooltipText), findsOneWidget);
+    expect(findByTooltip(tooltipText), findsOneWidget);
 
-    await tester.tap(find.byTooltip(tooltipText));
+    await tester.tap(findByTooltip(tooltipText));
     expect(mockOnPressedFunction.called, 1);
 
     // Hovering over the button should show the tooltip.

--- a/packages/material_ui/test/page_test.dart
+++ b/packages/material_ui/test/page_test.dart
@@ -14,6 +14,7 @@ import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:material_ui/material_ui.dart';
+import 'finders.dart';
 
 void main() {
   testWidgets(
@@ -1063,7 +1064,7 @@ void main() {
       expect(pageTapCount, 1);
 
       // Tapping the "page" route's back button doesn't do anything either.
-      await tester.tap(find.byTooltip('Back'), warnIfMissed: false);
+      await tester.tap(findByTooltip('Back'), warnIfMissed: false);
       await tester.pumpAndSettle();
       expect(tester.getTopLeft(find.byKey(pageScaffoldKey)), const Offset(400, 0));
       expect(tester.getTopLeft(find.byKey(homeScaffoldKey)).dx, lessThan(0));

--- a/packages/material_ui/test/paginated_data_table_test.dart
+++ b/packages/material_ui/test/paginated_data_table_test.dart
@@ -8,6 +8,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:material_ui/material_ui.dart';
 
 import 'data_table_test_utils.dart';
+import 'finders.dart';
 
 class TestDataSource extends DataTableSource {
   TestDataSource({this.allowSelection = false});
@@ -94,7 +95,7 @@ void main() {
       ),
     );
 
-    await tester.tap(find.byTooltip('Next page'));
+    await tester.tap(findByTooltip('Next page'));
 
     expect(log, <String>['page-changed: 2']);
     log.clear();
@@ -117,7 +118,7 @@ void main() {
     expect(find.text('Gingerbread (0)'), findsNothing);
 
     final Finder lastPageButton = find.ancestor(
-      of: find.byTooltip('Last page'),
+      of: findByTooltip('Last page'),
       matching: find.byWidgetPredicate((Widget widget) => widget is IconButton),
     );
 
@@ -137,7 +138,7 @@ void main() {
     expect(find.text('KitKat (49)'), findsOneWidget);
 
     final Finder firstPageButton = find.ancestor(
-      of: find.byTooltip('First page'),
+      of: findByTooltip('First page'),
       matching: find.byWidgetPredicate((Widget widget) => widget is IconButton),
     );
 
@@ -194,13 +195,13 @@ void main() {
 
     expect(find.text('1–2 of 500'), findsOneWidget);
 
-    await tester.tap(find.byTooltip('Next page'));
+    await tester.tap(findByTooltip('Next page'));
     await tester.pump();
 
     expect(find.text('3–4 of 500'), findsOneWidget);
 
     final Finder lastPageButton = find.ancestor(
-      of: find.byTooltip('Last page'),
+      of: findByTooltip('Last page'),
       matching: find.byWidgetPredicate((Widget widget) => widget is IconButton),
     );
 
@@ -220,7 +221,7 @@ void main() {
 
     expect(find.textContaining('1–3 of 500'), findsOneWidget);
 
-    await tester.tap(find.byTooltip('Next page'));
+    await tester.tap(findByTooltip('Next page'));
     await tester.pump();
 
     expect(find.text('4–6 of 500'), findsOneWidget);
@@ -238,7 +239,7 @@ void main() {
 
     expect(find.textContaining('1–4 of 500'), findsOneWidget);
 
-    await tester.tap(find.byTooltip('Next page'));
+    await tester.tap(findByTooltip('Next page'));
     await tester.pump();
 
     expect(find.text('5–8 of 500'), findsOneWidget);
@@ -256,7 +257,7 @@ void main() {
 
     expect(find.textContaining('1–5 of 500'), findsOneWidget);
 
-    await tester.tap(find.byTooltip('Next page'));
+    await tester.tap(findByTooltip('Next page'));
     await tester.pump();
 
     expect(find.text('6–10 of 500'), findsOneWidget);
@@ -274,7 +275,7 @@ void main() {
 
     expect(find.textContaining('1–8 of 500'), findsOneWidget);
 
-    await tester.tap(find.byTooltip('Next page'));
+    await tester.tap(findByTooltip('Next page'));
     await tester.pump();
 
     expect(find.text('9–16 of 500'), findsOneWidget);

--- a/packages/material_ui/test/popup_menu_test.dart
+++ b/packages/material_ui/test/popup_menu_test.dart
@@ -11,6 +11,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:material_ui/material_ui.dart';
 
 import 'feedback_tester.dart';
+import 'finders.dart';
 import 'semantics_tester.dart';
 
 void main() {
@@ -2356,7 +2357,7 @@ void main() {
     // The default tooltip is defined as [MaterialLocalizations.showMenuTooltip]
     // and it is used when no tooltip is provided.
     expect(find.byType(Tooltip), findsNWidgets(3));
-    expect(find.byTooltip(const DefaultMaterialLocalizations().showMenuTooltip), findsNWidgets(3));
+    expect(findByTooltip(const DefaultMaterialLocalizations().showMenuTooltip), findsNWidgets(3));
   });
 
   testWidgets('PopupMenuButton custom tooltip', (WidgetTester tester) async {
@@ -2404,7 +2405,7 @@ void main() {
     );
 
     expect(find.byType(Tooltip), findsNWidgets(3));
-    expect(find.byTooltip('Test tooltip'), findsNWidgets(3));
+    expect(findByTooltip('Test tooltip'), findsNWidgets(3));
   });
 
   testWidgets('Allow Widget for PopupMenuButton.icon', (WidgetTester tester) async {

--- a/packages/material_ui/test/search_test.dart
+++ b/packages/material_ui/test/search_test.dart
@@ -10,6 +10,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:material_ui/material_ui.dart';
 
 import 'clipboard_utils.dart';
+import 'finders.dart';
 import 'semantics_tester.dart';
 
 void main() {
@@ -38,7 +39,7 @@ void main() {
     addTearDown(() => delegate.dispose());
 
     await tester.pumpWidget(TestHomePage(delegate: delegate));
-    await tester.tap(find.byTooltip('Search'));
+    await tester.tap(findByTooltip('Search'));
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 300));
 
@@ -68,7 +69,7 @@ void main() {
     expect(find.text('Suggestions'), findsNothing);
 
     // Open search
-    await tester.tap(find.byTooltip('Search'));
+    await tester.tap(findByTooltip('Search'));
     await tester.pumpAndSettle();
 
     expect(find.text('HomeBody'), findsNothing);
@@ -80,7 +81,7 @@ void main() {
     expect(textField.focusNode!.hasFocus, isTrue);
 
     // Close search
-    await tester.tap(find.byTooltip('Back'));
+    await tester.tap(findByTooltip('Back'));
     await tester.pumpAndSettle();
 
     expect(find.text('HomeBody'), findsOneWidget);
@@ -106,7 +107,7 @@ void main() {
     expect(find.text('Suggestions'), findsNothing);
 
     // Open search
-    await tester.tap(find.byTooltip('Search'));
+    await tester.tap(findByTooltip('Search'));
     await tester.pumpAndSettle();
 
     expect(find.text('HomeBody'), findsNothing);
@@ -131,7 +132,7 @@ void main() {
     expect(find.text('Suggestions'), findsNothing);
 
     // Open search again
-    await tester.tap(find.byTooltip('Search'));
+    await tester.tap(findByTooltip('Search'));
     await tester.pumpAndSettle();
 
     expect(find.text('HomeBody'), findsNothing);
@@ -152,7 +153,7 @@ void main() {
     expect(find.text('Suggestions'), findsNothing);
 
     // Open search.
-    await tester.tap(find.byTooltip('Search'));
+    await tester.tap(findByTooltip('Search'));
     await tester.pumpAndSettle();
 
     expect(find.text('HomeBody'), findsNothing);
@@ -172,7 +173,7 @@ void main() {
     expect(find.text('Suggestions'), findsNothing);
 
     // Open search again.
-    await tester.tap(find.byTooltip('Search'));
+    await tester.tap(findByTooltip('Search'));
     await tester.pumpAndSettle();
 
     expect(find.text('HomeBody'), findsNothing);
@@ -186,7 +187,7 @@ void main() {
     addTearDown(() => delegate.dispose());
 
     await tester.pumpWidget(TestHomePage(delegate: delegate));
-    await tester.tap(find.byTooltip('Search'));
+    await tester.tap(findByTooltip('Search'));
     await tester.pumpAndSettle();
 
     final Text hintText = tester.widget(find.text(searchHintText));
@@ -198,7 +199,7 @@ void main() {
     addTearDown(() => delegate.dispose());
 
     await tester.pumpWidget(TestHomePage(delegate: delegate));
-    await tester.tap(find.byTooltip('Search'));
+    await tester.tap(findByTooltip('Search'));
     await tester.pumpAndSettle();
 
     expect(delegate.query, '');
@@ -227,7 +228,7 @@ void main() {
     final selectedResults = <String>[];
 
     await tester.pumpWidget(TestHomePage(delegate: delegate, results: selectedResults));
-    await tester.tap(find.byTooltip('Search'));
+    await tester.tap(findByTooltip('Search'));
     await tester.pumpAndSettle();
     await tester.enterText(find.byType(TextField), 'Wow');
     await tester.pumpAndSettle();
@@ -245,7 +246,7 @@ void main() {
     expect(delegate.queriesForResults, <String>['Wow']);
 
     // Close search
-    await tester.tap(find.byTooltip('Back'));
+    await tester.tap(findByTooltip('Back'));
     await tester.pumpAndSettle();
 
     expect(find.text('HomeBody'), findsOneWidget);
@@ -260,7 +261,7 @@ void main() {
     addTearDown(() => delegate.dispose());
 
     await tester.pumpWidget(TestHomePage(delegate: delegate));
-    await tester.tap(find.byTooltip('Search'));
+    await tester.tap(findByTooltip('Search'));
     await tester.pumpAndSettle();
 
     // Showing suggestions
@@ -329,15 +330,15 @@ void main() {
     addTearDown(() => delegate.dispose());
 
     await tester.pumpWidget(TestHomePage(delegate: delegate));
-    await tester.tap(find.byTooltip('Search'));
+    await tester.tap(findByTooltip('Search'));
     await tester.pumpAndSettle();
 
     expect(delegate.query, '');
 
     delegate.query = 'Foo';
-    await tester.tap(find.byTooltip('Back'));
+    await tester.tap(findByTooltip('Back'));
     await tester.pumpAndSettle();
-    await tester.tap(find.byTooltip('Search'));
+    await tester.tap(findByTooltip('Search'));
     await tester.pumpAndSettle();
 
     expect(delegate.query, '');
@@ -352,7 +353,7 @@ void main() {
     await tester.pumpWidget(
       TestHomePage(delegate: delegate, passInInitialQuery: true, initialQuery: 'Foo'),
     );
-    await tester.tap(find.byTooltip('Search'));
+    await tester.tap(findByTooltip('Search'));
     await tester.pumpAndSettle();
 
     expect(delegate.query, 'Foo');
@@ -365,7 +366,7 @@ void main() {
     delegate.query = 'Foo';
 
     await tester.pumpWidget(TestHomePage(delegate: delegate, passInInitialQuery: true));
-    await tester.tap(find.byTooltip('Search'));
+    await tester.tap(findByTooltip('Search'));
     await tester.pumpAndSettle();
 
     expect(delegate.query, 'Foo');
@@ -376,7 +377,7 @@ void main() {
     addTearDown(() => delegate.dispose());
 
     await tester.pumpWidget(TestHomePage(delegate: delegate, passInInitialQuery: true));
-    await tester.tap(find.byTooltip('Search'));
+    await tester.tap(findByTooltip('Search'));
     await tester.pumpAndSettle();
 
     delegate.query = 'Foo';
@@ -398,7 +399,7 @@ void main() {
 
     // runs while search fades in
     expect(delegate.transitionAnimation.status, AnimationStatus.dismissed);
-    await tester.tap(find.byTooltip('Search'));
+    await tester.tap(findByTooltip('Search'));
     expect(delegate.transitionAnimation.status, AnimationStatus.forward);
     await tester.pumpAndSettle();
     expect(delegate.transitionAnimation.status, AnimationStatus.completed);
@@ -410,7 +411,7 @@ void main() {
     expect(delegate.transitionAnimation.status, AnimationStatus.completed);
 
     // runs while search fades out
-    await tester.tap(find.byTooltip('Back'));
+    await tester.tap(findByTooltip('Back'));
     expect(delegate.transitionAnimation.status, AnimationStatus.reverse);
     await tester.pumpAndSettle();
     expect(delegate.transitionAnimation.status, AnimationStatus.dismissed);
@@ -448,21 +449,21 @@ void main() {
 
     await tester.pumpWidget(TestHomePage(delegate: delegate, results: selectedResults));
     expect(find.text('HomeBody'), findsOneWidget);
-    await tester.tap(find.byTooltip('Search'));
+    await tester.tap(findByTooltip('Search'));
     await tester.pumpAndSettle();
 
     expect(find.text('HomeBody'), findsNothing);
     expect(find.text('Suggestions'), findsOneWidget);
     expect(find.text('Nested Suggestions'), findsNothing);
 
-    await tester.tap(find.byTooltip('Nested Search'));
+    await tester.tap(findByTooltip('Nested Search'));
     await tester.pumpAndSettle();
 
     expect(find.text('HomeBody'), findsNothing);
     expect(find.text('Suggestions'), findsNothing);
     expect(find.text('Nested Suggestions'), findsOneWidget);
 
-    await tester.tap(find.byTooltip('Back'));
+    await tester.tap(findByTooltip('Back'));
     await tester.pumpAndSettle();
     expect(nestedSearchResults, <String>['Nested Result']);
 
@@ -470,7 +471,7 @@ void main() {
     expect(find.text('Suggestions'), findsOneWidget);
     expect(find.text('Nested Suggestions'), findsNothing);
 
-    await tester.tap(find.byTooltip('Back'));
+    await tester.tap(findByTooltip('Back'));
     await tester.pumpAndSettle();
 
     expect(find.text('HomeBody'), findsOneWidget);
@@ -528,21 +529,21 @@ void main() {
     await tester.pumpWidget(TestHomePage(delegate: delegate, results: selectedResults));
 
     expect(find.text('HomeBody'), findsOneWidget);
-    await tester.tap(find.byTooltip('Search'));
+    await tester.tap(findByTooltip('Search'));
     await tester.pumpAndSettle();
 
     expect(find.text('HomeBody'), findsNothing);
     expect(find.text('Suggestions'), findsOneWidget);
     expect(find.text('Nested Suggestions'), findsNothing);
 
-    await tester.tap(find.byTooltip('Nested Search'));
+    await tester.tap(findByTooltip('Nested Search'));
     await tester.pumpAndSettle();
 
     expect(find.text('HomeBody'), findsNothing);
     expect(find.text('Suggestions'), findsNothing);
     expect(find.text('Nested Suggestions'), findsOneWidget);
 
-    await tester.tap(find.byTooltip('Close Search'));
+    await tester.tap(findByTooltip('Close Search'));
     await tester.pumpAndSettle();
 
     expect(find.text('HomeBody'), findsOneWidget);
@@ -560,7 +561,7 @@ void main() {
     addTearDown(() => delegate.dispose());
 
     await tester.pumpWidget(TestHomePage(delegate: delegate));
-    await tester.tap(find.byTooltip('Search'));
+    await tester.tap(findByTooltip('Search'));
     await tester.pumpAndSettle();
 
     expect(find.text(searchHint), findsOneWidget);
@@ -576,7 +577,7 @@ void main() {
     addTearDown(() => delegate.dispose());
 
     await tester.pumpWidget(TestHomePage(delegate: delegate));
-    await tester.tap(find.byTooltip('Search'));
+    await tester.tap(findByTooltip('Search'));
     await tester.pumpAndSettle();
 
     expect(find.text(searchHint), findsOneWidget);
@@ -593,7 +594,7 @@ void main() {
     addTearDown(() => delegate.dispose());
 
     await tester.pumpWidget(TestHomePage(delegate: delegate));
-    await tester.tap(find.byTooltip('Search'));
+    await tester.tap(findByTooltip('Search'));
     await tester.pumpAndSettle();
 
     final Text hintText = tester.widget(find.text(searchHintText));
@@ -610,7 +611,7 @@ void main() {
     addTearDown(() => delegate.dispose());
 
     await tester.pumpWidget(TestHomePage(delegate: delegate));
-    await tester.tap(find.byTooltip('Search'));
+    await tester.tap(findByTooltip('Search'));
     await tester.pumpAndSettle();
 
     final TextField textField = tester.widget<TextField>(find.byType(TextField));
@@ -624,7 +625,7 @@ void main() {
     addTearDown(() => delegate.dispose());
 
     await tester.pumpWidget(TestHomePage(delegate: delegate));
-    await tester.tap(find.byTooltip('Search'));
+    await tester.tap(findByTooltip('Search'));
     await tester.pumpAndSettle();
 
     final TextField textField = tester.widget<TextField>(find.byType(TextField));
@@ -637,7 +638,7 @@ void main() {
     addTearDown(() => delegate.dispose());
 
     await tester.pumpWidget(TestHomePage(delegate: delegate));
-    await tester.tap(find.byTooltip('Search'));
+    await tester.tap(findByTooltip('Search'));
     await tester.pumpAndSettle();
 
     final TextField textField = tester.widget<TextField>(find.byType(TextField));
@@ -650,7 +651,7 @@ void main() {
     addTearDown(() => delegate.dispose());
 
     await tester.pumpWidget(TestHomePage(delegate: delegate));
-    await tester.tap(find.byTooltip('Search'));
+    await tester.tap(findByTooltip('Search'));
     await tester.pumpAndSettle();
 
     await tester.showKeyboard(find.byType(TextField));
@@ -665,7 +666,7 @@ void main() {
     addTearDown(() => delegate.dispose());
 
     await tester.pumpWidget(TestHomePage(delegate: delegate));
-    await tester.tap(find.byTooltip('Search'));
+    await tester.tap(findByTooltip('Search'));
     await tester.pumpAndSettle();
     await tester.showKeyboard(find.byType(TextField));
     expect(tester.testTextInput.setClientArgs!['inputAction'], TextInputAction.done.toString());
@@ -677,7 +678,7 @@ void main() {
     addTearDown(() => delegate.dispose());
 
     await tester.pumpWidget(TestHomePage(delegate: delegate));
-    await tester.tap(find.byTooltip('Search'));
+    await tester.tap(findByTooltip('Search'));
     await tester.pumpAndSettle();
 
     expect(find.byWidget(flexibleSpace), findsOneWidget);
@@ -843,7 +844,7 @@ void main() {
 
       await tester.pumpWidget(TestHomePage(delegate: delegate));
 
-      await tester.tap(find.byTooltip('Search'));
+      await tester.tap(findByTooltip('Search'));
       await tester.pumpAndSettle();
 
       expect(
@@ -868,7 +869,7 @@ void main() {
 
         await tester.pumpWidget(TestHomePage(delegate: delegate));
 
-        await tester.tap(find.byTooltip('Search'));
+        await tester.tap(findByTooltip('Search'));
         await tester.pumpAndSettle();
 
         expect(
@@ -1028,7 +1029,7 @@ void main() {
 
       await tester.pumpWidget(TestHomePage(delegate: delegate));
 
-      await tester.tap(find.byTooltip('Search'));
+      await tester.tap(findByTooltip('Search'));
       await tester.pumpAndSettle();
 
       expect(
@@ -1053,7 +1054,7 @@ void main() {
 
         await tester.pumpWidget(TestHomePage(delegate: delegate));
 
-        await tester.tap(find.byTooltip('Search'));
+        await tester.tap(findByTooltip('Search'));
         await tester.pumpAndSettle();
 
         expect(
@@ -1083,7 +1084,7 @@ void main() {
     addTearDown(() => delegate.dispose());
 
     await tester.pumpWidget(TestHomePage(delegate: delegate));
-    await tester.tap(find.byTooltip('Search'));
+    await tester.tap(findByTooltip('Search'));
     await tester.pumpAndSettle();
 
     final ThemeData textFieldTheme = Theme.of(tester.element(find.byType(TextField)));
@@ -1106,7 +1107,7 @@ void main() {
       ),
     );
 
-    await tester.tap(find.byTooltip('Search'));
+    await tester.tap(findByTooltip('Search'));
     await tester.pumpAndSettle();
 
     final Material appBarBackground = tester
@@ -1137,7 +1138,7 @@ void main() {
       ),
     );
 
-    await tester.tap(find.byTooltip('Search'));
+    await tester.tap(findByTooltip('Search'));
     await tester.pumpAndSettle();
 
     final Material appBarBackground = tester
@@ -1170,7 +1171,7 @@ void main() {
     expect(find.text('Suggestions'), findsNothing);
 
     // Open the search page.
-    await tester.tap(find.byTooltip('Search'));
+    await tester.tap(findByTooltip('Search'));
     await tester.pumpAndSettle();
 
     expect(find.text('HomeBody'), findsNothing);
@@ -1182,7 +1183,7 @@ void main() {
     expect(textField.focusNode!.hasFocus, isTrue);
 
     // Close the search page.
-    await tester.tap(find.byTooltip('Close'));
+    await tester.tap(findByTooltip('Close'));
     await tester.pumpAndSettle();
 
     expect(find.text('HomeBody'), findsOneWidget);
@@ -1199,7 +1200,7 @@ void main() {
     await tester.pumpWidget(TestHomePage(delegate: delegate, results: selectedResults));
 
     // Open the search page with check leading width smaller than 16.
-    await tester.tap(find.byTooltip('Search'));
+    await tester.tap(findByTooltip('Search'));
     await tester.pumpAndSettle();
     await tester.tapAt(const Offset(16, 16));
     expect(find.text('Suggestions'), findsOneWidget);
@@ -1266,7 +1267,7 @@ void main() {
     await tester.pumpAndSettle();
     final Finder backButtonFinder = find.byType(BackButton);
     expect(backButtonFinder, findsWidgets);
-    await tester.tap(find.byTooltip('Close'));
+    await tester.tap(findByTooltip('Close'));
     await tester.pumpAndSettle();
     expect(rootObserver.pushCount, 0);
     expect(localObserver.pushCount, 1);
@@ -1274,7 +1275,7 @@ void main() {
     // showSearch with rootNavigator.
     await tester.tap(find.text('showSearchRootNavigator'));
     await tester.pumpAndSettle();
-    await tester.tap(find.byTooltip('Close'));
+    await tester.tap(findByTooltip('Close'));
     await tester.pumpAndSettle();
 
     // showSearch without back button.
@@ -1284,8 +1285,8 @@ void main() {
     final Finder appBarFinder = find.byType(AppBar);
     final AppBar appBar = tester.widget<AppBar>(appBarFinder);
     expect(appBar.automaticallyImplyLeading, false);
-    expect(find.byTooltip('Back'), findsNothing);
-    await tester.tap(find.byTooltip('Close'));
+    expect(findByTooltip('Back'), findsNothing);
+    await tester.tap(findByTooltip('Close'));
     await tester.pumpAndSettle();
     expect(rootObserver.pushCount, 2);
     expect(localObserver.pushCount, 1);
@@ -1301,7 +1302,7 @@ void main() {
     await tester.pumpWidget(TestHomePage(delegate: delegate, results: selectedResults));
 
     // Open search.
-    await tester.tap(find.byTooltip('Search'));
+    await tester.tap(findByTooltip('Search'));
     await tester.pumpAndSettle();
 
     final Finder textFieldFinder = find.byType(TextField);
@@ -1361,7 +1362,7 @@ void main() {
     await tester.pumpAndSettle();
     final Finder backButtonFinder = find.byType(BackButton);
     expect(backButtonFinder, findsWidgets);
-    await tester.tap(find.byTooltip('Close'));
+    await tester.tap(findByTooltip('Close'));
     await tester.pumpAndSettle();
     expect(navigationObserver.pushCount, 1);
     expect(navigationObserver.maintainState, false);
@@ -1370,7 +1371,7 @@ void main() {
     await tester.tap(find.text('showSearchWithMaintainState'));
     await tester.pumpAndSettle();
     expect(backButtonFinder, findsWidgets);
-    await tester.tap(find.byTooltip('Close'));
+    await tester.tap(findByTooltip('Close'));
     await tester.pumpAndSettle();
     expect(navigationObserver.pushCount, 2);
     expect(navigationObserver.maintainState, true);

--- a/packages/material_ui/test/segmented_button_test.dart
+++ b/packages/material_ui/test/segmented_button_test.dart
@@ -15,6 +15,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:material_ui/material_ui.dart';
 
+import 'finders.dart';
 import 'semantics_tester.dart';
 
 void main() {
@@ -765,8 +766,8 @@ void main() {
     );
 
     expect(find.byType(Tooltip), findsNWidgets(2));
-    expect(find.byTooltip('t2'), findsOneWidget);
-    expect(find.byTooltip('t3'), findsOneWidget);
+    expect(findByTooltip('t2'), findsOneWidget);
+    expect(findByTooltip('t3'), findsOneWidget);
   });
 
   testWidgets('SegmentedButton.styleFrom is applied to the SegmentedButton', (

--- a/packages/material_ui/test/snack_bar_test.dart
+++ b/packages/material_ui/test/snack_bar_test.dart
@@ -15,6 +15,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:material_ui/material_ui.dart';
+import 'finders.dart';
 
 void main() {
   testWidgets('SnackBar control test', (WidgetTester tester) async {
@@ -3363,7 +3364,7 @@ void main() {
     await tester.pumpAndSettle(); // Have the SnackBar fully animate in.
 
     expect(
-      find.byTooltip(MaterialLocalizations.of(scaffoldMessengerState.context).closeButtonLabel),
+      findByTooltip(MaterialLocalizations.of(scaffoldMessengerState.context).closeButtonLabel),
       findsOneWidget,
     );
   });

--- a/packages/material_ui/test/will_pop_test.dart
+++ b/packages/material_ui/test/will_pop_test.dart
@@ -4,6 +4,7 @@
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:material_ui/material_ui.dart';
+import 'finders.dart';
 
 bool willPopValue = false;
 
@@ -114,7 +115,7 @@ void main() {
       ),
     );
 
-    expect(find.byTooltip('Back'), findsNothing);
+    expect(findByTooltip('Back'), findsNothing);
     expect(find.text('Sample Page'), findsNothing);
 
     await tester.tap(find.text('X'));
@@ -124,7 +125,7 @@ void main() {
     expect(find.text('Sample Page'), findsOneWidget);
 
     willPopValue = false;
-    await tester.tap(find.byTooltip('Back'));
+    await tester.tap(findByTooltip('Back'));
     await tester.pump();
     await tester.pump();
     await tester.pump(const Duration(seconds: 1));
@@ -138,7 +139,7 @@ void main() {
     expect(find.text('Sample Page'), findsOneWidget);
 
     willPopValue = true;
-    await tester.tap(find.byTooltip('Back'));
+    await tester.tap(findByTooltip('Back'));
     await tester.pump();
     await tester.pump();
     await tester.pump(const Duration(seconds: 1));
@@ -179,7 +180,7 @@ void main() {
 
     // Should pop if callback returns true
     willPopValue = true;
-    await tester.tap(find.byTooltip('Back'));
+    await tester.tap(findByTooltip('Back'));
     await tester.pumpAndSettle();
     expect(find.text('Sample Form'), findsNothing);
   });
@@ -221,7 +222,7 @@ void main() {
 
     willPopValue = false;
     willPopCount = 0;
-    await tester.tap(find.byTooltip('Back'));
+    await tester.tap(findByTooltip('Back'));
     await tester.pump(); // Start the pop "back" operation.
     await tester.pump(); // Complete the willPop() Future.
     await tester.pump(const Duration(seconds: 1)); // Wait until it has finished.
@@ -230,7 +231,7 @@ void main() {
 
     willPopValue = true;
     willPopCount = 0;
-    await tester.tap(find.byTooltip('Back'));
+    await tester.tap(findByTooltip('Back'));
     await tester.pump(); // Start the pop "back" operation.
     await tester.pump(); // Complete the willPop() Future.
     await tester.pump(const Duration(seconds: 1)); // Wait until it has finished.
@@ -300,7 +301,7 @@ void main() {
     // Press the Scaffold's back button. This causes the willPop callback
     // to run, which shows the YES/NO Alert Dialog. Veto the back operation
     // by pressing the Alert's NO button.
-    await tester.tap(find.byTooltip('Back'));
+    await tester.tap(findByTooltip('Back'));
     await tester.pump(); // Start the pop "back" operation.
     await tester.pump(); // Call willPop which will show an Alert.
     await tester.tap(find.text('NO'));
@@ -313,7 +314,7 @@ void main() {
     // Each time the Alert is shown and dismissed the FormState's
     // didChangeDependencies() method runs. We're making sure that the
     // didChangeDependencies() method doesn't add an extra willPop callback.
-    await tester.tap(find.byTooltip('Back'));
+    await tester.tap(findByTooltip('Back'));
     await tester.pump(); // Start the pop "back" operation.
     await tester.pump(); // Call willPop which will show an Alert.
     await tester.tap(find.text('NO'));
@@ -324,7 +325,7 @@ void main() {
 
     // This time really dismiss the SampleForm by pressing the Alert's
     // YES button.
-    await tester.tap(find.byTooltip('Back'));
+    await tester.tap(findByTooltip('Back'));
     await tester.pump(); // Start the pop "back" operation.
     await tester.pump(); // Call willPop which will show an Alert.
     await tester.tap(find.text('YES'));


### PR DESCRIPTION
The [find.byTooltip](https://github.com/flutter/flutter/blob/9a353b5ad5e00932819a1ff959f0dc1a65af8f73/packages/flutter_test/lib/src/finders.dart#L396-L415) finder in flutter/flutter's flutter_test package is unreliable for material_ui due to using flutter/flutter's Tooltip class. This PR migrates all usages to the existing [findByTooltip](https://github.com/flutter/packages/blob/a3e763e60321146e9f79571ca917c824b25e62ce/packages/material_ui/test/finders.dart#L24-L43) in material_ui, which does not have this problem.

See https://github.com/flutter/flutter/issues/191063#issuecomment-5321112440

Fixes https://github.com/flutter/flutter/issues/191063