### PR TITLE
[material_ui] Remove !chrome in text_field_test.dart

### DIFF
--- a/packages/material_ui/test/text_field_test.dart
+++ b/packages/material_ui/test/text_field_test.dart
@@ -11,9 +11,6 @@
 // https://github.com/flutter/flutter/issues/122950
 // Fails with "flutter test --test-randomize-ordering-seed=20230318"
 @Tags(<String>['reduced-test-set', 'no-shuffle'])
-// TODO(188666): Fix web test failures and re-enable. See also:
-// https://github.com/flutter/flutter/issues/71604.
-@TestOn('!chrome')
 library;
 
 import 'dart:async';

--- a/packages/material_ui/test/text_field_test.dart
+++ b/packages/material_ui/test/text_field_test.dart
@@ -2131,6 +2131,7 @@ void main() {
       TargetPlatform.linux,
       TargetPlatform.windows,
     }),
+    skip: isContextMenuProvidedByPlatform,
   );
 
   testWidgets('Swapping controllers should update selection', (WidgetTester tester) async {
@@ -3398,75 +3399,78 @@ void main() {
     ),
   );
 
-  testWidgets('assertion error is not thrown when attempting to drag both selection handles', (
-    WidgetTester tester,
-  ) async {
-    // Regression test for https://github.com/flutter/flutter/issues/168578.
-    final controller = TextEditingController(text: 'abc def ghi');
-    addTearDown(controller.dispose);
+  testWidgets(
+    'assertion error is not thrown when attempting to drag both selection handles',
+    (WidgetTester tester) async {
+      // Regression test for https://github.com/flutter/flutter/issues/168578.
+      final controller = TextEditingController(text: 'abc def ghi');
+      addTearDown(controller.dispose);
 
-    await tester.pumpWidget(
-      overlay(
-        child: Center(
-          child: TextField(
-            dragStartBehavior: DragStartBehavior.down,
-            controller: controller,
-            style: const TextStyle(fontSize: 10.0),
+      await tester.pumpWidget(
+        overlay(
+          child: Center(
+            child: TextField(
+              dragStartBehavior: DragStartBehavior.down,
+              controller: controller,
+              style: const TextStyle(fontSize: 10.0),
+            ),
           ),
         ),
-      ),
-    );
+      );
 
-    // Double tap on 'e' to select 'def'.
-    final Offset ePos = textOffsetToPosition(tester, 5);
-    await tester.tapAt(ePos, pointer: 7);
-    await tester.pump(const Duration(milliseconds: 50));
-    expect(controller.selection.isCollapsed, isTrue);
-    expect(controller.selection.baseOffset, 5);
-    await tester.tapAt(ePos, pointer: 7);
-    await tester.pumpAndSettle();
-    expect(controller.selection.baseOffset, 4);
-    expect(controller.selection.extentOffset, 7);
+      // Double tap on 'e' to select 'def'.
+      final Offset ePos = textOffsetToPosition(tester, 5);
+      await tester.tapAt(ePos, pointer: 7);
+      await tester.pump(const Duration(milliseconds: 50));
+      expect(controller.selection.isCollapsed, isTrue);
+      expect(controller.selection.baseOffset, 5);
+      await tester.tapAt(ePos, pointer: 7);
+      await tester.pumpAndSettle();
+      expect(controller.selection.baseOffset, 4);
+      expect(controller.selection.extentOffset, 7);
 
-    final RenderEditable renderEditable = findRenderEditable(tester);
-    final List<TextSelectionPoint> endpoints = globalize(
-      renderEditable.getEndpointsForSelection(controller.selection),
-      renderEditable,
-    );
-    expect(endpoints.length, 2);
+      final RenderEditable renderEditable = findRenderEditable(tester);
+      final List<TextSelectionPoint> endpoints = globalize(
+        renderEditable.getEndpointsForSelection(controller.selection),
+        renderEditable,
+      );
+      expect(endpoints.length, 2);
 
-    // Drag the end handle to 'g'.
-    final Offset endHandlePos = endpoints[1].point + const Offset(1.0, 1.0);
-    Offset newHandlePos = textOffsetToPosition(tester, 9); // Position of 'g'.
-    final TestGesture endHandleGesture = await tester.startGesture(endHandlePos, pointer: 7);
-    await tester.pump();
-    await endHandleGesture.moveTo(newHandlePos);
-    await tester.pump();
-    expect(controller.selection.baseOffset, 4);
-    expect(controller.selection.extentOffset, 9);
+      // Drag the end handle to 'g'.
+      final Offset endHandlePos = endpoints[1].point + const Offset(1.0, 1.0);
+      Offset newHandlePos = textOffsetToPosition(tester, 9); // Position of 'g'.
+      final TestGesture endHandleGesture = await tester.startGesture(endHandlePos, pointer: 7);
+      await tester.pump();
+      await endHandleGesture.moveTo(newHandlePos);
+      await tester.pump();
+      expect(controller.selection.baseOffset, 4);
+      expect(controller.selection.extentOffset, 9);
 
-    // Attempt to drag the start handle to the start of the text.
-    final Offset startHandlePos = endpoints[0].point + const Offset(1.0, 1.0);
-    newHandlePos = textOffsetToPosition(tester, 0);
-    final TestGesture startHandleGesture = await tester.startGesture(startHandlePos, pointer: 8);
-    await tester.pump();
-    await startHandleGesture.moveTo(newHandlePos);
-    await tester.pump();
-    await startHandleGesture.up();
-    await tester.pump();
+      // Attempt to drag the start handle to the start of the text.
+      final Offset startHandlePos = endpoints[0].point + const Offset(1.0, 1.0);
+      newHandlePos = textOffsetToPosition(tester, 0);
+      final TestGesture startHandleGesture = await tester.startGesture(startHandlePos, pointer: 8);
+      await tester.pump();
+      await startHandleGesture.moveTo(newHandlePos);
+      await tester.pump();
+      await startHandleGesture.up();
+      await tester.pump();
 
-    // Drag the end handle to the end of the text after releasing the start handle.
-    newHandlePos = textOffsetToPosition(tester, 11); // Position of 'i'.
-    await tester.pump();
-    await endHandleGesture.moveTo(newHandlePos);
-    await tester.pump();
-    await endHandleGesture.up();
-    await tester.pump();
+      // Drag the end handle to the end of the text after releasing the start handle.
+      newHandlePos = textOffsetToPosition(tester, 11); // Position of 'i'.
+      await tester.pump();
+      await endHandleGesture.moveTo(newHandlePos);
+      await tester.pump();
+      await endHandleGesture.up();
+      await tester.pump();
 
-    expect(tester.takeException(), isNull);
-    expect(controller.selection.baseOffset, 0);
-    expect(controller.selection.extentOffset, 11);
-  }, variant: TargetPlatformVariant.only(TargetPlatform.android));
+      expect(tester.takeException(), isNull);
+      expect(controller.selection.baseOffset, 0);
+      expect(controller.selection.extentOffset, 11);
+    },
+    variant: TargetPlatformVariant.only(TargetPlatform.android),
+    skip: kIsWeb, // [intended] on web only one selection handle can be dragged at a time.
+  );
 
   testWidgets('Can only drag one selection handle at a time on iOS', (WidgetTester tester) async {
     final controller = TextEditingController(text: 'abc def ghi');
@@ -12735,6 +12739,7 @@ void main() {
     variant: TargetPlatformVariant.all(
       excluding: <TargetPlatform>{TargetPlatform.iOS, TargetPlatform.macOS},
     ),
+    skip: isContextMenuProvidedByPlatform,
   );
 
   testWidgets(

--- a/packages/material_ui/test/text_field_test.dart
+++ b/packages/material_ui/test/text_field_test.dart
@@ -2131,7 +2131,8 @@ void main() {
       TargetPlatform.linux,
       TargetPlatform.windows,
     }),
-    skip: isContextMenuProvidedByPlatform,
+    skip:
+        isContextMenuProvidedByPlatform, // [intended] only applies to platforms where we supply the context menu.
   );
 
   testWidgets('Swapping controllers should update selection', (WidgetTester tester) async {
@@ -12739,7 +12740,8 @@ void main() {
     variant: TargetPlatformVariant.all(
       excluding: <TargetPlatform>{TargetPlatform.iOS, TargetPlatform.macOS},
     ),
-    skip: isContextMenuProvidedByPlatform,
+    skip:
+        isContextMenuProvidedByPlatform, // [intended] only applies to platforms where we supply the context menu.
   );
 
   testWidgets(


### PR DESCRIPTION
Part of https://github.com/flutter/flutter/pull/92134

It seems the issue is already closed and fixed, so I'm attempting to remove this TODO

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under[^1].
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[the version and CHANGELOG instructions]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version-and-changelog-updates
[semantic versioning]: https://dart.dev/tools/pub/versioning#semantic-versions
[repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
