### PR TITLE
[image_picker_ios] Add native tests for photo-library access and UIImagePicker completion

### DIFF
--- a/packages/image_picker/image_picker_ios/example/ios/RunnerTests/ImagePickerPluginTests.m
+++ b/packages/image_picker/image_picker_ios/example/ios/RunnerTests/ImagePickerPluginTests.m
@@ -9,6 +9,7 @@
 @import image_picker_ios.Test;
 #endif
 @import UniformTypeIdentifiers;
+@import MobileCoreServices;
 @import XCTest;
 
 #import <OCMock/OCMock.h>
@@ -17,6 +18,8 @@
 @property(nonatomic, strong) UIWindow *interactionBlockerWindow;
 @property(nonatomic, weak) UIWindow *previousKeyWindow;
 - (void)removeInteractionBlocker;
+- (void)launchUIImagePickerWithSource:(FLTSourceSpecification *)source
+                              context:(FLTImagePickerMethodCallContext *)context;
 - (void)showCamera:(UIImagePickerControllerCameraDevice)device
     withImagePicker:(UIImagePickerController *)imagePickerController;
 - (UIViewController *)presentingViewControllerForImagePickerInNewWindow;
@@ -1229,6 +1232,412 @@
   OCMStub([registrar viewController]).andReturn(host);
   FIPDefaultViewProvider *provider = [[FIPDefaultViewProvider alloc] initWithRegistrar:registrar];
   XCTAssertEqual(provider.viewController, host);
+}
+
+- (void)testLaunchUIImagePickerGalleryWithoutFullMetadataSkipsAuthorization {
+  id photoLibrary = OCMClassMock([PHPhotoLibrary class]);
+  FLTImagePickerPlugin *plugin =
+      [[FLTImagePickerPlugin alloc] initWithViewProvider:[[StubViewProvider alloc] init]];
+  UIImagePickerController *controller = [[UIImagePickerController alloc] init];
+  [plugin setImagePickerControllerOverrides:@[ controller ]];
+
+  FLTImagePickerMethodCallContext *context = [[FLTImagePickerMethodCallContext alloc]
+      initWithResult:^(NSArray<NSString *> *result, FlutterError *error){
+      }];
+  context.includeImages = YES;
+  context.requestFullMetadata = NO;
+
+  [plugin launchUIImagePickerWithSource:[FLTSourceSpecification makeWithType:FLTSourceTypeGallery
+                                                                      camera:FLTSourceCameraRear]
+                                context:context];
+  XCTAssertEqual(controller.sourceType, UIImagePickerControllerSourceTypePhotoLibrary);
+  OCMVerify(times(0), [photoLibrary authorizationStatus]);
+}
+
+- (void)testPhotoAccessDeniedReturnsError {
+  id photoLibrary = OCMClassMock([PHPhotoLibrary class]);
+  OCMStub(ClassMethod([photoLibrary authorizationStatus])).andReturn(PHAuthorizationStatusDenied);
+
+  FLTImagePickerPlugin *plugin =
+      [[FLTImagePickerPlugin alloc] initWithViewProvider:[[StubViewProvider alloc] init]];
+  [plugin setImagePickerControllerOverrides:@[ [[UIImagePickerController alloc] init] ]];
+
+  XCTestExpectation *resultExpectation = [self expectationWithDescription:@"photo denied"];
+  FLTImagePickerMethodCallContext *context = [[FLTImagePickerMethodCallContext alloc]
+      initWithResult:^(NSArray<NSString *> *result, FlutterError *error) {
+        XCTAssertEqualObjects(error.code, @"photo_access_denied");
+        [resultExpectation fulfill];
+      }];
+  context.includeImages = YES;
+  context.requestFullMetadata = YES;
+  [plugin launchUIImagePickerWithSource:[FLTSourceSpecification makeWithType:FLTSourceTypeGallery
+                                                                      camera:FLTSourceCameraRear]
+                                context:context];
+  [self waitForExpectationsWithTimeout:30 handler:nil];
+}
+
+- (void)testPhotoAccessRestrictedReturnsError {
+  id photoLibrary = OCMClassMock([PHPhotoLibrary class]);
+  OCMStub(ClassMethod([photoLibrary authorizationStatus]))
+      .andReturn(PHAuthorizationStatusRestricted);
+
+  FLTImagePickerPlugin *plugin =
+      [[FLTImagePickerPlugin alloc] initWithViewProvider:[[StubViewProvider alloc] init]];
+  [plugin setImagePickerControllerOverrides:@[ [[UIImagePickerController alloc] init] ]];
+
+  XCTestExpectation *resultExpectation = [self expectationWithDescription:@"photo restricted"];
+  FLTImagePickerMethodCallContext *context = [[FLTImagePickerMethodCallContext alloc]
+      initWithResult:^(NSArray<NSString *> *result, FlutterError *error) {
+        XCTAssertEqualObjects(error.code, @"photo_access_restricted");
+        [resultExpectation fulfill];
+      }];
+  context.includeImages = YES;
+  context.requestFullMetadata = YES;
+  [plugin launchUIImagePickerWithSource:[FLTSourceSpecification makeWithType:FLTSourceTypeGallery
+                                                                      camera:FLTSourceCameraRear]
+                                context:context];
+  [self waitForExpectationsWithTimeout:30 handler:nil];
+}
+
+- (void)testPhotoAccessAuthorizedShowsLibrary {
+  id photoLibrary = OCMClassMock([PHPhotoLibrary class]);
+  OCMStub(ClassMethod([photoLibrary authorizationStatus]))
+      .andReturn(PHAuthorizationStatusAuthorized);
+
+  FLTImagePickerPlugin *plugin =
+      [[FLTImagePickerPlugin alloc] initWithViewProvider:[[StubViewProvider alloc] init]];
+  UIImagePickerController *controller = [[UIImagePickerController alloc] init];
+  [plugin setImagePickerControllerOverrides:@[ controller ]];
+
+  FLTImagePickerMethodCallContext *context = [[FLTImagePickerMethodCallContext alloc]
+      initWithResult:^(NSArray<NSString *> *result, FlutterError *error){
+      }];
+  context.includeImages = YES;
+  context.requestFullMetadata = YES;
+  [plugin launchUIImagePickerWithSource:[FLTSourceSpecification makeWithType:FLTSourceTypeGallery
+                                                                      camera:FLTSourceCameraRear]
+                                context:context];
+  XCTAssertEqual(controller.sourceType, UIImagePickerControllerSourceTypePhotoLibrary);
+}
+
+- (void)testPhotoAccessNotDeterminedGrantedShowsLibrary {
+  id photoLibrary = OCMClassMock([PHPhotoLibrary class]);
+  OCMStub(ClassMethod([photoLibrary authorizationStatus]))
+      .andReturn(PHAuthorizationStatusNotDetermined);
+  OCMStub(ClassMethod([photoLibrary requestAuthorization:OCMOCK_ANY]))
+      .andDo(^(NSInvocation *invocation) {
+        void (^handler)(PHAuthorizationStatus status);
+        [invocation getArgument:&handler atIndex:2];
+        handler(PHAuthorizationStatusAuthorized);
+      });
+
+  FLTImagePickerPlugin *plugin =
+      [[FLTImagePickerPlugin alloc] initWithViewProvider:[[StubViewProvider alloc] init]];
+  UIImagePickerController *controller = [[UIImagePickerController alloc] init];
+  [plugin setImagePickerControllerOverrides:@[ controller ]];
+
+  XCTestExpectation *shown = [self expectationWithDescription:@"library shown"];
+  FLTImagePickerMethodCallContext *context = [[FLTImagePickerMethodCallContext alloc]
+      initWithResult:^(NSArray<NSString *> *result, FlutterError *error){
+      }];
+  context.includeImages = YES;
+  context.requestFullMetadata = YES;
+  [plugin launchUIImagePickerWithSource:[FLTSourceSpecification makeWithType:FLTSourceTypeGallery
+                                                                      camera:FLTSourceCameraRear]
+                                context:context];
+  dispatch_async(dispatch_get_main_queue(), ^{
+    XCTAssertEqual(controller.sourceType, UIImagePickerControllerSourceTypePhotoLibrary);
+    [shown fulfill];
+  });
+  [self waitForExpectationsWithTimeout:30 handler:nil];
+}
+
+- (void)testPhotoAccessNotDeterminedDeniedReturnsError {
+  id photoLibrary = OCMClassMock([PHPhotoLibrary class]);
+  OCMStub(ClassMethod([photoLibrary authorizationStatus]))
+      .andReturn(PHAuthorizationStatusNotDetermined);
+  OCMStub(ClassMethod([photoLibrary requestAuthorization:OCMOCK_ANY]))
+      .andDo(^(NSInvocation *invocation) {
+        void (^handler)(PHAuthorizationStatus status);
+        [invocation getArgument:&handler atIndex:2];
+        handler(PHAuthorizationStatusDenied);
+      });
+
+  FLTImagePickerPlugin *plugin =
+      [[FLTImagePickerPlugin alloc] initWithViewProvider:[[StubViewProvider alloc] init]];
+  [plugin setImagePickerControllerOverrides:@[ [[UIImagePickerController alloc] init] ]];
+
+  XCTestExpectation *resultExpectation = [self expectationWithDescription:@"denied after prompt"];
+  FLTImagePickerMethodCallContext *context = [[FLTImagePickerMethodCallContext alloc]
+      initWithResult:^(NSArray<NSString *> *result, FlutterError *error) {
+        XCTAssertEqualObjects(error.code, @"photo_access_denied");
+        [resultExpectation fulfill];
+      }];
+  context.includeImages = YES;
+  context.requestFullMetadata = YES;
+  [plugin launchUIImagePickerWithSource:[FLTSourceSpecification makeWithType:FLTSourceTypeGallery
+                                                                      camera:FLTSourceCameraRear]
+                                context:context];
+  [self waitForExpectationsWithTimeout:30 handler:nil];
+}
+
+- (void)testPhotoAccessLimitedReturnsDeniedError API_AVAILABLE(ios(14)) {
+  // Current behavior: Limited is not handled explicitly and falls through to the default
+  // denied error. Documented here so a later migration does not change it silently.
+  id photoLibrary = OCMClassMock([PHPhotoLibrary class]);
+  OCMStub(ClassMethod([photoLibrary authorizationStatus])).andReturn(PHAuthorizationStatusLimited);
+
+  FLTImagePickerPlugin *plugin =
+      [[FLTImagePickerPlugin alloc] initWithViewProvider:[[StubViewProvider alloc] init]];
+  [plugin setImagePickerControllerOverrides:@[ [[UIImagePickerController alloc] init] ]];
+
+  XCTestExpectation *resultExpectation = [self expectationWithDescription:@"limited"];
+  FLTImagePickerMethodCallContext *context = [[FLTImagePickerMethodCallContext alloc]
+      initWithResult:^(NSArray<NSString *> *result, FlutterError *error) {
+        XCTAssertEqualObjects(error.code, @"photo_access_denied");
+        [resultExpectation fulfill];
+      }];
+  context.includeImages = YES;
+  context.requestFullMetadata = YES;
+  [plugin launchUIImagePickerWithSource:[FLTSourceSpecification makeWithType:FLTSourceTypeGallery
+                                                                      camera:FLTSourceCameraRear]
+                                context:context];
+  [self waitForExpectationsWithTimeout:30 handler:nil];
+}
+
+- (void)testPhotoAccessUnknownStatusTreatedAsDenied {
+  id photoLibrary = OCMClassMock([PHPhotoLibrary class]);
+  OCMStub(ClassMethod([photoLibrary authorizationStatus])).andReturn((PHAuthorizationStatus)999);
+
+  FLTImagePickerPlugin *plugin =
+      [[FLTImagePickerPlugin alloc] initWithViewProvider:[[StubViewProvider alloc] init]];
+  [plugin setImagePickerControllerOverrides:@[ [[UIImagePickerController alloc] init] ]];
+
+  XCTestExpectation *resultExpectation = [self expectationWithDescription:@"unknown photo denied"];
+  FLTImagePickerMethodCallContext *context = [[FLTImagePickerMethodCallContext alloc]
+      initWithResult:^(NSArray<NSString *> *result, FlutterError *error) {
+        XCTAssertEqualObjects(error.code, @"photo_access_denied");
+        [resultExpectation fulfill];
+      }];
+  context.includeImages = YES;
+  context.requestFullMetadata = YES;
+  [plugin launchUIImagePickerWithSource:[FLTSourceSpecification makeWithType:FLTSourceTypeGallery
+                                                                      camera:FLTSourceCameraRear]
+                                context:context];
+  [self waitForExpectationsWithTimeout:30 handler:nil];
+}
+
+- (void)testLaunchUIImagePickerInvalidSourceReturnsError {
+  FLTImagePickerPlugin *plugin =
+      [[FLTImagePickerPlugin alloc] initWithViewProvider:[[StubViewProvider alloc] init]];
+  [plugin setImagePickerControllerOverrides:@[ [[UIImagePickerController alloc] init] ]];
+
+  XCTestExpectation *resultExpectation = [self expectationWithDescription:@"invalid source"];
+  FLTImagePickerMethodCallContext *context = [[FLTImagePickerMethodCallContext alloc]
+      initWithResult:^(NSArray<NSString *> *result, FlutterError *error) {
+        XCTAssertEqualObjects(error.code, @"invalid_source");
+        [resultExpectation fulfill];
+      }];
+  context.includeImages = YES;
+  FLTSourceSpecification *source = [FLTSourceSpecification makeWithType:FLTSourceTypeGallery
+                                                                 camera:FLTSourceCameraRear];
+  source.type = (FLTSourceType)99;
+  [plugin launchUIImagePickerWithSource:source context:context];
+  [self waitForExpectationsWithTimeout:30 handler:nil];
+}
+
+- (void)testLaunchUIImagePickerSetsImageAndVideoMediaTypes {
+  id mockAVCaptureDevice = OCMClassMock([AVCaptureDevice class]);
+  OCMStub([mockAVCaptureDevice authorizationStatusForMediaType:AVMediaTypeVideo])
+      .andReturn(AVAuthorizationStatusDenied);
+
+  FLTImagePickerPlugin *plugin =
+      [[FLTImagePickerPlugin alloc] initWithViewProvider:[[StubViewProvider alloc] init]];
+  UIImagePickerController *controller = [[UIImagePickerController alloc] init];
+  [plugin setImagePickerControllerOverrides:@[ controller ]];
+
+  FLTImagePickerMethodCallContext *context = [[FLTImagePickerMethodCallContext alloc]
+      initWithResult:^(NSArray<NSString *> *result, FlutterError *error){
+      }];
+  context.includeImages = YES;
+  context.includeVideo = YES;
+  context.maxDuration = 42;
+  [plugin launchUIImagePickerWithSource:[FLTSourceSpecification makeWithType:FLTSourceTypeCamera
+                                                                      camera:FLTSourceCameraRear]
+                                context:context];
+  XCTAssertEqual(controller.videoMaximumDuration, 42);
+  XCTAssertEqual(controller.videoQuality, UIImagePickerControllerQualityTypeHigh);
+  XCTAssertTrue([controller.mediaTypes containsObject:(NSString *)kUTTypeImage]);
+  XCTAssertTrue([controller.mediaTypes containsObject:(NSString *)kUTTypeMovie]);
+}
+
+- (void)testImagePickerDidFinishPickingOriginalImage {
+  FLTImagePickerPlugin *plugin =
+      [[FLTImagePickerPlugin alloc] initWithViewProvider:[[StubViewProvider alloc] init]];
+  UIImage *image = [UIImage imageWithData:ImagePickerTestImages.JPGTestData];
+  XCTestExpectation *resultExpectation = [self expectationWithDescription:@"image saved"];
+  plugin.callContext = [[FLTImagePickerMethodCallContext alloc]
+      initWithResult:^(NSArray<NSString *> *result, FlutterError *error) {
+        XCTAssertEqual(result.count, 1);
+        XCTAssertTrue([[NSFileManager defaultManager] fileExistsAtPath:result.firstObject]);
+        [resultExpectation fulfill];
+      }];
+  plugin.callContext.maxSize = [[FLTMaxSize alloc] init];
+  plugin.callContext.requestFullMetadata = NO;
+  UIImagePickerController *picker = [[UIImagePickerController alloc] init];
+  [plugin imagePickerController:picker
+      didFinishPickingMediaWithInfo:@{UIImagePickerControllerOriginalImage : image}];
+  [self waitForExpectationsWithTimeout:30 handler:nil];
+}
+
+- (void)testImagePickerDidFinishPickingPrefersEditedImage {
+  FLTImagePickerPlugin *plugin =
+      [[FLTImagePickerPlugin alloc] initWithViewProvider:[[StubViewProvider alloc] init]];
+  UIImage *original = [UIImage imageWithData:ImagePickerTestImages.JPGTestData];
+  UIImage *edited = [UIImage imageWithData:ImagePickerTestImages.PNGTestData];
+  XCTestExpectation *resultExpectation = [self expectationWithDescription:@"edited saved"];
+  plugin.callContext = [[FLTImagePickerMethodCallContext alloc]
+      initWithResult:^(NSArray<NSString *> *result, FlutterError *error) {
+        XCTAssertEqual(result.count, 1);
+        [resultExpectation fulfill];
+      }];
+  plugin.callContext.maxSize = [[FLTMaxSize alloc] init];
+  plugin.callContext.requestFullMetadata = NO;
+  UIImagePickerController *picker = [[UIImagePickerController alloc] init];
+  [plugin imagePickerController:picker
+      didFinishPickingMediaWithInfo:@{
+        UIImagePickerControllerOriginalImage : original,
+        UIImagePickerControllerEditedImage : edited
+      }];
+  [self waitForExpectationsWithTimeout:30 handler:nil];
+}
+
+- (void)testImagePickerDidFinishPickingScalesImage {
+  FLTImagePickerPlugin *plugin =
+      [[FLTImagePickerPlugin alloc] initWithViewProvider:[[StubViewProvider alloc] init]];
+  UIImage *image = [UIImage imageWithData:ImagePickerTestImages.JPGTestData];
+  XCTestExpectation *resultExpectation = [self expectationWithDescription:@"scaled"];
+  plugin.callContext = [[FLTImagePickerMethodCallContext alloc]
+      initWithResult:^(NSArray<NSString *> *result, FlutterError *error) {
+        XCTAssertEqual(result.count, 1);
+        UIImage *saved = [UIImage imageWithContentsOfFile:result.firstObject];
+        XCTAssertEqual(saved.size.width, 3);
+        XCTAssertEqual(saved.size.height, 2);
+        [resultExpectation fulfill];
+      }];
+  plugin.callContext.maxSize = [FLTMaxSize makeWithWidth:@3 height:@2];
+  plugin.callContext.requestFullMetadata = NO;
+  UIImagePickerController *picker = [[UIImagePickerController alloc] init];
+  [plugin imagePickerController:picker
+      didFinishPickingMediaWithInfo:@{UIImagePickerControllerOriginalImage : image}];
+  [self waitForExpectationsWithTimeout:30 handler:nil];
+}
+
+- (void)testImagePickerDidFinishPickingWithFullMetadataAsset {
+  UIImage *image = [UIImage imageWithData:ImagePickerTestImages.JPGTestData];
+  id mockAsset = OCMClassMock([PHAsset class]);
+  id mockManager = OCMClassMock([PHImageManager class]);
+  OCMStub(ClassMethod([mockManager defaultManager])).andReturn(mockManager);
+  OCMStub([mockManager requestImageDataAndOrientationForAsset:OCMOCK_ANY
+                                                      options:OCMOCK_ANY
+                                                resultHandler:OCMOCK_ANY])
+      .andDo(^(NSInvocation *invocation) {
+        void (^handler)(NSData *, NSString *, CGImagePropertyOrientation, NSDictionary *);
+        [invocation getArgument:&handler atIndex:4];
+        handler(ImagePickerTestImages.JPGTestData, @"public.jpeg", kCGImagePropertyOrientationUp,
+                nil);
+      });
+
+  FLTImagePickerPlugin *plugin =
+      [[FLTImagePickerPlugin alloc] initWithViewProvider:[[StubViewProvider alloc] init]];
+  XCTestExpectation *resultExpectation = [self expectationWithDescription:@"asset saved"];
+  plugin.callContext = [[FLTImagePickerMethodCallContext alloc]
+      initWithResult:^(NSArray<NSString *> *result, FlutterError *error) {
+        XCTAssertEqual(result.count, 1);
+        [resultExpectation fulfill];
+      }];
+  plugin.callContext.maxSize = [[FLTMaxSize alloc] init];
+  plugin.callContext.requestFullMetadata = YES;
+
+  UIImagePickerController *picker = [[UIImagePickerController alloc] init];
+  [plugin imagePickerController:picker
+      didFinishPickingMediaWithInfo:@{
+        UIImagePickerControllerOriginalImage : image,
+        UIImagePickerControllerPHAsset : mockAsset
+      }];
+  [self waitForExpectationsWithTimeout:30 handler:nil];
+}
+
+- (void)testImagePickerDidFinishPickingFullMetadataWithoutAsset {
+  FLTImagePickerPlugin *plugin =
+      [[FLTImagePickerPlugin alloc] initWithViewProvider:[[StubViewProvider alloc] init]];
+  UIImage *image = [UIImage imageWithData:ImagePickerTestImages.JPGTestData];
+  XCTestExpectation *resultExpectation = [self expectationWithDescription:@"saved without asset"];
+  plugin.callContext = [[FLTImagePickerMethodCallContext alloc]
+      initWithResult:^(NSArray<NSString *> *result, FlutterError *error) {
+        XCTAssertEqual(result.count, 1);
+        [resultExpectation fulfill];
+      }];
+  plugin.callContext.maxSize = [[FLTMaxSize alloc] init];
+  plugin.callContext.requestFullMetadata = YES;
+  UIImagePickerController *picker = [[UIImagePickerController alloc] init];
+  [plugin imagePickerController:picker
+      didFinishPickingMediaWithInfo:@{UIImagePickerControllerOriginalImage : image}];
+  [self waitForExpectationsWithTimeout:30 handler:nil];
+}
+
+- (void)testImagePickerDidFinishPickingVideo {
+  NSString *sourcePath = [NSTemporaryDirectory()
+      stringByAppendingPathComponent:[[NSUUID UUID].UUIDString
+                                         stringByAppendingPathExtension:@"mov"]];
+  XCTAssertTrue([[NSFileManager defaultManager]
+      createFileAtPath:sourcePath
+              contents:[@"video" dataUsingEncoding:NSUTF8StringEncoding]
+            attributes:nil]);
+
+  FLTImagePickerPlugin *plugin =
+      [[FLTImagePickerPlugin alloc] initWithViewProvider:[[StubViewProvider alloc] init]];
+  XCTestExpectation *resultExpectation = [self expectationWithDescription:@"video saved"];
+  plugin.callContext = [[FLTImagePickerMethodCallContext alloc]
+      initWithResult:^(NSArray<NSString *> *result, FlutterError *error) {
+        XCTAssertEqual(result.count, 1);
+        XCTAssertTrue([[NSFileManager defaultManager] fileExistsAtPath:result.firstObject]);
+        [resultExpectation fulfill];
+      }];
+  UIImagePickerController *picker = [[UIImagePickerController alloc] init];
+  [plugin imagePickerController:picker
+      didFinishPickingMediaWithInfo:@{
+        UIImagePickerControllerMediaURL : [NSURL fileURLWithPath:sourcePath]
+      }];
+  [self waitForExpectationsWithTimeout:30 handler:nil];
+  [[NSFileManager defaultManager] removeItemAtPath:sourcePath error:nil];
+}
+
+- (void)testImagePickerDidFinishPickingVideoCopyFailure {
+  FLTImagePickerPlugin *plugin =
+      [[FLTImagePickerPlugin alloc] initWithViewProvider:[[StubViewProvider alloc] init]];
+  XCTestExpectation *resultExpectation = [self expectationWithDescription:@"copy failed"];
+  plugin.callContext = [[FLTImagePickerMethodCallContext alloc]
+      initWithResult:^(NSArray<NSString *> *result, FlutterError *error) {
+        XCTAssertEqualObjects(error.code, @"flutter_image_picker_copy_video_error");
+        [resultExpectation fulfill];
+      }];
+  UIImagePickerController *picker = [[UIImagePickerController alloc] init];
+  [plugin imagePickerController:picker
+      didFinishPickingMediaWithInfo:@{
+        UIImagePickerControllerMediaURL :
+            [NSURL fileURLWithPath:@"/this/path/does/not/exist.mov"]
+      }];
+  [self waitForExpectationsWithTimeout:30 handler:nil];
+}
+
+- (void)testImagePickerDidFinishPickingIgnoredWhenNoCallContext {
+  FLTImagePickerPlugin *plugin =
+      [[FLTImagePickerPlugin alloc] initWithViewProvider:[[StubViewProvider alloc] init]];
+  UIImage *image = [UIImage imageWithData:ImagePickerTestImages.JPGTestData];
+  UIImagePickerController *picker = [[UIImagePickerController alloc] init];
+  [plugin imagePickerController:picker
+      didFinishPickingMediaWithInfo:@{UIImagePickerControllerOriginalImage : image}];
 }
 
 @end

--- a/packages/image_picker/image_picker_ios/example/ios/RunnerTests/ImagePickerPluginTests.m
+++ b/packages/image_picker/image_picker_ios/example/ios/RunnerTests/ImagePickerPluginTests.m
@@ -17,6 +17,9 @@
 @property(nonatomic, strong) UIWindow *interactionBlockerWindow;
 @property(nonatomic, weak) UIWindow *previousKeyWindow;
 - (void)removeInteractionBlocker;
+- (void)showCamera:(UIImagePickerControllerCameraDevice)device
+    withImagePicker:(UIImagePickerController *)imagePickerController;
+- (UIViewController *)presentingViewControllerForImagePickerInNewWindow;
 @end
 
 @interface MockViewController : UIViewController
@@ -813,6 +816,419 @@
                    }];
 
   OCMVerifyAll(mockPickerViewController);
+}
+
+- (void)testPickImageInvalidResultWhenMultiplePathsReturned {
+  FLTImagePickerPlugin *plugin =
+      [[FLTImagePickerPlugin alloc] initWithViewProvider:[[StubViewProvider alloc] init]];
+  XCTestExpectation *resultExpectation = [self expectationWithDescription:@"invalid_result"];
+  __block NSInteger completionCount = 0;
+  [plugin pickImageWithSource:[FLTSourceSpecification makeWithType:FLTSourceTypeGallery
+                                                            camera:FLTSourceCameraRear]
+                      maxSize:[[FLTMaxSize alloc] init]
+                      quality:nil
+                 fullMetadata:NO
+                   completion:^(NSString *result, FlutterError *error) {
+                     completionCount += 1;
+                     if (completionCount == 1) {
+                       // Current behavior: the invalid_result error is sent, then the adapter
+                       // also forwards paths.firstObject.
+                       XCTAssertNil(result);
+                       XCTAssertEqualObjects(error.code, @"invalid_result");
+                     } else {
+                       XCTAssertEqualObjects(result, @"a");
+                       [resultExpectation fulfill];
+                     }
+                   }];
+  [plugin sendCallResultWithSavedPathList:@[ @"a", @"b" ]];
+  [self waitForExpectationsWithTimeout:30 handler:nil];
+  XCTAssertEqual(completionCount, 2);
+}
+
+- (void)testPickVideoInvalidResultWhenMultiplePathsReturned {
+  FLTImagePickerPlugin *plugin =
+      [[FLTImagePickerPlugin alloc] initWithViewProvider:[[StubViewProvider alloc] init]];
+  XCTestExpectation *resultExpectation = [self expectationWithDescription:@"invalid_result"];
+  __block NSInteger completionCount = 0;
+  [plugin pickVideoWithSource:[FLTSourceSpecification makeWithType:FLTSourceTypeGallery
+                                                            camera:FLTSourceCameraRear]
+                  maxDuration:nil
+                   completion:^(NSString *result, FlutterError *error) {
+                     completionCount += 1;
+                     if (completionCount == 1) {
+                       XCTAssertNil(result);
+                       XCTAssertEqualObjects(error.code, @"invalid_result");
+                     } else {
+                       XCTAssertEqualObjects(result, @"a");
+                       [resultExpectation fulfill];
+                     }
+                   }];
+  [plugin sendCallResultWithSavedPathList:@[ @"a", @"b" ]];
+  [self waitForExpectationsWithTimeout:30 handler:nil];
+  XCTAssertEqual(completionCount, 2);
+}
+
+- (void)testPHPickerCancelSendsEmptyPathList API_AVAILABLE(ios(14)) {
+  id mockPickerViewController = OCMClassMock([PHPickerViewController class]);
+  FLTImagePickerPlugin *plugin =
+      [[FLTImagePickerPlugin alloc] initWithViewProvider:[[StubViewProvider alloc] init]];
+  XCTestExpectation *resultExpectation = [self expectationWithDescription:@"cancelled"];
+  plugin.callContext = [[FLTImagePickerMethodCallContext alloc]
+      initWithResult:^(NSArray<NSString *> *result, FlutterError *error) {
+        XCTAssertEqualObjects(result, @[]);
+        XCTAssertNil(error);
+        [resultExpectation fulfill];
+      }];
+  [plugin picker:mockPickerViewController didFinishPicking:@[]];
+  [self waitForExpectationsWithTimeout:30 handler:nil];
+}
+
+- (void)testPresentationControllerDidDismissSendsEmptyPathList {
+  FLTImagePickerPlugin *plugin =
+      [[FLTImagePickerPlugin alloc] initWithViewProvider:[[StubViewProvider alloc] init]];
+  XCTestExpectation *resultExpectation = [self expectationWithDescription:@"dismissed"];
+  plugin.callContext = [[FLTImagePickerMethodCallContext alloc]
+      initWithResult:^(NSArray<NSString *> *result, FlutterError *error) {
+        XCTAssertEqualObjects(result, @[]);
+        XCTAssertNil(error);
+        [resultExpectation fulfill];
+      }];
+  id mockPresentationController = OCMClassMock([UIPresentationController class]);
+  [plugin presentationControllerDidDismiss:mockPresentationController];
+  [self waitForExpectationsWithTimeout:30 handler:nil];
+}
+
+- (void)testDesiredImageQualityClampsOutOfRangeValues API_AVAILABLE(ios(14)) {
+  id mockPickerViewController = OCMClassMock([PHPickerViewController class]);
+  NSURL *pngURL = [[NSBundle bundleForClass:[self class]] URLForResource:@"pngImage"
+                                                           withExtension:@"png"];
+  NSItemProvider *pngItemProvider = [[NSItemProvider alloc] initWithContentsOfURL:pngURL];
+  PHPickerResult *pngResult = OCMClassMock([PHPickerResult class]);
+  OCMStub([pngResult itemProvider]).andReturn(pngItemProvider);
+
+  FLTImagePickerPlugin *plugin =
+      [[FLTImagePickerPlugin alloc] initWithViewProvider:[[StubViewProvider alloc] init]];
+  XCTestExpectation *resultExpectation = [self expectationWithDescription:@"saved"];
+  plugin.callContext = [[FLTImagePickerMethodCallContext alloc]
+      initWithResult:^(NSArray<NSString *> *result, FlutterError *error) {
+        XCTAssertEqual(result.count, 1);
+        XCTAssertNil(error);
+        [resultExpectation fulfill];
+      }];
+  plugin.callContext.imageQuality = @(-1);
+  [plugin picker:mockPickerViewController didFinishPicking:@[ pngResult ]];
+  [self waitForExpectationsWithTimeout:30 handler:nil];
+}
+
+- (void)testDesiredImageQualityScalesValidPercent API_AVAILABLE(ios(14)) {
+  id mockPickerViewController = OCMClassMock([PHPickerViewController class]);
+  NSURL *pngURL = [[NSBundle bundleForClass:[self class]] URLForResource:@"pngImage"
+                                                           withExtension:@"png"];
+  NSItemProvider *pngItemProvider = [[NSItemProvider alloc] initWithContentsOfURL:pngURL];
+  PHPickerResult *pngResult = OCMClassMock([PHPickerResult class]);
+  OCMStub([pngResult itemProvider]).andReturn(pngItemProvider);
+
+  FLTImagePickerPlugin *plugin =
+      [[FLTImagePickerPlugin alloc] initWithViewProvider:[[StubViewProvider alloc] init]];
+  XCTestExpectation *resultExpectation = [self expectationWithDescription:@"saved"];
+  plugin.callContext = [[FLTImagePickerMethodCallContext alloc]
+      initWithResult:^(NSArray<NSString *> *result, FlutterError *error) {
+        XCTAssertEqual(result.count, 1);
+        XCTAssertNil(error);
+        [resultExpectation fulfill];
+      }];
+  plugin.callContext.imageQuality = @50;
+  plugin.callContext.maxSize = [FLTMaxSize makeWithWidth:@3 height:@2];
+  [plugin picker:mockPickerViewController didFinishPicking:@[ pngResult ]];
+  [self waitForExpectationsWithTimeout:30 handler:nil];
+}
+
+- (void)testDesiredImageQualityOver100IsClamped API_AVAILABLE(ios(14)) {
+  id mockPickerViewController = OCMClassMock([PHPickerViewController class]);
+  NSURL *pngURL = [[NSBundle bundleForClass:[self class]] URLForResource:@"pngImage"
+                                                           withExtension:@"png"];
+  NSItemProvider *pngItemProvider = [[NSItemProvider alloc] initWithContentsOfURL:pngURL];
+  PHPickerResult *pngResult = OCMClassMock([PHPickerResult class]);
+  OCMStub([pngResult itemProvider]).andReturn(pngItemProvider);
+
+  FLTImagePickerPlugin *plugin =
+      [[FLTImagePickerPlugin alloc] initWithViewProvider:[[StubViewProvider alloc] init]];
+  XCTestExpectation *resultExpectation = [self expectationWithDescription:@"saved"];
+  plugin.callContext = [[FLTImagePickerMethodCallContext alloc]
+      initWithResult:^(NSArray<NSString *> *result, FlutterError *error) {
+        XCTAssertEqual(result.count, 1);
+        [resultExpectation fulfill];
+      }];
+  plugin.callContext.imageQuality = @150;
+  [plugin picker:mockPickerViewController didFinishPicking:@[ pngResult ]];
+  [self waitForExpectationsWithTimeout:30 handler:nil];
+}
+
+- (void)testCameraAccessDeniedReturnsError {
+  id mockAVCaptureDevice = OCMClassMock([AVCaptureDevice class]);
+  OCMStub([mockAVCaptureDevice authorizationStatusForMediaType:AVMediaTypeVideo])
+      .andReturn(AVAuthorizationStatusDenied);
+
+  FLTImagePickerPlugin *plugin =
+      [[FLTImagePickerPlugin alloc] initWithViewProvider:[[StubViewProvider alloc] init]];
+  [plugin setImagePickerControllerOverrides:@[ [[UIImagePickerController alloc] init] ]];
+
+  XCTestExpectation *resultExpectation = [self expectationWithDescription:@"denied"];
+  [plugin pickImageWithSource:[FLTSourceSpecification makeWithType:FLTSourceTypeCamera
+                                                            camera:FLTSourceCameraRear]
+                      maxSize:[[FLTMaxSize alloc] init]
+                      quality:nil
+                 fullMetadata:YES
+                   completion:^(NSString *result, FlutterError *error) {
+                     XCTAssertEqualObjects(error.code, @"camera_access_denied");
+                     [resultExpectation fulfill];
+                   }];
+  [self waitForExpectationsWithTimeout:30 handler:nil];
+}
+
+- (void)testCameraAccessRestrictedReturnsError {
+  id mockAVCaptureDevice = OCMClassMock([AVCaptureDevice class]);
+  OCMStub([mockAVCaptureDevice authorizationStatusForMediaType:AVMediaTypeVideo])
+      .andReturn(AVAuthorizationStatusRestricted);
+
+  FLTImagePickerPlugin *plugin =
+      [[FLTImagePickerPlugin alloc] initWithViewProvider:[[StubViewProvider alloc] init]];
+  [plugin setImagePickerControllerOverrides:@[ [[UIImagePickerController alloc] init] ]];
+
+  XCTestExpectation *resultExpectation = [self expectationWithDescription:@"restricted"];
+  [plugin pickImageWithSource:[FLTSourceSpecification makeWithType:FLTSourceTypeCamera
+                                                            camera:FLTSourceCameraRear]
+                      maxSize:[[FLTMaxSize alloc] init]
+                      quality:nil
+                 fullMetadata:YES
+                   completion:^(NSString *result, FlutterError *error) {
+                     XCTAssertEqualObjects(error.code, @"camera_access_restricted");
+                     [resultExpectation fulfill];
+                   }];
+  [self waitForExpectationsWithTimeout:30 handler:nil];
+}
+
+- (void)testCameraAccessNotDeterminedDenied {
+  id mockAVCaptureDevice = OCMClassMock([AVCaptureDevice class]);
+  OCMStub([mockAVCaptureDevice authorizationStatusForMediaType:AVMediaTypeVideo])
+      .andReturn(AVAuthorizationStatusNotDetermined);
+  OCMStub([mockAVCaptureDevice requestAccessForMediaType:AVMediaTypeVideo
+                                       completionHandler:OCMOCK_ANY])
+      .andDo(^(NSInvocation *invocation) {
+        void (^handler)(BOOL granted);
+        [invocation getArgument:&handler atIndex:3];
+        handler(NO);
+      });
+
+  FLTImagePickerPlugin *plugin =
+      [[FLTImagePickerPlugin alloc] initWithViewProvider:[[StubViewProvider alloc] init]];
+  [plugin setImagePickerControllerOverrides:@[ [[UIImagePickerController alloc] init] ]];
+
+  XCTestExpectation *resultExpectation = [self expectationWithDescription:@"request denied"];
+  [plugin pickImageWithSource:[FLTSourceSpecification makeWithType:FLTSourceTypeCamera
+                                                            camera:FLTSourceCameraRear]
+                      maxSize:[[FLTMaxSize alloc] init]
+                      quality:nil
+                 fullMetadata:YES
+                   completion:^(NSString *result, FlutterError *error) {
+                     XCTAssertEqualObjects(error.code, @"camera_access_denied");
+                     [resultExpectation fulfill];
+                   }];
+  [self waitForExpectationsWithTimeout:30 handler:nil];
+}
+
+- (void)testCameraAccessNotDeterminedGrantedPresentsCamera {
+  id mockUIImagePicker = OCMClassMock([UIImagePickerController class]);
+  id mockAVCaptureDevice = OCMClassMock([AVCaptureDevice class]);
+  OCMStub(ClassMethod(
+              [mockUIImagePicker isSourceTypeAvailable:UIImagePickerControllerSourceTypeCamera]))
+      .andReturn(YES);
+  OCMStub(ClassMethod(
+              [mockUIImagePicker isCameraDeviceAvailable:UIImagePickerControllerCameraDeviceRear]))
+      .andReturn(YES);
+  OCMStub([mockAVCaptureDevice authorizationStatusForMediaType:AVMediaTypeVideo])
+      .andReturn(AVAuthorizationStatusNotDetermined);
+  OCMStub([mockAVCaptureDevice requestAccessForMediaType:AVMediaTypeVideo
+                                       completionHandler:OCMOCK_ANY])
+      .andDo(^(NSInvocation *invocation) {
+        void (^handler)(BOOL granted);
+        [invocation getArgument:&handler atIndex:3];
+        handler(YES);
+      });
+
+  FLTImagePickerPlugin *plugin =
+      [[FLTImagePickerPlugin alloc] initWithViewProvider:[[StubViewProvider alloc] init]];
+  UIImagePickerController *controller = [[UIImagePickerController alloc] init];
+  [plugin setImagePickerControllerOverrides:@[ controller ]];
+
+  XCTestExpectation *presented = [self expectationWithDescription:@"camera presented"];
+  [plugin pickImageWithSource:[FLTSourceSpecification makeWithType:FLTSourceTypeCamera
+                                                            camera:FLTSourceCameraRear]
+                      maxSize:[[FLTMaxSize alloc] init]
+                      quality:nil
+                 fullMetadata:YES
+                   completion:^(NSString *result, FlutterError *error){
+                   }];
+  dispatch_async(dispatch_get_main_queue(), ^{
+    XCTAssertEqual(controller.sourceType, UIImagePickerControllerSourceTypeCamera);
+    [presented fulfill];
+  });
+  [self waitForExpectationsWithTimeout:30 handler:nil];
+}
+
+- (void)testShowCameraWhenUnavailableSendsNilPathList {
+  id mockUIImagePicker = OCMClassMock([UIImagePickerController class]);
+  id mockAVCaptureDevice = OCMClassMock([AVCaptureDevice class]);
+  OCMStub(ClassMethod(
+              [mockUIImagePicker isSourceTypeAvailable:UIImagePickerControllerSourceTypeCamera]))
+      .andReturn(NO);
+  OCMStub([mockAVCaptureDevice authorizationStatusForMediaType:AVMediaTypeVideo])
+      .andReturn(AVAuthorizationStatusAuthorized);
+
+  FLTImagePickerPlugin *plugin =
+      [[FLTImagePickerPlugin alloc] initWithViewProvider:[[StubViewProvider alloc] init]];
+  [plugin setImagePickerControllerOverrides:@[ [[UIImagePickerController alloc] init] ]];
+
+  XCTestExpectation *resultExpectation = [self expectationWithDescription:@"unavailable"];
+  [plugin pickImageWithSource:[FLTSourceSpecification makeWithType:FLTSourceTypeCamera
+                                                            camera:FLTSourceCameraRear]
+                      maxSize:[[FLTMaxSize alloc] init]
+                      quality:nil
+                 fullMetadata:YES
+                   completion:^(NSString *result, FlutterError *error) {
+                     XCTAssertNil(result);
+                     XCTAssertNil(error);
+                     [resultExpectation fulfill];
+                   }];
+  [self waitForExpectationsWithTimeout:30 handler:nil];
+}
+
+- (void)testShowCameraReturnsEarlyWhenAlreadyBeingPresented {
+  id mockPicker = OCMClassMock([UIImagePickerController class]);
+  OCMStub([mockPicker isBeingPresented]).andReturn(YES);
+
+  FLTImagePickerPlugin *plugin =
+      [[FLTImagePickerPlugin alloc] initWithViewProvider:[[StubViewProvider alloc] init]];
+  [plugin showCamera:UIImagePickerControllerCameraDeviceRear withImagePicker:mockPicker];
+  OCMVerify(times(0), [mockPicker setSourceType:UIImagePickerControllerSourceTypeCamera]);
+}
+
+- (void)testCameraAccessUnknownStatusTreatedAsDenied {
+  id mockAVCaptureDevice = OCMClassMock([AVCaptureDevice class]);
+  OCMStub([mockAVCaptureDevice authorizationStatusForMediaType:AVMediaTypeVideo])
+      .andReturn((AVAuthorizationStatus)999);
+
+  FLTImagePickerPlugin *plugin =
+      [[FLTImagePickerPlugin alloc] initWithViewProvider:[[StubViewProvider alloc] init]];
+  [plugin setImagePickerControllerOverrides:@[ [[UIImagePickerController alloc] init] ]];
+
+  XCTestExpectation *resultExpectation = [self expectationWithDescription:@"unknown denied"];
+  [plugin pickImageWithSource:[FLTSourceSpecification makeWithType:FLTSourceTypeCamera
+                                                            camera:FLTSourceCameraRear]
+                      maxSize:[[FLTMaxSize alloc] init]
+                      quality:nil
+                 fullMetadata:YES
+                   completion:^(NSString *result, FlutterError *error) {
+                     XCTAssertEqualObjects(error.code, @"camera_access_denied");
+                     [resultExpectation fulfill];
+                   }];
+  [self waitForExpectationsWithTimeout:30 handler:nil];
+}
+
+- (void)testShowCameraUnavailableAlertOKHandler {
+  id mockUIImagePicker = OCMClassMock([UIImagePickerController class]);
+  id mockAVCaptureDevice = OCMClassMock([AVCaptureDevice class]);
+  OCMStub(ClassMethod(
+              [mockUIImagePicker isSourceTypeAvailable:UIImagePickerControllerSourceTypeCamera]))
+      .andReturn(NO);
+  OCMStub([mockAVCaptureDevice authorizationStatusForMediaType:AVMediaTypeVideo])
+      .andReturn(AVAuthorizationStatusAuthorized);
+
+  UIWindowScene *scene =
+      (UIWindowScene *)UIApplication.sharedApplication.connectedScenes.allObjects.firstObject;
+  UIWindow *window = [[UIWindow alloc] initWithWindowScene:scene];
+  window.frame = scene.coordinateSpace.bounds;
+  UIViewController *rootViewController = [[UIViewController alloc] init];
+  window.rootViewController = rootViewController;
+  [rootViewController loadViewIfNeeded];
+  [window makeKeyAndVisible];
+
+  FLTImagePickerPlugin *plugin = [[FLTImagePickerPlugin alloc]
+      initWithViewProvider:[[StubViewProvider alloc] initWithViewController:rootViewController]];
+  [plugin setImagePickerControllerOverrides:@[ [[UIImagePickerController alloc] init] ]];
+
+  XCTestExpectation *resultExpectation = [self expectationWithDescription:@"unavailable"];
+  [plugin pickImageWithSource:[FLTSourceSpecification makeWithType:FLTSourceTypeCamera
+                                                            camera:FLTSourceCameraRear]
+                      maxSize:[[FLTMaxSize alloc] init]
+                      quality:nil
+                 fullMetadata:YES
+                   completion:^(NSString *result, FlutterError *error) {
+                     XCTAssertNil(result);
+                     [resultExpectation fulfill];
+                   }];
+  [self waitForExpectationsWithTimeout:30 handler:nil];
+
+  UIAlertController *alert = (UIAlertController *)rootViewController.presentedViewController;
+  XCTAssertTrue([alert isKindOfClass:[UIAlertController class]]);
+  void (^handler)(UIAlertAction *) = [alert.actions.firstObject valueForKey:@"handler"];
+  if (handler) {
+    handler(alert.actions.firstObject);
+  }
+}
+
+- (void)testPresentingViewControllerWithoutWindowReturnsHostController {
+  UIViewController *host = [[UIViewController alloc] init];
+  FLTImagePickerPlugin *plugin = [[FLTImagePickerPlugin alloc]
+      initWithViewProvider:[[StubViewProvider alloc] initWithViewController:host]];
+  UIViewController *presented = [plugin presentingViewControllerForImagePickerInNewWindow];
+  XCTAssertEqual(presented, host);
+}
+
+- (void)testPresentingViewControllerReusesExistingBlockerWindow {
+  UIWindowScene *scene =
+      (UIWindowScene *)UIApplication.sharedApplication.connectedScenes.allObjects.firstObject;
+  UIWindow *window = [[UIWindow alloc] initWithWindowScene:scene];
+  window.frame = scene.coordinateSpace.bounds;
+  UIViewController *rootViewController = [[UIViewController alloc] init];
+  window.rootViewController = rootViewController;
+  [rootViewController loadViewIfNeeded];
+  [window makeKeyAndVisible];
+
+  FLTImagePickerPlugin *plugin = [[FLTImagePickerPlugin alloc]
+      initWithViewProvider:[[StubViewProvider alloc] initWithViewController:rootViewController]];
+  UIViewController *first = [plugin presentingViewControllerForImagePickerInNewWindow];
+  UIViewController *second = [plugin presentingViewControllerForImagePickerInNewWindow];
+  XCTAssertEqual(first, second);
+  [plugin removeInteractionBlocker];
+}
+
+- (void)testPresentingViewControllerWithoutWindowSceneUsesFrame {
+  UIWindowScene *scene =
+      (UIWindowScene *)UIApplication.sharedApplication.connectedScenes.allObjects.firstObject;
+  UIWindow *window = [[UIWindow alloc] initWithWindowScene:scene];
+  window.frame = scene.coordinateSpace.bounds;
+  UIViewController *rootViewController = [[UIViewController alloc] init];
+  window.rootViewController = rootViewController;
+  [rootViewController loadViewIfNeeded];
+  [window makeKeyAndVisible];
+
+  id mockWindow = OCMPartialMock(window);
+  OCMStub([mockWindow windowScene]).andReturn(nil);
+
+  FLTImagePickerPlugin *plugin = [[FLTImagePickerPlugin alloc]
+      initWithViewProvider:[[StubViewProvider alloc] initWithViewController:rootViewController]];
+  XCTAssertNotNil([plugin presentingViewControllerForImagePickerInNewWindow]);
+  [plugin removeInteractionBlocker];
+  [mockWindow stopMocking];
+}
+
+- (void)testDefaultViewProviderReturnsRegistrarViewController {
+  UIViewController *host = [[UIViewController alloc] init];
+  id registrar = OCMProtocolMock(@protocol(FlutterPluginRegistrar));
+  OCMStub([registrar viewController]).andReturn(host);
+  FIPDefaultViewProvider *provider = [[FIPDefaultViewProvider alloc] initWithRegistrar:registrar];
+  XCTAssertEqual(provider.viewController, host);
 }
 
 @end


### PR DESCRIPTION
Stacked on https://github.com/flutter/packages/pull/12537 — please review the latest commit only until that PR lands.

Adds native unit tests for previously untested paths in `FLTImagePickerPlugin.m` (photo-library authorization, `UIImagePicker` launch, and `didFinishPickingMediaWithInfo:`) before the Objective-C → Swift migration. Production code is unchanged.

This is a tests-only change, so it does not bump the package version or CHANGELOG.

`ImagePickerPluginTests` go from 52 tests to 70 tests (+18). This PR is stacked on the camera/results coverage PR; open it against that branch (or against `main` after that PR lands).

### New test cases

**Photo-library access:**
- `testLaunchUIImagePickerGalleryWithoutFullMetadataSkipsAuthorization` — gallery without full metadata skips the authorization check
- `testPhotoAccessDeniedReturnsError` — denied photo access returns an error
- `testPhotoAccessRestrictedReturnsError` — restricted photo access returns an error
- `testPhotoAccessAuthorizedShowsLibrary` — authorized access presents the library
- `testPhotoAccessNotDeterminedGrantedShowsLibrary` — prompt granted presents the library
- `testPhotoAccessNotDeterminedDeniedReturnsError` — prompt denied returns an error
- `testPhotoAccessLimitedReturnsDeniedError` — Limited access falls through to denied
- `testPhotoAccessUnknownStatusTreatedAsDenied` — unknown status is treated as denied

**`launchUIImagePickerWithSource:`:**
- `testLaunchUIImagePickerInvalidSourceReturnsError` — an invalid source returns an error
- `testLaunchUIImagePickerSetsImageAndVideoMediaTypes` — image/video media types and duration are set on the picker

**`imagePickerController:didFinishPickingMediaWithInfo:`:**
- `testImagePickerDidFinishPickingOriginalImage` — original image is saved
- `testImagePickerDidFinishPickingPrefersEditedImage` — edited image is preferred over original
- `testImagePickerDidFinishPickingScalesImage` — the image is scaled when requested
- `testImagePickerDidFinishPickingWithFullMetadataAsset` — full-metadata path uses `PHImageManager` when an asset is present
- `testImagePickerDidFinishPickingFullMetadataWithoutAsset` — full metadata without an asset still completes
- `testImagePickerDidFinishPickingVideo` — video is copied successfully
- `testImagePickerDidFinishPickingVideoCopyFailure` — a video copy failure is reported
- `testImagePickerDidFinishPickingIgnoredWhenNoCallContext` — no `callContext` is a no-op

Third part of `image_picker_ios` coverage backfill before the Obj-C → Swift migration for https://github.com/flutter/flutter/issues/119107

## Pre-Review Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [ ] I read the [Tree Hygiene] page, which explains my responsibilities.
- [ ] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [ ] I signed the [CLA].
- [ ] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I [linked to at least one issue that this PR fixes] in the description above.
- [ ] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under[^1].
- [ ] I updated/added any relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[the version and CHANGELOG instructions]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version-and-changelog-updates
[semantic versioning]: https://dart.dev/tools/pub/versioning#semantic-versions
[repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
