### PR TITLE
[webview_flutter] Register the iOS platform view with the hit-test gesture blocking policy

### DIFF
--- a/packages/webview_flutter/webview_flutter_wkwebview/CHANGELOG.md
+++ b/packages/webview_flutter/webview_flutter_wkwebview/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 3.26.1
+
+* Fixes web views on iOS becoming unresponsive to touches after the first
+  interaction by registering the platform view with the hit-test based gesture
+  blocking policy.
+
 ## 3.26.0
 
 * Adds new method for accessing a native `WKWebView` from a `FlutterPluginRegistrar`.

--- a/packages/webview_flutter/webview_flutter_wkwebview/darwin/Tests/FWFWebViewFlutterWKWebViewExternalAPITests.swift
+++ b/packages/webview_flutter/webview_flutter_wkwebview/darwin/Tests/FWFWebViewFlutterWKWebViewExternalAPITests.swift
@@ -84,6 +84,16 @@ import WebKit
         forIdentifier: 0, withPluginRegistrar: registrar)
       #expect(result == nil)
     }
+
+    @MainActor @Test func registersViewFactoryWithHitTestGesturePolicy() throws {
+      let registrar = TestFlutterPluginRegistrar()
+
+      WebViewFlutterPlugin.register(with: registrar)
+
+      #expect(
+        registrar.registeredGestureRecognizersBlockingPolicy
+          == FlutterPlatformViewGestureRecognizersBlockingPolicyDoNotBlockGesture)
+    }
   #endif
 }
 
@@ -128,6 +138,8 @@ class TestFlutterPluginRegistrar: NSObject, FlutterPluginRegistrar {
 
   #if os(iOS)
     var viewController: UIViewController?
+    var registeredGestureRecognizersBlockingPolicy:
+      FlutterPlatformViewGestureRecognizersBlockingPolicy?
 
     func messenger() -> FlutterBinaryMessenger {
       return TestBinaryMessenger()
@@ -145,6 +157,7 @@ class TestFlutterPluginRegistrar: NSObject, FlutterPluginRegistrar {
       _ factory: FlutterPlatformViewFactory, withId factoryId: String,
       gestureRecognizersBlockingPolicy: FlutterPlatformViewGestureRecognizersBlockingPolicy
     ) {
+      registeredGestureRecognizersBlockingPolicy = gestureRecognizersBlockingPolicy
     }
 
     func addSceneDelegate(_ delegate: any FlutterSceneLifeCycleDelegate) {

--- a/packages/webview_flutter/webview_flutter_wkwebview/darwin/webview_flutter_wkwebview/Sources/webview_flutter_wkwebview/WebViewFlutterPlugin.swift
+++ b/packages/webview_flutter/webview_flutter_wkwebview/darwin/webview_flutter_wkwebview/Sources/webview_flutter_wkwebview/WebViewFlutterPlugin.swift
@@ -34,7 +34,20 @@ public class WebViewFlutterPlugin: NSObject, FlutterPlugin {
       registrar.addSceneDelegate(plugin)
     #endif
 
-    registrar.register(viewFactory, withId: "plugins.flutter.io/webview")
+    #if os(iOS)
+      // The default `eager` policy blocks the platform view's gesture
+      // recognizers through Flutter's gesture arena, which is stateful. When
+      // that state is stranded the web view stops receiving touches for the
+      // rest of its lifetime. `doNotBlockGesture` derives the same decision
+      // from hit testing instead, so there is no state left to strand.
+      // See https://github.com/flutter/flutter/issues/175099.
+      registrar.register(
+        viewFactory, withId: "plugins.flutter.io/webview",
+        gestureRecognizersBlockingPolicy:
+          FlutterPlatformViewGestureRecognizersBlockingPolicyDoNotBlockGesture)
+    #else
+      registrar.register(viewFactory, withId: "plugins.flutter.io/webview")
+    #endif
     registrar.publish(plugin)
   }
 

--- a/packages/webview_flutter/webview_flutter_wkwebview/pubspec.yaml
+++ b/packages/webview_flutter/webview_flutter_wkwebview/pubspec.yaml
@@ -2,7 +2,7 @@ name: webview_flutter_wkwebview
 description: A Flutter plugin that provides a WebView widget based on Apple's WKWebView control.
 repository: https://github.com/flutter/packages/tree/main/packages/webview_flutter/webview_flutter_wkwebview
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+webview%22
-version: 3.26.0
+version: 3.26.1
 
 environment:
   sdk: ^3.12.0


### PR DESCRIPTION
Registers the iOS platform view with `FlutterPlatformViewGestureRecognizersBlockingPolicyDoNotBlockGesture` instead of relying on the default `eager` policy.

`eager` blocks the platform view's gesture recognizers through Flutter's gesture arena, which is stateful. If that state is stranded the web view stops receiving touches for the rest of its lifetime. The engine used to recover from this in `ForwardingGestureRecognizer.forceResetStateIfNeeded`, but that reset returns early on iOS 26 and above (see flutter/flutter#179907), so on iOS 26 there is nothing left to recover it.

`doNotBlockGesture` derives the same blocking decision from `hitTest` rather than the arena, and does not install the delaying recognizer at all — so there is no recognizer state to strand. Blocking behaviour itself is preserved: `FlutterTouchInterceptingView.hitTest` still consults `platformViewShouldAcceptTouchAtTouchBeganLocation:` and returns itself when a Flutter widget is on top, and the forwarding recognizer is still installed so Flutter's arena keeps seeing the touches.

Verified on iOS 26.3 simulator, iOS 26.4 simulator and an iOS 26.6 device: the web view is unresponsive after the first interaction without this change, and behaves correctly with it.

Fixes flutter/flutter#191261

**Open question for the reviewer:** this change is unconditional rather than gated behind `if #available(iOS 26.0, *)`. I went that way because it is not iOS-26-specific in principle — the arena state can be stranded on any version, iOS 26 just removed the net that used to hide it — and because it matches the direction described in flutter/flutter#175099 ("help prevent regressions even if this WebKit bug happens again"). Happy to add a version gate instead if you would rather keep the blast radius smaller.

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under.
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[the version and CHANGELOG instructions]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version-and-changelog-updates
[semantic versioning]: https://dart.dev/tools/pub/versioning#semantic-versions
[repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
