### PR TITLE
[material_ui] Add barrierBuilder support to Material dialogs

### DIFF
--- a/packages/material_ui/lib/src/dialog.dart
+++ b/packages/material_ui/lib/src/dialog.dart
@@ -1683,6 +1683,7 @@ Future<T?> showDialog<T>({
   bool fullscreenDialog = false,
   bool? requestFocus,
   AnimationStyle? animationStyle,
+  RouteBarrierBuilder? barrierBuilder,
 }) {
   assert(_debugIsActive(context));
   assert(debugCheckHasMaterialLocalizations(context));
@@ -1717,6 +1718,7 @@ Future<T?> showDialog<T>({
         requestFocus: requestFocus,
         animationStyle: animationStyle,
         fullscreenDialog: fullscreenDialog,
+        barrierBuilder: barrierBuilder,
       );
     },
     builder: (BuildContext routeContext) {
@@ -1767,6 +1769,7 @@ Future<T?> showAdaptiveDialog<T>({
   TraversalEdgeBehavior? traversalEdgeBehavior,
   bool? requestFocus,
   AnimationStyle? animationStyle,
+  RouteBarrierBuilder? barrierBuilder,
 }) {
   final ThemeData theme = Theme.of(context);
   switch (theme.platform) {
@@ -1787,6 +1790,7 @@ Future<T?> showAdaptiveDialog<T>({
         traversalEdgeBehavior: traversalEdgeBehavior,
         requestFocus: requestFocus,
         animationStyle: animationStyle,
+        barrierBuilder: barrierBuilder,
       );
     case TargetPlatform.iOS:
     case TargetPlatform.macOS:
@@ -1881,6 +1885,7 @@ class DialogRoute<T> extends RawDialogRoute<T> {
     super.anchorPoint,
     super.traversalEdgeBehavior,
     super.fullscreenDialog,
+    super.barrierBuilder,
     AnimationStyle? animationStyle,
   }) : _animationStyle = animationStyle,
        super(

--- a/packages/material_ui/pending_changelogs/change_2026_08_19_1787143102918.yaml
+++ b/packages/material_ui/pending_changelogs/change_2026_08_19_1787143102918.yaml
@@ -1,0 +1,3 @@
+changelog: |
+  - Add barrierBuilder support to Material dialogs.
+version: minor

--- a/packages/material_ui/test/dialog_test.dart
+++ b/packages/material_ui/test/dialog_test.dart
@@ -3505,6 +3505,58 @@ void main() {
 
     semantics.dispose();
   });
+
+  testWidgets('showDialog applies custom barrierBuilder', (WidgetTester tester) async {
+    const expectedPadding = 12.0;
+    const barrierKey = ValueKey<String>('custom-barrier-padding');
+    RouteBarrierDetails? capturedDetails;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Builder(
+          builder: (BuildContext context) {
+            return ElevatedButton(
+              onPressed: () {
+                showDialog<void>(
+                  context: context,
+                  barrierLabel: 'barrier_label',
+                  barrierColor: const Color(0xFF00FF00),
+                  barrierBuilder:
+                      (BuildContext context, RouteBarrierDetails details, Widget barrier) {
+                        capturedDetails = details;
+                        return Padding(
+                          key: barrierKey,
+                          padding: const EdgeInsets.all(expectedPadding),
+                          child: barrier,
+                        );
+                      },
+                  builder: (BuildContext context) => const Text('Dialog'),
+                );
+              },
+              child: const Text('Show Dialog'),
+            );
+          },
+        ),
+      ),
+    );
+
+    // Open the dialog.
+    await tester.tap(find.byType(ElevatedButton));
+    await tester.pumpAndSettle();
+
+    final Padding paddingWidget = tester.widget<Padding>(find.byKey(barrierKey));
+    expect(paddingWidget.padding, const EdgeInsets.all(expectedPadding));
+
+    final ModalBarrier barrierWidget = tester.widget<ModalBarrier>(
+      find.descendant(of: find.byKey(barrierKey), matching: find.byType(ModalBarrier)),
+    );
+    expect(barrierWidget.color, const Color(0xFF00FF00));
+
+    expect(capturedDetails, isNotNull);
+    expect(capturedDetails!.barrierColor, const Color(0xFF00FF00));
+    expect(capturedDetails!.barrierDismissible, true);
+    expect(capturedDetails!.barrierLabel, 'barrier_label');
+  });
 }
 
 @pragma('vm:entry-point')


### PR DESCRIPTION
This adds `barrierBuilder` to `showDialog`, `showAdaptiveDialog`, and `DialogRoute`, continuing PR [#187992.](https://github.com/flutter/flutter/pull/187992)

Closes https://github.com/flutter/flutter/issues/21039

Port of https://github.com/flutter/flutter/pull/190393

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under[^1].
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[the version and CHANGELOG instructions]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version-and-changelog-updates
[semantic versioning]: https://dart.dev/tools/pub/versioning#semantic-versions
[repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
