### PR TITLE
Update chrome version in `ci.yaml` to (probably) unblock tree

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -73,7 +73,7 @@ platform_properties:
       device_type: none
       dependencies: >-
         [
-          {"dependency": "chrome_and_driver", "version": "version:125.0.6422.141"}
+          {"dependency": "chrome_and_driver", "version": "version:145.0.7632.117"}
         ]
   windows_arm64:
     properties:

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -321,7 +321,7 @@ targets:
           {"dependency": "clang", "version": "git_revision:5d5aba78dbbee75508f01bcaa69aedb2ab79065a"},
           {"dependency": "cmake", "version": "build_id:8787856497187628321"},
           {"dependency": "ninja", "version": "version:1.9.0"},
-          {"dependency": "chrome_and_driver", "version": "version:125.0.6422.141"}
+          {"dependency": "chrome_and_driver", "version": "version:145.0.7632.117"}
         ]
       channel: master
 
@@ -340,7 +340,7 @@ targets:
           {"dependency": "clang", "version": "git_revision:5d5aba78dbbee75508f01bcaa69aedb2ab79065a"},
           {"dependency": "cmake", "version": "build_id:8787856497187628321"},
           {"dependency": "ninja", "version": "version:1.9.0"},
-          {"dependency": "chrome_and_driver", "version": "version:125.0.6422.141"}
+          {"dependency": "chrome_and_driver", "version": "version:145.0.7632.117"}
         ]
       channel: stable
 
@@ -769,7 +769,7 @@ targets:
       # Install Chrome as a default handler for schemes for url_launcher.
       dependencies: >-
         [
-          {"dependency": "chrome_and_driver", "version": "version:125.0.6422.141"}
+          {"dependency": "chrome_and_driver", "version": "version:145.0.7632.117"}
         ]
 
   - name: Linux_desktop platform_tests stable
@@ -783,7 +783,7 @@ targets:
       # Install Chrome as a default handler for schemes for url_launcher.
       dependencies: >-
         [
-          {"dependency": "chrome_and_driver", "version": "version:125.0.6422.141"}
+          {"dependency": "chrome_and_driver", "version": "version:145.0.7632.117"}
         ]
 
   ### iOS+macOS tasks ###


### PR DESCRIPTION
Upgrades the `chrome_and_driver` CIPD dependency in `.ci.yaml` from `125.0.6422.141` to `145.0.7632.117` to align with `flutter/flutter`.

Gemini suspects this is what's causing the timeouts in the tree:
> A recent flutter roll (specifically [flutter/flutter#183835](https://github.com/flutter/flutter/pull/183835)) updated `flutter.js` Wasm compatibility checks to require WebAssembly `js-string` builtins. Chrome 125 lacks support for `js-string` builtins, causing `flutter test --platform=chrome --wasm` targets to fail with `"no compatible build found for this browser"`. Upgrading Chrome resolves the failure and unblocks the packages tree.

and that seems reasonable to me