### PR TITLE
[pigeon] Treat NSNull as null for non-null Flutter API returns

### DIFF
--- a/packages/pigeon/CHANGELOG.md
+++ b/packages/pigeon/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 28.0.1
+
+* [swift] Fixes a crash when a Flutter API returns null for a non-null return
+  value and the null arrives as `NSNull`.
+
 ## 28.0.0
 
 * **Breaking Change** Updates Kotlin and Swift generators to generate `suspend` functions and `async throws` signatures for `@FlutterApi` methods by default, and for `@HostApi` methods annotated with `@async`.

--- a/packages/pigeon/example/app/ios/Runner/Messages.g.swift
+++ b/packages/pigeon/example/app/ios/Runner/Messages.g.swift
@@ -401,7 +401,7 @@ class MessageFlutterApi: MessageFlutterApiProtocol {
           let message: String? = nilOrValue(listResponse[1])
           let details: String? = nilOrValue(listResponse[2])
           continuation.resume(throwing: PigeonError(code: code, message: message, details: details))
-        } else if listResponse[0] == nil {
+        } else if listResponse[0] == nil || listResponse[0] is NSNull {
           continuation.resume(
             throwing: PigeonError(
               code: "null-error",

--- a/packages/pigeon/lib/src/generator_tools.dart
+++ b/packages/pigeon/lib/src/generator_tools.dart
@@ -15,7 +15,7 @@ import 'generator.dart';
 /// The current version of pigeon.
 ///
 /// This must match the version in pubspec.yaml.
-const String pigeonVersion = '28.0.0';
+const String pigeonVersion = '28.0.1';
 
 /// Default plugin package name.
 const String defaultPluginPackageName = 'dev.flutter.pigeon';

--- a/packages/pigeon/lib/src/swift/swift_generator.dart
+++ b/packages/pigeon/lib/src/swift/swift_generator.dart
@@ -1751,13 +1751,21 @@ static func deepHash(value: Any?, hasher: inout Hasher) {
           );
         }, addTrailingNewline: false);
         if (!returnType.isNullable && !returnType.isVoid) {
-          indent.addScoped('else if listResponse[0] == nil {', '} ', () {
-            indent.writeln(
-              resumeError(
-                '${_getErrorClassName(generatorOptions)}(code: "null-error", message: "Flutter api returned null value for non-null return value.", details: "")',
-              ),
-            );
-          }, addTrailingNewline: false);
+          // `FlutterStandardReader` substitutes `NSNull` for a `nil` element of
+          // a list, so a null reply can arrive as either. See
+          // https://github.com/flutter/flutter/issues/191254.
+          indent.addScoped(
+            'else if listResponse[0] == nil || listResponse[0] is NSNull {',
+            '} ',
+            () {
+              indent.writeln(
+                resumeError(
+                  '${_getErrorClassName(generatorOptions)}(code: "null-error", message: "Flutter api returned null value for non-null return value.", details: "")',
+                ),
+              );
+            },
+            addTrailingNewline: false,
+          );
         }
         indent.addScoped('else {', '}', () {
           if (returnType.isVoid) {

--- a/packages/pigeon/lib/src/swift/swift_generator.dart
+++ b/packages/pigeon/lib/src/swift/swift_generator.dart
@@ -1751,9 +1751,6 @@ static func deepHash(value: Any?, hasher: inout Hasher) {
           );
         }, addTrailingNewline: false);
         if (!returnType.isNullable && !returnType.isVoid) {
-          // `FlutterStandardReader` substitutes `NSNull` for a `nil` element of
-          // a list, so a null reply can arrive as either. See
-          // https://github.com/flutter/flutter/issues/191254.
           indent.addScoped(
             'else if listResponse[0] == nil || listResponse[0] is NSNull {',
             '} ',

--- a/packages/pigeon/platform_tests/test_plugin/darwin/test_plugin/Sources/test_plugin/CoreTests.gen.swift
+++ b/packages/pigeon/platform_tests/test_plugin/darwin/test_plugin/Sources/test_plugin/CoreTests.gen.swift
@@ -4815,7 +4815,7 @@ class FlutterCallbackCoreApi: FlutterCallbackCoreApiProtocol {
         let message: String? = nilOrValue(listResponse[1])
         let details: String? = nilOrValue(listResponse[2])
         completion(.failure(PigeonError(code: code, message: message, details: details)))
-      } else if listResponse[0] == nil {
+      } else if listResponse[0] == nil || listResponse[0] is NSNull {
         completion(
           .failure(
             PigeonError(
@@ -5098,7 +5098,7 @@ class FlutterIntegrationCoreApi: FlutterIntegrationCoreApiProtocol {
           let message: String? = nilOrValue(listResponse[1])
           let details: String? = nilOrValue(listResponse[2])
           continuation.resume(throwing: PigeonError(code: code, message: message, details: details))
-        } else if listResponse[0] == nil {
+        } else if listResponse[0] == nil || listResponse[0] is NSNull {
           continuation.resume(
             throwing: PigeonError(
               code: "null-error",
@@ -5157,7 +5157,7 @@ class FlutterIntegrationCoreApi: FlutterIntegrationCoreApiProtocol {
           let message: String? = nilOrValue(listResponse[1])
           let details: String? = nilOrValue(listResponse[2])
           continuation.resume(throwing: PigeonError(code: code, message: message, details: details))
-        } else if listResponse[0] == nil {
+        } else if listResponse[0] == nil || listResponse[0] is NSNull {
           continuation.resume(
             throwing: PigeonError(
               code: "null-error",
@@ -5218,7 +5218,7 @@ class FlutterIntegrationCoreApi: FlutterIntegrationCoreApiProtocol {
           let message: String? = nilOrValue(listResponse[1])
           let details: String? = nilOrValue(listResponse[2])
           continuation.resume(throwing: PigeonError(code: code, message: message, details: details))
-        } else if listResponse[0] == nil {
+        } else if listResponse[0] == nil || listResponse[0] is NSNull {
           continuation.resume(
             throwing: PigeonError(
               code: "null-error",
@@ -5247,7 +5247,7 @@ class FlutterIntegrationCoreApi: FlutterIntegrationCoreApiProtocol {
           let message: String? = nilOrValue(listResponse[1])
           let details: String? = nilOrValue(listResponse[2])
           continuation.resume(throwing: PigeonError(code: code, message: message, details: details))
-        } else if listResponse[0] == nil {
+        } else if listResponse[0] == nil || listResponse[0] is NSNull {
           continuation.resume(
             throwing: PigeonError(
               code: "null-error",
@@ -5276,7 +5276,7 @@ class FlutterIntegrationCoreApi: FlutterIntegrationCoreApiProtocol {
           let message: String? = nilOrValue(listResponse[1])
           let details: String? = nilOrValue(listResponse[2])
           continuation.resume(throwing: PigeonError(code: code, message: message, details: details))
-        } else if listResponse[0] == nil {
+        } else if listResponse[0] == nil || listResponse[0] is NSNull {
           continuation.resume(
             throwing: PigeonError(
               code: "null-error",
@@ -5305,7 +5305,7 @@ class FlutterIntegrationCoreApi: FlutterIntegrationCoreApiProtocol {
           let message: String? = nilOrValue(listResponse[1])
           let details: String? = nilOrValue(listResponse[2])
           continuation.resume(throwing: PigeonError(code: code, message: message, details: details))
-        } else if listResponse[0] == nil {
+        } else if listResponse[0] == nil || listResponse[0] is NSNull {
           continuation.resume(
             throwing: PigeonError(
               code: "null-error",
@@ -5334,7 +5334,7 @@ class FlutterIntegrationCoreApi: FlutterIntegrationCoreApiProtocol {
           let message: String? = nilOrValue(listResponse[1])
           let details: String? = nilOrValue(listResponse[2])
           continuation.resume(throwing: PigeonError(code: code, message: message, details: details))
-        } else if listResponse[0] == nil {
+        } else if listResponse[0] == nil || listResponse[0] is NSNull {
           continuation.resume(
             throwing: PigeonError(
               code: "null-error",
@@ -5363,7 +5363,7 @@ class FlutterIntegrationCoreApi: FlutterIntegrationCoreApiProtocol {
           let message: String? = nilOrValue(listResponse[1])
           let details: String? = nilOrValue(listResponse[2])
           continuation.resume(throwing: PigeonError(code: code, message: message, details: details))
-        } else if listResponse[0] == nil {
+        } else if listResponse[0] == nil || listResponse[0] is NSNull {
           continuation.resume(
             throwing: PigeonError(
               code: "null-error",
@@ -5392,7 +5392,7 @@ class FlutterIntegrationCoreApi: FlutterIntegrationCoreApiProtocol {
           let message: String? = nilOrValue(listResponse[1])
           let details: String? = nilOrValue(listResponse[2])
           continuation.resume(throwing: PigeonError(code: code, message: message, details: details))
-        } else if listResponse[0] == nil {
+        } else if listResponse[0] == nil || listResponse[0] is NSNull {
           continuation.resume(
             throwing: PigeonError(
               code: "null-error",
@@ -5421,7 +5421,7 @@ class FlutterIntegrationCoreApi: FlutterIntegrationCoreApiProtocol {
           let message: String? = nilOrValue(listResponse[1])
           let details: String? = nilOrValue(listResponse[2])
           continuation.resume(throwing: PigeonError(code: code, message: message, details: details))
-        } else if listResponse[0] == nil {
+        } else if listResponse[0] == nil || listResponse[0] is NSNull {
           continuation.resume(
             throwing: PigeonError(
               code: "null-error",
@@ -5450,7 +5450,7 @@ class FlutterIntegrationCoreApi: FlutterIntegrationCoreApiProtocol {
           let message: String? = nilOrValue(listResponse[1])
           let details: String? = nilOrValue(listResponse[2])
           continuation.resume(throwing: PigeonError(code: code, message: message, details: details))
-        } else if listResponse[0] == nil {
+        } else if listResponse[0] == nil || listResponse[0] is NSNull {
           continuation.resume(
             throwing: PigeonError(
               code: "null-error",
@@ -5479,7 +5479,7 @@ class FlutterIntegrationCoreApi: FlutterIntegrationCoreApiProtocol {
           let message: String? = nilOrValue(listResponse[1])
           let details: String? = nilOrValue(listResponse[2])
           continuation.resume(throwing: PigeonError(code: code, message: message, details: details))
-        } else if listResponse[0] == nil {
+        } else if listResponse[0] == nil || listResponse[0] is NSNull {
           continuation.resume(
             throwing: PigeonError(
               code: "null-error",
@@ -5508,7 +5508,7 @@ class FlutterIntegrationCoreApi: FlutterIntegrationCoreApiProtocol {
           let message: String? = nilOrValue(listResponse[1])
           let details: String? = nilOrValue(listResponse[2])
           continuation.resume(throwing: PigeonError(code: code, message: message, details: details))
-        } else if listResponse[0] == nil {
+        } else if listResponse[0] == nil || listResponse[0] is NSNull {
           continuation.resume(
             throwing: PigeonError(
               code: "null-error",
@@ -5537,7 +5537,7 @@ class FlutterIntegrationCoreApi: FlutterIntegrationCoreApiProtocol {
           let message: String? = nilOrValue(listResponse[1])
           let details: String? = nilOrValue(listResponse[2])
           continuation.resume(throwing: PigeonError(code: code, message: message, details: details))
-        } else if listResponse[0] == nil {
+        } else if listResponse[0] == nil || listResponse[0] is NSNull {
           continuation.resume(
             throwing: PigeonError(
               code: "null-error",
@@ -5566,7 +5566,7 @@ class FlutterIntegrationCoreApi: FlutterIntegrationCoreApiProtocol {
           let message: String? = nilOrValue(listResponse[1])
           let details: String? = nilOrValue(listResponse[2])
           continuation.resume(throwing: PigeonError(code: code, message: message, details: details))
-        } else if listResponse[0] == nil {
+        } else if listResponse[0] == nil || listResponse[0] is NSNull {
           continuation.resume(
             throwing: PigeonError(
               code: "null-error",
@@ -5595,7 +5595,7 @@ class FlutterIntegrationCoreApi: FlutterIntegrationCoreApiProtocol {
           let message: String? = nilOrValue(listResponse[1])
           let details: String? = nilOrValue(listResponse[2])
           continuation.resume(throwing: PigeonError(code: code, message: message, details: details))
-        } else if listResponse[0] == nil {
+        } else if listResponse[0] == nil || listResponse[0] is NSNull {
           continuation.resume(
             throwing: PigeonError(
               code: "null-error",
@@ -5624,7 +5624,7 @@ class FlutterIntegrationCoreApi: FlutterIntegrationCoreApiProtocol {
           let message: String? = nilOrValue(listResponse[1])
           let details: String? = nilOrValue(listResponse[2])
           continuation.resume(throwing: PigeonError(code: code, message: message, details: details))
-        } else if listResponse[0] == nil {
+        } else if listResponse[0] == nil || listResponse[0] is NSNull {
           continuation.resume(
             throwing: PigeonError(
               code: "null-error",
@@ -5655,7 +5655,7 @@ class FlutterIntegrationCoreApi: FlutterIntegrationCoreApiProtocol {
           let message: String? = nilOrValue(listResponse[1])
           let details: String? = nilOrValue(listResponse[2])
           continuation.resume(throwing: PigeonError(code: code, message: message, details: details))
-        } else if listResponse[0] == nil {
+        } else if listResponse[0] == nil || listResponse[0] is NSNull {
           continuation.resume(
             throwing: PigeonError(
               code: "null-error",
@@ -5684,7 +5684,7 @@ class FlutterIntegrationCoreApi: FlutterIntegrationCoreApiProtocol {
           let message: String? = nilOrValue(listResponse[1])
           let details: String? = nilOrValue(listResponse[2])
           continuation.resume(throwing: PigeonError(code: code, message: message, details: details))
-        } else if listResponse[0] == nil {
+        } else if listResponse[0] == nil || listResponse[0] is NSNull {
           continuation.resume(
             throwing: PigeonError(
               code: "null-error",
@@ -5713,7 +5713,7 @@ class FlutterIntegrationCoreApi: FlutterIntegrationCoreApiProtocol {
           let message: String? = nilOrValue(listResponse[1])
           let details: String? = nilOrValue(listResponse[2])
           continuation.resume(throwing: PigeonError(code: code, message: message, details: details))
-        } else if listResponse[0] == nil {
+        } else if listResponse[0] == nil || listResponse[0] is NSNull {
           continuation.resume(
             throwing: PigeonError(
               code: "null-error",
@@ -5742,7 +5742,7 @@ class FlutterIntegrationCoreApi: FlutterIntegrationCoreApiProtocol {
           let message: String? = nilOrValue(listResponse[1])
           let details: String? = nilOrValue(listResponse[2])
           continuation.resume(throwing: PigeonError(code: code, message: message, details: details))
-        } else if listResponse[0] == nil {
+        } else if listResponse[0] == nil || listResponse[0] is NSNull {
           continuation.resume(
             throwing: PigeonError(
               code: "null-error",
@@ -5773,7 +5773,7 @@ class FlutterIntegrationCoreApi: FlutterIntegrationCoreApiProtocol {
           let message: String? = nilOrValue(listResponse[1])
           let details: String? = nilOrValue(listResponse[2])
           continuation.resume(throwing: PigeonError(code: code, message: message, details: details))
-        } else if listResponse[0] == nil {
+        } else if listResponse[0] == nil || listResponse[0] is NSNull {
           continuation.resume(
             throwing: PigeonError(
               code: "null-error",
@@ -5802,7 +5802,7 @@ class FlutterIntegrationCoreApi: FlutterIntegrationCoreApiProtocol {
           let message: String? = nilOrValue(listResponse[1])
           let details: String? = nilOrValue(listResponse[2])
           continuation.resume(throwing: PigeonError(code: code, message: message, details: details))
-        } else if listResponse[0] == nil {
+        } else if listResponse[0] == nil || listResponse[0] is NSNull {
           continuation.resume(
             throwing: PigeonError(
               code: "null-error",
@@ -5831,7 +5831,7 @@ class FlutterIntegrationCoreApi: FlutterIntegrationCoreApiProtocol {
           let message: String? = nilOrValue(listResponse[1])
           let details: String? = nilOrValue(listResponse[2])
           continuation.resume(throwing: PigeonError(code: code, message: message, details: details))
-        } else if listResponse[0] == nil {
+        } else if listResponse[0] == nil || listResponse[0] is NSNull {
           continuation.resume(
             throwing: PigeonError(
               code: "null-error",
@@ -6401,7 +6401,7 @@ class FlutterIntegrationCoreApi: FlutterIntegrationCoreApiProtocol {
           let message: String? = nilOrValue(listResponse[1])
           let details: String? = nilOrValue(listResponse[2])
           continuation.resume(throwing: PigeonError(code: code, message: message, details: details))
-        } else if listResponse[0] == nil {
+        } else if listResponse[0] == nil || listResponse[0] is NSNull {
           continuation.resume(
             throwing: PigeonError(
               code: "null-error",
@@ -6700,7 +6700,7 @@ class FlutterSmallApi: FlutterSmallApiProtocol {
           let message: String? = nilOrValue(listResponse[1])
           let details: String? = nilOrValue(listResponse[2])
           continuation.resume(throwing: PigeonError(code: code, message: message, details: details))
-        } else if listResponse[0] == nil {
+        } else if listResponse[0] == nil || listResponse[0] is NSNull {
           continuation.resume(
             throwing: PigeonError(
               code: "null-error",
@@ -6728,7 +6728,7 @@ class FlutterSmallApi: FlutterSmallApiProtocol {
           let message: String? = nilOrValue(listResponse[1])
           let details: String? = nilOrValue(listResponse[2])
           continuation.resume(throwing: PigeonError(code: code, message: message, details: details))
-        } else if listResponse[0] == nil {
+        } else if listResponse[0] == nil || listResponse[0] is NSNull {
           continuation.resume(
             throwing: PigeonError(
               code: "null-error",

--- a/packages/pigeon/platform_tests/test_plugin/darwin/test_plugin/Sources/test_plugin/ProxyApiTests.gen.swift
+++ b/packages/pigeon/platform_tests/test_plugin/darwin/test_plugin/Sources/test_plugin/ProxyApiTests.gen.swift
@@ -3019,7 +3019,7 @@ final class PigeonApiProxyApiTestClass: PigeonApiProtocolProxyApiTestClass {
         let message: String? = nilOrValue(listResponse[1])
         let details: String? = nilOrValue(listResponse[2])
         completion(.failure(ProxyApiTestsError(code: code, message: message, details: details)))
-      } else if listResponse[0] == nil {
+      } else if listResponse[0] == nil || listResponse[0] is NSNull {
         completion(
           .failure(
             ProxyApiTestsError(
@@ -3070,7 +3070,7 @@ final class PigeonApiProxyApiTestClass: PigeonApiProtocolProxyApiTestClass {
         let message: String? = nilOrValue(listResponse[1])
         let details: String? = nilOrValue(listResponse[2])
         completion(.failure(ProxyApiTestsError(code: code, message: message, details: details)))
-      } else if listResponse[0] == nil {
+      } else if listResponse[0] == nil || listResponse[0] is NSNull {
         completion(
           .failure(
             ProxyApiTestsError(
@@ -3121,7 +3121,7 @@ final class PigeonApiProxyApiTestClass: PigeonApiProtocolProxyApiTestClass {
         let message: String? = nilOrValue(listResponse[1])
         let details: String? = nilOrValue(listResponse[2])
         completion(.failure(ProxyApiTestsError(code: code, message: message, details: details)))
-      } else if listResponse[0] == nil {
+      } else if listResponse[0] == nil || listResponse[0] is NSNull {
         completion(
           .failure(
             ProxyApiTestsError(
@@ -3172,7 +3172,7 @@ final class PigeonApiProxyApiTestClass: PigeonApiProtocolProxyApiTestClass {
         let message: String? = nilOrValue(listResponse[1])
         let details: String? = nilOrValue(listResponse[2])
         completion(.failure(ProxyApiTestsError(code: code, message: message, details: details)))
-      } else if listResponse[0] == nil {
+      } else if listResponse[0] == nil || listResponse[0] is NSNull {
         completion(
           .failure(
             ProxyApiTestsError(
@@ -3223,7 +3223,7 @@ final class PigeonApiProxyApiTestClass: PigeonApiProtocolProxyApiTestClass {
         let message: String? = nilOrValue(listResponse[1])
         let details: String? = nilOrValue(listResponse[2])
         completion(.failure(ProxyApiTestsError(code: code, message: message, details: details)))
-      } else if listResponse[0] == nil {
+      } else if listResponse[0] == nil || listResponse[0] is NSNull {
         completion(
           .failure(
             ProxyApiTestsError(
@@ -3274,7 +3274,7 @@ final class PigeonApiProxyApiTestClass: PigeonApiProtocolProxyApiTestClass {
         let message: String? = nilOrValue(listResponse[1])
         let details: String? = nilOrValue(listResponse[2])
         completion(.failure(ProxyApiTestsError(code: code, message: message, details: details)))
-      } else if listResponse[0] == nil {
+      } else if listResponse[0] == nil || listResponse[0] is NSNull {
         completion(
           .failure(
             ProxyApiTestsError(
@@ -3326,7 +3326,7 @@ final class PigeonApiProxyApiTestClass: PigeonApiProtocolProxyApiTestClass {
         let message: String? = nilOrValue(listResponse[1])
         let details: String? = nilOrValue(listResponse[2])
         completion(.failure(ProxyApiTestsError(code: code, message: message, details: details)))
-      } else if listResponse[0] == nil {
+      } else if listResponse[0] == nil || listResponse[0] is NSNull {
         completion(
           .failure(
             ProxyApiTestsError(
@@ -3377,7 +3377,7 @@ final class PigeonApiProxyApiTestClass: PigeonApiProtocolProxyApiTestClass {
         let message: String? = nilOrValue(listResponse[1])
         let details: String? = nilOrValue(listResponse[2])
         completion(.failure(ProxyApiTestsError(code: code, message: message, details: details)))
-      } else if listResponse[0] == nil {
+      } else if listResponse[0] == nil || listResponse[0] is NSNull {
         completion(
           .failure(
             ProxyApiTestsError(
@@ -3430,7 +3430,7 @@ final class PigeonApiProxyApiTestClass: PigeonApiProtocolProxyApiTestClass {
         let message: String? = nilOrValue(listResponse[1])
         let details: String? = nilOrValue(listResponse[2])
         completion(.failure(ProxyApiTestsError(code: code, message: message, details: details)))
-      } else if listResponse[0] == nil {
+      } else if listResponse[0] == nil || listResponse[0] is NSNull {
         completion(
           .failure(
             ProxyApiTestsError(
@@ -3481,7 +3481,7 @@ final class PigeonApiProxyApiTestClass: PigeonApiProtocolProxyApiTestClass {
         let message: String? = nilOrValue(listResponse[1])
         let details: String? = nilOrValue(listResponse[2])
         completion(.failure(ProxyApiTestsError(code: code, message: message, details: details)))
-      } else if listResponse[0] == nil {
+      } else if listResponse[0] == nil || listResponse[0] is NSNull {
         completion(
           .failure(
             ProxyApiTestsError(
@@ -3532,7 +3532,7 @@ final class PigeonApiProxyApiTestClass: PigeonApiProtocolProxyApiTestClass {
         let message: String? = nilOrValue(listResponse[1])
         let details: String? = nilOrValue(listResponse[2])
         completion(.failure(ProxyApiTestsError(code: code, message: message, details: details)))
-      } else if listResponse[0] == nil {
+      } else if listResponse[0] == nil || listResponse[0] is NSNull {
         completion(
           .failure(
             ProxyApiTestsError(
@@ -4034,7 +4034,7 @@ final class PigeonApiProxyApiTestClass: PigeonApiProtocolProxyApiTestClass {
         let message: String? = nilOrValue(listResponse[1])
         let details: String? = nilOrValue(listResponse[2])
         completion(.failure(ProxyApiTestsError(code: code, message: message, details: details)))
-      } else if listResponse[0] == nil {
+      } else if listResponse[0] == nil || listResponse[0] is NSNull {
         completion(
           .failure(
             ProxyApiTestsError(

--- a/packages/pigeon/platform_tests/test_plugin/example/ios/RunnerTests/NullableReturnsTests.swift
+++ b/packages/pigeon/platform_tests/test_plugin/example/ios/RunnerTests/NullableReturnsTests.swift
@@ -53,3 +53,29 @@ struct NullableReturnsTests {
     #expect(api.x == nil)
   }
 }
+
+/// Regression test for https://github.com/flutter/flutter/issues/191254.
+///
+/// `FlutterStandardReader` substitutes `NSNull` for a `nil` element of a list,
+/// so a null reply for a non-null return value arrives as `NSNull` rather than
+/// as `nil`. Before the fix that value was force-cast to the return type, which
+/// aborted the process instead of reporting an error.
+@MainActor
+struct NullReplyForNonNullReturnTests {
+  let codec = FlutterStandardMessageCodec.sharedInstance()
+
+  @Test
+  func nullReplyForNonNullReturnFailsWithoutCrashing() async throws {
+    let binaryMessenger = MockBinaryMessenger<NSNull>(codec: codec)
+    binaryMessenger.result = NSNull()
+    let api = FlutterIntegrationCoreApi(binaryMessenger: binaryMessenger)
+
+    do {
+      // `sendMultipleNullableTypes` has a non-null return value.
+      _ = try await api.sendMultipleNullableTypes(aBool: nil, anInt: nil, aString: nil)
+      Issue.record("Expected a null-error but the call succeeded.")
+    } catch let error as PigeonError {
+      #expect(error.code == "null-error")
+    }
+  }
+}

--- a/packages/pigeon/platform_tests/test_plugin/example/ios/RunnerTests/NullableReturnsTests.swift
+++ b/packages/pigeon/platform_tests/test_plugin/example/ios/RunnerTests/NullableReturnsTests.swift
@@ -52,26 +52,14 @@ struct NullableReturnsTests {
     #expect(api.didCall)
     #expect(api.x == nil)
   }
-}
-
-/// Regression test for https://github.com/flutter/flutter/issues/191254.
-///
-/// `FlutterStandardReader` substitutes `NSNull` for a `nil` element of a list,
-/// so a null reply for a non-null return value arrives as `NSNull` rather than
-/// as `nil`. Before the fix that value was force-cast to the return type, which
-/// aborted the process instead of reporting an error.
-@MainActor
-struct NullReplyForNonNullReturnTests {
-  let codec = FlutterStandardMessageCodec.sharedInstance()
 
   @Test
-  func nullReplyForNonNullReturnFailsWithoutCrashing() async throws {
+  func nonNullReturnFailsOnNSNullResponse() async throws {
     let binaryMessenger = MockBinaryMessenger<NSNull>(codec: codec)
     binaryMessenger.result = NSNull()
     let api = FlutterIntegrationCoreApi(binaryMessenger: binaryMessenger)
 
     do {
-      // `sendMultipleNullableTypes` has a non-null return value.
       _ = try await api.sendMultipleNullableTypes(aBool: nil, anInt: nil, aString: nil)
       Issue.record("Expected a null-error but the call succeeded.")
     } catch let error as PigeonError {

--- a/packages/pigeon/pubspec.yaml
+++ b/packages/pigeon/pubspec.yaml
@@ -2,7 +2,7 @@ name: pigeon
 description: Code generator tool to make communication between Flutter and the host platform type-safe and easier.
 repository: https://github.com/flutter/packages/tree/main/packages/pigeon
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+pigeon%22
-version: 28.0.0 # This must match the version in lib/src/generator_tools.dart
+version: 28.0.1 # This must match the version in lib/src/generator_tools.dart
 
 environment:
   sdk: ^3.11.0

--- a/packages/pigeon/test/swift_generator_test.dart
+++ b/packages/pigeon/test/swift_generator_test.dart
@@ -1149,6 +1149,35 @@ void main() {
     expect(code, contains('channel.sendMessage([xArg, yArg] as [Any?]) { response in'));
   });
 
+  test('non-null return from flutter api treats NSNull as null', () {
+    final root = Root(
+      apis: <Api>[
+        AstFlutterApi(
+          name: 'Api',
+          methods: <Method>[
+            Method(
+              name: 'doit',
+              location: ApiLocation.flutter,
+              parameters: <Parameter>[],
+              returnType: const TypeDeclaration(baseName: 'int', isNullable: false),
+            ),
+          ],
+        ),
+      ],
+      classes: <Class>[],
+      enums: <Enum>[],
+    );
+    final sink = StringBuffer();
+    const swiftOptions = InternalSwiftOptions(swiftOut: '');
+    const generator = SwiftGenerator();
+    generator.generate(swiftOptions, root, sink, dartPackageName: DEFAULT_PACKAGE_NAME);
+    final code = sink.toString();
+    // `FlutterStandardReader` substitutes `NSNull` for a `nil` element of a
+    // list, so both need to be treated as a null reply before the value is
+    // cast. See https://github.com/flutter/flutter/issues/191254.
+    expect(code, contains('else if listResponse[0] == nil || listResponse[0] is NSNull {'));
+  });
+
   test('return nullable host', () {
     final root = Root(
       apis: <Api>[

--- a/packages/pigeon/test/swift_generator_test.dart
+++ b/packages/pigeon/test/swift_generator_test.dart
@@ -1172,9 +1172,6 @@ void main() {
     const generator = SwiftGenerator();
     generator.generate(swiftOptions, root, sink, dartPackageName: DEFAULT_PACKAGE_NAME);
     final code = sink.toString();
-    // `FlutterStandardReader` substitutes `NSNull` for a `nil` element of a
-    // list, so both need to be treated as a null reply before the value is
-    // cast. See https://github.com/flutter/flutter/issues/191254.
     expect(code, contains('else if listResponse[0] == nil || listResponse[0] is NSNull {'));
   });
 


### PR DESCRIPTION
## Description

`FlutterStandardReader` substitutes `NSNull` for a `nil` element when it decodes a list, so a null reply for a non-null return value reaches the generated Swift code as `NSNull` rather than as `nil`. The generated guard only checks `listResponse[0] == nil`, so `NSNull` falls through to the force cast below it and aborts the process:

```swift
} else if listResponse[0] == nil {
  completion(.failure(PigeonError(code: "null-error", ...)))
} else {
  let result = listResponse[0] as! AuthenticationChallengeResponse  // 💥
```

This crashes production apps through `webview_flutter_wkwebview`: the plugin clears its native instance manager in `WebViewFlutterPlugin.tearDownProxyAPIRegistrar()`, which iOS triggers on `sceneDidDisconnect` / `applicationWillTerminate`. A `WKNavigationDelegate.didReceiveAuthenticationChallenge` reply that is still in flight then carries an identifier the native instance manager can no longer resolve, the codec reader returns `nil`, and the app dies with:

```
Could not cast value of type 'NSNull' (0x...) to 'webview_flutter_wkwebview.AuthenticationChallengeResponse' (0x...).
```

The same shape was reported before for other types (`URLRequestWrapper` in flutter/flutter#162437), which is expected: the generator emits this guard for every non-null return value, so any unresolvable instance crashes instead of reporting an error.

This PR treats `NSNull` as a null reply, so the existing `null-error` path handles it.

## Verification

* Added a Swift generator unit test asserting the generated guard covers `NSNull`.
* Added a native regression test in `platform_tests` that replies `NSNull` to a non-null Flutter API return. It passes with this change; with the generated guard reverted it aborts with `Could not cast value of type 'NSNull' (0x...) to 'test_plugin.AllNullableTypes' (0x...)`.
* `dart test` and `flutter_plugin_tools format` pass locally.

*Fixes flutter/flutter#191254*

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/packages repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style], or this PR is [exempt from CHANGELOG changes].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#formatting
[CLA]: https://cla.developers.google.com/
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/blob/main/docs/ecosystem/contributing/README.md#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/blob/main/docs/ecosystem/contributing/README.md#changelog-style
[exempt from CHANGELOG changes]: https://github.com/flutter/flutter/blob/main/docs/ecosystem/contributing/README.md#version-and-changelog-updates
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
