### PR TITLE
[camera_android_camerax] Migrate from dart_skills_lint to skills_lint

### DIFF
--- a/.repo_tool_config.yaml
+++ b/.repo_tool_config.yaml
@@ -116,7 +116,6 @@ allowed_dependencies:
     # Google-owned packages
     - _discoveryapis_commons
     - adaptive_navigation
-    - dart_skills_lint
     - googleapis
     - googleapis_auth
     - json_annotation
@@ -124,6 +123,7 @@ allowed_dependencies:
     - protobuf
     - quiver
     - sanitize_html
+    - skills_lint
     - source_helper
     - vector_math
     - webkit_inspection_protocol

--- a/packages/camera/camera_android_camerax/.agents/skills/README.md
+++ b/packages/camera/camera_android_camerax/.agents/skills/README.md
@@ -1,6 +1,6 @@
 # Agent Skills
 
-This directory contains skills intended for repository maintainers and contributors. Local, checked-in skills are evaluated by `dart_skills_lint` and should be configured to prevent publishing to pub.dev.
+This directory contains skills intended for repository maintainers and contributors. Local, checked-in skills are evaluated by `skills_lint` and should be configured to prevent publishing to pub.dev.
 
 ## Key Terms for Skills
 - **user**: The human user of the skill.

--- a/packages/camera/camera_android_camerax/pubspec.yaml
+++ b/packages/camera/camera_android_camerax/pubspec.yaml
@@ -28,11 +28,6 @@ dependencies:
 dev_dependencies:
   build_runner: ^2.2.0
   cognitive_complexity: 0.2.1
-  dart_skills_lint:
-    git:
-      url: https://github.com/flutter/skills.git
-      path: tool/dart_skills_lint
-      ref: 05e5a45fa412ddbdd1d694eee0c71f4bbaea2617
   flutter_test:
     sdk: flutter
   leak_tracker_flutter_testing: any
@@ -40,6 +35,11 @@ dev_dependencies:
   mockito: ^5.4.4
   path: ^1.8.0
   pigeon: ^26.1.4
+  skills_lint:
+    git:
+      url: https://github.com/google/skills_lint.dart.git
+      path: packages/skills_lint
+      ref: e6e695e1550f81342fe5acd4dbe65040b5aa44c3
 
 topics:
   - camera

--- a/packages/camera/camera_android_camerax/skills_lint.yaml
+++ b/packages/camera/camera_android_camerax/skills_lint.yaml
@@ -1,4 +1,4 @@
-dart_skills_lint:
+skills_lint:
   rules:
     check-relative-paths: error
     check-trailing-whitespace: error

--- a/packages/camera/camera_android_camerax/test/enforce_tracked_skills_prevent_publishing_rule.dart
+++ b/packages/camera/camera_android_camerax/test/enforce_tracked_skills_prevent_publishing_rule.dart
@@ -4,11 +4,11 @@
 
 import 'dart:io';
 
-import 'package:dart_skills_lint/dart_skills_lint.dart';
 import 'package:path/path.dart' as p;
+import 'package:skills_lint/skills_lint.dart';
 
 /// A custom lint rule that enforces that all skills tracked in version control
-/// have the `prevent-skills-sh-publishing` rule enabled in `dart_skills_lint.yaml`.
+/// have the `prevent-skills-sh-publishing` rule enabled in `skills_lint.yaml`.
 ///
 /// Third-party skills symlinked from the repository root's `third_party` directory
 /// are exempt.
@@ -46,7 +46,7 @@ class EnforceTrackedSkillsPreventPublishingRule extends SkillRule {
         ValidationError(
           ruleId: name,
           severity: severity,
-          file: 'dart_skills_lint.yaml',
+          file: 'skills_lint.yaml',
           message: 'Failed to run git to check tracked status. Error: $e',
         ),
       ];
@@ -60,7 +60,7 @@ class EnforceTrackedSkillsPreventPublishingRule extends SkillRule {
       return [];
     }
 
-    // 3. Check dart_skills_lint.yaml config
+    // 3. Check skills_lint.yaml config
     final Configuration config = await ConfigParser.loadConfig();
     var ruleEnabled = false;
     var pathFound = false;
@@ -84,7 +84,7 @@ class EnforceTrackedSkillsPreventPublishingRule extends SkillRule {
         ValidationError(
           ruleId: name,
           severity: severity,
-          file: 'dart_skills_lint.yaml',
+          file: 'skills_lint.yaml',
           message: _buildErrorMessage(
             relativePath: context.directory.path,
             pathFound: pathFound,
@@ -101,7 +101,7 @@ class EnforceTrackedSkillsPreventPublishingRule extends SkillRule {
   ///
   /// The [relativePath] is the path to the skill directory being validated.
   /// If [pathFound] is false, the message indicates that the skill is entirely
-  /// missing from `dart_skills_lint.yaml`. If [pathFound] is true but
+  /// missing from `skills_lint.yaml`. If [pathFound] is true but
   /// [configuredSeverity] is null, it indicates the rule is missing. If
   /// [configuredSeverity] is provided, it indicates the rule is set to an
   /// invalid severity.
@@ -116,14 +116,14 @@ class EnforceTrackedSkillsPreventPublishingRule extends SkillRule {
 
     if (!pathFound) {
       buffer.writeln(
-        'The skill at "$relativePath" is tracked in git, but is missing from dart_skills_lint.yaml.',
+        'The skill at "$relativePath" is tracked in git, but is missing from skills_lint.yaml.',
       );
       buffer.writeln(
         'Please add it under `individual_skills:` with the `prevent-skills-sh-publishing` rule set to `error`:',
       );
     } else if (configuredSeverity == null) {
       buffer.writeln(
-        'The skill at "$relativePath" is listed in dart_skills_lint.yaml, but the `prevent-skills-sh-publishing` rule is missing.',
+        'The skill at "$relativePath" is listed in skills_lint.yaml, but the `prevent-skills-sh-publishing` rule is missing.',
       );
       buffer.writeln('Please add it to the `rules` section for this skill:');
     } else {
@@ -134,7 +134,7 @@ class EnforceTrackedSkillsPreventPublishingRule extends SkillRule {
         'Tracked skills strictly require this rule to be set to `error` to prevent accidental publishing.',
       );
       buffer.writeln();
-      buffer.writeln('Please update dart_skills_lint.yaml:');
+      buffer.writeln('Please update skills_lint.yaml:');
     }
 
     buffer.writeln();

--- a/packages/camera/camera_android_camerax/test/validate_skills_test.dart
+++ b/packages/camera/camera_android_camerax/test/validate_skills_test.dart
@@ -4,10 +4,10 @@
 
 import 'dart:async';
 
-import 'package:dart_skills_lint/dart_skills_lint.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:logging/logging.dart';
+import 'package:skills_lint/skills_lint.dart';
 
 import 'enforce_tracked_skills_prevent_publishing_rule.dart';
 


### PR DESCRIPTION
The skills_lint code is moving out of flutter/agent-plugins to its own github repo skills_lint.dart. 
-@reidbaker

---
Relevant prompts 
```
ok our task today is to migrate (and document how to migrate) the use of dart_skills_lint in the package repo to skills_lint.dart. 

Feel free to ask me questions  
```
---
Agent authored description 
Migrates `camera_android_camerax` from the legacy `dart_skills_lint` dependency to `skills_lint` from `google/skills_lint.dart` pinned to commit hash `e6e695e1550f81342fe5acd4dbe65040b5aa44c3`.

- Renames `dart_skills_lint.yaml` to `skills_lint.yaml` and updates root key to `skills_lint:`.
- Updates Dart imports in `test/validate_skills_test.dart` and `test/enforce_tracked_skills_prevent_publishing_rule.dart` to `package:skills_lint/skills_lint.dart`.
- Updates diagnostic messages and skill documentation references.

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[the version and CHANGELOG instructions]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version-and-changelog-updates
[semantic versioning]: https://dart.dev/tools/pub/versioning#semantic-versions
[repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests