### PR TITLE
[go_router] Fix ShellRoute key collisions during imperative navigation

### DIFF
--- a/packages/go_router/lib/src/builder.dart
+++ b/packages/go_router/lib/src/builder.dart
@@ -302,7 +302,7 @@ class _CustomNavigatorState extends State<_CustomNavigator> {
               canPop: match.matches.length == 1,
               child: _CustomNavigator(
                 // The state needs to persist across rebuild.
-                key: GlobalObjectKey(navigatorKey.hashCode),
+                key: GlobalObjectKey(navigatorKey),
                 navigatorRestorationId: restorationScopeId,
                 navigatorKey: navigatorKey,
                 matches: match.matches,

--- a/packages/go_router/lib/src/configuration.dart
+++ b/packages/go_router/lib/src/configuration.dart
@@ -340,15 +340,18 @@ class RouteConfiguration {
   RouteMatchList reparse(RouteMatchList matchList) {
     RouteMatchList result = findMatch(matchList.uri, extra: matchList.extra);
 
-    for (final ImperativeRouteMatch imperativeMatch
-        in matchList.matches.whereType<ImperativeRouteMatch>()) {
-      final match = ImperativeRouteMatch(
-        pageKey: imperativeMatch.pageKey,
-        matches: findMatch(imperativeMatch.matches.uri, extra: imperativeMatch.matches.extra),
-        completer: imperativeMatch.completer,
-      );
-      result = result.push(match);
-    }
+    matchList.visitRouteMatches((RouteMatchBase match) {
+      if (match is ImperativeRouteMatch) {
+        result = result.push(
+          ImperativeRouteMatch(
+            pageKey: match.pageKey,
+            matches: findMatch(match.matches.uri, extra: match.matches.extra),
+            completer: match.completer,
+          ),
+        );
+      }
+      return true;
+    });
     return result;
   }
 

--- a/packages/go_router/lib/src/match.dart
+++ b/packages/go_router/lib/src/match.dart
@@ -682,27 +682,41 @@ class RouteMatchList with Diagnosticable {
       return newMatches;
     }
     final RouteMatchBase branch = otherMatches.last;
-    final bool needsScopedKeys =
-        branch is ShellRouteMatch &&
-        branch.route is ShellRoute &&
-        newMatches.whereType<ShellRouteMatch>().any(
-          (ShellRouteMatch existingMatch) =>
-              existingMatch.pageKey == branch.pageKey ||
-              existingMatch.navigatorKey == branch.navigatorKey,
-        );
+    final List<ShellRouteMatch> existingShellRouteMatches = _shellRouteMatches(
+      newMatches,
+    ).toList(growable: false);
     newMatches.add(
-      _cloneBranchAndInsertImperativeMatch(branch, match, needsScopedKeys: needsScopedKeys),
+      _cloneBranchAndInsertImperativeMatch(
+        branch,
+        match,
+        existingShellRouteMatches: existingShellRouteMatches,
+      ),
     );
     return newMatches;
+  }
+
+  static Iterable<ShellRouteMatch> _shellRouteMatches(Iterable<RouteMatchBase> matches) sync* {
+    for (final match in matches) {
+      if (match is ShellRouteMatch) {
+        yield match;
+        yield* _shellRouteMatches(match.matches);
+      }
+    }
   }
 
   static RouteMatchBase _cloneBranchAndInsertImperativeMatch(
     RouteMatchBase branch,
     ImperativeRouteMatch match, {
-    required bool needsScopedKeys,
+    required List<ShellRouteMatch> existingShellRouteMatches,
   }) {
     if (branch is ShellRouteMatch) {
-      final bool scopeKeys = needsScopedKeys && branch.route is ShellRoute;
+      final bool scopeKeys =
+          branch.route is ShellRoute &&
+          existingShellRouteMatches.any(
+            (ShellRouteMatch existingMatch) =>
+                existingMatch.pageKey == branch.pageKey ||
+                existingMatch.navigatorKey == branch.navigatorKey,
+          );
       final ValueKey<String> pageKey = scopeKeys
           ? _ShellRoutePageKey(branch.route, match.pageKey)
           : branch.pageKey;
@@ -714,7 +728,7 @@ class RouteMatchList with Diagnosticable {
           _cloneBranchAndInsertImperativeMatch(
             branch.matches.last,
             match,
-            needsScopedKeys: needsScopedKeys,
+            existingShellRouteMatches: existingShellRouteMatches,
           ),
         ],
         pageKey: pageKey,

--- a/packages/go_router/lib/src/match.dart
+++ b/packages/go_router/lib/src/match.dart
@@ -338,43 +338,45 @@ class RouteMatch extends RouteMatchBase {
 
 class _ShellRoutePageKey extends ValueKey<String> {
   _ShellRoutePageKey(ShellRouteBase route, [ValueKey<String>? imperativePageKey])
-    : _route = route,
+    : _routeIdentity = route.pageIdentity,
       _imperativePageKey = imperativePageKey,
       super(
         imperativePageKey == null
-            ? route.hashCode.toString()
-            : '${route.hashCode}-${imperativePageKey.value}',
+            ? identityHashCode(route.pageIdentity).toString()
+            : '${identityHashCode(route.pageIdentity)}-${imperativePageKey.value}',
       );
 
-  final ShellRouteBase _route;
+  final Object _routeIdentity;
   final ValueKey<String>? _imperativePageKey;
 
   @override
   bool operator ==(Object other) {
     return other is _ShellRoutePageKey &&
-        identical(other._route, _route) &&
+        identical(other._routeIdentity, _routeIdentity) &&
         other._imperativePageKey == _imperativePageKey;
   }
 
   @override
-  int get hashCode => Object.hash(identityHashCode(_route), _imperativePageKey);
+  int get hashCode => Object.hash(identityHashCode(_routeIdentity), _imperativePageKey);
 }
 
 class _ShellRouteNavigatorKey extends GlobalKey<NavigatorState> {
-  const _ShellRouteNavigatorKey(this.route, this.imperativePageKey) : super.constructor();
+  _ShellRouteNavigatorKey(ShellRouteBase route, this.imperativePageKey)
+    : _routeIdentity = route.pageIdentity,
+      super.constructor();
 
-  final ShellRouteBase route;
+  final Object _routeIdentity;
   final ValueKey<String> imperativePageKey;
 
   @override
   bool operator ==(Object other) {
     return other is _ShellRouteNavigatorKey &&
-        identical(other.route, route) &&
+        identical(other._routeIdentity, _routeIdentity) &&
         other.imperativePageKey == imperativePageKey;
   }
 
   @override
-  int get hashCode => Object.hash(identityHashCode(route), imperativePageKey);
+  int get hashCode => Object.hash(identityHashCode(_routeIdentity), imperativePageKey);
 }
 
 /// An matched result by matching a [ShellRoute] against a location.

--- a/packages/go_router/lib/src/match.dart
+++ b/packages/go_router/lib/src/match.dart
@@ -174,7 +174,7 @@ abstract class RouteMatchBase with Diagnosticable {
       // have at least one match for this ShellRouteBase.
       matches: subRouteMatches!.remove(null)!,
       matchedLocation: remainingLocation,
-      pageKey: ValueKey<String>(route.hashCode.toString()),
+      pageKey: _ShellRoutePageKey(route),
       navigatorKey: navigatorKeyUsed,
     );
     subRouteMatches.putIfAbsent(parentKey, () => <RouteMatchBase>[]).insert(0, result);
@@ -336,6 +336,47 @@ class RouteMatch extends RouteMatchBase {
   }
 }
 
+class _ShellRoutePageKey extends ValueKey<String> {
+  _ShellRoutePageKey(ShellRouteBase route, [ValueKey<String>? imperativePageKey])
+    : _route = route,
+      _imperativePageKey = imperativePageKey,
+      super(
+        imperativePageKey == null
+            ? route.hashCode.toString()
+            : '${route.hashCode}-${imperativePageKey.value}',
+      );
+
+  final ShellRouteBase _route;
+  final ValueKey<String>? _imperativePageKey;
+
+  @override
+  bool operator ==(Object other) {
+    return other is _ShellRoutePageKey &&
+        identical(other._route, _route) &&
+        other._imperativePageKey == _imperativePageKey;
+  }
+
+  @override
+  int get hashCode => Object.hash(identityHashCode(_route), _imperativePageKey);
+}
+
+class _ShellRouteNavigatorKey extends GlobalKey<NavigatorState> {
+  const _ShellRouteNavigatorKey(this.route, this.imperativePageKey) : super.constructor();
+
+  final ShellRouteBase route;
+  final ValueKey<String> imperativePageKey;
+
+  @override
+  bool operator ==(Object other) {
+    return other is _ShellRouteNavigatorKey &&
+        identical(other.route, route) &&
+        other.imperativePageKey == imperativePageKey;
+  }
+
+  @override
+  int get hashCode => Object.hash(identityHashCode(route), imperativePageKey);
+}
+
 /// An matched result by matching a [ShellRoute] against a location.
 ///
 /// This is typically created by calling [RouteMatchBase.match].
@@ -404,13 +445,17 @@ class ShellRouteMatch extends RouteMatchBase {
   // TODO(loic-sharma): Remove meta library prefix.
   // https://github.com/flutter/flutter/issues/171410
   @meta.internal
-  ShellRouteMatch copyWith({required List<RouteMatchBase>? matches}) {
+  ShellRouteMatch copyWith({
+    required List<RouteMatchBase>? matches,
+    ValueKey<String>? pageKey,
+    GlobalKey<NavigatorState>? navigatorKey,
+  }) {
     return ShellRouteMatch(
       matches: matches ?? this.matches,
       route: route,
       matchedLocation: matchedLocation,
-      pageKey: pageKey,
-      navigatorKey: navigatorKey,
+      pageKey: pageKey ?? this.pageKey,
+      navigatorKey: navigatorKey ?? this.navigatorKey,
     );
   }
 
@@ -636,17 +681,44 @@ class RouteMatchList with Diagnosticable {
       );
       return newMatches;
     }
-    newMatches.add(_cloneBranchAndInsertImperativeMatch(otherMatches.last, match));
+    final RouteMatchBase branch = otherMatches.last;
+    final bool needsScopedKeys =
+        branch is ShellRouteMatch &&
+        branch.route is ShellRoute &&
+        newMatches.whereType<ShellRouteMatch>().any(
+          (ShellRouteMatch existingMatch) =>
+              existingMatch.pageKey == branch.pageKey ||
+              existingMatch.navigatorKey == branch.navigatorKey,
+        );
+    newMatches.add(
+      _cloneBranchAndInsertImperativeMatch(branch, match, needsScopedKeys: needsScopedKeys),
+    );
     return newMatches;
   }
 
   static RouteMatchBase _cloneBranchAndInsertImperativeMatch(
     RouteMatchBase branch,
-    ImperativeRouteMatch match,
-  ) {
+    ImperativeRouteMatch match, {
+    required bool needsScopedKeys,
+  }) {
     if (branch is ShellRouteMatch) {
+      final bool scopeKeys = needsScopedKeys && branch.route is ShellRoute;
+      final ValueKey<String> pageKey = scopeKeys
+          ? _ShellRoutePageKey(branch.route, match.pageKey)
+          : branch.pageKey;
+      final GlobalKey<NavigatorState> navigatorKey = scopeKeys
+          ? _ShellRouteNavigatorKey(branch.route, match.pageKey)
+          : branch.navigatorKey;
       return branch.copyWith(
-        matches: <RouteMatchBase>[_cloneBranchAndInsertImperativeMatch(branch.matches.last, match)],
+        matches: <RouteMatchBase>[
+          _cloneBranchAndInsertImperativeMatch(
+            branch.matches.last,
+            match,
+            needsScopedKeys: needsScopedKeys,
+          ),
+        ],
+        pageKey: pageKey,
+        navigatorKey: navigatorKey,
       );
     }
     // Add the input `match` instead of the incompatibleMatch since it contains

--- a/packages/go_router/lib/src/match.dart
+++ b/packages/go_router/lib/src/match.dart
@@ -684,9 +684,13 @@ class RouteMatchList with Diagnosticable {
       return newMatches;
     }
     final RouteMatchBase branch = otherMatches.last;
-    final List<ShellRouteMatch> existingShellRouteMatches = _shellRouteMatches(
-      newMatches,
-    ).toList(growable: false);
+    final existingShellRouteMatches = <ShellRouteMatch>[];
+    _visitRouteMatches(newMatches, (RouteMatchBase match) {
+      if (match is ShellRouteMatch) {
+        existingShellRouteMatches.add(match);
+      }
+      return true;
+    });
     newMatches.add(
       _cloneBranchAndInsertImperativeMatch(
         branch,
@@ -695,15 +699,6 @@ class RouteMatchList with Diagnosticable {
       ),
     );
     return newMatches;
-  }
-
-  static Iterable<ShellRouteMatch> _shellRouteMatches(Iterable<RouteMatchBase> matches) sync* {
-    for (final match in matches) {
-      if (match is ShellRouteMatch) {
-        yield match;
-        yield* _shellRouteMatches(match.matches);
-      }
-    }
   }
 
   static RouteMatchBase _cloneBranchAndInsertImperativeMatch(

--- a/packages/go_router/lib/src/route.dart
+++ b/packages/go_router/lib/src/route.dart
@@ -520,6 +520,14 @@ abstract class ShellRouteBase extends RouteBase {
   /// Defaults to `true`.
   final bool notifyRootObserver;
 
+  /// The stable identity used to build this shell's page key.
+  ///
+  /// Applications that replace their routing table using
+  /// [GoRouter.routingConfig] must reuse this identity for an equivalent shell
+  /// to preserve the shell's page and nested navigator state.
+  @meta.internal
+  Object get pageIdentity;
+
   static void _debugCheckSubRouteParentNavigatorKeys(
     List<RouteBase> subRoutes,
     GlobalKey<NavigatorState> navigatorKey,
@@ -798,11 +806,18 @@ class ShellRoute extends ShellRouteBase {
   /// The [GlobalKey] to be used by the [Navigator] built for this route.
   /// All ShellRoutes build a Navigator by default. Child GoRoutes
   /// are placed onto this Navigator instead of the root Navigator.
+  ///
+  /// Applications that rebuild their routing table using
+  /// [GoRouter.routingConfig] should provide and reuse this key to preserve the
+  /// shell's page and navigator state.
   final GlobalKey<NavigatorState> navigatorKey;
 
   /// Restoration ID to save and restore the state of the navigator, including
   /// its history.
   final String? restorationScopeId;
+
+  @override
+  Object get pageIdentity => navigatorKey;
 
   @override
   GlobalKey<NavigatorState> navigatorKeyForSubRoute(RouteBase subRoute) {
@@ -893,6 +908,10 @@ class StatefulShellRoute extends ShellRouteBase {
   /// the navigator key specified in [StatefulShellBranch]. The Widget
   /// implementing the container for the branch Navigators is provided by
   /// [navigatorContainerBuilder].
+  ///
+  /// Applications that rebuild their routing table using
+  /// [GoRouter.routingConfig] should provide and reuse [key] to preserve the
+  /// shell's page and branch navigator state.
   StatefulShellRoute({
     required this.branches,
     super.redirect,
@@ -928,6 +947,10 @@ class StatefulShellRoute extends ShellRouteBase {
   ///
   /// See [Stateful Nested Navigation](https://github.com/flutter/packages/blob/main/packages/go_router/example/lib/stacked_shell_route.dart)
   /// for a complete runnable example using StatefulShellRoute.indexedStack.
+  ///
+  /// Applications that rebuild their routing table using
+  /// [GoRouter.routingConfig] should provide and reuse [key] to preserve the
+  /// shell's page and branch navigator state.
   StatefulShellRoute.indexedStack({
     required List<StatefulShellBranch> branches,
     bool notifyRootObserver = true,
@@ -1003,6 +1026,9 @@ class StatefulShellRoute extends ShellRouteBase {
   final List<StatefulShellBranch> branches;
 
   final GlobalKey<StatefulNavigationShellState> _shellStateKey;
+
+  @override
+  Object get pageIdentity => _shellStateKey;
 
   @override
   Widget? buildWidget(
@@ -1117,6 +1143,10 @@ class StatefulShellRoute extends ShellRouteBase {
 /// provided when creating a StatefulShellBranch, which can be useful when the
 /// Navigator needs to be accessed elsewhere. If no key is provided, a default
 /// one will be created.
+///
+/// Applications that rebuild their routing table using
+/// [GoRouter.routingConfig] should provide and reuse [navigatorKey] to preserve
+/// this branch's navigator state.
 @immutable
 class StatefulShellBranch {
   /// Constructs a [StatefulShellBranch].
@@ -1325,17 +1355,19 @@ class StatefulNavigationShell extends StatefulWidget {
 
 /// State for StatefulNavigationShell.
 class StatefulNavigationShellState extends State<StatefulNavigationShell> with RestorationMixin {
-  final Map<StatefulShellBranch, _StatefulShellBranchState> _branchState =
-      <StatefulShellBranch, _StatefulShellBranchState>{};
+  final Map<GlobalKey<NavigatorState>, _StatefulShellBranchState> _branchState =
+      <GlobalKey<NavigatorState>, _StatefulShellBranchState>{};
 
   /// The associated [StatefulShellRoute].
   StatefulShellRoute get route => widget.route;
 
   GoRouter get _router => widget._router;
 
-  bool _isBranchLoaded(StatefulShellBranch branch) => _branchState[branch] != null;
+  bool _isBranchLoaded(StatefulShellBranch branch) => _branchState[branch.navigatorKey] != null;
 
-  List<StatefulShellBranch> get _loadedBranches => _branchState.keys.toList();
+  List<StatefulShellBranch> get _loadedBranches => route.branches
+      .where((StatefulShellBranch branch) => _branchState.containsKey(branch.navigatorKey))
+      .toList();
 
   @override
   String? get restorationId => route.restorationScopeId;
@@ -1350,7 +1382,7 @@ class StatefulNavigationShellState extends State<StatefulNavigationShell> with R
   }
 
   _StatefulShellBranchState _branchStateFor(StatefulShellBranch branch, [bool register = true]) {
-    return _branchState.putIfAbsent(branch, () {
+    return _branchState.putIfAbsent(branch.navigatorKey, () {
       final branchState = _StatefulShellBranchState(
         location: _RestorableRouteMatchList(_router.configuration),
       );
@@ -1362,7 +1394,7 @@ class StatefulNavigationShellState extends State<StatefulNavigationShell> with R
   }
 
   RouteMatchList? _matchListForBranch(int index) =>
-      _branchState[route.branches[index]]?.location.value;
+      _branchState[route.branches[index].navigatorKey]?.location.value;
 
   /// Creates a new RouteMatchList that is scoped to the Navigators of the
   /// current shell route or it's descendants. This involves removing all the
@@ -1448,8 +1480,14 @@ class StatefulNavigationShellState extends State<StatefulNavigationShell> with R
   }
 
   void _cleanUpObsoleteBranches() {
-    _branchState.removeWhere((StatefulShellBranch branch, _StatefulShellBranchState branchState) {
-      if (!route.branches.contains(branch)) {
+    final Set<GlobalKey<NavigatorState>> validKeys = route.branches
+        .map((StatefulShellBranch branch) => branch.navigatorKey)
+        .toSet();
+    _branchState.removeWhere((
+      GlobalKey<NavigatorState> navigatorKey,
+      _StatefulShellBranchState branchState,
+    ) {
+      if (!validKeys.contains(navigatorKey)) {
         branchState.dispose();
         return true;
       }
@@ -1509,9 +1547,10 @@ class StatefulNavigationShellState extends State<StatefulNavigationShell> with R
     final List<Widget> children = route.branches
         .map(
           (StatefulShellBranch branch) => _BranchNavigatorProxy(
-            key: ObjectKey(branch),
+            key: ValueKey<GlobalKey<NavigatorState>>(branch.navigatorKey),
             branch: branch,
-            navigatorForBranch: (StatefulShellBranch branch) => _branchState[branch]?.navigator,
+            navigatorForBranch: (StatefulShellBranch branch) =>
+                _branchState[branch.navigatorKey]?.navigator,
           ),
         )
         .toList();

--- a/packages/go_router/pending_changelogs/shell_route_key_collisions.yaml
+++ b/packages/go_router/pending_changelogs/shell_route_key_collisions.yaml
@@ -1,3 +1,3 @@
 changelog: |
-  - Fixes `ShellRoute` key collisions during imperative navigation while preserving navigator state across reparses.
+  - Fixes `ShellRoute` key collisions during imperative navigation and preserves shell navigator state across dynamic routing configuration updates.
 version: patch

--- a/packages/go_router/pending_changelogs/shell_route_key_collisions.yaml
+++ b/packages/go_router/pending_changelogs/shell_route_key_collisions.yaml
@@ -1,0 +1,3 @@
+changelog: |
+  - Fixes `ShellRoute` key collisions during imperative navigation while preserving navigator state across reparses.
+version: patch

--- a/packages/go_router/test/go_router_test.dart
+++ b/packages/go_router/test/go_router_test.dart
@@ -4739,14 +4739,18 @@ void main() {
     testWidgets(
       'Obsolete branches in StatefulShellRoute are cleaned up after route '
       'configuration change',
-      // TODO(tolo): Temporarily skipped due to a bug that causes test to faiL
-      skip: true,
+      // Reusing explicit keys identifies equivalent branches across configurations.
       (WidgetTester tester) async {
         final rootNavigatorKey = GlobalKey<NavigatorState>(debugLabel: 'root');
         final statefulShellKey = GlobalKey<StatefulNavigationShellState>(debugLabel: 'shell');
+        final branchNavigatorKeys = <String, GlobalKey<NavigatorState>>{
+          'a': GlobalKey<NavigatorState>(debugLabel: 'branch-a'),
+          'b': GlobalKey<NavigatorState>(debugLabel: 'branch-b'),
+          'c': GlobalKey<NavigatorState>(debugLabel: 'branch-c'),
+        };
         StatefulNavigationShell? routeState;
         StatefulShellBranch makeBranch(String name) => StatefulShellBranch(
-          navigatorKey: GlobalKey<NavigatorState>(debugLabel: 'branch-$name'),
+          navigatorKey: branchNavigatorKeys[name],
           preload: true,
           initialLocation: '/$name',
           routes: <GoRoute>[
@@ -4795,6 +4799,9 @@ void main() {
         expect(hasLoadedBranch('a'), isTrue);
         expect(hasLoadedBranch('b'), isTrue);
         expect(hasLoadedBranch('c'), isTrue);
+        final NavigatorState branchAState = branchNavigatorKeys['a']!.currentState!;
+        final NavigatorState branchBState = branchNavigatorKeys['b']!.currentState!;
+        final NavigatorState branchCState = branchNavigatorKeys['c']!.currentState!;
 
         // Unload branch 'c' by changing the route configuration
         config.value = RoutingConfig(routes: createRoutes(false));
@@ -4803,6 +4810,10 @@ void main() {
         expect(hasLoadedBranch('a'), isTrue);
         expect(hasLoadedBranch('b'), isTrue);
         expect(hasLoadedBranch('c'), isFalse);
+        expect(branchNavigatorKeys['a']!.currentState, same(branchAState));
+        expect(branchNavigatorKeys['b']!.currentState, same(branchBState));
+        expect(branchNavigatorKeys['c']!.currentState, isNull);
+        expect(branchCState.mounted, isFalse);
       },
     );
   });

--- a/packages/go_router/test/imperative_api_test.dart
+++ b/packages/go_router/test/imperative_api_test.dart
@@ -4,6 +4,7 @@
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
+import 'package:go_router/src/match.dart';
 import 'package:material_ui/material_ui.dart';
 
 import 'test_helpers.dart';
@@ -241,10 +242,29 @@ void main() {
     final DummyStatefulWidgetState pushedFirstPage = tester.state<DummyStatefulWidgetState>(
       find.byType(DummyStatefulWidget),
     );
+    final NavigatorState pushedFirstNavigator = Navigator.of(pushedFirstPage.context);
     expect(pushedFirstPage, isNot(same(firstPage)));
+    expect(pushedFirstNavigator, isNot(same(firstNavigator)));
+    expect(pushedFirstNavigator, isNot(same(secondNavigator)));
     pushedFirstPage.increment();
     await tester.pump();
     expect(pushedFirstPage.counter, 1);
+
+    // Recreate the full match list so the scoped shell keys are reconstructed
+    // from the stable imperative page key.
+    final codec = RouteMatchListCodec(router.configuration);
+    final RouteMatchList restoredConfiguration = codec.decode(
+      codec.encode(router.routerDelegate.currentConfiguration),
+    );
+    expect(restoredConfiguration, isNot(same(router.routerDelegate.currentConfiguration)));
+    router.restore(restoredConfiguration);
+    await tester.pumpAndSettle();
+    expect(tester.takeException(), isNull);
+    expect(
+      tester.state<DummyStatefulWidgetState>(find.byType(DummyStatefulWidget)),
+      same(pushedFirstPage),
+    );
+    expect(Navigator.of(pushedFirstPage.context), same(pushedFirstNavigator));
 
     router.refresh();
     await tester.pumpAndSettle();

--- a/packages/go_router/test/imperative_api_test.dart
+++ b/packages/go_router/test/imperative_api_test.dart
@@ -172,6 +172,120 @@ void main() {
     expect(find.byKey(b), findsOneWidget);
   });
 
+  testWidgets('push to a sibling shell route under the same parent shell route', (
+    WidgetTester tester,
+  ) async {
+    const firstNavigatorKey = _CollidingNavigatorKey('first');
+    const secondNavigatorKey = _CollidingNavigatorKey('second');
+    expect(firstNavigatorKey, isNot(equals(secondNavigatorKey)));
+    expect(firstNavigatorKey.hashCode, secondNavigatorKey.hashCode);
+    final secondPageKey = UniqueKey();
+    final firstRoute = _CollidingShellRoute(
+      navigatorKey: firstNavigatorKey,
+      builder: (_, _, Widget child) => child,
+      routes: <RouteBase>[GoRoute(path: '/first', builder: (_, _) => const DummyStatefulWidget())],
+    );
+    final secondRoute = _CollidingShellRoute(
+      navigatorKey: secondNavigatorKey,
+      builder: (_, _, Widget child) => child,
+      routes: <RouteBase>[
+        GoRoute(
+          path: '/second',
+          builder: (_, _) => DummyScreen(key: secondPageKey),
+        ),
+      ],
+    );
+    expect(firstRoute, isNot(equals(secondRoute)));
+    expect(firstRoute.hashCode, secondRoute.hashCode);
+    final routes = <RouteBase>[
+      ShellRoute(
+        builder: (_, _, Widget child) => child,
+        routes: <RouteBase>[firstRoute, secondRoute],
+      ),
+    ];
+    final GoRouter router = await createRouter(routes, tester, initialLocation: '/first');
+
+    final NavigatorState firstNavigator = firstNavigatorKey.currentState!;
+    final DummyStatefulWidgetState firstPage = tester.state<DummyStatefulWidgetState>(
+      find.byType(DummyStatefulWidget),
+    );
+    expect(secondNavigatorKey.currentState, isNull);
+
+    firstPage.increment();
+    await tester.pump();
+    expect(firstPage.counter, 1);
+
+    router.push('/second');
+    await tester.pumpAndSettle();
+    expect(tester.takeException(), isNull);
+    final NavigatorState secondNavigator = secondNavigatorKey.currentState!;
+    expect(firstNavigatorKey.currentState, same(firstNavigator));
+    expect(secondNavigator, isNot(same(firstNavigator)));
+    expect(firstNavigator.mounted, isTrue);
+    expect(secondNavigator.mounted, isTrue);
+    expect(firstPage.mounted, isTrue);
+    expect(firstPage.counter, 1);
+    expect(find.byKey(secondPageKey), findsOneWidget);
+
+    router.push('/first');
+    await tester.pumpAndSettle();
+    expect(tester.takeException(), isNull);
+    expect(firstNavigatorKey.currentState, same(firstNavigator));
+    expect(secondNavigatorKey.currentState, same(secondNavigator));
+    expect(firstNavigator.mounted, isTrue);
+    expect(secondNavigator.mounted, isTrue);
+    expect(firstPage.mounted, isTrue);
+    expect(firstPage.counter, 1);
+    expect(find.byType(DummyStatefulWidget), findsOneWidget);
+
+    final DummyStatefulWidgetState pushedFirstPage = tester.state<DummyStatefulWidgetState>(
+      find.byType(DummyStatefulWidget),
+    );
+    expect(pushedFirstPage, isNot(same(firstPage)));
+    pushedFirstPage.increment();
+    await tester.pump();
+    expect(pushedFirstPage.counter, 1);
+
+    router.refresh();
+    await tester.pumpAndSettle();
+    expect(tester.takeException(), isNull);
+    expect(firstNavigatorKey.currentState, same(firstNavigator));
+    expect(secondNavigatorKey.currentState, same(secondNavigator));
+    expect(pushedFirstPage.mounted, isTrue);
+    expect(pushedFirstPage.counter, 1);
+
+    router.pop();
+    await tester.pumpAndSettle();
+    expect(tester.takeException(), isNull);
+    expect(secondNavigatorKey.currentState, same(secondNavigator));
+    expect(secondNavigator.mounted, isTrue);
+    expect(find.byKey(secondPageKey), findsOneWidget);
+
+    router.pop();
+    await tester.pumpAndSettle();
+    expect(tester.takeException(), isNull);
+    expect(firstNavigatorKey.currentState, same(firstNavigator));
+    expect(firstNavigator.mounted, isTrue);
+    expect(secondNavigatorKey.currentState, isNull);
+    expect(secondNavigator.mounted, isFalse);
+    expect(firstPage.mounted, isTrue);
+    expect(firstPage.counter, 1);
+    expect(find.byKey(secondPageKey), findsNothing);
+
+    router.refresh();
+    await tester.pumpAndSettle();
+    expect(tester.takeException(), isNull);
+    expect(firstNavigatorKey.currentState, same(firstNavigator));
+    expect(firstPage.mounted, isTrue);
+    expect(firstPage.counter, 1);
+
+    router.go('/second');
+    await tester.pumpAndSettle();
+    expect(tester.takeException(), isNull);
+    expect(secondNavigatorKey.currentState, isNotNull);
+    expect(find.byKey(secondPageKey), findsOneWidget);
+  });
+
   testWidgets('push inside or outside shell route', (WidgetTester tester) async {
     // Regression test for https://github.com/flutter/flutter/issues/120665.
     final inside = UniqueKey();
@@ -286,4 +400,30 @@ void main() {
     expect(find.text('shell'), findsNothing);
     expect(find.byKey(e), findsOneWidget);
   });
+}
+
+class _CollidingShellRoute extends ShellRoute {
+  _CollidingShellRoute({
+    required super.navigatorKey,
+    required super.builder,
+    required super.routes,
+  });
+
+  @override
+  bool operator ==(Object other) => identical(this, other);
+
+  @override
+  int get hashCode => 0;
+}
+
+class _CollidingNavigatorKey extends GlobalKey<NavigatorState> {
+  const _CollidingNavigatorKey(this._label) : super.constructor();
+
+  final String _label;
+
+  @override
+  int get hashCode => 0;
+
+  @override
+  bool operator ==(Object other) => other is _CollidingNavigatorKey && other._label == _label;
 }

--- a/packages/go_router/test/match_test.dart
+++ b/packages/go_router/test/match_test.dart
@@ -64,6 +64,8 @@ void main() {
       expect(matches1.length, 1);
       expect(matches2.length, 1);
       expect(matches1.first.pageKey, matches2.first.pageKey);
+      expect((matches1.first as ShellRouteMatch).navigatorKey, same(route.navigatorKey));
+      expect((matches2.first as ShellRouteMatch).navigatorKey, same(route.navigatorKey));
     });
 
     test('GoRoute Match has stable unique key', () {

--- a/packages/go_router/test/match_test.dart
+++ b/packages/go_router/test/match_test.dart
@@ -201,6 +201,82 @@ void main() {
       expect(match1 == match2, isFalse);
       expect(match1.hashCode == match2.hashCode, isFalse);
     });
+
+    test('push scopes key collisions in nested ShellRouteMatch', () {
+      final leafRoute = GoRoute(path: '/leaf', builder: _builder);
+      final nestedNavigatorKey = GlobalKey<NavigatorState>();
+      final nestedRoute = ShellRoute(
+        navigatorKey: nestedNavigatorKey,
+        builder: _shellBuilder,
+        routes: <RouteBase>[leafRoute],
+      );
+      final currentOuterRoute = ShellRoute(
+        builder: _shellBuilder,
+        routes: <RouteBase>[nestedRoute],
+      );
+      final pushedOuterRoute = ShellRoute(builder: _shellBuilder, routes: <RouteBase>[nestedRoute]);
+      const nestedPageKey = ValueKey<String>('nested');
+      const currentOuterPageKey = ValueKey<String>('current-outer');
+      const pushedOuterPageKey = ValueKey<String>('pushed-outer');
+      expect(currentOuterPageKey, isNot(pushedOuterPageKey));
+      expect(currentOuterRoute.navigatorKey, isNot(equals(pushedOuterRoute.navigatorKey)));
+
+      ShellRouteMatch nestedMatch() => ShellRouteMatch(
+        route: nestedRoute,
+        matches: <RouteMatchBase>[
+          RouteMatch(
+            route: leafRoute,
+            matchedLocation: '/leaf',
+            pageKey: const ValueKey<String>('/leaf'),
+          ),
+        ],
+        matchedLocation: '/leaf',
+        pageKey: nestedPageKey,
+        navigatorKey: nestedNavigatorKey,
+      );
+
+      final currentMatchList = RouteMatchList(
+        matches: <RouteMatchBase>[
+          ShellRouteMatch(
+            route: currentOuterRoute,
+            matches: <RouteMatchBase>[nestedMatch()],
+            matchedLocation: '/leaf',
+            pageKey: currentOuterPageKey,
+            navigatorKey: currentOuterRoute.navigatorKey,
+          ),
+        ],
+        uri: Uri.parse('/leaf'),
+        pathParameters: const <String, String>{},
+      );
+      final pushedMatchList = RouteMatchList(
+        matches: <RouteMatchBase>[
+          ShellRouteMatch(
+            route: pushedOuterRoute,
+            matches: <RouteMatchBase>[nestedMatch()],
+            matchedLocation: '/leaf',
+            pageKey: pushedOuterPageKey,
+            navigatorKey: pushedOuterRoute.navigatorKey,
+          ),
+        ],
+        uri: Uri.parse('/leaf'),
+        pathParameters: const <String, String>{},
+      );
+
+      final RouteMatchList result = currentMatchList.push(
+        ImperativeRouteMatch(
+          pageKey: const ValueKey<String>('push'),
+          matches: pushedMatchList,
+          completer: Completer<void>(),
+        ),
+      );
+
+      final pushedOuterMatch = result.matches.last as ShellRouteMatch;
+      final pushedNestedMatch = pushedOuterMatch.matches.single as ShellRouteMatch;
+      expect(pushedOuterMatch.pageKey, pushedOuterPageKey);
+      expect(pushedOuterMatch.navigatorKey, same(pushedOuterRoute.navigatorKey));
+      expect(pushedNestedMatch.pageKey, isNot(nestedPageKey));
+      expect(pushedNestedMatch.navigatorKey, isNot(equals(nestedNavigatorKey)));
+    });
   });
 }
 

--- a/packages/go_router/test/routing_config_test.dart
+++ b/packages/go_router/test/routing_config_test.dart
@@ -231,6 +231,72 @@ void main() {
     expect(detailState.value, 1);
   });
 
+  testWidgets('routing config preserves multiple nested imperative shell matches', (
+    WidgetTester tester,
+  ) async {
+    final shellNavigatorKey = GlobalKey<NavigatorState>(debugLabel: 'shell');
+    final firstDetailKey = GlobalKey<_StatefulTestState>(debugLabel: 'firstDetailState');
+    final secondDetailKey = GlobalKey<_StatefulTestState>(debugLabel: 'secondDetailState');
+
+    RoutingConfig buildConfig() => RoutingConfig(
+      routes: <RouteBase>[
+        ShellRoute(
+          navigatorKey: shellNavigatorKey,
+          routes: <RouteBase>[
+            GoRoute(path: '/', builder: (_, _) => const Text('home')),
+            GoRoute(
+              path: '/detail/:id',
+              builder: (_, GoRouterState state) {
+                final isFirst = state.pathParameters['id'] == 'first';
+                return StatefulTest(
+                  key: isFirst ? firstDetailKey : secondDetailKey,
+                  child: Text('detail ${state.pathParameters['id']}'),
+                );
+              },
+            ),
+          ],
+          builder: (_, _, Widget widget) => widget,
+        ),
+      ],
+    );
+
+    final config = ValueNotifier<RoutingConfig>(buildConfig());
+    addTearDown(config.dispose);
+    final GoRouter router = await createRouterWithRoutingConfig(config, tester);
+
+    final Future<String?> firstResult = router.push<String>('/detail/first');
+    await tester.pumpAndSettle();
+    final _StatefulTestState firstDetailState = firstDetailKey.currentState!;
+    firstDetailState.value = 1;
+
+    final Future<String?> secondResult = router.push<String>('/detail/second');
+    await tester.pumpAndSettle();
+    final _StatefulTestState secondDetailState = secondDetailKey.currentState!;
+    secondDetailState.value = 2;
+
+    config.value = buildConfig();
+    await tester.pumpAndSettle();
+
+    expect(tester.takeException(), isNull);
+    expect(find.text('detail second'), findsOneWidget);
+    expect(firstDetailKey.currentState, same(firstDetailState));
+    expect(secondDetailKey.currentState, same(secondDetailState));
+    expect(firstDetailState.value, 1);
+    expect(secondDetailState.value, 2);
+
+    router.pop('second result');
+    await tester.pumpAndSettle();
+    expect(await secondResult, 'second result');
+    expect(find.text('detail first'), findsOneWidget);
+    expect(firstDetailKey.currentState, same(firstDetailState));
+    expect(firstDetailState.value, 1);
+
+    router.pop('first result');
+    await tester.pumpAndSettle();
+    expect(await firstResult, 'first result');
+    expect(find.text('home'), findsOneWidget);
+  });
+
   testWidgets('routing config preserves stateful shell branch state', (WidgetTester tester) async {
     final shellKey = GlobalKey<StatefulNavigationShellState>(debugLabel: 'statefulShell');
     final branchNavigatorKey = GlobalKey<NavigatorState>(debugLabel: 'branch');

--- a/packages/go_router/test/routing_config_test.dart
+++ b/packages/go_router/test/routing_config_test.dart
@@ -136,53 +136,145 @@ void main() {
     expect(key.currentState!.value == 1, isTrue);
   });
 
-  testWidgets(
-    'routing config works with shell route',
-    // TODO(tolo): Temporarily skipped due to a bug that causes test to faiL
-    skip: true,
-    (WidgetTester tester) async {
-      final key = GlobalKey<_StatefulTestState>(debugLabel: 'testState');
-      final rootNavigatorKey = GlobalKey<NavigatorState>(debugLabel: 'root');
-      final shellNavigatorKey = GlobalKey<NavigatorState>(debugLabel: 'shell');
+  testWidgets('routing config works with shell route', (WidgetTester tester) async {
+    final key = GlobalKey<_StatefulTestState>(debugLabel: 'testState');
+    final rootNavigatorKey = GlobalKey<NavigatorState>(debugLabel: 'root');
+    final shellNavigatorKey = GlobalKey<NavigatorState>(debugLabel: 'shell');
 
-      final config = ValueNotifier<RoutingConfig>(
-        RoutingConfig(
-          routes: <RouteBase>[
-            ShellRoute(
-              navigatorKey: shellNavigatorKey,
-              routes: <RouteBase>[GoRoute(path: '/', builder: (_, _) => const Text('home'))],
-              builder: (_, _, Widget widget) => StatefulTest(key: key, child: widget),
-            ),
-          ],
-        ),
-      );
-      addTearDown(config.dispose);
-      await createRouterWithRoutingConfig(
-        navigatorKey: rootNavigatorKey,
-        config,
-        tester,
-        errorBuilder: (_, _) => const Text('error'),
-      );
-      expect(find.text('home'), findsOneWidget);
-      key.currentState!.value = 1;
-
-      config.value = RoutingConfig(
+    final config = ValueNotifier<RoutingConfig>(
+      RoutingConfig(
         routes: <RouteBase>[
           ShellRoute(
             navigatorKey: shellNavigatorKey,
-            routes: <RouteBase>[
-              GoRoute(path: '/', builder: (_, _) => const Text('home')),
-              GoRoute(path: '/abc', builder: (_, _) => const Text('/abc')),
-            ],
+            routes: <RouteBase>[GoRoute(path: '/', builder: (_, _) => const Text('home'))],
             builder: (_, _, Widget widget) => StatefulTest(key: key, child: widget),
           ),
         ],
-      );
-      await tester.pumpAndSettle();
+      ),
+    );
+    addTearDown(config.dispose);
+    await createRouterWithRoutingConfig(
+      navigatorKey: rootNavigatorKey,
+      config,
+      tester,
+      errorBuilder: (_, _) => const Text('error'),
+    );
+    expect(find.text('home'), findsOneWidget);
+    final _StatefulTestState shellState = key.currentState!;
+    final NavigatorState shellNavigatorState = shellNavigatorKey.currentState!;
+    shellState.value = 1;
 
-      expect(key.currentState!.value == 1, isTrue);
-    },
-  );
+    config.value = RoutingConfig(
+      routes: <RouteBase>[
+        ShellRoute(
+          navigatorKey: shellNavigatorKey,
+          routes: <RouteBase>[
+            GoRoute(path: '/', builder: (_, _) => const Text('home')),
+            GoRoute(path: '/abc', builder: (_, _) => const Text('/abc')),
+          ],
+          builder: (_, _, Widget widget) => StatefulTest(key: key, child: widget),
+        ),
+      ],
+    );
+    await tester.pumpAndSettle();
+
+    expect(tester.takeException(), isNull);
+    expect(key.currentState, same(shellState));
+    expect(shellNavigatorKey.currentState, same(shellNavigatorState));
+    expect(shellState.value, 1);
+  });
+
+  testWidgets('routing config preserves nested imperative shell state', (
+    WidgetTester tester,
+  ) async {
+    final shellNavigatorKey = GlobalKey<NavigatorState>(debugLabel: 'shell');
+    final detailKey = GlobalKey<_StatefulTestState>(debugLabel: 'detailState');
+
+    RoutingConfig buildConfig() => RoutingConfig(
+      routes: <RouteBase>[
+        ShellRoute(
+          navigatorKey: shellNavigatorKey,
+          routes: <RouteBase>[
+            GoRoute(path: '/', builder: (_, _) => const Text('home')),
+            GoRoute(
+              path: '/detail',
+              builder: (_, _) => StatefulTest(key: detailKey, child: const Text('detail')),
+            ),
+          ],
+          builder: (_, _, Widget widget) => widget,
+        ),
+      ],
+    );
+
+    final config = ValueNotifier<RoutingConfig>(buildConfig());
+    addTearDown(config.dispose);
+    final GoRouter router = await createRouterWithRoutingConfig(config, tester);
+    final NavigatorState configuredNavigator = shellNavigatorKey.currentState!;
+
+    router.push('/detail');
+    await tester.pumpAndSettle();
+    expect(tester.takeException(), isNull);
+    final _StatefulTestState detailState = detailKey.currentState!;
+    final NavigatorState scopedNavigator = Navigator.of(detailState.context);
+    final State<StatefulWidget> scopedNavigatorWrapper = _customNavigatorStateFor(scopedNavigator);
+    detailState.value = 1;
+
+    config.value = buildConfig();
+    await tester.pumpAndSettle();
+
+    expect(tester.takeException(), isNull);
+    expect(find.text('detail'), findsOneWidget);
+    expect(shellNavigatorKey.currentState, same(configuredNavigator));
+    expect(detailKey.currentState, same(detailState));
+    expect(Navigator.of(detailState.context), same(scopedNavigator));
+    expect(_customNavigatorStateFor(scopedNavigator), same(scopedNavigatorWrapper));
+    expect(detailState.value, 1);
+  });
+
+  testWidgets('routing config preserves stateful shell branch state', (WidgetTester tester) async {
+    final shellKey = GlobalKey<StatefulNavigationShellState>(debugLabel: 'statefulShell');
+    final branchNavigatorKey = GlobalKey<NavigatorState>(debugLabel: 'branch');
+    final pageKey = GlobalKey<_StatefulTestState>(debugLabel: 'branchPage');
+
+    RoutingConfig buildConfig({required bool includeSecondRoute}) => RoutingConfig(
+      routes: <RouteBase>[
+        StatefulShellRoute.indexedStack(
+          key: shellKey,
+          branches: <StatefulShellBranch>[
+            StatefulShellBranch(
+              navigatorKey: branchNavigatorKey,
+              routes: <RouteBase>[
+                GoRoute(
+                  path: '/',
+                  builder: (_, _) => StatefulTest(key: pageKey, child: const Text('home')),
+                ),
+                if (includeSecondRoute)
+                  GoRoute(path: '/second', builder: (_, _) => const Text('second')),
+              ],
+            ),
+          ],
+          builder: (_, _, StatefulNavigationShell navigationShell) => navigationShell,
+        ),
+      ],
+    );
+
+    final config = ValueNotifier<RoutingConfig>(buildConfig(includeSecondRoute: false));
+    addTearDown(config.dispose);
+    await createRouterWithRoutingConfig(config, tester);
+    final StatefulNavigationShellState shellState = shellKey.currentState!;
+    final NavigatorState branchNavigator = branchNavigatorKey.currentState!;
+    final _StatefulTestState pageState = pageKey.currentState!;
+    pageState.value = 1;
+
+    config.value = buildConfig(includeSecondRoute: true);
+    await tester.pumpAndSettle();
+
+    expect(tester.takeException(), isNull);
+    expect(shellKey.currentState, same(shellState));
+    expect(branchNavigatorKey.currentState, same(branchNavigator));
+    expect(pageKey.currentState, same(pageState));
+    expect(pageState.value, 1);
+  });
 
   testWidgets('routing config works with named route', (WidgetTester tester) async {
     final config = ValueNotifier<RoutingConfig>(
@@ -241,4 +333,16 @@ class _StatefulTestState extends State<StatefulTest> {
   Widget build(BuildContext context) {
     return Column(children: <Widget>[widget.child, Text('State: $value')]);
   }
+}
+
+State<StatefulWidget> _customNavigatorStateFor(NavigatorState navigator) {
+  StatefulElement? customNavigatorElement;
+  (navigator.context as Element).visitAncestorElements((Element element) {
+    if (element.widget.runtimeType.toString() == '_CustomNavigator') {
+      customNavigatorElement = element as StatefulElement;
+      return false;
+    }
+    return true;
+  });
+  return customNavigatorElement!.state;
 }


### PR DESCRIPTION
This supersedes https://github.com/flutter/packages/pull/11143, which was closed as inactive. It incorporates the review feedback from that PR.

## Problem

When `push()` navigates between sibling regular `ShellRoute` branches under the same parent, multiple shell pages and navigators can coexist in the widget tree.

This could produce duplicate page or widget keys because:

- `_CustomNavigator` was keyed using `GlobalObjectKey(navigatorKey.hashCode)`, so distinct navigator keys with the same hash were treated as the same key.
- `ShellRouteMatch.pageKey` was derived only from `route.hashCode`.
- Re-entering a `ShellRoute` that was already present in the imperative stack reused its page and navigator identities.

The first implementation in #11143 created fresh page and navigator keys for every `ShellRouteMatch`. Review correctly pointed out that this made navigator identity unstable across route reparses and prevented the configured `ShellRoute.navigatorKey` from consistently identifying its navigator.

## Fix

This version addresses that feedback by:

- preserving the configured navigator key during normal route matching and reparsing;
- making shell page keys identity-aware, so distinct routes remain distinct even when their `hashCode` values collide;
- keying only the nested `_CustomNavigator` wrapper by the navigator key object instead of its `hashCode`;
- assigning scoped page and navigator keys only when an imperative push would otherwise collide with another live regular `ShellRoute` match;
- deriving that scope from the persistent `ImperativeRouteMatch.pageKey`;
- leaving `StatefulShellRoute`, the root navigator wrapper, and normal configured-key navigation unchanged.

## Tests

The regression test `push to a sibling shell route under the same parent shell route` forces both navigator-key and route-hash collisions.

It covers:

- pushing to a sibling shell route;
- re-entering the first shell route while its original instance is still in the stack;
- preserving navigator and page state across match-list reconstruction and `refresh()`;
- detecting and scoping collisions in nested `ShellRouteMatch` trees;
- popping back through both shell routes;
- navigating with `go()` after the imperative stack is removed.

No screenshots are included because this is a routing/runtime fix.

- Fixes flutter/flutter#148712
- Fixes flutter/flutter#140586

## Validation

- `flutter test`: 438 passed, 2 skipped
- `flutter analyze`: no issues
- `flutter_plugin_tools validate --check-for-missing-changes --packages go_router`: no issues

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under[^1].
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [x] All existing and new tests are passing.

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[the version and CHANGELOG instructions]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version-and-changelog-updates
[semantic versioning]: https://dart.dev/tools/pub/versioning#semantic-versions
[repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests