### PR TITLE
[material_ui] Make onChanged optional and add `enabled` to DropdownButtonFormField

### DIFF
--- a/packages/material_ui/lib/src/dropdown.dart
+++ b/packages/material_ui/lib/src/dropdown.dart
@@ -1034,6 +1034,7 @@ class DropdownButton<T> extends StatefulWidget {
     this.barrierDismissible = true,
     this.mouseCursor,
     this.dropdownMenuItemMouseCursor,
+    this.enabled = true,
     // When adding new arguments, consider adding similar arguments to
     // DropdownButtonFormField.
   }) : assert(
@@ -1060,7 +1061,7 @@ class DropdownButton<T> extends StatefulWidget {
     this.value,
     this.hint,
     this.disabledHint,
-    required this.onChanged,
+    this.onChanged,
     this.onTap,
     this.elevation = 8,
     this.style,
@@ -1087,6 +1088,7 @@ class DropdownButton<T> extends StatefulWidget {
     this.dropdownMenuItemMouseCursor,
     required this._inputDecoration,
     required this._isEmpty,
+    this.enabled = true,
   }) : assert(
          items == null ||
              items.isEmpty ||
@@ -1362,6 +1364,14 @@ class DropdownButton<T> extends StatefulWidget {
   /// If this property is null, [WidgetStateMouseCursor.adaptiveClickable] will be used.
   final MouseCursor? dropdownMenuItemMouseCursor;
 
+  /// Whether the [DropdownButton] is enabled.
+  ///
+  /// When set to false, the field is disabled and does not allow user
+  /// interaction or value changes, regardless of the `onChanged` callback.
+  ///
+  /// Defaults to true.
+  final bool enabled;
+
   final InputDecoration? _inputDecoration;
 
   final bool _isEmpty;
@@ -1574,7 +1584,7 @@ class _DropdownButtonState<T> extends State<DropdownButton<T>> with WidgetsBindi
     }
   }
 
-  bool get _enabled => widget.items != null && widget.items!.isNotEmpty && widget.onChanged != null;
+  bool get _enabled => widget.items != null && widget.items!.isNotEmpty && widget.enabled;
 
   Orientation _getOrientation(BuildContext context) {
     Orientation? result = MediaQuery.maybeOrientationOf(context);
@@ -1839,7 +1849,7 @@ class DropdownButtonFormField<T> extends FormField<T> {
     T? initialValue,
     Widget? hint,
     Widget? disabledHint,
-    required this.onChanged,
+    this.onChanged,
     VoidCallback? onTap,
     int elevation = 8,
     TextStyle? style,
@@ -1859,6 +1869,7 @@ class DropdownButtonFormField<T> extends FormField<T> {
     super.validator,
     super.errorBuilder,
     super.forceErrorText,
+    super.enabled,
     AutovalidateMode? autovalidateMode,
     double? menuMaxHeight,
     bool? enableFeedback,
@@ -1900,7 +1911,7 @@ class DropdownButtonFormField<T> extends FormField<T> {
            final bool showSelectedItem =
                items != null &&
                items.where((DropdownMenuItem<T> item) => item.value == state.value).isNotEmpty;
-           final bool isDropdownEnabled = onChanged != null && items != null && items.isNotEmpty;
+           final bool isDropdownEnabled = enabled && items != null && items.isNotEmpty;
            // If decoration hintText is provided, use it as the default value for both hint and disabledHint.
            final Widget? decorationHint = effectiveDecoration.hintText != null
                ? Text(effectiveDecoration.hintText!)
@@ -1939,7 +1950,7 @@ class DropdownButtonFormField<T> extends FormField<T> {
                  value: state.value,
                  hint: effectiveHint,
                  disabledHint: effectiveDisabledHint,
-                 onChanged: onChanged == null ? null : state.didChange,
+                 onChanged: state.didChange,
                  onTap: onTap,
                  elevation: elevation,
                  style: style,
@@ -1964,6 +1975,7 @@ class DropdownButtonFormField<T> extends FormField<T> {
                  barrierDismissible: barrierDismissible,
                  mouseCursor: mouseCursor,
                  dropdownMenuItemMouseCursor: dropdownMenuItemMouseCursor,
+                 enabled: isDropdownEnabled,
                ),
              ),
            );

--- a/packages/material_ui/pending_changelogs/change_2026_08_23_1787515547285.yaml
+++ b/packages/material_ui/pending_changelogs/change_2026_08_23_1787515547285.yaml
@@ -1,0 +1,3 @@
+changelog: |
+  - Make onChanged optional and add enabled to DropdownButtonFormField
+version: minor

--- a/packages/material_ui/test/dropdown_test.dart
+++ b/packages/material_ui/test/dropdown_test.dart
@@ -68,6 +68,7 @@ Widget buildDropdown({
   double? menuMaxHeight,
   EdgeInsetsGeometry? padding,
   InputDecoration? decoration,
+  bool enabled = true,
 }) {
   final List<DropdownMenuItem<String>>? listItems = items?.map<DropdownMenuItem<String>>((
     String item,
@@ -75,6 +76,7 @@ Widget buildDropdown({
     return DropdownMenuItem<String>(
       key: ValueKey<String>(item),
       value: item,
+      enabled: enabled,
       child: Text(item, key: ValueKey<String>('${item}Text')),
     );
   }).toList();
@@ -106,6 +108,7 @@ Widget buildDropdown({
         menuMaxHeight: menuMaxHeight,
         padding: padding,
         decoration: decoration,
+        enabled: enabled,
       ),
     );
   }
@@ -134,6 +137,7 @@ Widget buildDropdown({
     alignment: alignment,
     menuMaxHeight: menuMaxHeight,
     padding: padding,
+    enabled: enabled,
   );
 }
 
@@ -169,6 +173,7 @@ Widget buildFrame({
   bool? useMaterial3,
   InputDecoration? decoration,
   InputDecorationThemeData? localInputDecorationTheme,
+  bool enabled = true,
 }) {
   return Theme(
     data: ThemeData(useMaterial3: useMaterial3),
@@ -208,6 +213,7 @@ Widget buildFrame({
                 menuMaxHeight: menuMaxHeight,
                 padding: padding,
                 decoration: decoration,
+                enabled: enabled,
               ),
             ),
           ),
@@ -872,7 +878,7 @@ void main() {
     expect(enabledRichText.text.style!.color, Colors.grey.shade700);
 
     // test for disabled color
-    await tester.pumpWidget(buildFrame(icon: customIcon));
+    await tester.pumpWidget(buildFrame(icon: customIcon, enabled: false));
 
     final RichText disabledRichText = tester.widget<RichText>(_iconRichText(iconKey));
     expect(disabledRichText.text.style!.color, Colors.grey.shade400);
@@ -909,6 +915,7 @@ void main() {
         iconSize: 30.0,
         iconEnabledColor: Colors.pink,
         iconDisabledColor: Colors.orange,
+        enabled: false,
       ),
     );
 
@@ -1617,34 +1624,36 @@ void main() {
   testWidgets('disabledHint displays on empty items or onChanged', (WidgetTester tester) async {
     final Key buttonKey = UniqueKey();
 
-    Widget build({List<String>? items, ValueChanged<String?>? onChanged}) => buildFrame(
-      items: items,
-      onChanged: onChanged,
-      buttonKey: buttonKey,
-      initialValue: null,
-      hint: const Text('enabled'),
-      disabledHint: const Text('disabled'),
-    );
+    Widget build({List<String>? items, ValueChanged<String?>? onChanged, required bool enabled}) =>
+        buildFrame(
+          items: items,
+          onChanged: onChanged,
+          buttonKey: buttonKey,
+          initialValue: null,
+          hint: const Text('enabled'),
+          disabledHint: const Text('disabled'),
+          enabled: enabled,
+        );
 
     // [disabledHint] should display when [items] is null
-    await tester.pumpWidget(build(onChanged: onChanged));
+    await tester.pumpWidget(build(onChanged: onChanged, enabled: false));
     expect(find.text('enabled'), findsNothing);
     expect(find.text('disabled'), findsOneWidget);
 
     // [disabledHint] should display when [items] is an empty list.
-    await tester.pumpWidget(build(items: <String>[], onChanged: onChanged));
+    await tester.pumpWidget(build(items: <String>[], onChanged: onChanged, enabled: true));
     expect(find.text('enabled'), findsNothing);
     expect(find.text('disabled'), findsOneWidget);
 
     // [disabledHint] should display when [onChanged] is null
-    await tester.pumpWidget(build(items: menuItems));
+    await tester.pumpWidget(build(items: menuItems, enabled: false));
     expect(find.text('enabled'), findsNothing);
     expect(find.text('disabled'), findsOneWidget);
     final RenderBox disabledHintBox = tester.renderObject<RenderBox>(find.byKey(buttonKey));
 
     // A Dropdown button with a disabled hint should be the same size as a
     // one with a regular enabled hint.
-    await tester.pumpWidget(build(items: menuItems, onChanged: onChanged));
+    await tester.pumpWidget(build(items: menuItems, onChanged: onChanged, enabled: true));
     expect(find.text('disabled'), findsNothing);
     expect(find.text('enabled'), findsOneWidget);
     final RenderBox enabledHintBox = tester.renderObject<RenderBox>(find.byKey(buttonKey));
@@ -1663,16 +1672,18 @@ void main() {
       String? value,
       Widget? hint,
       Widget? disabledHint,
+      required bool enabled,
     }) => buildFrame(
       items: items,
       onChanged: onChanged,
       initialValue: value,
       hint: hint,
       disabledHint: disabledHint,
+      enabled: enabled,
     );
 
     // The selected value should be displayed when the button is disabled.
-    await tester.pumpWidget(build(items: menuItems, value: 'two'));
+    await tester.pumpWidget(build(items: menuItems, value: 'two', enabled: false));
     // The dropdown icon and the selected menu item are vertically aligned.
     expect(tester.getCenter(find.text('two')).dy, tester.getCenter(find.byType(Icon)).dy);
 
@@ -1683,18 +1694,24 @@ void main() {
         onChanged: onChanged,
         hint: const Text('hint'),
         disabledHint: const Text('disabledHint'),
+        enabled: true,
       ),
     );
     expect(tester.getCenter(find.text('hint')).dy, tester.getCenter(find.byType(Icon)).dy);
 
     // If [value] is null, the button is disabled, [disabledHint] is displayed when [disabledHint] is non-null.
     await tester.pumpWidget(
-      build(items: menuItems, hint: const Text('hint'), disabledHint: const Text('disabledHint')),
+      build(
+        items: menuItems,
+        hint: const Text('hint'),
+        disabledHint: const Text('disabledHint'),
+        enabled: false,
+      ),
     );
     expect(tester.getCenter(find.text('disabledHint')).dy, tester.getCenter(find.byType(Icon)).dy);
 
     // If [value] is null, the button is disabled, [hint] is displayed when [disabledHint] is null.
-    await tester.pumpWidget(build(items: menuItems, hint: const Text('hint')));
+    await tester.pumpWidget(build(items: menuItems, hint: const Text('hint'), enabled: false));
     expect(tester.getCenter(find.text('hint')).dy, tester.getCenter(find.byType(Icon)).dy);
 
     int? getIndex() {
@@ -1703,11 +1720,11 @@ void main() {
     }
 
     // If [value], [hint] and [disabledHint] are null, the button is disabled, nothing displayed.
-    await tester.pumpWidget(build(items: menuItems));
+    await tester.pumpWidget(build(items: menuItems, enabled: false));
     expect(getIndex(), null);
 
     // If [value], [hint] and [disabledHint] are null, the button is enabled, nothing displayed.
-    await tester.pumpWidget(build(items: menuItems, onChanged: onChanged));
+    await tester.pumpWidget(build(items: menuItems, onChanged: onChanged, enabled: true));
     expect(getIndex(), null);
   });
 
@@ -1717,6 +1734,7 @@ void main() {
       String? value,
       Widget? hint,
       Widget? disabledHint,
+      required bool enabled,
     }) {
       return MaterialApp(
         theme: ThemeData(disabledColor: Colors.pink),
@@ -1734,6 +1752,7 @@ void main() {
                   ],
                   initialValue: value,
                   onChanged: onChanged,
+                  enabled: enabled,
                 ),
               ],
             ),
@@ -1747,7 +1766,7 @@ void main() {
     }
 
     // The selected value should be displayed when the button is enabled.
-    await tester.pumpWidget(build(onChanged: onChanged, value: 'two'));
+    await tester.pumpWidget(build(onChanged: onChanged, value: 'two', enabled: true));
     // The dropdown icon and the selected menu item are vertically aligned.
     expect(tester.getCenter(find.text('two')).dy, tester.getCenter(find.byType(Icon)).dy);
     // Selected item has a normal color from [DropdownButtonFormField.style]
@@ -1755,7 +1774,7 @@ void main() {
     expect(textColor('two'), Colors.yellow);
 
     // The selected value should be displayed when the button is disabled.
-    await tester.pumpWidget(build(value: 'two'));
+    await tester.pumpWidget(build(value: 'two', enabled: false));
     expect(tester.getCenter(find.text('two')).dy, tester.getCenter(find.byType(Icon)).dy);
     // Selected item has a disabled color from [theme.disabledColor]
     // when the button is disable.
@@ -1991,6 +2010,7 @@ void main() {
           disabledHint: const SizedBox(height: 50, width: 50, child: Text('hint')),
           items: items,
           itemHeight: null,
+          enabled: false,
           selectedItemBuilder: (BuildContext context) => [
             for (final item in items)
               SizedBox.square(
@@ -2024,6 +2044,7 @@ void main() {
           disabledHint: const SizedBox(height: 125, width: 125, child: Text('hint')),
           items: items,
           itemHeight: null,
+          enabled: false,
           selectedItemBuilder: (BuildContext context) => [
             for (final item in items)
               SizedBox.square(
@@ -2866,6 +2887,7 @@ void main() {
         focusNode: focusNode,
         autofocus: true,
         focusColor: const Color(0xff00ff00),
+        enabled: false,
       ),
     );
     await tester.pump(); // Pump a frame for autofocus to take effect (although it shouldn't).
@@ -4633,6 +4655,7 @@ void main() {
           disabledHint: const Text(disabledHintText),
           isFormField: true,
           decoration: const InputDecoration(hintText: decorationHintText),
+          enabled: false,
         ),
       );
 


### PR DESCRIPTION
Made `onChanged` optional and introduced the `enabled` parameter in `DropdownButtonFormField`, allowing proper disabled/read-only usage without dummy callbacks.

**Breaking change**

Previously, setting `onChanged: null` disabled the widget. This is no longer the case. The disabled state must now be controlled via the `enabled` property.

Most simple usages are handled by the automated fix tool. Code that conditionally relied on `onChanged` being null to disable the widget must be updated to use `enabled`.

If not migrated, the widget will remain interactive but will not trigger a callback.

Closes https://github.com/flutter/flutter/issues/57953.

Port of https://github.com/flutter/flutter/pull/182419.

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under[^1].
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[the version and CHANGELOG instructions]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version-and-changelog-updates
[semantic versioning]: https://dart.dev/tools/pub/versioning#semantic-versions
[repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
