### PR TITLE
[cupertino_ui] Remove two items assert to allow CupertinoTabBar to have one tab

### DIFF
--- a/packages/cupertino_ui/lib/src/bottom_tab_bar.dart
+++ b/packages/cupertino_ui/lib/src/bottom_tab_bar.dart
@@ -81,7 +81,7 @@ class CupertinoTabBar extends StatelessWidget implements PreferredSizeWidget {
         width: 0.0, // 0.0 means one physical pixel
       ),
     ),
-  }) : assert(items.length >= 2, "Tabs need at least 2 items to conform to Apple's HIG"),
+  }) : assert(items.length > 0, 'CupertinoTabBar requires at least one tab.'),
        assert(0 <= currentIndex && currentIndex < items.length),
        assert(height >= 0.0);
 

--- a/packages/cupertino_ui/pending_changelogs/change_2026_08_22_cupertino_tab_bar_single_item.yaml
+++ b/packages/cupertino_ui/pending_changelogs/change_2026_08_22_cupertino_tab_bar_single_item.yaml
@@ -1,0 +1,3 @@
+changelog: |
+  - Allows `CupertinoTabBar` to contain a single item.
+version: patch

--- a/packages/cupertino_ui/test/bottom_tab_bar_test.dart
+++ b/packages/cupertino_ui/test/bottom_tab_bar_test.dart
@@ -22,24 +22,30 @@ Future<void> pumpWidgetWithBoilerplate(WidgetTester tester, Widget widget) async
 }
 
 Future<void> main() async {
-  testWidgets('Need at least 2 tabs', (WidgetTester tester) async {
-    await expectLater(
-      () => pumpWidgetWithBoilerplate(
-        tester,
-        CupertinoTabBar(
-          items: const <BottomNavigationBarItem>[
-            BottomNavigationBarItem(icon: Icon(CupertinoIcons.search), label: 'Tab 1'),
-          ],
-        ),
-      ),
+  test('CupertinoTabBar requires at least one item', () {
+    expect(
+      () => CupertinoTabBar(items: const <BottomNavigationBarItem>[]),
       throwsA(
         isAssertionError.having(
           (AssertionError error) => error.toString(),
           '.toString()',
-          contains('items.length'),
+          contains('CupertinoTabBar requires at least one tab.'),
         ),
       ),
     );
+  });
+
+  testWidgets('CupertinoTabBar supports one item', (WidgetTester tester) async {
+    await pumpWidgetWithBoilerplate(
+      tester,
+      CupertinoTabBar(
+        items: const <BottomNavigationBarItem>[
+          BottomNavigationBarItem(icon: Icon(CupertinoIcons.search), label: 'Tab 1'),
+        ],
+      ),
+    );
+
+    expect(find.byType(CupertinoTabBar), findsOneWidget);
   });
 
   testWidgets('Active and inactive colors', (WidgetTester tester) async {


### PR DESCRIPTION
Based on [discussion](https://github.com/flutter/flutter/issues/42430#issuecomment-719884650)
Removed assert to enable CupertinoTabBar to support 1 tab and updated the test.

Fixes [#42430](https://github.com/flutter/flutter/issues/42430)

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under[^1].
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[the version and CHANGELOG instructions]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version-and-changelog-updates
[semantic versioning]: https://dart.dev/tools/pub/versioning#semantic-versions
[repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
