### PR TITLE
[go_router] Fixes "Bad state: Future already completed" when a route with onExit is popped twice

### DIFF
--- a/packages/go_router/CHANGELOG.md
+++ b/packages/go_router/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 17.5.1
+
+- Fixes a `StateError` ("Bad state: Future already completed") when a route with an `onExit` callback is popped twice before the navigator rebuilds.
+
 ## 17.5.0
 
 - Adds route `metadata` support, including inheritance and override behavior with exposure on `GoRouterState`.

--- a/packages/go_router/lib/src/match.dart
+++ b/packages/go_router/lib/src/match.dart
@@ -458,7 +458,15 @@ class ImperativeRouteMatch extends RouteMatch {
 
   /// Called when the corresponding [Route] associated with this route match is
   /// completed.
+  ///
+  /// A route match can be completed more than once when the same route is
+  /// popped again before the navigator has rebuilt; for example, two back
+  /// events in quick succession while an `onExit` callback defers the pop to a
+  /// microtask. Only the first completion is reported; later ones are ignored.
   void complete([dynamic value]) {
+    if (completer.isCompleted) {
+      return;
+    }
     completer.complete(value);
   }
 

--- a/packages/go_router/pubspec.yaml
+++ b/packages/go_router/pubspec.yaml
@@ -1,7 +1,7 @@
 name: go_router
 description: A declarative router for Flutter based on Navigation 2 supporting
   deep linking, data-driven routes and more
-version: 17.5.0
+version: 17.5.1
 repository: https://github.com/flutter/packages/tree/main/packages/go_router
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+go_router%22
 

--- a/packages/go_router/test/on_exit_test.dart
+++ b/packages/go_router/test/on_exit_test.dart
@@ -529,6 +529,45 @@ void main() {
     expect(find.byKey(homeKey), findsNothing);
   });
 
+  // Regression test for https://github.com/flutter/flutter/issues/191280
+  testWidgets('popping a route with onExit twice before the navigator rebuilds does not throw', (
+    WidgetTester tester,
+  ) async {
+    final homeKey = UniqueKey();
+    final detailKey = UniqueKey();
+
+    final GoRouter router = await createRouter(
+      <RouteBase>[
+        GoRoute(
+          path: '/',
+          builder: (_, _) => DummyScreen(key: homeKey),
+          routes: <RouteBase>[
+            GoRoute(
+              path: 'detail',
+              onExit: (_, _) => true,
+              builder: (_, _) => DummyScreen(key: detailKey),
+            ),
+          ],
+        ),
+      ],
+      tester,
+    );
+
+    final Future<Object?> pushFuture = router.push('/detail');
+    await tester.pumpAndSettle();
+    expect(find.byKey(detailKey), findsOneWidget);
+
+    // Two back events arrive before the deferred pop is applied — e.g. a user
+    // tapping the back button twice in quick succession.
+    router.pop('first');
+    router.pop('second');
+    await tester.pumpAndSettle();
+
+    expect(tester.takeException(), isNull);
+    expect(find.byKey(homeKey), findsOneWidget);
+    expect(await pushFuture, 'first');
+  });
+
   // Regression test for https://github.com/flutter/flutter/issues/137829
   testWidgets('back button works synchronously with ShellRoute', (WidgetTester tester) async {
     var allow = false;


### PR DESCRIPTION
When a route with an `onExit` callback is popped, `GoRouterDelegate._handlePopPageWithRouteMatch` vetoes the synchronous pop (returns `false`) and defers completion to a `scheduleMicrotask`. Because the page is still on the navigator until the configuration change is applied, a second back event arriving in that window (e.g. a user tapping the back button twice in quick succession) reaches the delegate with the **same** `RouteMatchBase` and schedules a second microtask. Both microtasks call `_completeRouteMatch` → `ImperativeRouteMatch.complete()` on the same completer, and the second call throws an unhandled `StateError: Bad state: Future already completed`.

This affects far more apps than explicit `onExit` users: any app using go_router_builder typed routes generated before the `hasOverriddenOnExit` parameter existed gets an implicit `onExit` wired by `GoRouteData.$route` (it treats a null `hasOverriddenOnExit` as `true` for backward compatibility), so every typed route takes the deferred pop path. We hit this in production from users double-tapping the AppBar back button.

This PR makes `ImperativeRouteMatch.complete()` ignore completions after the first, so the first pop's result is reported and the redundant second pop becomes a no-op (`RouteMatchList.remove` already returns the list unchanged when the match is gone). A regression test reproducing the double-pop is included; it fails with a `StateError` without the fix.

*Fixes https://github.com/flutter/flutter/issues/191280*

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [ ] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under[^1].
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [x] All existing and new tests are passing.

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[the version and CHANGELOG instructions]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version-and-changelog-updates
[semantic versioning]: https://dart.dev/tools/pub/versioning#semantic-versions
[repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
