### PR TITLE
[cupertino_ui] Prevent intercepting CupertinoSheet transitions mid-animation

### DIFF
--- a/packages/cupertino_ui/lib/src/sheet.dart
+++ b/packages/cupertino_ui/lib/src/sheet.dart
@@ -776,7 +776,7 @@ class CupertinoSheetRoute<T> extends PageRoute<T> with _CupertinoSheetRouteTrans
           data: CupertinoUserInterfaceLevelData.elevated,
           child: _CupertinoSheetScope(
             child: _CupertinoDraggableScrollableSheet<T>(
-              enabledCallback: () => enableDrag,
+              enabledCallback: () => enableDrag && !(controller?.isAnimating ?? false),
               onStartPopGesture: () =>
                   _CupertinoSheetRouteTransitionMixin._startPopGesture<T>(this, topGap),
               builder: _sheetWithDragHandle,
@@ -906,7 +906,7 @@ mixin _CupertinoSheetRouteTransitionMixin<T> on PageRoute<T> {
       linearTransition: linearTransition,
       topGap: topGap,
       child: _CupertinoDragGestureDetector<T>(
-        enabledCallback: () => enableDrag,
+        enabledCallback: () => enableDrag && !(route.controller?.isAnimating ?? false),
         onStartPopGesture: () => _startPopGesture<T>(route, topGap),
         child: child,
       ),
@@ -1377,6 +1377,9 @@ class _CupertinoDraggableScrollableSheetState<T>
 
   void _dragStart() {
     assert(mounted);
+    if (!widget.enabledCallback()) {
+      return;
+    }
     _dragGestureController ??= widget.onStartPopGesture();
   }
 

--- a/packages/cupertino_ui/test/sheet_test.dart
+++ b/packages/cupertino_ui/test/sheet_test.dart
@@ -1395,6 +1395,57 @@ void main() {
       expect(rootNavigatorPopped, false);
     });
 
+    testWidgets('Sheet ignores gestures mid-dismissal and finishes closing', (
+      WidgetTester tester,
+    ) async {
+      final GlobalKey homeKey = GlobalKey();
+      final GlobalKey sheetKey = GlobalKey();
+
+      await tester.pumpWidget(dragGestureApp(homeKey, sheetKey));
+
+      // Open sheet
+      await tester.tap(find.text('Push Page 2'));
+      await tester.pumpAndSettle();
+
+      final Finder sheetFinder = find.byKey(sheetKey);
+      final Size sheetSize = tester.getSize(sheetFinder);
+      final double sheetHeight = sheetSize.height;
+
+      final double dragDistance = sheetHeight / 1.8;
+
+      final Offset sheetTopLeft = tester.getTopLeft(sheetFinder);
+      final startPoint = Offset(sheetTopLeft.dx + (sheetSize.width / 1.8), sheetTopLeft.dy + 20.0);
+
+      // Drag sheet down
+      final TestGesture gesture = await tester.startGesture(startPoint);
+      await gesture.moveBy(Offset(0, dragDistance));
+      await tester.pump();
+
+      // Release sheet
+      await gesture.up();
+      await tester.pump();
+
+      await tester.pump(const Duration(milliseconds: 50));
+
+      final box = tester.renderObject(sheetFinder) as RenderBox;
+      final double currentY = box.localToGlobal(Offset.zero).dy;
+
+      // Try to intercept the gesture by dragging up
+      final TestGesture interceptGesture = await tester.startGesture(
+        Offset(startPoint.dx, currentY + 100),
+      );
+      await tester.pump();
+
+      // Drag up
+      await interceptGesture.moveBy(const Offset(0, -50));
+      await interceptGesture.up();
+
+      await tester.pumpAndSettle();
+
+      expect(find.text('Page 2'), findsNothing);
+      expect(find.text('Page 1'), findsOneWidget);
+    });
+
     testWidgets('dragging does not move the sheet when enableDrag is false', (
       WidgetTester tester,
     ) async {


### PR DESCRIPTION
Fixed an incompatibility between CupertinoSheetRoute and SwiftUI sheet, which allowed users to intercept animations for opening and closing a CupertinoSheetRoute, resulting in unexpected gesture behavior and animation failures.

This PR is a follow-up to https://github.com/flutter/flutter/pull/181605

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under[^1].
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[the version and CHANGELOG instructions]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version-and-changelog-updates
[semantic versioning]: https://dart.dev/tools/pub/versioning#semantic-versions
[repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
