### PR TITLE
[google_maps_flutter] Support mouse hover callback on AdvancedMarker

### DIFF
--- a/packages/google_maps_flutter/google_maps_flutter/CHANGELOG.md
+++ b/packages/google_maps_flutter/google_maps_flutter/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.19.0
+
+* Adds support for `AdvancedMarker.onHover`, reporting mouse hover state
+  changes. Only supported on the web platform.
+
 ## 2.18.0
 
 * Adds support for mapTypeControlEnabled, fullscreenControlEnabled, and streetViewControlEnabled on web.

--- a/packages/google_maps_flutter/google_maps_flutter/lib/src/controller.dart
+++ b/packages/google_maps_flutter/google_maps_flutter/lib/src/controller.dart
@@ -83,6 +83,11 @@ class GoogleMapController {
     );
     _streamSubscriptions.add(
       GoogleMapsFlutterPlatform.instance
+          .onMarkerHover(mapId: mapId)
+          .listen((MarkerHoverEvent e) => _googleMapState.onMarkerHover(e.value, e.isHovering)),
+    );
+    _streamSubscriptions.add(
+      GoogleMapsFlutterPlatform.instance
           .onInfoWindowTap(mapId: mapId)
           .listen((InfoWindowTapEvent e) => _googleMapState.onInfoWindowTap(e.value)),
     );

--- a/packages/google_maps_flutter/google_maps_flutter/lib/src/google_map.dart
+++ b/packages/google_maps_flutter/google_maps_flutter/lib/src/google_map.dart
@@ -648,6 +648,16 @@ class _GoogleMapState extends State<GoogleMap> {
     }
   }
 
+  void onMarkerHover(MarkerId markerId, bool isHovering) {
+    final Marker? marker = _markers[markerId];
+    if (marker == null) {
+      throw UnknownMapObjectIdError('marker', markerId, 'onHover');
+    }
+    if (marker is AdvancedMarker) {
+      marker.onHover?.call(isHovering);
+    }
+  }
+
   void onPolygonTap(PolygonId polygonId) {
     final Polygon? polygon = _polygons[polygonId];
     if (polygon == null) {

--- a/packages/google_maps_flutter/google_maps_flutter/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter/pubspec.yaml
@@ -2,7 +2,7 @@ name: google_maps_flutter
 description: A Flutter plugin for integrating Google Maps in iOS and Android applications.
 repository: https://github.com/flutter/packages/tree/main/packages/google_maps_flutter/google_maps_flutter
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+maps%22
-version: 2.18.0
+version: 2.19.0
 
 environment:
   sdk: ^3.10.0
@@ -21,10 +21,10 @@ flutter:
 dependencies:
   flutter:
     sdk: flutter
-  google_maps_flutter_android: ^2.19.1
-  google_maps_flutter_ios: ^2.18.0
-  google_maps_flutter_platform_interface: ^2.16.0
-  google_maps_flutter_web: ^0.6.3
+  google_maps_flutter_android: ^2.19.13
+  google_maps_flutter_ios: ^2.18.5
+  google_maps_flutter_platform_interface: ^2.17.0
+  google_maps_flutter_web: ^0.7.0
 
 dev_dependencies:
   flutter_test:

--- a/packages/google_maps_flutter/google_maps_flutter/test/fake_google_maps_flutter_platform.dart
+++ b/packages/google_maps_flutter/google_maps_flutter/test/fake_google_maps_flutter_platform.dart
@@ -213,6 +213,11 @@ class FakeGoogleMapsFlutterPlatform extends GoogleMapsFlutterPlatform {
   }
 
   @override
+  Stream<MarkerHoverEvent> onMarkerHover({required int mapId}) {
+    return mapEventStreamController.stream.whereType<MarkerHoverEvent>();
+  }
+
+  @override
   Stream<PolylineTapEvent> onPolylineTap({required int mapId}) {
     return mapEventStreamController.stream.whereType<PolylineTapEvent>();
   }

--- a/packages/google_maps_flutter/google_maps_flutter_android/CHANGELOG.md
+++ b/packages/google_maps_flutter/google_maps_flutter_android/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## 2.19.13
 
 * Updates pigeon dev_dependency to ^27.3.2 for analyzer 14 compatibility.
+* Implements `onMarkerHover` as a no-op stream, since hovering a marker with
+  a mouse is only supported on the web platform.
 
 ## 2.19.12
 

--- a/packages/google_maps_flutter/google_maps_flutter_android/example/test/fake_google_maps_flutter_platform.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_android/example/test/fake_google_maps_flutter_platform.dart
@@ -192,6 +192,11 @@ class FakeGoogleMapsFlutterPlatform extends GoogleMapsFlutterPlatform {
   }
 
   @override
+  Stream<MarkerHoverEvent> onMarkerHover({required int mapId}) {
+    return mapEventStreamController.stream.whereType<MarkerHoverEvent>();
+  }
+
+  @override
   Stream<PolylineTapEvent> onPolylineTap({required int mapId}) {
     return mapEventStreamController.stream.whereType<PolylineTapEvent>();
   }

--- a/packages/google_maps_flutter/google_maps_flutter_android/lib/src/google_maps_flutter_android.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_android/lib/src/google_maps_flutter_android.dart
@@ -191,6 +191,12 @@ class GoogleMapsFlutterAndroid extends GoogleMapsFlutterPlatform {
   }
 
   @override
+  Stream<MarkerHoverEvent> onMarkerHover({required int mapId}) {
+    // Hovering a marker with a mouse is only supported on the web platform.
+    return _events(mapId).whereType<MarkerHoverEvent>();
+  }
+
+  @override
   Stream<PolylineTapEvent> onPolylineTap({required int mapId}) {
     return _events(mapId).whereType<PolylineTapEvent>();
   }

--- a/packages/google_maps_flutter/google_maps_flutter_android/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter_android/pubspec.yaml
@@ -21,7 +21,7 @@ dependencies:
   flutter:
     sdk: flutter
   flutter_plugin_android_lifecycle: ^2.0.1
-  google_maps_flutter_platform_interface: ^2.13.0
+  google_maps_flutter_platform_interface: ^2.17.0
   meta: ^1.10.0
   stream_transform: ^2.0.0
 

--- a/packages/google_maps_flutter/google_maps_flutter_ios/CHANGELOG.md
+++ b/packages/google_maps_flutter/google_maps_flutter_ios/CHANGELOG.md
@@ -1,9 +1,8 @@
 ## 2.18.6
-
 * Updates pigeon dev_dependency to ^27.3.2 for analyzer 14 compatibility.
-
+* Implements `onMarkerHover` as a no-op stream, since hovering a marker with
+  a mouse is only supported on the web platform.
 ## 2.18.5
-
 * Updates README to indicate that this package will not receive feature updates
   going forward. Please see the README for information about adopting one of
   the maintained implementation packages.

--- a/packages/google_maps_flutter/google_maps_flutter_ios/example/test/fake_google_maps_flutter_platform.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_ios/example/test/fake_google_maps_flutter_platform.dart
@@ -192,6 +192,11 @@ class FakeGoogleMapsFlutterPlatform extends GoogleMapsFlutterPlatform {
   }
 
   @override
+  Stream<MarkerHoverEvent> onMarkerHover({required int mapId}) {
+    return mapEventStreamController.stream.whereType<MarkerHoverEvent>();
+  }
+
+  @override
   Stream<PolylineTapEvent> onPolylineTap({required int mapId}) {
     return mapEventStreamController.stream.whereType<PolylineTapEvent>();
   }

--- a/packages/google_maps_flutter/google_maps_flutter_ios/lib/src/google_maps_flutter_ios.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_ios/lib/src/google_maps_flutter_ios.dart
@@ -168,6 +168,12 @@ class GoogleMapsFlutterIOS extends GoogleMapsFlutterPlatform {
   }
 
   @override
+  Stream<MarkerHoverEvent> onMarkerHover({required int mapId}) {
+    // Hovering a marker with a mouse is only supported on the web platform.
+    return _events(mapId).whereType<MarkerHoverEvent>();
+  }
+
+  @override
   Stream<PolylineTapEvent> onPolylineTap({required int mapId}) {
     return _events(mapId).whereType<PolylineTapEvent>();
   }

--- a/packages/google_maps_flutter/google_maps_flutter_ios/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter_ios/pubspec.yaml
@@ -19,7 +19,7 @@ flutter:
 dependencies:
   flutter:
     sdk: flutter
-  google_maps_flutter_platform_interface: ^2.14.2
+  google_maps_flutter_platform_interface: ^2.17.0
   meta: ^1.10.0
   stream_transform: ^2.0.0
 

--- a/packages/google_maps_flutter/google_maps_flutter_ios_sdk10/CHANGELOG.md
+++ b/packages/google_maps_flutter/google_maps_flutter_ios_sdk10/CHANGELOG.md
@@ -1,21 +1,14 @@
 ## 2.18.10
-
 * Converts marker controllers to Swift.
-
+* Implements `onMarkerHover` as a no-op stream, since hovering a marker with
+  a mouse is only supported on the web platform.
 ## 2.18.9
-
 * Updates pigeon dev_dependency to ^27.3.2 for analyzer 14 compatibility.
-
 ## 2.18.8
-
 * Converts overlay controllers to Swift.
-
 ## 2.18.7
-
 * Converts circle, polygon, and polyline controllers to Swift.
-
 ## 2.18.6
-
 * Converts parts of the implementation to Swift.
 
 ## 2.18.5

--- a/packages/google_maps_flutter/google_maps_flutter_ios_sdk10/example/test/fake_google_maps_flutter_platform.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_ios_sdk10/example/test/fake_google_maps_flutter_platform.dart
@@ -192,6 +192,11 @@ class FakeGoogleMapsFlutterPlatform extends GoogleMapsFlutterPlatform {
   }
 
   @override
+  Stream<MarkerHoverEvent> onMarkerHover({required int mapId}) {
+    return mapEventStreamController.stream.whereType<MarkerHoverEvent>();
+  }
+
+  @override
   Stream<PolylineTapEvent> onPolylineTap({required int mapId}) {
     return mapEventStreamController.stream.whereType<PolylineTapEvent>();
   }

--- a/packages/google_maps_flutter/google_maps_flutter_ios_sdk10/lib/src/google_maps_flutter_ios.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_ios_sdk10/lib/src/google_maps_flutter_ios.dart
@@ -168,6 +168,12 @@ class GoogleMapsFlutterIOS extends GoogleMapsFlutterPlatform {
   }
 
   @override
+  Stream<MarkerHoverEvent> onMarkerHover({required int mapId}) {
+    // Hovering a marker with a mouse is only supported on the web platform.
+    return _events(mapId).whereType<MarkerHoverEvent>();
+  }
+
+  @override
   Stream<PolylineTapEvent> onPolylineTap({required int mapId}) {
     return _events(mapId).whereType<PolylineTapEvent>();
   }

--- a/packages/google_maps_flutter/google_maps_flutter_ios_sdk10/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter_ios_sdk10/pubspec.yaml
@@ -19,7 +19,7 @@ flutter:
 dependencies:
   flutter:
     sdk: flutter
-  google_maps_flutter_platform_interface: ^2.14.2
+  google_maps_flutter_platform_interface: ^2.17.0
   meta: ^1.10.0
   stream_transform: ^2.0.0
 

--- a/packages/google_maps_flutter/google_maps_flutter_ios_sdk9/CHANGELOG.md
+++ b/packages/google_maps_flutter/google_maps_flutter_ios_sdk9/CHANGELOG.md
@@ -1,21 +1,14 @@
 ## 2.18.11
-
 * Converts marker controllers to Swift.
-
+* Implements `onMarkerHover` as a no-op stream, since hovering a marker with
+  a mouse is only supported on the web platform.
 ## 2.18.10
-
 * Updates pigeon dev_dependency to ^27.3.2 for analyzer 14 compatibility.
-
 ## 2.18.9
-
 * Converts overlay controllers to Swift.
-
 ## 2.18.8
-
 * Converts circle, polygon, and polyline controllers to Swift.
-
 ## 2.18.7
-
 * Converts parts of the implementation to Swift.
 
 ## 2.18.6

--- a/packages/google_maps_flutter/google_maps_flutter_ios_sdk9/example/test/fake_google_maps_flutter_platform.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_ios_sdk9/example/test/fake_google_maps_flutter_platform.dart
@@ -192,6 +192,11 @@ class FakeGoogleMapsFlutterPlatform extends GoogleMapsFlutterPlatform {
   }
 
   @override
+  Stream<MarkerHoverEvent> onMarkerHover({required int mapId}) {
+    return mapEventStreamController.stream.whereType<MarkerHoverEvent>();
+  }
+
+  @override
   Stream<PolylineTapEvent> onPolylineTap({required int mapId}) {
     return mapEventStreamController.stream.whereType<PolylineTapEvent>();
   }

--- a/packages/google_maps_flutter/google_maps_flutter_ios_sdk9/lib/src/google_maps_flutter_ios.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_ios_sdk9/lib/src/google_maps_flutter_ios.dart
@@ -168,6 +168,12 @@ class GoogleMapsFlutterIOS extends GoogleMapsFlutterPlatform {
   }
 
   @override
+  Stream<MarkerHoverEvent> onMarkerHover({required int mapId}) {
+    // Hovering a marker with a mouse is only supported on the web platform.
+    return _events(mapId).whereType<MarkerHoverEvent>();
+  }
+
+  @override
   Stream<PolylineTapEvent> onPolylineTap({required int mapId}) {
     return _events(mapId).whereType<PolylineTapEvent>();
   }

--- a/packages/google_maps_flutter/google_maps_flutter_ios_sdk9/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter_ios_sdk9/pubspec.yaml
@@ -19,7 +19,7 @@ flutter:
 dependencies:
   flutter:
     sdk: flutter
-  google_maps_flutter_platform_interface: ^2.14.2
+  google_maps_flutter_platform_interface: ^2.17.0
   meta: ^1.10.0
   stream_transform: ^2.0.0
 

--- a/packages/google_maps_flutter/google_maps_flutter_ios_shared_code/example/test/fake_google_maps_flutter_platform.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_ios_shared_code/example/test/fake_google_maps_flutter_platform.dart
@@ -192,6 +192,11 @@ class FakeGoogleMapsFlutterPlatform extends GoogleMapsFlutterPlatform {
   }
 
   @override
+  Stream<MarkerHoverEvent> onMarkerHover({required int mapId}) {
+    return mapEventStreamController.stream.whereType<MarkerHoverEvent>();
+  }
+
+  @override
   Stream<PolylineTapEvent> onPolylineTap({required int mapId}) {
     return mapEventStreamController.stream.whereType<PolylineTapEvent>();
   }

--- a/packages/google_maps_flutter/google_maps_flutter_ios_shared_code/lib/src/google_maps_flutter_ios.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_ios_shared_code/lib/src/google_maps_flutter_ios.dart
@@ -168,6 +168,12 @@ class GoogleMapsFlutterIOS extends GoogleMapsFlutterPlatform {
   }
 
   @override
+  Stream<MarkerHoverEvent> onMarkerHover({required int mapId}) {
+    // Hovering a marker with a mouse is only supported on the web platform.
+    return _events(mapId).whereType<MarkerHoverEvent>();
+  }
+
+  @override
   Stream<PolylineTapEvent> onPolylineTap({required int mapId}) {
     return _events(mapId).whereType<PolylineTapEvent>();
   }

--- a/packages/google_maps_flutter/google_maps_flutter_platform_interface/CHANGELOG.md
+++ b/packages/google_maps_flutter/google_maps_flutter_platform_interface/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.17.0
+
+* Adds `AdvancedMarker.onHover`, `MarkerHoverEvent`, and
+  `GoogleMapsFlutterPlatform.onMarkerHover` to support reporting mouse hover
+  state changes for advanced markers. Only supported on the web platform.
+
 ## 2.16.1
 
 * Fixes the `PinConfig` code sample in the `BitmapDescriptor` documentation.

--- a/packages/google_maps_flutter/google_maps_flutter_platform_interface/lib/src/events/map_event.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_platform_interface/lib/src/events/map_event.dart
@@ -128,6 +128,21 @@ class MarkerDragEndEvent extends _PositionedMapEvent<MarkerId> {
   MarkerDragEndEvent(super.mapId, super.position, super.markerId);
 }
 
+/// An event fired when the mouse starts or stops hovering over a [Marker].
+///
+/// This is only fired on the web platform, for [AdvancedMarker]s.
+class MarkerHoverEvent extends MapEvent<MarkerId> {
+  /// Build a MarkerHover Event triggered from the map represented by `mapId`.
+  ///
+  /// The `value` of this event is a [MarkerId] object that represents the Marker.
+  /// The `isHovering` is `true` when the mouse starts hovering the marker, and
+  /// `false` when it stops.
+  MarkerHoverEvent(super.mapId, super.markerId, this.isHovering);
+
+  /// Whether the mouse is hovering the marker.
+  final bool isHovering;
+}
+
 /// An event fired when a [Polyline] is tapped.
 class PolylineTapEvent extends MapEvent<PolylineId> {
   /// Build an PolylineTap Event triggered from the map represented by `mapId`.

--- a/packages/google_maps_flutter/google_maps_flutter_platform_interface/lib/src/method_channel/method_channel_google_maps_flutter.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_platform_interface/lib/src/method_channel/method_channel_google_maps_flutter.dart
@@ -141,6 +141,11 @@ class MethodChannelGoogleMapsFlutter extends GoogleMapsFlutterPlatform {
   }
 
   @override
+  Stream<MarkerHoverEvent> onMarkerHover({required int mapId}) {
+    return _events(mapId).whereType<MarkerHoverEvent>();
+  }
+
+  @override
   Stream<PolylineTapEvent> onPolylineTap({required int mapId}) {
     return _events(mapId).whereType<PolylineTapEvent>();
   }

--- a/packages/google_maps_flutter/google_maps_flutter_platform_interface/lib/src/platform_interface/google_maps_flutter_platform.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_platform_interface/lib/src/platform_interface/google_maps_flutter_platform.dart
@@ -322,6 +322,13 @@ abstract class GoogleMapsFlutterPlatform extends PlatformInterface {
     throw UnimplementedError('onMarkerDragEnd() has not been implemented.');
   }
 
+  /// The mouse has started or stopped hovering over a [Marker].
+  ///
+  /// This is only fired on the web platform, for [AdvancedMarker]s.
+  Stream<MarkerHoverEvent> onMarkerHover({required int mapId}) {
+    throw UnimplementedError('onMarkerHover() has not been implemented.');
+  }
+
   /// A [Polyline] has been tapped.
   Stream<PolylineTapEvent> onPolylineTap({required int mapId}) {
     throw UnimplementedError('onPolylineTap() has not been implemented.');

--- a/packages/google_maps_flutter/google_maps_flutter_platform_interface/lib/src/types/advanced_marker.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_platform_interface/lib/src/types/advanced_marker.dart
@@ -35,10 +35,21 @@ class AdvancedMarker extends Marker {
     super.onDragEnd,
     int zIndex = 0,
     this.collisionBehavior = MarkerCollisionBehavior.requiredDisplay,
+    this.onHover,
   }) : super(zIndex: zIndex.toDouble());
 
   /// Indicates how the marker behaves when it collides with other markers.
   final MarkerCollisionBehavior collisionBehavior;
+
+  /// Callback reporting when the mouse starts or stops hovering over the
+  /// marker.
+  ///
+  /// The `isHovering` argument is `true` when the mouse starts hovering the
+  /// marker, and `false` when it stops.
+  ///
+  /// This is only supported on the web platform. On other platforms, this
+  /// callback is never called.
+  final ValueChanged<bool>? onHover;
 
   /// Creates a new [AdvancedMarker] object whose values are the same as this
   /// instance, unless overwritten by the specified parameters.
@@ -67,6 +78,7 @@ class AdvancedMarker extends Marker {
     ClusterManagerId? clusterManagerIdParam,
     MarkerCollisionBehavior? collisionBehaviorParam,
     double? altitudeParam,
+    ValueChanged<bool>? onHoverParam,
   }) {
     return AdvancedMarker(
       markerId: markerId,
@@ -87,6 +99,7 @@ class AdvancedMarker extends Marker {
       onDragEnd: onDragEndParam ?? onDragEnd,
       clusterManagerId: clusterManagerIdParam ?? clusterManagerId,
       collisionBehavior: collisionBehaviorParam ?? collisionBehavior,
+      onHover: onHoverParam ?? onHover,
     );
   }
 
@@ -148,7 +161,7 @@ class AdvancedMarker extends Marker {
         'icon: $icon, infoWindow: $infoWindow, position: $position, rotation: $rotation, '
         'visible: $visible, zIndex: $zIndex, onTap: $onTap, onDragStart: $onDragStart, '
         'onDrag: $onDrag, onDragEnd: $onDragEnd, clusterManagerId: $clusterManagerId, '
-        'collisionBehavior: $collisionBehavior}';
+        'collisionBehavior: $collisionBehavior, onHover: $onHover}';
   }
 }
 

--- a/packages/google_maps_flutter/google_maps_flutter_platform_interface/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter_platform_interface/pubspec.yaml
@@ -4,7 +4,7 @@ repository: https://github.com/flutter/packages/tree/main/packages/google_maps_f
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+maps%22
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 2.16.1
+version: 2.17.0
 
 environment:
   sdk: ^3.10.0

--- a/packages/google_maps_flutter/google_maps_flutter_web/CHANGELOG.md
+++ b/packages/google_maps_flutter/google_maps_flutter_web/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.7.0
+
+* Adds support for `AdvancedMarker.onHover`, reporting mouse hover state
+  changes via the `gmp-mouseenter`/`gmp-mouseleave` DOM events.
+
 ## 0.6.3
 
 * Adds support for mapTypeControlEnabled, fullscreenControlEnabled, and streetViewControlEnabled.

--- a/packages/google_maps_flutter/google_maps_flutter_web/example/latest/integration_test/advanced_marker_test.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_web/example/latest/integration_test/advanced_marker_test.dart
@@ -10,6 +10,7 @@ import 'package:google_maps/google_maps.dart' as gmaps;
 import 'package:google_maps_flutter_web/google_maps_flutter_web.dart';
 import 'package:google_maps_flutter_web/src/utils.dart';
 import 'package:integration_test/integration_test.dart';
+import 'package:web/web.dart' as web;
 
 /// Test Markers
 void main() {
@@ -87,6 +88,38 @@ void main() {
       gmaps.event.trigger(marker, 'dragend', gmaps.MapMouseEvent()..latLng = gmaps.LatLng(0, 0));
 
       expect(await methodCalled, isTrue);
+    });
+
+    testWidgets('onHover gets called on gmp-mouseenter/gmp-mouseleave', (
+      WidgetTester tester,
+    ) async {
+      final hoverStates = <bool>[];
+      AdvancedMarkerController(marker: marker, onHover: hoverStates.add);
+
+      marker.dispatchEvent(web.Event('gmp-mouseenter'));
+      marker.dispatchEvent(web.Event('gmp-mouseleave'));
+
+      expect(hoverStates, <bool>[true, false]);
+    });
+
+    testWidgets('gmp-mouseenter/gmp-mouseleave are ignored when onHover is null', (
+      WidgetTester tester,
+    ) async {
+      AdvancedMarkerController(marker: marker);
+
+      // Should not throw when no listener was attached.
+      marker.dispatchEvent(web.Event('gmp-mouseenter'));
+      marker.dispatchEvent(web.Event('gmp-mouseleave'));
+    });
+
+    testWidgets('onHover stops being called after remove', (WidgetTester tester) async {
+      final hoverStates = <bool>[];
+      final controller = AdvancedMarkerController(marker: marker, onHover: hoverStates.add);
+
+      controller.remove();
+      marker.dispatchEvent(web.Event('gmp-mouseenter'));
+
+      expect(hoverStates, isEmpty);
     });
 
     testWidgets('update', (WidgetTester tester) async {

--- a/packages/google_maps_flutter/google_maps_flutter_web/example/latest/integration_test/advanced_marker_test.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_web/example/latest/integration_test/advanced_marker_test.dart
@@ -107,9 +107,36 @@ void main() {
     ) async {
       AdvancedMarkerController(marker: marker);
 
-      // Should not throw when no listener was attached.
+      // Should not throw when onHover is unset.
       marker.dispatchEvent(web.Event('gmp-mouseenter'));
       marker.dispatchEvent(web.Event('gmp-mouseleave'));
+    });
+
+    testWidgets('onHover can be set after construction', (WidgetTester tester) async {
+      // Regression test: the marker starts with no onHover callback, so no
+      // hover events should be reported until one is assigned later, at
+      // which point the already-attached DOM listeners must start using it.
+      final controller = AdvancedMarkerController(marker: marker);
+
+      marker.dispatchEvent(web.Event('gmp-mouseenter'));
+
+      final hoverStates = <bool>[];
+      controller.onHover = hoverStates.add;
+
+      marker.dispatchEvent(web.Event('gmp-mouseenter'));
+      marker.dispatchEvent(web.Event('gmp-mouseleave'));
+
+      expect(hoverStates, <bool>[true, false]);
+    });
+
+    testWidgets('onHover can be cleared after construction', (WidgetTester tester) async {
+      final hoverStates = <bool>[];
+      final controller = AdvancedMarkerController(marker: marker, onHover: hoverStates.add);
+
+      controller.onHover = null;
+      marker.dispatchEvent(web.Event('gmp-mouseenter'));
+
+      expect(hoverStates, isEmpty);
     });
 
     testWidgets('onHover stops being called after remove', (WidgetTester tester) async {

--- a/packages/google_maps_flutter/google_maps_flutter_web/example/latest/integration_test/advanced_markers_test.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_web/example/latest/integration_test/advanced_markers_test.dart
@@ -96,6 +96,49 @@ void main() {
       expect(receivedEvents, isEmpty);
     });
 
+    testWidgets('changeMarkers propagates a newly-added onHover callback', (
+      WidgetTester tester,
+    ) async {
+      // Regression test: the marker is first added with no onHover callback,
+      // then updated (not recreated) to have one. The already-existing DOM
+      // listeners must pick up the new callback.
+      const markerId = MarkerId('1');
+      await controller.addMarkers(<AdvancedMarker>{AdvancedMarker(markerId: markerId)});
+
+      final gmaps.AdvancedMarkerElement gmMarker = controller.markers[markerId]!.marker!;
+
+      await controller.changeMarkers(<AdvancedMarker>{
+        AdvancedMarker(markerId: markerId, onHover: (bool _) {}),
+      });
+
+      final Future<MapEvent<Object?>> firstEvent = events.stream.first;
+      gmMarker.dispatchEvent(Event('gmp-mouseenter'));
+      final MapEvent<Object?> event = await firstEvent;
+
+      expect(event, isA<MarkerHoverEvent>());
+      expect((event as MarkerHoverEvent).value, markerId);
+      expect(event.isHovering, isTrue);
+    });
+
+    testWidgets('changeMarkers propagates a removed onHover callback', (WidgetTester tester) async {
+      const markerId = MarkerId('1');
+      await controller.addMarkers(<AdvancedMarker>{
+        AdvancedMarker(markerId: markerId, onHover: (bool _) {}),
+      });
+
+      final gmaps.AdvancedMarkerElement gmMarker = controller.markers[markerId]!.marker!;
+
+      await controller.changeMarkers(<AdvancedMarker>{AdvancedMarker(markerId: markerId)});
+
+      final receivedEvents = <MapEvent<Object?>>[];
+      final StreamSubscription<MapEvent<Object?>> sub = events.stream.listen(receivedEvents.add);
+      gmMarker.dispatchEvent(Event('gmp-mouseenter'));
+      await tester.pump();
+      await sub.cancel();
+
+      expect(receivedEvents, isEmpty);
+    });
+
     testWidgets('changeMarkers', (WidgetTester tester) async {
       gmaps.AdvancedMarkerElement? marker;
       gmaps.LatLngLiteral? position;

--- a/packages/google_maps_flutter/google_maps_flutter_web/example/latest/integration_test/advanced_markers_test.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_web/example/latest/integration_test/advanced_markers_test.dart
@@ -60,6 +60,42 @@ void main() {
       expect(controller.markers, isNot(contains(const MarkerId('66'))));
     });
 
+    testWidgets('fires MarkerHoverEvent when the marker has an onHover callback', (
+      WidgetTester tester,
+    ) async {
+      const markerId = MarkerId('1');
+      await controller.addMarkers(<AdvancedMarker>{
+        AdvancedMarker(markerId: markerId, onHover: (bool _) {}),
+      });
+
+      final gmaps.AdvancedMarkerElement gmMarker = controller.markers[markerId]!.marker!;
+
+      final Future<MapEvent<Object?>> firstEvent = events.stream.first;
+      gmMarker.dispatchEvent(Event('gmp-mouseenter'));
+      final MapEvent<Object?> event = await firstEvent;
+
+      expect(event, isA<MarkerHoverEvent>());
+      expect((event as MarkerHoverEvent).value, markerId);
+      expect(event.isHovering, isTrue);
+    });
+
+    testWidgets('does not attach a hover listener when onHover is null', (
+      WidgetTester tester,
+    ) async {
+      const markerId = MarkerId('1');
+      await controller.addMarkers(<AdvancedMarker>{AdvancedMarker(markerId: markerId)});
+
+      final gmaps.AdvancedMarkerElement gmMarker = controller.markers[markerId]!.marker!;
+
+      final receivedEvents = <MapEvent<Object?>>[];
+      final StreamSubscription<MapEvent<Object?>> sub = events.stream.listen(receivedEvents.add);
+      gmMarker.dispatchEvent(Event('gmp-mouseenter'));
+      await tester.pump();
+      await sub.cancel();
+
+      expect(receivedEvents, isEmpty);
+    });
+
     testWidgets('changeMarkers', (WidgetTester tester) async {
       gmaps.AdvancedMarkerElement? marker;
       gmaps.LatLngLiteral? position;

--- a/packages/google_maps_flutter/google_maps_flutter_web/lib/src/google_maps_flutter_web.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_web/lib/src/google_maps_flutter_web.dart
@@ -230,6 +230,11 @@ class GoogleMapsPlugin extends GoogleMapsFlutterPlatform {
   }
 
   @override
+  Stream<MarkerHoverEvent> onMarkerHover({required int mapId}) {
+    return _events(mapId).whereType<MarkerHoverEvent>();
+  }
+
+  @override
   Stream<PolylineTapEvent> onPolylineTap({required int mapId}) {
     return _events(mapId).whereType<PolylineTapEvent>();
   }

--- a/packages/google_maps_flutter/google_maps_flutter_web/lib/src/marker.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_web/lib/src/marker.dart
@@ -223,7 +223,13 @@ class AdvancedMarkerController
     super.onDragEnd,
     super.onTap,
     super.clusterManagerId,
-  });
+    ValueChanged<bool>? onHover,
+  }) : _onHover = onHover {
+    if (_onHover != null) {
+      _marker!.addEventListener('gmp-mouseenter', _onMouseEnter);
+      _marker!.addEventListener('gmp-mouseleave', _onMouseLeave);
+    }
+  }
 
   /// List of active stream subscriptions for marker events.
   ///
@@ -231,6 +237,14 @@ class AdvancedMarkerController
   /// including taps and different drag events.
   /// These subscriptions should be disposed when the controller is disposed.
   final List<StreamSubscription<dynamic>> _subscriptions = <StreamSubscription<dynamic>>[];
+
+  // Reports mouse hover state changes. Only supported on the web, through the
+  // `gmp-mouseenter`/`gmp-mouseleave` DOM events dispatched by
+  // [gmaps.AdvancedMarkerElement].
+  final ValueChanged<bool>? _onHover;
+
+  late final JSFunction _onMouseEnter = ((JSAny? _) => _onHover?.call(true)).toJS;
+  late final JSFunction _onMouseLeave = ((JSAny? _) => _onHover?.call(false)).toJS;
 
   @override
   void addMarkerListener({
@@ -277,6 +291,11 @@ class AdvancedMarkerController
   void remove() {
     if (_marker != null) {
       _infoWindowShown = false;
+
+      if (_onHover != null) {
+        _marker!.removeEventListener('gmp-mouseenter', _onMouseEnter);
+        _marker!.removeEventListener('gmp-mouseleave', _onMouseLeave);
+      }
 
       _marker!.remove();
       _marker!.map = null;

--- a/packages/google_maps_flutter/google_maps_flutter_web/lib/src/marker.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_web/lib/src/marker.dart
@@ -223,12 +223,13 @@ class AdvancedMarkerController
     super.onDragEnd,
     super.onTap,
     super.clusterManagerId,
-    ValueChanged<bool>? onHover,
-  }) : _onHover = onHover {
-    if (_onHover != null) {
-      _marker!.addEventListener('gmp-mouseenter', _onMouseEnter);
-      _marker!.addEventListener('gmp-mouseleave', _onMouseLeave);
-    }
+    this.onHover,
+  }) {
+    // Always attached, regardless of whether `onHover` is initially set, so
+    // that a later update to [onHover] (see [MarkersController.changeMarkers])
+    // is honored without needing to add/remove the underlying DOM listeners.
+    _marker!.addEventListener('gmp-mouseenter', _onMouseEnter);
+    _marker!.addEventListener('gmp-mouseleave', _onMouseLeave);
   }
 
   /// List of active stream subscriptions for marker events.
@@ -238,13 +239,17 @@ class AdvancedMarkerController
   /// These subscriptions should be disposed when the controller is disposed.
   final List<StreamSubscription<dynamic>> _subscriptions = <StreamSubscription<dynamic>>[];
 
-  // Reports mouse hover state changes. Only supported on the web, through the
-  // `gmp-mouseenter`/`gmp-mouseleave` DOM events dispatched by
-  // [gmaps.AdvancedMarkerElement].
-  final ValueChanged<bool>? _onHover;
+  /// Reports mouse hover state changes. Only supported on the web, through
+  /// the `gmp-mouseenter`/`gmp-mouseleave` DOM events dispatched by
+  /// [gmaps.AdvancedMarkerElement].
+  ///
+  /// Mutable so that [MarkersController.changeMarkers] can propagate a new
+  /// callback without having to recreate the underlying
+  /// [gmaps.AdvancedMarkerElement] and its DOM listeners.
+  ValueChanged<bool>? onHover;
 
-  late final JSFunction _onMouseEnter = ((JSAny? _) => _onHover?.call(true)).toJS;
-  late final JSFunction _onMouseLeave = ((JSAny? _) => _onHover?.call(false)).toJS;
+  late final JSFunction _onMouseEnter = ((JSAny? _) => onHover?.call(true)).toJS;
+  late final JSFunction _onMouseLeave = ((JSAny? _) => onHover?.call(false)).toJS;
 
   @override
   void addMarkerListener({
@@ -292,10 +297,8 @@ class AdvancedMarkerController
     if (_marker != null) {
       _infoWindowShown = false;
 
-      if (_onHover != null) {
-        _marker!.removeEventListener('gmp-mouseenter', _onMouseEnter);
-        _marker!.removeEventListener('gmp-mouseleave', _onMouseLeave);
-      }
+      _marker!.removeEventListener('gmp-mouseenter', _onMouseEnter);
+      _marker!.removeEventListener('gmp-mouseleave', _onMouseLeave);
 
       _marker!.remove();
       _marker!.map = null;

--- a/packages/google_maps_flutter/google_maps_flutter_web/lib/src/markers.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_web/lib/src/markers.dart
@@ -249,6 +249,10 @@ abstract class MarkersController<T extends Object, O> extends GeometryController
     _streamController.add(MarkerDragEndEvent(mapId, gmLatLngToLatLng(latLng), markerId));
   }
 
+  void _onMarkerHover(MarkerId markerId, bool isHovering) {
+    _streamController.add(MarkerHoverEvent(mapId, markerId, isHovering));
+  }
+
   void _hideAllMarkerInfoWindow() {
     _markerIdToController.values
         .where((MarkerController<T, O>? controller) => controller?.infoWindowShown ?? false)
@@ -308,6 +312,7 @@ class AdvancedMarkersController
     gmaps.InfoWindow? gmInfoWindow,
   ) async {
     assert(marker is AdvancedMarker, 'Marker must be an AdvancedMarker.');
+    final advancedMarker = marker as AdvancedMarker;
 
     final gmMarker = gmaps.AdvancedMarkerElement(markerOptions);
     gmMarker.setAttribute('id', marker.markerId.value);
@@ -330,6 +335,11 @@ class AdvancedMarkersController
       onDragEnd: (gmaps.LatLng latLng) {
         _onMarkerDragEnd(marker.markerId, latLng);
       },
+      onHover: advancedMarker.onHover == null
+          ? null
+          : (bool isHovering) {
+              _onMarkerHover(marker.markerId, isHovering);
+            },
     );
   }
 }

--- a/packages/google_maps_flutter/google_maps_flutter_web/lib/src/markers.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_web/lib/src/markers.dart
@@ -142,6 +142,13 @@ abstract class MarkersController<T extends Object, O> extends GeometryController
           markerOptions,
           newInfoWindowContent: infoWindow?.content as web.HTMLElement?,
         );
+        if (marker is AdvancedMarker && markerController is AdvancedMarkerController) {
+          (markerController as AdvancedMarkerController).onHover = marker.onHover == null
+              ? null
+              : (bool isHovering) {
+                  _onMarkerHover(marker.markerId, isHovering);
+                };
+        }
       }
     }
   }

--- a/packages/google_maps_flutter/google_maps_flutter_web/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter_web/pubspec.yaml
@@ -2,7 +2,7 @@ name: google_maps_flutter_web
 description: Web platform implementation of google_maps_flutter
 repository: https://github.com/flutter/packages/tree/main/packages/google_maps_flutter/google_maps_flutter_web
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+maps%22
-version: 0.6.3
+version: 0.7.0
 
 environment:
   sdk: ^3.10.0
@@ -23,7 +23,7 @@ dependencies:
   flutter_web_plugins:
     sdk: flutter
   google_maps: ^8.1.0
-  google_maps_flutter_platform_interface: ^2.16.0
+  google_maps_flutter_platform_interface: ^2.17.0
   sanitize_html: ^2.0.0
   stream_transform: ^2.0.0
   web: ^1.0.0


### PR DESCRIPTION
## Description

Adds `AdvancedMarker.onHover`, reporting mouse hover state changes on advanced markers. This is only supported on the web platform, via the JS `gmp-mouseenter`/`gmp-mouseleave` DOM events dispatched by `AdvancedMarkerElement`. Android/iOS implement the new `onMarkerHover` stream as a no-op, since there's no mouse to hover with.

The callback follows the `AdvancedMarker(onHover: (bool isHovering) => ...)` shape discussed and agreed on in the linked issue, for consistency with `InkWell`.

Fixes flutter/flutter#191544

## Changes

- `google_maps_flutter_platform_interface`: adds `AdvancedMarker.onHover`, `MarkerHoverEvent`, and `GoogleMapsFlutterPlatform.onMarkerHover`.
- `google_maps_flutter_web`: implements the feature — attaches/detaches `gmp-mouseenter`/`gmp-mouseleave` listeners on the underlying `AdvancedMarkerElement` and forwards state changes as `MarkerHoverEvent`s.
- `google_maps_flutter`: subscribes to the new event stream and dispatches to `AdvancedMarker.onHover`.
- `google_maps_flutter_android`, `google_maps_flutter_ios(_sdk9/_sdk10)`: implement `onMarkerHover` as a no-op stream (required since the app-facing package now subscribes to it unconditionally on every platform).

All touched packages have version bumps and CHANGELOG entries.

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under[^1].
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[the version and CHANGELOG instructions]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version-and-changelog-updates
[semantic versioning]: https://dart.dev/tools/pub/versioning#semantic-versions
[repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests