### PR TITLE
[cupertino_ui] Add rubber-band physics simulation to CupertinoSheet when enableDrag is false

### DIFF
--- a/packages/cupertino_ui/lib/src/sheet.dart
+++ b/packages/cupertino_ui/lib/src/sheet.dart
@@ -776,7 +776,7 @@ class CupertinoSheetRoute<T> extends PageRoute<T> with _CupertinoSheetRouteTrans
           data: CupertinoUserInterfaceLevelData.elevated,
           child: _CupertinoSheetScope(
             child: _CupertinoDraggableScrollableSheet<T>(
-              enabledCallback: () => enableDrag,
+              enabledCallback: () => enableDrag && !(controller?.isAnimating ?? false),
               onStartPopGesture: () =>
                   _CupertinoSheetRouteTransitionMixin._startPopGesture<T>(this, topGap),
               builder: _sheetWithDragHandle,
@@ -906,7 +906,7 @@ mixin _CupertinoSheetRouteTransitionMixin<T> on PageRoute<T> {
       linearTransition: linearTransition,
       topGap: topGap,
       child: _CupertinoDragGestureDetector<T>(
-        enabledCallback: () => enableDrag,
+        enabledCallback: () => enableDrag && !(route.controller?.isAnimating ?? false),
         onStartPopGesture: () => _startPopGesture<T>(route, topGap),
         child: child,
       ),
@@ -1377,6 +1377,9 @@ class _CupertinoDraggableScrollableSheetState<T>
 
   void _dragStart() {
     assert(mounted);
+    if (!widget.enabledCallback()) {
+      return;
+    }
     _dragGestureController ??= widget.onStartPopGesture();
   }
 

--- a/packages/cupertino_ui/lib/src/sheet.dart
+++ b/packages/cupertino_ui/lib/src/sheet.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:math' as math;
-
 import 'package:flutter/gestures.dart';
 import 'package:flutter/physics.dart';
 import 'package:flutter/services.dart';
@@ -41,7 +39,7 @@ const double _kStretchedTopGapRatio = 0.072;
 
 // Spring description used for the bounce-back animation when enableDrag == false
 // or when snapping back to position. Measured on iOS 26
-SpringDescription _sheetSpring = SpringDescription.withDurationAndBounce(
+final SpringDescription _sheetSpring = SpringDescription.withDurationAndBounce(
   duration: const Duration(milliseconds: 430),
 );
 
@@ -68,7 +66,8 @@ double _computeRubberBandFriction({
   double constant = _kAppleRubberBandElasticity,
 }) {
   final double stretchProgress = (currentDisplacement / dimension).clamp(0.0, 1.0);
-  return constant * math.pow(1.0 - stretchProgress, 2.0);
+  final double remainingProgress = 1.0 - stretchProgress;
+  return constant * remainingProgress * remainingProgress;
 }
 
 // Tween for animating a Cupertino sheet onto the screen.
@@ -1190,7 +1189,9 @@ class _CupertinoDragGestureController<T> {
       if (popDragController.isAnimating) {
         void animationStatusCallback(AnimationStatus status) {
           if (status == AnimationStatus.completed || status == AnimationStatus.dismissed) {
-            navigator.didStopUserGesture();
+            if (navigator.mounted) {
+              navigator.didStopUserGesture();
+            }
             popDragController.removeStatusListener(animationStatusCallback);
           }
         }

--- a/packages/cupertino_ui/lib/src/sheet.dart
+++ b/packages/cupertino_ui/lib/src/sheet.dart
@@ -2,7 +2,10 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:math' as math;
+
 import 'package:flutter/gestures.dart';
+import 'package:flutter/physics.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 
@@ -35,6 +38,38 @@ const double _kTopGapRatio = 0.08;
 // Determined through visual tuning to feel natural on <iPhone16, iPhone 16 Pro>
 // running iOS 18.0 simulators.
 const double _kStretchedTopGapRatio = 0.072;
+
+// Spring description used for the bounce-back animation when enableDrag == false
+// or when snapping back to position. Measured on iOS 26
+SpringDescription _sheetSpring = SpringDescription.withDurationAndBounce(
+  duration: const Duration(milliseconds: 430),
+);
+
+// The standard elasticity coefficient used in Apple's Rubber-Banding formula
+// (WWDC 2018: "Designing Fluid Interfaces")
+const double _kAppleRubberBandElasticity = 0.55;
+
+// The asymptotic maximum stretch distance in logical pixels when pulling against resistance.
+const double _kMaxRubberBandDistance = 180.0;
+
+// Calculates the instantaneous friction factor for overscroll resistance using
+// the exact derivative of Apple's Rubber-Banding equation:
+//
+//   y(x) = (x * c * d) / (d + c * x)
+//   dy/dx = c * (1.0 - y / d)^2
+//
+// where `c` is [_kAppleRubberBandElasticity], `d` is [_kMaxRubberBandDistance],
+// and `y` is the current physical displacement in logical pixels.
+//
+// https://gist.github.com/originell/6961057
+double _computeRubberBandFriction({
+  required double currentDisplacement,
+  double dimension = _kMaxRubberBandDistance,
+  double constant = _kAppleRubberBandElasticity,
+}) {
+  final double stretchProgress = (currentDisplacement / dimension).clamp(0.0, 1.0);
+  return constant * math.pow(1.0 - stretchProgress, 2.0);
+}
 
 // Tween for animating a Cupertino sheet onto the screen.
 //
@@ -776,9 +811,14 @@ class CupertinoSheetRoute<T> extends PageRoute<T> with _CupertinoSheetRouteTrans
           data: CupertinoUserInterfaceLevelData.elevated,
           child: _CupertinoSheetScope(
             child: _CupertinoDraggableScrollableSheet<T>(
-              enabledCallback: () => enableDrag && !(controller?.isAnimating ?? false),
-              onStartPopGesture: () =>
-                  _CupertinoSheetRouteTransitionMixin._startPopGesture<T>(this, topGap),
+              enabledCallback: () => !(controller?.isAnimating ?? false),
+              enableDrag: enableDrag,
+              onStartPopGesture: () => _CupertinoSheetRouteTransitionMixin._startPopGesture<T>(
+                this,
+                topGap,
+                enableDrag: enableDrag,
+              ),
+              topGap: topGap,
               builder: _sheetWithDragHandle,
             ),
           ),
@@ -878,14 +918,16 @@ mixin _CupertinoSheetRouteTransitionMixin<T> on PageRoute<T> {
 
   static _CupertinoDragGestureController<T> _startPopGesture<T>(
     ModalRoute<T> route,
-    double topGap,
-  ) {
+    double topGap, {
+    required bool enableDrag,
+  }) {
     return _CupertinoDragGestureController<T>(
       topGap: topGap,
       navigator: route.navigator!,
       getIsCurrent: () => route.isCurrent,
       getIsActive: () => route.isActive,
       popDragController: route.controller!, // protected access
+      enableDrag: enableDrag,
     );
   }
 
@@ -906,8 +948,8 @@ mixin _CupertinoSheetRouteTransitionMixin<T> on PageRoute<T> {
       linearTransition: linearTransition,
       topGap: topGap,
       child: _CupertinoDragGestureDetector<T>(
-        enabledCallback: () => enableDrag && !(route.controller?.isAnimating ?? false),
-        onStartPopGesture: () => _startPopGesture<T>(route, topGap),
+        enabledCallback: () => !(route.controller?.isAnimating ?? false),
+        onStartPopGesture: () => _startPopGesture<T>(route, topGap, enableDrag: enableDrag),
         child: child,
       ),
     );
@@ -1023,9 +1065,9 @@ class _CupertinoDragGestureDetectorState<T> extends State<_CupertinoDragGestureD
     }
     final double delta = sheetHeight > 0 ? details.primaryDelta! / sheetHeight : 0.0;
     _dragGestureController!.dragUpdate(
-      // Divide by size of the sheet.
       delta,
       _stretchDragController!.controller,
+      sheetHeight: sheetHeight,
     );
   }
 
@@ -1079,6 +1121,7 @@ class _CupertinoDragGestureController<T> {
     required this.getIsActive,
     required this.getIsCurrent,
     required this.topGap,
+    required this.enableDrag,
   }) {
     navigator.didStartUserGesture();
   }
@@ -1088,10 +1131,11 @@ class _CupertinoDragGestureController<T> {
   final ValueGetter<bool> getIsActive;
   final ValueGetter<bool> getIsCurrent;
   final double topGap;
+  final bool enableDrag;
 
   /// The drag gesture has changed by [delta]. The total range of the drag
   /// should be 0.0 to 1.0.
-  void dragUpdate(double delta, AnimationController? upController) {
+  void dragUpdate(double delta, AnimationController? upController, {required double sheetHeight}) {
     if (upController != null &&
         popDragController.value == 1.0 &&
         (upController.value > 0 || delta < 0)) {
@@ -1100,7 +1144,17 @@ class _CupertinoDragGestureController<T> {
       const double stretchDistance = _kTopGapRatio - _kStretchedTopGapRatio;
       upController.value -= delta / stretchDistance;
     } else {
-      popDragController.value -= delta;
+      if (!enableDrag) {
+        // Applies the exact derivative of Apple's Rubber-Banding equation.
+        final double currentDisplacement =
+            (1.0 - popDragController.value).clamp(0.0, 1.0) * sheetHeight;
+        final double friction = _computeRubberBandFriction(
+          currentDisplacement: currentDisplacement,
+        );
+        popDragController.value -= delta * friction;
+      } else {
+        popDragController.value -= delta;
+      }
     }
   }
 
@@ -1120,6 +1174,31 @@ class _CupertinoDragGestureController<T> {
         curve: Curves.easeOut,
       );
       navigator.didStopUserGesture();
+      return;
+    }
+
+    if (!enableDrag) {
+      // When dragging is disabled, spring back to the open position using a physical spring simulation.
+      final Simulation simulation = SpringSimulation(
+        _sheetSpring,
+        popDragController.value,
+        1.0,
+        -velocity,
+      );
+      popDragController.animateWith(simulation);
+
+      if (popDragController.isAnimating) {
+        void animationStatusCallback(AnimationStatus status) {
+          if (status == AnimationStatus.completed || status == AnimationStatus.dismissed) {
+            navigator.didStopUserGesture();
+            popDragController.removeStatusListener(animationStatusCallback);
+          }
+        }
+
+        popDragController.addStatusListener(animationStatusCallback);
+      } else {
+        navigator.didStopUserGesture();
+      }
       return;
     }
 
@@ -1195,12 +1274,14 @@ class _CupertinoSheetScrollController extends ScrollController {
     required this.onDragUpdate,
     required this.onDragEnd,
     required this.sheetIsDraggedDown,
+    required this.hasActiveDragController,
   });
 
   final _DragStartCallback onDragStart;
   final _DragEndCallback onDragUpdate;
   final _DragUpdateCallback onDragEnd;
   final _GetSheetDragged sheetIsDraggedDown;
+  final ValueGetter<bool> hasActiveDragController;
 
   @override
   _CupertinoSheetScrollPosition createScrollPosition(
@@ -1216,6 +1297,7 @@ class _CupertinoSheetScrollController extends ScrollController {
       onDragUpdate: onDragUpdate,
       onDragEnd: onDragEnd,
       sheetIsDraggedDown: sheetIsDraggedDown,
+      hasActiveDragController: hasActiveDragController,
     );
   }
 }
@@ -1241,6 +1323,7 @@ class _CupertinoSheetScrollPosition extends ScrollPositionWithSingleContext {
     required this.onDragUpdate,
     required this.onDragEnd,
     required this.sheetIsDraggedDown,
+    required this.hasActiveDragController,
   });
 
   VoidCallback? _dragCancelCallback;
@@ -1252,6 +1335,7 @@ class _CupertinoSheetScrollPosition extends ScrollPositionWithSingleContext {
   final _DragUpdateCallback onDragEnd;
 
   final _GetSheetDragged sheetIsDraggedDown;
+  final ValueGetter<bool> hasActiveDragController;
 
   @override
   void absorb(ScrollPosition other) {
@@ -1289,7 +1373,8 @@ class _CupertinoSheetScrollPosition extends ScrollPositionWithSingleContext {
   @override
   void applyUserOffset(double delta) {
     onDragStart();
-    if (!listShouldScroll && (delta > 0 || sheetIsDraggedDown())) {
+    final bool canDragSheet = hasActiveDragController() || sheetIsDraggedDown();
+    if (canDragSheet && !listShouldScroll && (delta > 0 || sheetIsDraggedDown())) {
       onDragUpdate(delta);
     } else {
       super.applyUserOffset(delta);
@@ -1309,9 +1394,15 @@ class _CupertinoSheetScrollPosition extends ScrollPositionWithSingleContext {
     _dragCancelCallback?.call();
     _dragCancelCallback = null;
     if (velocity < 0.0 && !listShouldScroll) {
-      onDragEnd(velocity);
-      super.goBallistic(0);
-      return;
+      if (sheetIsDraggedDown()) {
+        onDragEnd(velocity);
+        super.goBallistic(0);
+        return;
+      } else {
+        onDragEnd(0.0);
+        super.goBallistic(velocity);
+        return;
+      }
     }
     onDragEnd(0.0);
     super.goBallistic(velocity);
@@ -1329,13 +1420,19 @@ class _CupertinoDraggableScrollableSheet<T> extends StatefulWidget {
   const _CupertinoDraggableScrollableSheet({
     super.key,
     required this.enabledCallback,
+    required this.enableDrag,
     required this.onStartPopGesture,
     required this.builder,
+    this.topGap = _kTopGapRatio,
   });
 
   final ScrollableWidgetBuilder builder;
 
   final ValueGetter<bool> enabledCallback;
+
+  final bool enableDrag;
+
+  final double topGap;
 
   final ValueGetter<_CupertinoDragGestureController<T>> onStartPopGesture;
 
@@ -1357,6 +1454,7 @@ class _CupertinoDraggableScrollableSheetState<T>
       onDragUpdate: _dragUpdate,
       onDragEnd: _handleDragEnd,
       sheetIsDraggedDown: () => _dragGestureController?.isDragged() ?? false,
+      hasActiveDragController: () => _dragGestureController != null,
     );
   }
 
@@ -1386,9 +1484,11 @@ class _CupertinoDraggableScrollableSheetState<T>
   void _dragUpdate(double delta) {
     assert(mounted);
     if (_dragGestureController != null) {
+      final double sheetHeight = context.size?.height ?? 0.0;
       _dragGestureController!.dragUpdate(
-        delta / (context.size!.height - (context.size!.height * _kTopGapRatio)),
+        sheetHeight > 0 ? delta / sheetHeight : 0.0,
         null,
+        sheetHeight: sheetHeight,
       );
     }
   }
@@ -1396,7 +1496,8 @@ class _CupertinoDraggableScrollableSheetState<T>
   void _handleDragEnd(double velocity) {
     assert(mounted);
     if (_dragGestureController != null) {
-      _dragGestureController!.dragEnd(-velocity / context.size!.height, null);
+      final double sheetHeight = context.size?.height ?? 0.0;
+      _dragGestureController!.dragEnd(sheetHeight > 0 ? -velocity / sheetHeight : 0.0, null);
       _dragGestureController = null;
     }
   }

--- a/packages/cupertino_ui/lib/src/sheet.dart
+++ b/packages/cupertino_ui/lib/src/sheet.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:async';
+
 import 'package:flutter/gestures.dart';
 import 'package:flutter/physics.dart';
 import 'package:flutter/services.dart';
@@ -810,7 +812,8 @@ class CupertinoSheetRoute<T> extends PageRoute<T> with _CupertinoSheetRouteTrans
           data: CupertinoUserInterfaceLevelData.elevated,
           child: _CupertinoSheetScope(
             child: _CupertinoDraggableScrollableSheet<T>(
-              enabledCallback: () => !(controller?.isAnimating ?? false),
+              animationController: controller,
+              enabledCallback: _isInteractionEnabled,
               enableDrag: enableDrag,
               onStartPopGesture: () => _CupertinoSheetRouteTransitionMixin._startPopGesture<T>(
                 this,
@@ -877,7 +880,35 @@ class _CupertinoSheetScope extends InheritedWidget {
 ///
 ///  * [CupertinoSheetRoute], which is a [PageRoute] that leverages this mixin.
 mixin _CupertinoSheetRouteTransitionMixin<T> on PageRoute<T> {
-  /// Builds the primary contents of the route.
+  bool _hasCompletedInitialAnimation = false;
+  ScrollController? _registeredScrollController;
+
+  @override
+  AnimationController createAnimationController() {
+    final AnimationController ctrl = super.createAnimationController();
+    ctrl.addStatusListener(_handleAnimationStatus);
+    return ctrl;
+  }
+
+  @override
+  void dispose() {
+    controller?.removeStatusListener(_handleAnimationStatus);
+    super.dispose();
+  }
+
+  void _handleAnimationStatus(AnimationStatus status) {
+    if (status == AnimationStatus.completed) {
+      _hasCompletedInitialAnimation = true;
+    }
+  }
+
+  bool _isInteractionEnabled() {
+    if (!isActive || !_hasCompletedInitialAnimation) {
+      return false;
+    }
+    return true;
+  }
+
   @protected
   Widget buildContent(BuildContext context);
 
@@ -927,6 +958,12 @@ mixin _CupertinoSheetRouteTransitionMixin<T> on PageRoute<T> {
       getIsActive: () => route.isActive,
       popDragController: route.controller!, // protected access
       enableDrag: enableDrag,
+      getScrollController: () {
+        if (route is _CupertinoSheetRouteTransitionMixin<T>) {
+          return route._registeredScrollController;
+        }
+        return null;
+      },
     );
   }
 
@@ -939,6 +976,7 @@ mixin _CupertinoSheetRouteTransitionMixin<T> on PageRoute<T> {
     Widget child,
     bool enableDrag,
     double topGap,
+    ValueGetter<bool> enabledCallback,
   ) {
     final bool linearTransition = route.popGestureInProgress;
     return CupertinoSheetTransition(
@@ -947,7 +985,8 @@ mixin _CupertinoSheetRouteTransitionMixin<T> on PageRoute<T> {
       linearTransition: linearTransition,
       topGap: topGap,
       child: _CupertinoDragGestureDetector<T>(
-        enabledCallback: () => !(route.controller?.isAnimating ?? false),
+        animationController: route.controller,
+        enabledCallback: enabledCallback,
         onStartPopGesture: () => _startPopGesture<T>(route, topGap, enableDrag: enableDrag),
         child: child,
       ),
@@ -982,6 +1021,7 @@ mixin _CupertinoSheetRouteTransitionMixin<T> on PageRoute<T> {
       child,
       enableDrag,
       topGap,
+      _isInteractionEnabled,
     );
   }
 }
@@ -989,10 +1029,13 @@ mixin _CupertinoSheetRouteTransitionMixin<T> on PageRoute<T> {
 class _CupertinoDragGestureDetector<T> extends StatefulWidget {
   const _CupertinoDragGestureDetector({
     super.key,
+    required this.animationController,
     required this.enabledCallback,
     required this.onStartPopGesture,
     required this.child,
   });
+
+  final AnimationController? animationController;
 
   final Widget child;
 
@@ -1010,6 +1053,8 @@ class _CupertinoDragGestureDetectorState<T> extends State<_CupertinoDragGestureD
   late VerticalDragGestureRecognizer _recognizer;
   _StretchDragControllerProvider? _stretchDragController;
 
+  bool _hasCompletedInitialAnimation = false;
+
   static VelocityTracker _cupertinoVelocityBuilder(PointerEvent event) =>
       IOSScrollViewFlingVelocityTracker(event.kind);
 
@@ -1026,6 +1071,8 @@ class _CupertinoDragGestureDetectorState<T> extends State<_CupertinoDragGestureD
       ..onUpdate = _handleDragUpdate
       ..onEnd = _handleDragEnd
       ..onCancel = _handleDragCancel;
+
+    widget.animationController?.addStatusListener(_onAnimationStatusChanged);
   }
 
   @override
@@ -1036,6 +1083,7 @@ class _CupertinoDragGestureDetectorState<T> extends State<_CupertinoDragGestureD
 
   @override
   void dispose() {
+    widget.animationController?.removeStatusListener(_onAnimationStatusChanged);
     _recognizer.dispose();
 
     // If this is disposed during a drag, call navigator.didStopUserGesture.
@@ -1048,6 +1096,16 @@ class _CupertinoDragGestureDetectorState<T> extends State<_CupertinoDragGestureD
       });
     }
     super.dispose();
+  }
+
+  void _onAnimationStatusChanged(AnimationStatus status) {
+    if (!_hasCompletedInitialAnimation) {
+      if (mounted) {
+        setState(() {
+          _hasCompletedInitialAnimation = true;
+        });
+      }
+    }
   }
 
   void _handleDragStart(DragStartDetails details) {
@@ -1067,6 +1125,7 @@ class _CupertinoDragGestureDetectorState<T> extends State<_CupertinoDragGestureD
       delta,
       _stretchDragController!.controller,
       sheetHeight: sheetHeight,
+      pixelsDelta: details.primaryDelta,
     );
   }
 
@@ -1080,7 +1139,11 @@ class _CupertinoDragGestureDetectorState<T> extends State<_CupertinoDragGestureD
     final double velocity = sheetHeight > 0
         ? details.velocity.pixelsPerSecond.dy / sheetHeight
         : 0.0;
-    _dragGestureController!.dragEnd(velocity, _stretchDragController!.controller);
+    _dragGestureController!.dragEnd(
+      velocity,
+      _stretchDragController!.controller,
+      pixelsVelocity: details.velocity.pixelsPerSecond.dy,
+    );
     _dragGestureController = null;
   }
 
@@ -1092,7 +1155,7 @@ class _CupertinoDragGestureDetectorState<T> extends State<_CupertinoDragGestureD
       _dragGestureController = null;
       return;
     }
-    _dragGestureController?.dragEnd(0.0, _stretchDragController!.controller);
+    _dragGestureController?.dragEnd(0.0, _stretchDragController!.controller, pixelsVelocity: 0.0);
     _dragGestureController = null;
   }
 
@@ -1104,10 +1167,22 @@ class _CupertinoDragGestureDetectorState<T> extends State<_CupertinoDragGestureD
 
   @override
   Widget build(BuildContext context) {
-    return Listener(
-      onPointerDown: _handlePointerDown,
-      behavior: HitTestBehavior.translucent,
-      child: widget.child,
+    final ModalRoute<Object?>? route = ModalRoute.of(context);
+    var isIgnoring = false;
+
+    if (!_hasCompletedInitialAnimation) {
+      isIgnoring = true;
+    } else if (route != null && !route.isActive) {
+      isIgnoring = true;
+    }
+
+    return IgnorePointer(
+      ignoring: isIgnoring,
+      child: Listener(
+        onPointerDown: _handlePointerDown,
+        behavior: HitTestBehavior.translucent,
+        child: widget.child,
+      ),
     );
   }
 }
@@ -1121,6 +1196,7 @@ class _CupertinoDragGestureController<T> {
     required this.getIsCurrent,
     required this.topGap,
     required this.enableDrag,
+    this.getScrollController,
   }) {
     navigator.didStartUserGesture();
   }
@@ -1131,29 +1207,85 @@ class _CupertinoDragGestureController<T> {
   final ValueGetter<bool> getIsCurrent;
   final double topGap;
   final bool enableDrag;
+  final ValueGetter<ScrollController?>? getScrollController;
+
+  Drag? _innerDrag;
 
   /// The drag gesture has changed by [delta]. The total range of the drag
   /// should be 0.0 to 1.0.
-  void dragUpdate(double delta, AnimationController? upController, {required double sheetHeight}) {
+  void dragUpdate(
+    double delta,
+    AnimationController? upController, {
+    required double sheetHeight,
+    double? pixelsDelta,
+    bool fromInnerScroll = false,
+  }) {
+    if (fromInnerScroll) {
+      _applySheetDrag(delta, sheetHeight);
+      return;
+    }
+
+    final ScrollController? scrollController = getScrollController?.call();
+    final ScrollPosition? position = scrollController?.hasClients ?? false
+        ? scrollController!.position
+        : null;
+
+    if (_innerDrag != null && pixelsDelta != null) {
+      _innerDrag!.update(
+        DragUpdateDetails(
+          globalPosition: Offset.zero,
+          delta: Offset(0.0, pixelsDelta),
+          primaryDelta: pixelsDelta,
+        ),
+      );
+      return;
+    }
+
+    final bool listHasScrolled = position != null && position.pixels > position.minScrollExtent;
+
+    if (listHasScrolled && pixelsDelta != null) {
+      _startInnerDrag(position, pixelsDelta);
+      return;
+    }
+
     if (upController != null &&
         popDragController.value == 1.0 &&
         (upController.value > 0 || delta < 0)) {
+      if (upController.value == 0.0 && delta < 0 && position != null && pixelsDelta != null) {
+        _startInnerDrag(position, pixelsDelta);
+        return;
+      }
       // Divide by stretchable range (when dragging upward at max extent).
       // Maintain the same stretch distance regardless of custom topGap.
       const double stretchDistance = _kTopGapRatio - _kStretchedTopGapRatio;
       upController.value -= delta / stretchDistance;
     } else {
-      if (!enableDrag) {
-        // Applies the exact derivative of Apple's Rubber-Banding equation.
-        final double currentDisplacement =
-            (1.0 - popDragController.value).clamp(0.0, 1.0) * sheetHeight;
-        final double friction = _computeRubberBandFriction(
-          currentDisplacement: currentDisplacement,
-        );
-        popDragController.value -= delta * friction;
-      } else {
-        popDragController.value -= delta;
-      }
+      _applySheetDrag(delta, sheetHeight);
+    }
+  }
+
+  void _startInnerDrag(ScrollPosition position, double pixelsDelta) {
+    _innerDrag = position.drag(DragStartDetails(), () {
+      _innerDrag = null;
+    });
+    _innerDrag!.update(
+      DragUpdateDetails(
+        globalPosition: Offset.zero,
+        delta: Offset(0.0, pixelsDelta),
+        primaryDelta: pixelsDelta,
+      ),
+    );
+  }
+
+  void _applySheetDrag(double delta, double sheetHeight) {
+    if (!enableDrag) {
+      // Applies the exact derivative of Apple's Rubber-Banding equation.
+      final double currentDisplacement =
+          (1.0 - popDragController.value).clamp(0.0, 1.0) * sheetHeight;
+      final double friction = _computeRubberBandFriction(currentDisplacement: currentDisplacement);
+      popDragController.value -= delta * friction;
+    } else {
+      popDragController.value -= delta;
     }
   }
 
@@ -1163,7 +1295,29 @@ class _CupertinoDragGestureController<T> {
 
   /// The drag gesture has ended with a vertical motion of [velocity] as a
   /// fraction of screen height per second.
-  void dragEnd(double velocity, AnimationController? upController) {
+  void dragEnd(
+    double velocity,
+    AnimationController? upController, {
+    double? pixelsVelocity,
+    bool fromInnerScroll = false,
+  }) {
+    if (fromInnerScroll) {
+      _applySheetDragEnd(velocity);
+      return;
+    }
+
+    if (_innerDrag != null) {
+      _innerDrag!.end(
+        DragEndDetails(
+          velocity: Velocity(pixelsPerSecond: Offset(0, pixelsVelocity ?? 0)),
+          primaryVelocity: pixelsVelocity,
+        ),
+      );
+      _innerDrag = null;
+      navigator.didStopUserGesture();
+      return;
+    }
+
     // If the sheet is in a stretched state (dragged upward beyond max size),
     // reverse the stretch to return to the normal max height.
     if (upController != null && upController.value > 0) {
@@ -1176,6 +1330,10 @@ class _CupertinoDragGestureController<T> {
       return;
     }
 
+    _applySheetDragEnd(velocity);
+  }
+
+  void _applySheetDragEnd(double velocity) {
     if (!enableDrag) {
       // When dragging is disabled, spring back to the open position using a physical spring simulation.
       final Simulation simulation = SpringSimulation(
@@ -1420,12 +1578,15 @@ class _CupertinoSheetScrollPosition extends ScrollPositionWithSingleContext {
 class _CupertinoDraggableScrollableSheet<T> extends StatefulWidget {
   const _CupertinoDraggableScrollableSheet({
     super.key,
+    required this.animationController,
     required this.enabledCallback,
     required this.enableDrag,
     required this.onStartPopGesture,
     required this.builder,
     this.topGap = _kTopGapRatio,
   });
+
+  final AnimationController? animationController;
 
   final ScrollableWidgetBuilder builder;
 
@@ -1446,6 +1607,7 @@ class _CupertinoDraggableScrollableSheetState<T>
     extends State<_CupertinoDraggableScrollableSheet<T>> {
   late _CupertinoSheetScrollController _scrollController;
   _CupertinoDragGestureController<T>? _dragGestureController;
+  _CupertinoSheetRouteTransitionMixin<dynamic>? _route;
 
   @override
   void initState() {
@@ -1460,7 +1622,20 @@ class _CupertinoDraggableScrollableSheetState<T>
   }
 
   @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    final ModalRoute<Object?>? route = ModalRoute.of(context);
+    if (route is _CupertinoSheetRouteTransitionMixin<dynamic>) {
+      _route = route;
+      _route!._registeredScrollController = _scrollController;
+    }
+  }
+
+  @override
   void dispose() {
+    if (_route?._registeredScrollController == _scrollController) {
+      _route!._registeredScrollController = null;
+    }
     // If this is disposed during a drag, call navigator.didStopUserGesture.
     if (_dragGestureController != null) {
       WidgetsBinding.instance.addPostFrameCallback((_) {
@@ -1490,6 +1665,7 @@ class _CupertinoDraggableScrollableSheetState<T>
         sheetHeight > 0 ? delta / sheetHeight : 0.0,
         null,
         sheetHeight: sheetHeight,
+        fromInnerScroll: true,
       );
     }
   }
@@ -1498,7 +1674,11 @@ class _CupertinoDraggableScrollableSheetState<T>
     assert(mounted);
     if (_dragGestureController != null) {
       final double sheetHeight = context.size?.height ?? 0.0;
-      _dragGestureController!.dragEnd(sheetHeight > 0 ? -velocity / sheetHeight : 0.0, null);
+      _dragGestureController!.dragEnd(
+        sheetHeight > 0 ? -velocity / sheetHeight : 0.0,
+        null,
+        fromInnerScroll: true,
+      );
       _dragGestureController = null;
     }
   }

--- a/packages/cupertino_ui/test/sheet_test.dart
+++ b/packages/cupertino_ui/test/sheet_test.dart
@@ -1395,6 +1395,57 @@ void main() {
       expect(rootNavigatorPopped, false);
     });
 
+    testWidgets('Sheet ignores gestures mid-dismissal and finishes closing', (
+      WidgetTester tester,
+    ) async {
+      final GlobalKey homeKey = GlobalKey();
+      final GlobalKey sheetKey = GlobalKey();
+
+      await tester.pumpWidget(dragGestureApp(homeKey, sheetKey));
+
+      // Open sheet
+      await tester.tap(find.text('Push Page 2'));
+      await tester.pumpAndSettle();
+
+      final Finder sheetFinder = find.byKey(sheetKey);
+      final Size sheetSize = tester.getSize(sheetFinder);
+      final double sheetHeight = sheetSize.height;
+
+      final double dragDistance = sheetHeight / 1.8;
+
+      final Offset sheetTopLeft = tester.getTopLeft(sheetFinder);
+      final startPoint = Offset(sheetTopLeft.dx + (sheetSize.width / 1.8), sheetTopLeft.dy + 20.0);
+
+      // Drag sheet down
+      final TestGesture gesture = await tester.startGesture(startPoint);
+      await gesture.moveBy(Offset(0, dragDistance));
+      await tester.pump();
+
+      // Release sheet
+      await gesture.up();
+      await tester.pump();
+
+      await tester.pump(const Duration(milliseconds: 50));
+
+      final box = tester.renderObject(sheetFinder) as RenderBox;
+      final double currentY = box.localToGlobal(Offset.zero).dy;
+
+      // Try to intercept the gesture by dragging up
+      final TestGesture interceptGesture = await tester.startGesture(
+        Offset(startPoint.dx, currentY + 100),
+      );
+      await tester.pump();
+
+      // Drag up
+      await interceptGesture.moveBy(const Offset(0, -50));
+      await interceptGesture.up();
+
+      await tester.pumpAndSettle();
+
+      expect(find.text('Page 2'), findsNothing);
+      expect(find.text('Page 1'), findsOneWidget);
+    });
+
     testWidgets('dragging does not move the sheet when enableDrag is false', (
       WidgetTester tester,
     ) async {

--- a/packages/cupertino_ui/test/sheet_test.dart
+++ b/packages/cupertino_ui/test/sheet_test.dart
@@ -1395,6 +1395,105 @@ void main() {
       expect(rootNavigatorPopped, false);
     });
 
+    testWidgets(
+      'dragging with enableDrag: false rubber-bands and springs back without dismissing',
+      (WidgetTester tester) async {
+        Widget nonDragGestureApp(GlobalKey homeScaffoldKey, GlobalKey sheetScaffoldKey) {
+          return CupertinoApp(
+            home: CupertinoPageScaffold(
+              key: homeScaffoldKey,
+              child: Center(
+                child: Column(
+                  children: <Widget>[
+                    const Text('Page 1'),
+                    CupertinoButton(
+                      onPressed: () {
+                        showCupertinoSheet<void>(
+                          context: homeScaffoldKey.currentContext!,
+                          pageBuilder: (BuildContext context) {
+                            return CupertinoPageScaffold(
+                              key: sheetScaffoldKey,
+                              child: const Center(child: Text('Page 2')),
+                            );
+                          },
+                          enableDrag: false,
+                        );
+                      },
+                      child: const Text('Push Page 2'),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          );
+        }
+
+        final GlobalKey homeKey = GlobalKey();
+        final GlobalKey sheetKey = GlobalKey();
+
+        await tester.pumpWidget(nonDragGestureApp(homeKey, sheetKey));
+
+        await tester.tap(find.text('Push Page 2'));
+        await tester.pumpAndSettle();
+
+        expect(find.text('Page 2'), findsOneWidget);
+
+        var box = tester.renderObject(find.byKey(sheetKey)) as RenderBox;
+        final double initialPosition = box.localToGlobal(Offset.zero).dy;
+
+        final TestGesture gesture = await tester.startGesture(const Offset(100, 200));
+        await gesture.moveBy(const Offset(0, 200));
+        await tester.pump();
+
+        box = tester.renderObject(find.byKey(sheetKey)) as RenderBox;
+        final double middlePosition = box.localToGlobal(Offset.zero).dy;
+
+        expect(middlePosition, greaterThan(initialPosition));
+
+        await gesture.up();
+        await tester.pumpAndSettle();
+
+        expect(find.text('Page 2'), findsOneWidget);
+
+        box = tester.renderObject(find.byKey(sheetKey)) as RenderBox;
+        final double finalPosition = box.localToGlobal(Offset.zero).dy;
+
+        expect(finalPosition, closeTo(initialPosition, 0.1));
+      },
+    );
+
+    testWidgets('partial upward drag stretches and returns without popping', (
+      WidgetTester tester,
+    ) async {
+      final GlobalKey homeKey = GlobalKey();
+      final GlobalKey sheetKey = GlobalKey();
+
+      await tester.pumpWidget(dragGestureApp(homeKey, sheetKey));
+
+      await tester.tap(find.text('Push Page 2'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Page 2'), findsOneWidget);
+
+      var box = tester.renderObject(find.byKey(sheetKey)) as RenderBox;
+      final double initialPosition = box.localToGlobal(Offset.zero).dy;
+
+      final TestGesture gesture = await tester.startGesture(const Offset(100, 400));
+      await gesture.moveBy(const Offset(0, -100));
+      await tester.pump();
+
+      box = tester.renderObject(find.byKey(sheetKey)) as RenderBox;
+      final double stretchedPosition = box.localToGlobal(Offset.zero).dy;
+      expect(stretchedPosition, lessThan(initialPosition));
+
+      await gesture.up();
+      await tester.pumpAndSettle();
+
+      box = tester.renderObject(find.byKey(sheetKey)) as RenderBox;
+      final double finalPosition = box.localToGlobal(Offset.zero).dy;
+      expect(finalPosition, initialPosition);
+    });
+
     testWidgets('Sheet ignores gestures mid-dismissal and finishes closing', (
       WidgetTester tester,
     ) async {
@@ -1444,107 +1543,6 @@ void main() {
 
       expect(find.text('Page 2'), findsNothing);
       expect(find.text('Page 1'), findsOneWidget);
-    });
-
-    testWidgets('dragging does not move the sheet when enableDrag is false', (
-      WidgetTester tester,
-    ) async {
-      Widget nonDragGestureApp(GlobalKey homeScaffoldKey, GlobalKey sheetScaffoldKey) {
-        return CupertinoApp(
-          home: CupertinoPageScaffold(
-            key: homeScaffoldKey,
-            child: Center(
-              child: Column(
-                children: <Widget>[
-                  const Text('Page 1'),
-                  CupertinoButton(
-                    onPressed: () {
-                      showCupertinoSheet<void>(
-                        context: homeScaffoldKey.currentContext!,
-                        pageBuilder: (BuildContext context) {
-                          return CupertinoPageScaffold(
-                            key: sheetScaffoldKey,
-                            child: const Center(child: Text('Page 2')),
-                          );
-                        },
-                        enableDrag: false,
-                      );
-                    },
-                    child: const Text('Push Page 2'),
-                  ),
-                ],
-              ),
-            ),
-          ),
-        );
-      }
-
-      final GlobalKey homeKey = GlobalKey();
-      final GlobalKey sheetKey = GlobalKey();
-
-      await tester.pumpWidget(nonDragGestureApp(homeKey, sheetKey));
-
-      await tester.tap(find.text('Push Page 2'));
-      await tester.pumpAndSettle();
-
-      expect(find.text('Page 2'), findsOneWidget);
-
-      var box = tester.renderObject(find.byKey(sheetKey)) as RenderBox;
-      final double initialPosition = box.localToGlobal(Offset.zero).dy;
-
-      final TestGesture gesture = await tester.startGesture(const Offset(100, 200));
-      // Partial drag down
-      await gesture.moveBy(const Offset(0, 200));
-      await tester.pump();
-
-      // Release gesture. Sheet should not move.
-      box = tester.renderObject(find.byKey(sheetKey)) as RenderBox;
-      final double middlePosition = box.localToGlobal(Offset.zero).dy;
-
-      expect(middlePosition, equals(initialPosition));
-
-      await gesture.up();
-      await tester.pumpAndSettle();
-
-      expect(find.text('Page 2'), findsOneWidget);
-
-      box = tester.renderObject(find.byKey(sheetKey)) as RenderBox;
-      final double finalPosition = box.localToGlobal(Offset.zero).dy;
-
-      expect(finalPosition, equals(middlePosition));
-      expect(finalPosition, equals(initialPosition));
-    });
-
-    testWidgets('partial upward drag stretches and returns without popping', (
-      WidgetTester tester,
-    ) async {
-      final GlobalKey homeKey = GlobalKey();
-      final GlobalKey sheetKey = GlobalKey();
-
-      await tester.pumpWidget(dragGestureApp(homeKey, sheetKey));
-
-      await tester.tap(find.text('Push Page 2'));
-      await tester.pumpAndSettle();
-
-      expect(find.text('Page 2'), findsOneWidget);
-
-      var box = tester.renderObject(find.byKey(sheetKey)) as RenderBox;
-      final double initialPosition = box.localToGlobal(Offset.zero).dy;
-
-      final TestGesture gesture = await tester.startGesture(const Offset(100, 400));
-      await gesture.moveBy(const Offset(0, -100));
-      await tester.pump();
-
-      box = tester.renderObject(find.byKey(sheetKey)) as RenderBox;
-      final double stretchedPosition = box.localToGlobal(Offset.zero).dy;
-      expect(stretchedPosition, lessThan(initialPosition));
-
-      await gesture.up();
-      await tester.pumpAndSettle();
-
-      box = tester.renderObject(find.byKey(sheetKey)) as RenderBox;
-      final double finalPosition = box.localToGlobal(Offset.zero).dy;
-      expect(finalPosition, initialPosition);
     });
   });
 

--- a/packages/cupertino_ui/test/sheet_test.dart
+++ b/packages/cupertino_ui/test/sheet_test.dart
@@ -1462,6 +1462,55 @@ void main() {
       },
     );
 
+    testWidgets('Sheet during snap-back animation (drag down lightly and release)', (
+      WidgetTester tester,
+    ) async {
+      final GlobalKey homeKey = GlobalKey();
+      final GlobalKey sheetKey = GlobalKey();
+
+      await tester.pumpWidget(dragGestureApp(homeKey, sheetKey));
+
+      // Open sheet
+      await tester.tap(find.text('Push Page 2'));
+      await tester.pumpAndSettle();
+
+      final Finder sheetFinder = find.byKey(sheetKey);
+      final Size sheetSize = tester.getSize(sheetFinder);
+
+      final Offset sheetTopLeft = tester.getTopLeft(sheetFinder);
+      final startPoint = Offset(sheetTopLeft.dx + (sheetSize.width / 2), sheetTopLeft.dy + 20.0);
+
+      // Lightly drag sheet down by 50px (snap-back threshold is > 0.52 height)
+      final TestGesture gesture1 = await tester.startGesture(startPoint);
+      await gesture1.moveBy(const Offset(0, 50));
+      await tester.pump();
+      await gesture1.up();
+      await tester.pump();
+
+      // Pump 50ms into the 300ms snap-back animation
+      await tester.pump(const Duration(milliseconds: 50));
+
+      final box1 = tester.renderObject(sheetFinder) as RenderBox;
+      final double yDuringSnapback = box1.localToGlobal(Offset.zero).dy;
+
+      // Try to catch the sheet mid-snapback and drag down by 100px throughout 250ms
+      final TestGesture gesture2 = await tester.startGesture(
+        Offset(startPoint.dx, yDuringSnapback + 20),
+      );
+      for (var i = 0; i < 5; i += 1) {
+        await tester.pump(const Duration(milliseconds: 50));
+        await gesture2.moveBy(const Offset(0, 20));
+      }
+
+      final box2 = tester.renderObject(sheetFinder) as RenderBox;
+      final double yAfterDrag = box2.localToGlobal(Offset.zero).dy;
+
+      expect(yAfterDrag - yDuringSnapback, greaterThan(20));
+
+      await gesture2.up();
+      await tester.pumpAndSettle();
+    });
+
     testWidgets('partial upward drag stretches and returns without popping', (
       WidgetTester tester,
     ) async {


### PR DESCRIPTION
> This PR is stacked on top of #12515  
> Please review #12515 first

This PR adds native iOS-style rubber-banding resistance to `CupertinoSheetRoute` / `showCupertinoSheet` when dragging is disabled (`enableDrag: false`)


Flutter on the left, SwiftUI on the right

https://github.com/user-attachments/assets/138a1834-d428-4bd4-8cf6-60aba1b96ab6

<details><summary>Flutter example</summary>

```dart
import 'package:cupertino_ui/cupertino_ui.dart';

void main() {
  runApp(const CupertinoSheetDemoApp());
}

class CupertinoSheetDemoApp extends StatelessWidget {
  const CupertinoSheetDemoApp({super.key});

  @override
  Widget build(BuildContext context) {
    return const CupertinoApp(
      theme: CupertinoThemeData(
        brightness: Brightness.light,
        primaryColor: CupertinoColors.systemBlue,
      ),
      home: ContentView(),
    );
  }
}

class ContentView extends StatelessWidget {
  const ContentView({super.key});

  void _openStandardSheet(BuildContext context) {
    showCupertinoSheet<void>(
      context: context,
      showDragHandle: true,
      enableDrag: true,
      scrollableBuilder:
          (BuildContext context, ScrollController scrollController) {
            return const StandardSheetView();
          },
    );
  }

  void _openNonDismissibleListSheet(BuildContext context) {
    showCupertinoSheet<void>(
      context: context,
      showDragHandle: false,
      enableDrag: false,
      scrollableBuilder:
          (BuildContext context, ScrollController scrollController) {
            return NonDismissibleListSheetView(
              scrollController: scrollController,
            );
          },
    );
  }

  @override
  Widget build(BuildContext context) {
    return CupertinoPageScaffold(
      navigationBar: const CupertinoNavigationBar(
        middle: Text('Cupertino Sheet Demo'),
      ),
      child: SafeArea(
        child: Padding(
          padding: const EdgeInsets.symmetric(horizontal: 20.0),
          child: Column(
            mainAxisAlignment: MainAxisAlignment.center,
            children: <Widget>[
              SizedBox(
                width: double.infinity,
                child: CupertinoButton.filled(
                  borderRadius: BorderRadius.circular(12.0),
                  padding: const EdgeInsets.symmetric(vertical: 16.0),
                  onPressed: () => _openStandardSheet(context),
                  child: const Text(
                    '1. Open Standard Sheet',
                    style: TextStyle(fontSize: 17, fontWeight: FontWeight.w600),
                  ),
                ),
              ),
              const SizedBox(height: 20),
              SizedBox(
                width: double.infinity,
                child: CupertinoButton.filled(
                  borderRadius: BorderRadius.circular(12.0),
                  padding: const EdgeInsets.symmetric(vertical: 16.0),
                  onPressed: () => _openNonDismissibleListSheet(context),
                  child: const Text(
                    '2. Open Sheet with List',
                    textAlign: TextAlign.center,
                    style: TextStyle(fontSize: 17, fontWeight: FontWeight.w600),
                  ),
                ),
              ),
            ],
          ),
        ),
      ),
    );
  }
}

class StandardSheetView extends StatelessWidget {
  const StandardSheetView({super.key});

  @override
  Widget build(BuildContext context) {
    return CupertinoPageScaffold(
      navigationBar: CupertinoNavigationBar(
        middle: const Text('Standard Sheet'),
        leading: CupertinoButton(
          padding: EdgeInsets.zero,
          onPressed: () => Navigator.of(context).pop(),
          child: const Text('Close'),
        ),
      ),
      child: SafeArea(
        child: Center(
          child: Padding(
            padding: const EdgeInsets.all(24.0),
            child: Column(
              mainAxisAlignment: MainAxisAlignment.center,
              children: <Widget>[
                const Icon(
                  CupertinoIcons.arrow_down_circle,
                  size: 64,
                  color: CupertinoColors.systemBlue,
                ),
                const SizedBox(height: 16),
                const Text(
                  'Standard Dismissible Sheet',
                  style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold),
                  textAlign: TextAlign.center,
                ),
                const SizedBox(height: 8),
                Text(
                  'Swipe down on the sheet to dismiss it.',
                  style: TextStyle(
                    fontSize: 15,
                    color: CupertinoColors.secondaryLabel.resolveFrom(context),
                  ),
                  textAlign: TextAlign.center,
                ),
              ],
            ),
          ),
        ),
      ),
    );
  }
}

class NonDismissibleListSheetView extends StatelessWidget {
  const NonDismissibleListSheetView({
    super.key,
    required this.scrollController,
  });

  final ScrollController scrollController;

  @override
  Widget build(BuildContext context) {
    return CupertinoPageScaffold(
      backgroundColor: CupertinoColors.systemGroupedBackground,
      navigationBar: CupertinoNavigationBar(
        middle: const Text('enableDrag: false'),
        trailing: CupertinoButton(
          padding: EdgeInsets.zero,
          onPressed: () => Navigator.of(context).pop(),
          child: const Text(
            'Done',
            style: TextStyle(fontWeight: FontWeight.bold),
          ),
        ),
      ),
      child: SafeArea(
        bottom: false,
        child: ListView(
          controller: scrollController,
          physics: const AlwaysScrollableScrollPhysics(),
          children: <Widget>[
            CupertinoListSection.insetGrouped(
              hasLeading: false,
              children: List.generate(30, (int index) {
                final int itemIndex = index + 1;
                return CupertinoListTile(
                  title: Text('Item $itemIndex'),
                  subtitle: Text(
                    'Subtitle for item $itemIndex',
                    style: TextStyle(
                      color: CupertinoColors.secondaryLabel.resolveFrom(
                        context,
                      ),
                      fontSize: 13,
                    ),
                  ),
                  trailing: const CupertinoListTileChevron(),
                  onTap: () {},
                );
              }),
            ),
          ],
        ),
      ),
    );
  }
}

``` 

</details> 


<details><summary>SwiftUI example</summary>

```swift
import SwiftUI

struct ContentView: View {
    @State private var isStandardSheetPresented = false
    @State private var isNonDismissibleSheetPresented = false

    var body: some View {
        NavigationStack {
            VStack(spacing: 20) {
                Button {
                    isStandardSheetPresented = true
                } label: {
                    Text("1. Open Standard Sheet")
                        .frame(maxWidth: .infinity)
                }
                .buttonStyle(.borderedProminent)
                .controlSize(.large)

                Button {
                    isNonDismissibleSheetPresented = true
                } label: {
                    Text("2. Open Sheet with List")
                        .multilineTextAlignment(.center)
                        .frame(maxWidth: .infinity)
                }
                .buttonStyle(.borderedProminent)
                .controlSize(.large)
            }
            .padding(.horizontal, 20)
            .navigationTitle("Cupertino Sheet Demo")
            .navigationBarTitleDisplayMode(.inline)
            .sheet(isPresented: $isStandardSheetPresented) {
                StandardSheetView()
            }
            .sheet(isPresented: $isNonDismissibleSheetPresented) {
                NonDismissibleListSheetView()
            }
        }
    }
}

struct StandardSheetView: View {
    @Environment(\.dismiss) private var dismiss

    var body: some View {
        NavigationStack {
            VStack(spacing: 16) {
                Image(systemName: "arrow.down.circle")
                    .font(.system(size: 64))
                    .foregroundStyle(.blue)

                Text("Standard Dismissible Sheet")
                    .font(.title3)
                    .fontWeight(.bold)

                Text("Swipe down on the sheet to dismiss it.")
                    .font(.subheadline)
                    .foregroundStyle(.secondary)
                    .multilineTextAlignment(.center)
            }
            .padding(24)
            .frame(maxWidth: .infinity, maxHeight: .infinity)
            .navigationTitle("Standard Sheet")
            .navigationBarTitleDisplayMode(.inline)
            .toolbar {
                ToolbarItem(placement: .cancellationAction) {
                    Button("Close") {
                        dismiss()
                    }
                }
            }
        }
        .presentationDragIndicator(.visible)
    }
}

struct NonDismissibleListSheetView: View {
    @Environment(\.dismiss) private var dismiss

    var body: some View {
        NavigationStack {
            List {

                ForEach(1...30, id: \.self) { index in
                    HStack {
                        VStack(alignment: .leading, spacing: 2) {
                            Text("Item \(index)")
                                .font(.body)
                            Text("Subtitle for item \(index)")
                                .font(.footnote)
                                .foregroundStyle(.secondary)
                        }
                        Spacer()
                        Image(systemName: "chevron.right")
                            .font(.footnote)
                            .fontWeight(.semibold)
                            .foregroundStyle(.tertiary)
                    }
                    .contentShape(Rectangle())
                    .onTapGesture {
                    }
                }
            }
            .navigationTitle("enableDrag: false")
            .navigationBarTitleDisplayMode(.inline)
            .toolbar {
                ToolbarItem(placement: .confirmationAction) {
                    Button("Done") {
                        dismiss()
                    }
                    .fontWeight(.bold)
                }
            }
        }
        .presentationDragIndicator(.hidden)
        .interactiveDismissDisabled(true)
    }
}

``` 

</details> 



## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under[^1].
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[the version and CHANGELOG instructions]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version-and-changelog-updates
[semantic versioning]: https://dart.dev/tools/pub/versioning#semantic-versions
[repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
