### PR TITLE
[material_ui]  Fix DropdownButtonFormField underline alignment at bottom

### DIFF
--- a/packages/material_ui/lib/src/dropdown.dart
+++ b/packages/material_ui/lib/src/dropdown.dart
@@ -1050,6 +1050,7 @@ class DropdownButton<T> extends StatefulWidget {
          'with the same value',
        ),
        assert(itemHeight == null || itemHeight >= kMinInteractiveDimension),
+       isVerticallyExpanded = true,
        _inputDecoration = null,
        _isEmpty = false;
 
@@ -1085,6 +1086,7 @@ class DropdownButton<T> extends StatefulWidget {
     this.barrierDismissible = true,
     this.mouseCursor,
     this.dropdownMenuItemMouseCursor,
+    this.isVerticallyExpanded = false,
     required this._inputDecoration,
     required this._isEmpty,
   }) : assert(
@@ -1251,11 +1253,10 @@ class DropdownButton<T> extends StatefulWidget {
   /// its own decorations, like [InputDecorator].
   final bool isDense;
 
-  /// Set the dropdown's inner contents to horizontally fill its parent.
+  /// See also:
   ///
-  /// By default this button's inner width is the minimum size of its contents.
-  /// If [isExpanded] is true, the inner width is expanded to fill its
-  /// surrounding container.
+  ///  * [DropdownButton.isVerticallyExpanded], which expands the inner height of the
+  ///    dropdown to fill the available vertical space.
   final bool isExpanded;
 
   /// If null, then the menu item heights will vary according to each menu item's
@@ -1361,6 +1362,26 @@ class DropdownButton<T> extends StatefulWidget {
   ///
   /// If this property is null, [WidgetStateMouseCursor.adaptiveClickable] will be used.
   final MouseCursor? dropdownMenuItemMouseCursor;
+
+  /// Whether the dropdown's inner contents expand to fill the
+  /// available vertical space.
+  ///
+  /// When true, the inner height of the dropdown is expanded to match its
+  /// parent container. When false, the inner height is determined by the
+  /// height of the selected item (its intrinsic height).
+  ///
+  /// This is particularly useful when the dropdown is used inside a fixed-height
+  /// container, ensuring that the underline and items align properly within
+  /// the allocated space.
+  ///
+  /// Defaults to false for [DropdownButtonFormField] to ensure the input decorator
+  /// handles the vertical constraints correctly by default.
+  ///
+  /// See also:
+  ///
+  ///  * [DropdownButton.isExpanded], which expands the inner width of the
+  ///    dropdown to fill the available horizontal space.
+  final bool isVerticallyExpanded;
 
   final InputDecoration? _inputDecoration;
 
@@ -1772,7 +1793,7 @@ class _DropdownButtonState<T> extends State<DropdownButton<T>> with WidgetsBindi
               isEmpty: widget._isEmpty,
               isFocused: _hasPrimaryFocus,
               isHovering: _isHovering,
-              expands: widget.isExpanded,
+              expands: widget.isVerticallyExpanded,
               child: widget.padding == null
                   ? result
                   : Padding(padding: widget.padding!, child: result),
@@ -1792,6 +1813,13 @@ class _DropdownButtonState<T> extends State<DropdownButton<T>> with WidgetsBindi
         enableFeedback: false,
         child: widget.padding == null ? result : Padding(padding: widget.padding!, child: result),
       );
+    }
+
+    // When vertical expansion is disabled, wrap with Align
+    // to prevent the widget from stretching to fill the parent's
+    // available height.
+    if (!widget.isVerticallyExpanded) {
+      result = Align(alignment: AlignmentDirectional.topStart, heightFactor: 1.0, child: result);
     }
 
     final bool childHasButtonSemantic =
@@ -1869,6 +1897,7 @@ class DropdownButtonFormField<T> extends FormField<T> {
     this.barrierDismissible = true,
     this.mouseCursor,
     this.dropdownMenuItemMouseCursor,
+    bool isVerticallyExpanded = false,
     // When adding new arguments, consider adding similar arguments to
     // DropdownButton.
   }) : assert(
@@ -1965,6 +1994,7 @@ class DropdownButtonFormField<T> extends FormField<T> {
                  barrierDismissible: barrierDismissible,
                  mouseCursor: mouseCursor,
                  dropdownMenuItemMouseCursor: dropdownMenuItemMouseCursor,
+                 isVerticallyExpanded: isVerticallyExpanded,
                ),
              ),
            );

--- a/packages/material_ui/lib/src/dropdown.dart
+++ b/packages/material_ui/lib/src/dropdown.dart
@@ -1772,6 +1772,7 @@ class _DropdownButtonState<T> extends State<DropdownButton<T>> with WidgetsBindi
               isEmpty: widget._isEmpty,
               isFocused: _hasPrimaryFocus,
               isHovering: _isHovering,
+              expands: widget.isExpanded,
               child: widget.padding == null
                   ? result
                   : Padding(padding: widget.padding!, child: result),

--- a/packages/material_ui/pending_changelogs/change_2026_08_22_1787409702353.yaml
+++ b/packages/material_ui/pending_changelogs/change_2026_08_22_1787409702353.yaml
@@ -1,0 +1,3 @@
+changelog: |
+  - Fixes DropdownButtonFormField underline alignment at bottom
+version: patch

--- a/packages/material_ui/test/dropdown_form_field_test.dart
+++ b/packages/material_ui/test/dropdown_form_field_test.dart
@@ -1056,7 +1056,7 @@ void main() {
     expect(find.text(currentValue), findsOneWidget);
 
     // Tap the DropdownButtonFormField widget
-    await tester.tap(find.byType(DropdownButton<String>));
+    await tester.tap(find.text(currentValue));
     await tester.pumpAndSettle();
 
     // Tap the first dropdown menu item.

--- a/packages/material_ui/test/dropdown_test.dart
+++ b/packages/material_ui/test/dropdown_test.dart
@@ -4989,4 +4989,38 @@ void main() {
       );
     },
   );
+
+  testWidgets('DropdownButtonFormField underline is at the bottom of the expanded height', (
+    WidgetTester tester,
+  ) async {
+    const containerHeight = 200.0;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: SizedBox(
+            height: containerHeight,
+            child: DropdownButtonFormField<int>(
+              isExpanded: true,
+              items: const [DropdownMenuItem(value: 1, child: Text('Option 1'))],
+              onChanged: (_) {},
+            ),
+          ),
+        ),
+      ),
+    );
+
+    final Finder decorator = find.byType(InputDecorator);
+
+    final RenderBox box = tester.renderObject(decorator);
+    final double width = box.size.width;
+
+    expect(
+      decorator,
+      paints..line(
+        p1: const Offset(0, containerHeight - 0.5),
+        p2: Offset(width, containerHeight - 0.5),
+      ),
+    );
+  });
 }

--- a/packages/material_ui/test/dropdown_test.dart
+++ b/packages/material_ui/test/dropdown_test.dart
@@ -5002,6 +5002,7 @@ void main() {
             height: containerHeight,
             child: DropdownButtonFormField<int>(
               isExpanded: true,
+              isVerticallyExpanded: true,
               items: const [DropdownMenuItem(value: 1, child: Text('Option 1'))],
               onChanged: (_) {},
             ),


### PR DESCRIPTION
This PR fixes the visual issue where the underline of a `DropdownButtonFormField` did not align at the bottom of its expanded container.

Fixes flutter/flutter#162350

Port of https://github.com/flutter/flutter/pull/181040.

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under[^1].
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[the version and CHANGELOG instructions]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version-and-changelog-updates
[semantic versioning]: https://dart.dev/tools/pub/versioning#semantic-versions
[repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
