### PR TITLE
[cupertino_ui] Fix covered sheet revealing root route through top gap

### DIFF
--- a/packages/cupertino_ui/lib/src/sheet.dart
+++ b/packages/cupertino_ui/lib/src/sheet.dart
@@ -552,13 +552,13 @@ class _CupertinoSheetTransitionState extends State<CupertinoSheetTransition>
         child: AnimatedBuilder(
           animation: _stretchDragAnimation,
           builder: (BuildContext context, Widget? child) {
-            return Padding(
-              padding: EdgeInsets.only(
-                top: MediaQuery.heightOf(context) * _stretchDragAnimation.value,
-              ),
-              child: _coverSheetSecondaryTransition(
-                widget.secondaryRouteAnimation,
-                _coverSheetPrimaryTransition(
+            return _coverSheetSecondaryTransition(
+              widget.secondaryRouteAnimation,
+              Padding(
+                padding: EdgeInsets.only(
+                  top: MediaQuery.heightOf(context) * _stretchDragAnimation.value,
+                ),
+                child: _coverSheetPrimaryTransition(
                   context,
                   widget.primaryRouteAnimation,
                   widget.linearTransition,

--- a/packages/cupertino_ui/pending_changelogs/change_2026_08_21_cupertino_sheet_top_gap.yaml
+++ b/packages/cupertino_ui/pending_changelogs/change_2026_08_21_cupertino_sheet_top_gap.yaml
@@ -1,0 +1,3 @@
+changelog: |
+  - Fixes lower routes being revealed through the top gap when multiple `CupertinoSheetRoute`s are stacked.
+version: patch

--- a/packages/cupertino_ui/test/sheet_test.dart
+++ b/packages/cupertino_ui/test/sheet_test.dart
@@ -317,6 +317,85 @@ void main() {
     );
   });
 
+  testWidgets('covered sheet does not reveal the root route through its top gap', (
+    WidgetTester tester,
+  ) async {
+    final GlobalKey scaffoldKey = GlobalKey();
+
+    await tester.pumpWidget(
+      CupertinoApp(
+        home: CupertinoPageScaffold(
+          key: scaffoldKey,
+          child: Column(
+            children: <Widget>[
+              const Text('Page 1'),
+              CupertinoButton(
+                onPressed: () {
+                  Navigator.push<void>(
+                    scaffoldKey.currentContext!,
+                    CupertinoSheetRoute<void>(
+                      builder: (BuildContext context) {
+                        return CupertinoPageScaffold(
+                          child: Column(
+                            children: <Widget>[
+                              const Text('Page 2'),
+                              CupertinoButton(
+                                onPressed: () {
+                                  Navigator.push<void>(
+                                    context,
+                                    CupertinoSheetRoute<void>(
+                                      builder: (BuildContext context) {
+                                        return const CupertinoPageScaffold(child: Text('Page 3'));
+                                      },
+                                    ),
+                                  );
+                                },
+                                child: const Text('Push Page 3'),
+                              ),
+                            ],
+                          ),
+                        );
+                      },
+                    ),
+                  );
+                },
+                child: const Text('Push Page 2'),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('Push Page 2'));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Push Page 3'));
+    await tester.pumpAndSettle();
+
+    final double page1Top = tester
+        .getTopLeft(
+          find.ancestor(of: find.text('Page 1'), matching: find.byType(CupertinoPageScaffold)),
+        )
+        .dy;
+    final double page2Top = tester
+        .getTopLeft(
+          find.ancestor(of: find.text('Page 2'), matching: find.byType(CupertinoPageScaffold)),
+        )
+        .dy;
+    final double page3Top = tester
+        .getTopLeft(
+          find.ancestor(of: find.text('Page 3'), matching: find.byType(CupertinoPageScaffold)),
+        )
+        .dy;
+
+    // Sheet 2 moves up above Page 1 so that the root route (Page 1) is completely hidden behind
+    // Sheet 2.
+    expect(page2Top, lessThanOrEqualTo(page1Top));
+    // Sheet 3 is stacked on top of Sheet 2, with Sheet 2 peeking out above Sheet 3.
+    expect(page2Top, lessThanOrEqualTo(page3Top));
+  });
+
   testWidgets('by default showCupertinoSheet does not enable nested navigation', (
     WidgetTester tester,
   ) async {


### PR DESCRIPTION
Ports flutter/flutter#187058 to `cupertino_ui` following flutter/flutter#188444.

Fixes flutter/flutter#187057.

When multiple `CupertinoSheetRoute`s are stacked, the covered sheet's top gap can reveal the root route because the top-gap padding sits outside the secondary route transition.

This change applies the covered sheet's secondary transition outside the top-gap padding, so the sheet and its gap move together. It also adds a coordinate-based regression test that verifies the root route remains fully covered.

## Tests

- `flutter test test/sheet_test.dart --no-pub`
- `dart run script/tool/bin/flutter_plugin_tools.dart analyze --packages cupertino_ui`
- `dart run script/tool/bin/flutter_plugin_tools.dart validate --packages cupertino_ui --base-sha=252bb33ad3666c7d28621c87edccafff86e210fd --check-for-missing-changes`
- `dart run script/tool/bin/flutter_plugin_tools.dart publish-check --packages cupertino_ui`

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets.
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I followed [the version and CHANGELOG instructions] and added a pending patch changelog.
- [x] I updated or added relevant documentation.
- [x] I added a regression test for this change.
- [x] All relevant existing and new tests are passing.

[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[the version and CHANGELOG instructions]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version-and-changelog-updates
