### PR TITLE
[image_picker] Add native tests for pick results, camera access, and presentation

### DIFF
--- a/packages/image_picker/image_picker_ios/example/ios/RunnerTests/ImagePickerPluginTests.m
+++ b/packages/image_picker/image_picker_ios/example/ios/RunnerTests/ImagePickerPluginTests.m
@@ -17,6 +17,9 @@
 @property(nonatomic, strong) UIWindow *interactionBlockerWindow;
 @property(nonatomic, weak) UIWindow *previousKeyWindow;
 - (void)removeInteractionBlocker;
+- (void)showCamera:(UIImagePickerControllerCameraDevice)device
+    withImagePicker:(UIImagePickerController *)imagePickerController;
+- (UIViewController *)presentingViewControllerForImagePickerInNewWindow;
 @end
 
 @interface MockViewController : UIViewController
@@ -813,6 +816,419 @@
                    }];
 
   OCMVerifyAll(mockPickerViewController);
+}
+
+- (void)testPickImageInvalidResultWhenMultiplePathsReturned {
+  FLTImagePickerPlugin *plugin =
+      [[FLTImagePickerPlugin alloc] initWithViewProvider:[[StubViewProvider alloc] init]];
+  XCTestExpectation *resultExpectation = [self expectationWithDescription:@"invalid_result"];
+  __block NSInteger completionCount = 0;
+  [plugin pickImageWithSource:[FLTSourceSpecification makeWithType:FLTSourceTypeGallery
+                                                            camera:FLTSourceCameraRear]
+                      maxSize:[[FLTMaxSize alloc] init]
+                      quality:nil
+                 fullMetadata:NO
+                   completion:^(NSString *result, FlutterError *error) {
+                     completionCount += 1;
+                     if (completionCount == 1) {
+                       // Current behavior: the invalid_result error is sent, then the adapter
+                       // also forwards paths.firstObject.
+                       XCTAssertNil(result);
+                       XCTAssertEqualObjects(error.code, @"invalid_result");
+                     } else {
+                       XCTAssertEqualObjects(result, @"a");
+                       [resultExpectation fulfill];
+                     }
+                   }];
+  [plugin sendCallResultWithSavedPathList:@[ @"a", @"b" ]];
+  [self waitForExpectationsWithTimeout:30 handler:nil];
+  XCTAssertEqual(completionCount, 2);
+}
+
+- (void)testPickVideoInvalidResultWhenMultiplePathsReturned {
+  FLTImagePickerPlugin *plugin =
+      [[FLTImagePickerPlugin alloc] initWithViewProvider:[[StubViewProvider alloc] init]];
+  XCTestExpectation *resultExpectation = [self expectationWithDescription:@"invalid_result"];
+  __block NSInteger completionCount = 0;
+  [plugin pickVideoWithSource:[FLTSourceSpecification makeWithType:FLTSourceTypeGallery
+                                                            camera:FLTSourceCameraRear]
+                  maxDuration:nil
+                   completion:^(NSString *result, FlutterError *error) {
+                     completionCount += 1;
+                     if (completionCount == 1) {
+                       XCTAssertNil(result);
+                       XCTAssertEqualObjects(error.code, @"invalid_result");
+                     } else {
+                       XCTAssertEqualObjects(result, @"a");
+                       [resultExpectation fulfill];
+                     }
+                   }];
+  [plugin sendCallResultWithSavedPathList:@[ @"a", @"b" ]];
+  [self waitForExpectationsWithTimeout:30 handler:nil];
+  XCTAssertEqual(completionCount, 2);
+}
+
+- (void)testPHPickerCancelSendsEmptyPathList API_AVAILABLE(ios(14)) {
+  id mockPickerViewController = OCMClassMock([PHPickerViewController class]);
+  FLTImagePickerPlugin *plugin =
+      [[FLTImagePickerPlugin alloc] initWithViewProvider:[[StubViewProvider alloc] init]];
+  XCTestExpectation *resultExpectation = [self expectationWithDescription:@"cancelled"];
+  plugin.callContext = [[FLTImagePickerMethodCallContext alloc]
+      initWithResult:^(NSArray<NSString *> *result, FlutterError *error) {
+        XCTAssertEqualObjects(result, @[]);
+        XCTAssertNil(error);
+        [resultExpectation fulfill];
+      }];
+  [plugin picker:mockPickerViewController didFinishPicking:@[]];
+  [self waitForExpectationsWithTimeout:30 handler:nil];
+}
+
+- (void)testPresentationControllerDidDismissSendsEmptyPathList {
+  FLTImagePickerPlugin *plugin =
+      [[FLTImagePickerPlugin alloc] initWithViewProvider:[[StubViewProvider alloc] init]];
+  XCTestExpectation *resultExpectation = [self expectationWithDescription:@"dismissed"];
+  plugin.callContext = [[FLTImagePickerMethodCallContext alloc]
+      initWithResult:^(NSArray<NSString *> *result, FlutterError *error) {
+        XCTAssertEqualObjects(result, @[]);
+        XCTAssertNil(error);
+        [resultExpectation fulfill];
+      }];
+  id mockPresentationController = OCMClassMock([UIPresentationController class]);
+  [plugin presentationControllerDidDismiss:mockPresentationController];
+  [self waitForExpectationsWithTimeout:30 handler:nil];
+}
+
+- (void)testDesiredImageQualityClampsOutOfRangeValues API_AVAILABLE(ios(14)) {
+  id mockPickerViewController = OCMClassMock([PHPickerViewController class]);
+  NSURL *pngURL = [[NSBundle bundleForClass:[self class]] URLForResource:@"pngImage"
+                                                           withExtension:@"png"];
+  NSItemProvider *pngItemProvider = [[NSItemProvider alloc] initWithContentsOfURL:pngURL];
+  PHPickerResult *pngResult = OCMClassMock([PHPickerResult class]);
+  OCMStub([pngResult itemProvider]).andReturn(pngItemProvider);
+
+  FLTImagePickerPlugin *plugin =
+      [[FLTImagePickerPlugin alloc] initWithViewProvider:[[StubViewProvider alloc] init]];
+  XCTestExpectation *resultExpectation = [self expectationWithDescription:@"saved"];
+  plugin.callContext = [[FLTImagePickerMethodCallContext alloc]
+      initWithResult:^(NSArray<NSString *> *result, FlutterError *error) {
+        XCTAssertEqual(result.count, 1);
+        XCTAssertNil(error);
+        [resultExpectation fulfill];
+      }];
+  plugin.callContext.imageQuality = @(-1);
+  [plugin picker:mockPickerViewController didFinishPicking:@[ pngResult ]];
+  [self waitForExpectationsWithTimeout:30 handler:nil];
+}
+
+- (void)testDesiredImageQualityScalesValidPercent API_AVAILABLE(ios(14)) {
+  id mockPickerViewController = OCMClassMock([PHPickerViewController class]);
+  NSURL *pngURL = [[NSBundle bundleForClass:[self class]] URLForResource:@"pngImage"
+                                                           withExtension:@"png"];
+  NSItemProvider *pngItemProvider = [[NSItemProvider alloc] initWithContentsOfURL:pngURL];
+  PHPickerResult *pngResult = OCMClassMock([PHPickerResult class]);
+  OCMStub([pngResult itemProvider]).andReturn(pngItemProvider);
+
+  FLTImagePickerPlugin *plugin =
+      [[FLTImagePickerPlugin alloc] initWithViewProvider:[[StubViewProvider alloc] init]];
+  XCTestExpectation *resultExpectation = [self expectationWithDescription:@"saved"];
+  plugin.callContext = [[FLTImagePickerMethodCallContext alloc]
+      initWithResult:^(NSArray<NSString *> *result, FlutterError *error) {
+        XCTAssertEqual(result.count, 1);
+        XCTAssertNil(error);
+        [resultExpectation fulfill];
+      }];
+  plugin.callContext.imageQuality = @50;
+  plugin.callContext.maxSize = [FLTMaxSize makeWithWidth:@3 height:@2];
+  [plugin picker:mockPickerViewController didFinishPicking:@[ pngResult ]];
+  [self waitForExpectationsWithTimeout:30 handler:nil];
+}
+
+- (void)testDesiredImageQualityOver100IsClamped API_AVAILABLE(ios(14)) {
+  id mockPickerViewController = OCMClassMock([PHPickerViewController class]);
+  NSURL *pngURL = [[NSBundle bundleForClass:[self class]] URLForResource:@"pngImage"
+                                                           withExtension:@"png"];
+  NSItemProvider *pngItemProvider = [[NSItemProvider alloc] initWithContentsOfURL:pngURL];
+  PHPickerResult *pngResult = OCMClassMock([PHPickerResult class]);
+  OCMStub([pngResult itemProvider]).andReturn(pngItemProvider);
+
+  FLTImagePickerPlugin *plugin =
+      [[FLTImagePickerPlugin alloc] initWithViewProvider:[[StubViewProvider alloc] init]];
+  XCTestExpectation *resultExpectation = [self expectationWithDescription:@"saved"];
+  plugin.callContext = [[FLTImagePickerMethodCallContext alloc]
+      initWithResult:^(NSArray<NSString *> *result, FlutterError *error) {
+        XCTAssertEqual(result.count, 1);
+        [resultExpectation fulfill];
+      }];
+  plugin.callContext.imageQuality = @150;
+  [plugin picker:mockPickerViewController didFinishPicking:@[ pngResult ]];
+  [self waitForExpectationsWithTimeout:30 handler:nil];
+}
+
+- (void)testCameraAccessDeniedReturnsError {
+  id mockAVCaptureDevice = OCMClassMock([AVCaptureDevice class]);
+  OCMStub([mockAVCaptureDevice authorizationStatusForMediaType:AVMediaTypeVideo])
+      .andReturn(AVAuthorizationStatusDenied);
+
+  FLTImagePickerPlugin *plugin =
+      [[FLTImagePickerPlugin alloc] initWithViewProvider:[[StubViewProvider alloc] init]];
+  [plugin setImagePickerControllerOverrides:@[ [[UIImagePickerController alloc] init] ]];
+
+  XCTestExpectation *resultExpectation = [self expectationWithDescription:@"denied"];
+  [plugin pickImageWithSource:[FLTSourceSpecification makeWithType:FLTSourceTypeCamera
+                                                            camera:FLTSourceCameraRear]
+                      maxSize:[[FLTMaxSize alloc] init]
+                      quality:nil
+                 fullMetadata:YES
+                   completion:^(NSString *result, FlutterError *error) {
+                     XCTAssertEqualObjects(error.code, @"camera_access_denied");
+                     [resultExpectation fulfill];
+                   }];
+  [self waitForExpectationsWithTimeout:30 handler:nil];
+}
+
+- (void)testCameraAccessRestrictedReturnsError {
+  id mockAVCaptureDevice = OCMClassMock([AVCaptureDevice class]);
+  OCMStub([mockAVCaptureDevice authorizationStatusForMediaType:AVMediaTypeVideo])
+      .andReturn(AVAuthorizationStatusRestricted);
+
+  FLTImagePickerPlugin *plugin =
+      [[FLTImagePickerPlugin alloc] initWithViewProvider:[[StubViewProvider alloc] init]];
+  [plugin setImagePickerControllerOverrides:@[ [[UIImagePickerController alloc] init] ]];
+
+  XCTestExpectation *resultExpectation = [self expectationWithDescription:@"restricted"];
+  [plugin pickImageWithSource:[FLTSourceSpecification makeWithType:FLTSourceTypeCamera
+                                                            camera:FLTSourceCameraRear]
+                      maxSize:[[FLTMaxSize alloc] init]
+                      quality:nil
+                 fullMetadata:YES
+                   completion:^(NSString *result, FlutterError *error) {
+                     XCTAssertEqualObjects(error.code, @"camera_access_restricted");
+                     [resultExpectation fulfill];
+                   }];
+  [self waitForExpectationsWithTimeout:30 handler:nil];
+}
+
+- (void)testCameraAccessNotDeterminedDenied {
+  id mockAVCaptureDevice = OCMClassMock([AVCaptureDevice class]);
+  OCMStub([mockAVCaptureDevice authorizationStatusForMediaType:AVMediaTypeVideo])
+      .andReturn(AVAuthorizationStatusNotDetermined);
+  OCMStub([mockAVCaptureDevice requestAccessForMediaType:AVMediaTypeVideo
+                                       completionHandler:OCMOCK_ANY])
+      .andDo(^(NSInvocation *invocation) {
+        void (^handler)(BOOL granted);
+        [invocation getArgument:&handler atIndex:3];
+        handler(NO);
+      });
+
+  FLTImagePickerPlugin *plugin =
+      [[FLTImagePickerPlugin alloc] initWithViewProvider:[[StubViewProvider alloc] init]];
+  [plugin setImagePickerControllerOverrides:@[ [[UIImagePickerController alloc] init] ]];
+
+  XCTestExpectation *resultExpectation = [self expectationWithDescription:@"request denied"];
+  [plugin pickImageWithSource:[FLTSourceSpecification makeWithType:FLTSourceTypeCamera
+                                                            camera:FLTSourceCameraRear]
+                      maxSize:[[FLTMaxSize alloc] init]
+                      quality:nil
+                 fullMetadata:YES
+                   completion:^(NSString *result, FlutterError *error) {
+                     XCTAssertEqualObjects(error.code, @"camera_access_denied");
+                     [resultExpectation fulfill];
+                   }];
+  [self waitForExpectationsWithTimeout:30 handler:nil];
+}
+
+- (void)testCameraAccessNotDeterminedGrantedPresentsCamera {
+  id mockUIImagePicker = OCMClassMock([UIImagePickerController class]);
+  id mockAVCaptureDevice = OCMClassMock([AVCaptureDevice class]);
+  OCMStub(ClassMethod(
+              [mockUIImagePicker isSourceTypeAvailable:UIImagePickerControllerSourceTypeCamera]))
+      .andReturn(YES);
+  OCMStub(ClassMethod(
+              [mockUIImagePicker isCameraDeviceAvailable:UIImagePickerControllerCameraDeviceRear]))
+      .andReturn(YES);
+  OCMStub([mockAVCaptureDevice authorizationStatusForMediaType:AVMediaTypeVideo])
+      .andReturn(AVAuthorizationStatusNotDetermined);
+  OCMStub([mockAVCaptureDevice requestAccessForMediaType:AVMediaTypeVideo
+                                       completionHandler:OCMOCK_ANY])
+      .andDo(^(NSInvocation *invocation) {
+        void (^handler)(BOOL granted);
+        [invocation getArgument:&handler atIndex:3];
+        handler(YES);
+      });
+
+  FLTImagePickerPlugin *plugin =
+      [[FLTImagePickerPlugin alloc] initWithViewProvider:[[StubViewProvider alloc] init]];
+  UIImagePickerController *controller = [[UIImagePickerController alloc] init];
+  [plugin setImagePickerControllerOverrides:@[ controller ]];
+
+  XCTestExpectation *presented = [self expectationWithDescription:@"camera presented"];
+  [plugin pickImageWithSource:[FLTSourceSpecification makeWithType:FLTSourceTypeCamera
+                                                            camera:FLTSourceCameraRear]
+                      maxSize:[[FLTMaxSize alloc] init]
+                      quality:nil
+                 fullMetadata:YES
+                   completion:^(NSString *result, FlutterError *error){
+                   }];
+  dispatch_async(dispatch_get_main_queue(), ^{
+    XCTAssertEqual(controller.sourceType, UIImagePickerControllerSourceTypeCamera);
+    [presented fulfill];
+  });
+  [self waitForExpectationsWithTimeout:30 handler:nil];
+}
+
+- (void)testShowCameraWhenUnavailableSendsNilPathList {
+  id mockUIImagePicker = OCMClassMock([UIImagePickerController class]);
+  id mockAVCaptureDevice = OCMClassMock([AVCaptureDevice class]);
+  OCMStub(ClassMethod(
+              [mockUIImagePicker isSourceTypeAvailable:UIImagePickerControllerSourceTypeCamera]))
+      .andReturn(NO);
+  OCMStub([mockAVCaptureDevice authorizationStatusForMediaType:AVMediaTypeVideo])
+      .andReturn(AVAuthorizationStatusAuthorized);
+
+  FLTImagePickerPlugin *plugin =
+      [[FLTImagePickerPlugin alloc] initWithViewProvider:[[StubViewProvider alloc] init]];
+  [plugin setImagePickerControllerOverrides:@[ [[UIImagePickerController alloc] init] ]];
+
+  XCTestExpectation *resultExpectation = [self expectationWithDescription:@"unavailable"];
+  [plugin pickImageWithSource:[FLTSourceSpecification makeWithType:FLTSourceTypeCamera
+                                                            camera:FLTSourceCameraRear]
+                      maxSize:[[FLTMaxSize alloc] init]
+                      quality:nil
+                 fullMetadata:YES
+                   completion:^(NSString *result, FlutterError *error) {
+                     XCTAssertNil(result);
+                     XCTAssertNil(error);
+                     [resultExpectation fulfill];
+                   }];
+  [self waitForExpectationsWithTimeout:30 handler:nil];
+}
+
+- (void)testShowCameraReturnsEarlyWhenAlreadyBeingPresented {
+  id mockPicker = OCMClassMock([UIImagePickerController class]);
+  OCMStub([mockPicker isBeingPresented]).andReturn(YES);
+
+  FLTImagePickerPlugin *plugin =
+      [[FLTImagePickerPlugin alloc] initWithViewProvider:[[StubViewProvider alloc] init]];
+  [plugin showCamera:UIImagePickerControllerCameraDeviceRear withImagePicker:mockPicker];
+  OCMVerify(times(0), [mockPicker setSourceType:UIImagePickerControllerSourceTypeCamera]);
+}
+
+- (void)testCameraAccessUnknownStatusTreatedAsDenied {
+  id mockAVCaptureDevice = OCMClassMock([AVCaptureDevice class]);
+  OCMStub([mockAVCaptureDevice authorizationStatusForMediaType:AVMediaTypeVideo])
+      .andReturn((AVAuthorizationStatus)999);
+
+  FLTImagePickerPlugin *plugin =
+      [[FLTImagePickerPlugin alloc] initWithViewProvider:[[StubViewProvider alloc] init]];
+  [plugin setImagePickerControllerOverrides:@[ [[UIImagePickerController alloc] init] ]];
+
+  XCTestExpectation *resultExpectation = [self expectationWithDescription:@"unknown denied"];
+  [plugin pickImageWithSource:[FLTSourceSpecification makeWithType:FLTSourceTypeCamera
+                                                            camera:FLTSourceCameraRear]
+                      maxSize:[[FLTMaxSize alloc] init]
+                      quality:nil
+                 fullMetadata:YES
+                   completion:^(NSString *result, FlutterError *error) {
+                     XCTAssertEqualObjects(error.code, @"camera_access_denied");
+                     [resultExpectation fulfill];
+                   }];
+  [self waitForExpectationsWithTimeout:30 handler:nil];
+}
+
+- (void)testShowCameraUnavailableAlertOKHandler {
+  id mockUIImagePicker = OCMClassMock([UIImagePickerController class]);
+  id mockAVCaptureDevice = OCMClassMock([AVCaptureDevice class]);
+  OCMStub(ClassMethod(
+              [mockUIImagePicker isSourceTypeAvailable:UIImagePickerControllerSourceTypeCamera]))
+      .andReturn(NO);
+  OCMStub([mockAVCaptureDevice authorizationStatusForMediaType:AVMediaTypeVideo])
+      .andReturn(AVAuthorizationStatusAuthorized);
+
+  UIWindowScene *scene =
+      (UIWindowScene *)UIApplication.sharedApplication.connectedScenes.allObjects.firstObject;
+  UIWindow *window = [[UIWindow alloc] initWithWindowScene:scene];
+  window.frame = scene.coordinateSpace.bounds;
+  UIViewController *rootViewController = [[UIViewController alloc] init];
+  window.rootViewController = rootViewController;
+  [rootViewController loadViewIfNeeded];
+  [window makeKeyAndVisible];
+
+  FLTImagePickerPlugin *plugin = [[FLTImagePickerPlugin alloc]
+      initWithViewProvider:[[StubViewProvider alloc] initWithViewController:rootViewController]];
+  [plugin setImagePickerControllerOverrides:@[ [[UIImagePickerController alloc] init] ]];
+
+  XCTestExpectation *resultExpectation = [self expectationWithDescription:@"unavailable"];
+  [plugin pickImageWithSource:[FLTSourceSpecification makeWithType:FLTSourceTypeCamera
+                                                            camera:FLTSourceCameraRear]
+                      maxSize:[[FLTMaxSize alloc] init]
+                      quality:nil
+                 fullMetadata:YES
+                   completion:^(NSString *result, FlutterError *error) {
+                     XCTAssertNil(result);
+                     [resultExpectation fulfill];
+                   }];
+  [self waitForExpectationsWithTimeout:30 handler:nil];
+
+  UIAlertController *alert = (UIAlertController *)rootViewController.presentedViewController;
+  XCTAssertTrue([alert isKindOfClass:[UIAlertController class]]);
+  void (^handler)(UIAlertAction *) = [alert.actions.firstObject valueForKey:@"handler"];
+  if (handler) {
+    handler(alert.actions.firstObject);
+  }
+}
+
+- (void)testPresentingViewControllerWithoutWindowReturnsHostController {
+  UIViewController *host = [[UIViewController alloc] init];
+  FLTImagePickerPlugin *plugin = [[FLTImagePickerPlugin alloc]
+      initWithViewProvider:[[StubViewProvider alloc] initWithViewController:host]];
+  UIViewController *presented = [plugin presentingViewControllerForImagePickerInNewWindow];
+  XCTAssertEqual(presented, host);
+}
+
+- (void)testPresentingViewControllerReusesExistingBlockerWindow {
+  UIWindowScene *scene =
+      (UIWindowScene *)UIApplication.sharedApplication.connectedScenes.allObjects.firstObject;
+  UIWindow *window = [[UIWindow alloc] initWithWindowScene:scene];
+  window.frame = scene.coordinateSpace.bounds;
+  UIViewController *rootViewController = [[UIViewController alloc] init];
+  window.rootViewController = rootViewController;
+  [rootViewController loadViewIfNeeded];
+  [window makeKeyAndVisible];
+
+  FLTImagePickerPlugin *plugin = [[FLTImagePickerPlugin alloc]
+      initWithViewProvider:[[StubViewProvider alloc] initWithViewController:rootViewController]];
+  UIViewController *first = [plugin presentingViewControllerForImagePickerInNewWindow];
+  UIViewController *second = [plugin presentingViewControllerForImagePickerInNewWindow];
+  XCTAssertEqual(first, second);
+  [plugin removeInteractionBlocker];
+}
+
+- (void)testPresentingViewControllerWithoutWindowSceneUsesFrame {
+  UIWindowScene *scene =
+      (UIWindowScene *)UIApplication.sharedApplication.connectedScenes.allObjects.firstObject;
+  UIWindow *window = [[UIWindow alloc] initWithWindowScene:scene];
+  window.frame = scene.coordinateSpace.bounds;
+  UIViewController *rootViewController = [[UIViewController alloc] init];
+  window.rootViewController = rootViewController;
+  [rootViewController loadViewIfNeeded];
+  [window makeKeyAndVisible];
+
+  id mockWindow = OCMPartialMock(window);
+  OCMStub([mockWindow windowScene]).andReturn(nil);
+
+  FLTImagePickerPlugin *plugin = [[FLTImagePickerPlugin alloc]
+      initWithViewProvider:[[StubViewProvider alloc] initWithViewController:rootViewController]];
+  XCTAssertNotNil([plugin presentingViewControllerForImagePickerInNewWindow]);
+  [plugin removeInteractionBlocker];
+  [mockWindow stopMocking];
+}
+
+- (void)testDefaultViewProviderReturnsRegistrarViewController {
+  UIViewController *host = [[UIViewController alloc] init];
+  id registrar = OCMProtocolMock(@protocol(FlutterPluginRegistrar));
+  OCMStub([registrar viewController]).andReturn(host);
+  FIPDefaultViewProvider *provider = [[FIPDefaultViewProvider alloc] initWithRegistrar:registrar];
+  XCTAssertEqual(provider.viewController, host);
 }
 
 @end


### PR DESCRIPTION
Adds native unit tests for previously untested paths in `FLTImagePickerPlugin.m` (pick-result handling, camera authorization, and presentation) before the Objective-C → Swift migration. Production code is unchanged. New cases follow the existing `StubViewProvider` / OCMock conventions in `ImagePickerPluginTests.m`.

This is a tests-only change, so it does not bump the package version or CHANGELOG.

`ImagePickerPluginTests` go from 33 tests to 52 tests (+19).

### New test cases

**Pick results / dismiss:**
- `testPickImageInvalidResultWhenMultiplePathsReturned` — image pick with multiple paths uses the existing `invalid_result` double-completion behavior
- `testPickVideoInvalidResultWhenMultiplePathsReturned` — same for video pick
- `testPHPickerCancelSendsEmptyPathList` — PHPicker cancel completes with an empty path list
- `testPresentationControllerDidDismissSendsEmptyPathList` — dismiss completes with an empty path list

**Image quality:**
- `testDesiredImageQualityClampsOutOfRangeValues` — quality below 0 is clamped
- `testDesiredImageQualityScalesValidPercent` — a valid percent is scaled
- `testDesiredImageQualityOver100IsClamped` — quality above 100 is clamped

**Camera access:**
- `testCameraAccessDeniedReturnsError` — denied authorization returns an error
- `testCameraAccessRestrictedReturnsError` — restricted authorization returns an error
- `testCameraAccessNotDeterminedDenied` — prompt denied returns an error
- `testCameraAccessNotDeterminedGrantedPresentsCamera` — prompt granted presents the camera
- `testCameraAccessUnknownStatusTreatedAsDenied` — unknown status is treated as denied
- `testShowCameraWhenUnavailableSendsNilPathList` — unavailable camera completes with a nil path list
- `testShowCameraReturnsEarlyWhenAlreadyBeingPresented` — a second present is a no-op
- `testShowCameraUnavailableAlertOKHandler` — the unavailable-camera alert OK handler runs

**Presentation / blocker window:**
- `testPresentingViewControllerWithoutWindowReturnsHostController` — no window returns the host view controller
- `testPresentingViewControllerReusesExistingBlockerWindow` — an existing interaction-blocker window is reused
- `testPresentingViewControllerWithoutWindowSceneUsesFrame` — missing window scene falls back to a frame
- `testDefaultViewProviderReturnsRegistrarViewController` — the default view provider returns the registrar’s view controller

Second part of `image_picker_ios` coverage backfill before the Obj-C → Swift migration for https://github.com/flutter/flutter/issues/119107

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under[^1].
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[the version and CHANGELOG instructions]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version-and-changelog-updates
[semantic versioning]: https://dart.dev/tools/pub/versioning#semantic-versions
[repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
