### PR TITLE
[camera_android_camerax] Add lens type information

### DIFF
--- a/packages/camera/camera_android_camerax/CHANGELOG.md
+++ b/packages/camera/camera_android_camerax/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.7.5
+
+* Adds `lensType` to the `CameraDescription`s returned by `availableCameras`,
+  determined from `CameraInfo.getIntrinsicZoomRatio`.
+
 ## 0.7.4+6
 
 * Adds explicit `androidx.concurrent:concurrent-futures:1.2.0` dependency to fix

--- a/packages/camera/camera_android_camerax/android/src/main/java/io/flutter/plugins/camerax/CameraInfoProxyApi.java
+++ b/packages/camera/camera_android_camerax/android/src/main/java/io/flutter/plugins/camerax/CameraInfoProxyApi.java
@@ -61,4 +61,9 @@ class CameraInfoProxyApi extends PigeonApiCameraInfo {
     return new LiveDataProxyApi.LiveDataWrapper(
         pigeonInstance.getZoomState(), LiveDataSupportedType.ZOOM_STATE);
   }
+
+  @Override
+  public double getIntrinsicZoomRatio(CameraInfo pigeonInstance) {
+    return pigeonInstance.getIntrinsicZoomRatio();
+  }
 }

--- a/packages/camera/camera_android_camerax/android/src/main/java/io/flutter/plugins/camerax/CameraXLibrary.g.kt
+++ b/packages/camera/camera_android_camerax/android/src/main/java/io/flutter/plugins/camerax/CameraXLibrary.g.kt
@@ -2199,6 +2199,19 @@ abstract class PigeonApiCameraInfo(
       pigeon_instance: androidx.camera.core.CameraInfo
   ): io.flutter.plugins.camerax.LiveDataProxyApi.LiveDataWrapper
 
+  /**
+   * Returns the intrinsic zoom ratio of this camera.
+   *
+   * The intrinsic zoom ratio is the ratio of the camera's field of view to that of the default
+   * camera with the same lens facing direction. A ratio smaller than 1.0 describes a wider field of
+   * view than the default camera (an ultra wide lens), and a ratio larger than 1.0 describes a
+   * narrower field of view (a telephoto lens).
+   *
+   * See
+   * https://developer.android.com/reference/androidx/camera/core/CameraInfo#getIntrinsicZoomRatio().
+   */
+  abstract fun getIntrinsicZoomRatio(pigeon_instance: androidx.camera.core.CameraInfo): Double
+
   companion object {
     @Suppress("LocalVariableName")
     fun setUpMessageHandlers(binaryMessenger: BinaryMessenger, api: PigeonApiCameraInfo?) {
@@ -2238,6 +2251,28 @@ abstract class PigeonApiCameraInfo(
             val wrapped: List<Any?> =
                 try {
                   listOf(api.getZoomState(pigeon_instanceArg))
+                } catch (exception: Throwable) {
+                  CameraXLibraryPigeonUtils.wrapError(exception)
+                }
+            reply.reply(wrapped)
+          }
+        } else {
+          channel.setMessageHandler(null)
+        }
+      }
+      run {
+        val channel =
+            BasicMessageChannel<Any?>(
+                binaryMessenger,
+                "dev.flutter.pigeon.camera_android_camerax.CameraInfo.getIntrinsicZoomRatio",
+                codec)
+        if (api != null) {
+          channel.setMessageHandler { message, reply ->
+            val args = message as List<Any?>
+            val pigeon_instanceArg = args[0] as androidx.camera.core.CameraInfo
+            val wrapped: List<Any?> =
+                try {
+                  listOf(api.getIntrinsicZoomRatio(pigeon_instanceArg))
                 } catch (exception: Throwable) {
                   CameraXLibraryPigeonUtils.wrapError(exception)
                 }

--- a/packages/camera/camera_android_camerax/android/src/test/java/io/flutter/plugins/camerax/CameraInfoTest.java
+++ b/packages/camera/camera_android_camerax/android/src/test/java/io/flutter/plugins/camerax/CameraInfoTest.java
@@ -99,4 +99,15 @@ public class CameraInfoTest {
 
     assertEquals(value, api.getZoomState(instance).getLiveData());
   }
+
+  @Test
+  public void getIntrinsicZoomRatio_retrievesExpectedIntrinsicZoomRatio() {
+    final PigeonApiCameraInfo api = new TestProxyApiRegistrar().getPigeonApiCameraInfo();
+
+    final CameraInfo instance = mock(CameraInfo.class);
+    final float value = 0.5f;
+    when(instance.getIntrinsicZoomRatio()).thenReturn(value);
+
+    assertEquals(value, api.getIntrinsicZoomRatio(instance), 0.0001);
+  }
 }

--- a/packages/camera/camera_android_camerax/lib/src/android_camera_camerax.dart
+++ b/packages/camera/camera_android_camerax/lib/src/android_camera_camerax.dart
@@ -325,11 +325,49 @@ class AndroidCameraCameraX extends CameraPlatform {
           name: cameraName,
           lensDirection: cameraLensDirection,
           sensorOrientation: cameraSensorOrientation,
+          lensType: await _lensTypeFromCameraInfo(cameraInfo),
         ),
       );
     }
 
     return cameraDescriptions;
+  }
+
+  /// Returns the [CameraLensType] of the camera that [cameraInfo] describes,
+  /// based on its intrinsic zoom ratio.
+  ///
+  /// The intrinsic zoom ratio compares the field of view of a camera to that of
+  /// the default camera with the same lens facing direction, so a ratio smaller
+  /// than 1.0 identifies an ultra wide lens and a ratio larger than 1.0
+  /// identifies a telephoto lens.
+  Future<CameraLensType> _lensTypeFromCameraInfo(CameraInfo cameraInfo) async {
+    final double intrinsicZoomRatio;
+    try {
+      intrinsicZoomRatio = await cameraInfo.getIntrinsicZoomRatio();
+    } on PlatformException {
+      // Reporting a lens type is best effort: a camera that fails to answer the
+      // query must not prevent the remaining cameras from being enumerated.
+      // Pigeon wraps every host-side `Throwable`, as well as channel and codec
+      // failures, in a `PlatformException`, so this covers all failure modes of
+      // the call above.
+      return CameraLensType.unknown;
+    }
+
+    // A ratio of exactly 1.0 is ambiguous and must not be reported as
+    // `CameraLensType.wide`. CameraX documents that the default camera of a
+    // lens facing direction reports 1.0, but 1.0 is also what
+    // `INTRINSIC_ZOOM_RATIO_UNKNOWN` is defined as, which is returned both when
+    // the computation fails and by the default implementation of
+    // `CameraInfo.getIntrinsicZoomRatio()`. Because those cases cannot be told
+    // apart, 1.0 is reported as unknown rather than claiming a lens role that
+    // may be wrong.
+    if (intrinsicZoomRatio < 1.0) {
+      return CameraLensType.ultraWide;
+    }
+    if (intrinsicZoomRatio > 1.0) {
+      return CameraLensType.telephoto;
+    }
+    return CameraLensType.unknown;
   }
 
   /// Creates an uninitialized camera instance with default settings and returns the camera ID.

--- a/packages/camera/camera_android_camerax/lib/src/camerax_library.g.dart
+++ b/packages/camera/camera_android_camerax/lib/src/camerax_library.g.dart
@@ -1917,6 +1917,36 @@ class CameraInfo extends PigeonInternalProxyApiBaseClass {
     return pigeonVar_replyValue! as LiveData;
   }
 
+  /// Returns the intrinsic zoom ratio of this camera.
+  ///
+  /// The intrinsic zoom ratio is the ratio of the camera's field of view to
+  /// that of the default camera with the same lens facing direction. A ratio
+  /// smaller than 1.0 describes a wider field of view than the default camera
+  /// (an ultra wide lens), and a ratio larger than 1.0 describes a narrower
+  /// field of view (a telephoto lens).
+  ///
+  /// See https://developer.android.com/reference/androidx/camera/core/CameraInfo#getIntrinsicZoomRatio().
+  Future<double> getIntrinsicZoomRatio() async {
+    final _PigeonInternalProxyApiBaseCodec pigeonChannelCodec = _pigeonVar_codecCameraInfo;
+    final BinaryMessenger? pigeonVar_binaryMessenger = pigeon_binaryMessenger;
+    const pigeonVar_channelName =
+        'dev.flutter.pigeon.camera_android_camerax.CameraInfo.getIntrinsicZoomRatio';
+    final pigeonVar_channel = BasicMessageChannel<Object?>(
+      pigeonVar_channelName,
+      pigeonChannelCodec,
+      binaryMessenger: pigeonVar_binaryMessenger,
+    );
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[this]);
+    final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
+
+    final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
+      pigeonVar_replyList,
+      pigeonVar_channelName,
+      isNullValid: false,
+    );
+    return pigeonVar_replyValue! as double;
+  }
+
   @override
   CameraInfo pigeon_copy() {
     return CameraInfo.pigeon_detached(

--- a/packages/camera/camera_android_camerax/pigeons/camerax_library.dart
+++ b/packages/camera/camera_android_camerax/pigeons/camerax_library.dart
@@ -241,6 +241,17 @@ abstract class CameraInfo {
 
   /// A LiveData of ZoomState.
   LiveData getZoomState();
+
+  /// Returns the intrinsic zoom ratio of this camera.
+  ///
+  /// The intrinsic zoom ratio is the ratio of the camera's field of view to
+  /// that of the default camera with the same lens facing direction. A ratio
+  /// smaller than 1.0 describes a wider field of view than the default camera
+  /// (an ultra wide lens), and a ratio larger than 1.0 describes a narrower
+  /// field of view (a telephoto lens).
+  ///
+  /// See https://developer.android.com/reference/androidx/camera/core/CameraInfo#getIntrinsicZoomRatio().
+  double getIntrinsicZoomRatio();
 }
 
 /// Direction of lens of a camera.

--- a/packages/camera/camera_android_camerax/pubspec.yaml
+++ b/packages/camera/camera_android_camerax/pubspec.yaml
@@ -2,7 +2,7 @@ name: camera_android_camerax
 description: Android implementation of the camera plugin using the CameraX library.
 repository: https://github.com/flutter/packages/tree/main/packages/camera/camera_android_camerax
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+camera%22
-version: 0.7.4+6
+version: 0.7.5
 
 environment:
   sdk: ^3.12.0

--- a/packages/camera/camera_android_camerax/test/android_camera_camerax_test.dart
+++ b/packages/camera/camera_android_camerax/test/android_camera_camerax_test.dart
@@ -448,9 +448,13 @@ void main() {
     ).thenAnswer((_) async => <MockCameraInfo>[mockBackCameraInfo, mockFrontCameraInfo]);
     when(mockBackCameraInfo.sensorRotationDegrees).thenReturn(0);
     when(mockBackCameraInfo.lensFacing).thenReturn(LensFacing.back);
+    // An intrinsic zoom ratio of 1.0 identifies the default camera of a lens
+    // facing direction, which maps to CameraLensType.unknown.
+    when(mockBackCameraInfo.getIntrinsicZoomRatio()).thenAnswer((_) async => 1.0);
 
     when(mockFrontCameraInfo.sensorRotationDegrees).thenReturn(90);
     when(mockFrontCameraInfo.lensFacing).thenReturn(LensFacing.front);
+    when(mockFrontCameraInfo.getIntrinsicZoomRatio()).thenAnswer((_) async => 1.0);
 
     final List<CameraDescription> cameraDescriptions = await camera.availableCameras();
 
@@ -467,6 +471,66 @@ void main() {
       );
       expect(cameraDescriptions[i], cameraDescription);
     }
+  });
+
+  group('availableCameras reports the lens type of each camera', () {
+    /// Runs `availableCameras` against a single back-facing camera whose
+    /// `getIntrinsicZoomRatio` behaves as [intrinsicZoomRatio] describes, and
+    /// returns the [CameraLensType] reported for it.
+    Future<CameraLensType> lensTypeForIntrinsicZoomRatio(
+      Future<double> Function() intrinsicZoomRatio,
+    ) async {
+      final camera = AndroidCameraCameraX();
+      final mockProcessCameraProvider = MockProcessCameraProvider();
+      final mockCameraInfo = MockCameraInfo();
+
+      PigeonOverrides.processCameraProvider_getInstance = () async => mockProcessCameraProvider;
+      PigeonOverrides.camera2CameraInfo_from = ({required dynamic cameraInfo}) {
+        final camera2CameraInfo = MockCamera2CameraInfo();
+        when(camera2CameraInfo.getCameraId()).thenAnswer((_) async => '0');
+        return camera2CameraInfo;
+      };
+      PigeonOverrides.systemServicesManager_new =
+          ({required void Function(SystemServicesManager, String) onCameraError}) {
+            return MockSystemServicesManager();
+          };
+
+      when(
+        mockProcessCameraProvider.getAvailableCameraInfos(),
+      ).thenAnswer((_) async => <MockCameraInfo>[mockCameraInfo]);
+      when(mockCameraInfo.sensorRotationDegrees).thenReturn(0);
+      when(mockCameraInfo.lensFacing).thenReturn(LensFacing.back);
+      when(mockCameraInfo.getIntrinsicZoomRatio()).thenAnswer((_) => intrinsicZoomRatio());
+
+      final List<CameraDescription> cameraDescriptions = await camera.availableCameras();
+      expect(cameraDescriptions, hasLength(1));
+      return cameraDescriptions.single.lensType;
+    }
+
+    test('as ultraWide when the intrinsic zoom ratio is less than 1.0', () async {
+      expect(await lensTypeForIntrinsicZoomRatio(() async => 0.5), CameraLensType.ultraWide);
+    });
+
+    test('as telephoto when the intrinsic zoom ratio is greater than 1.0', () async {
+      expect(await lensTypeForIntrinsicZoomRatio(() async => 2.0), CameraLensType.telephoto);
+    });
+
+    test('as unknown when the intrinsic zoom ratio is exactly 1.0', () async {
+      // 1.0 is ambiguous: CameraX reports it for the default camera of a lens
+      // facing direction, but it is also the value of
+      // INTRINSIC_ZOOM_RATIO_UNKNOWN, which is returned when the ratio cannot
+      // be computed. It must therefore not be reported as CameraLensType.wide.
+      expect(await lensTypeForIntrinsicZoomRatio(() async => 1.0), CameraLensType.unknown);
+    });
+
+    test('as unknown when retrieving the intrinsic zoom ratio fails', () async {
+      expect(
+        await lensTypeForIntrinsicZoomRatio(
+          () async => throw PlatformException(code: 'testErrorCode'),
+        ),
+        CameraLensType.unknown,
+      );
+    });
   });
 
   test(
@@ -1423,6 +1487,11 @@ void main() {
     when(mockFrontCameraInfo.lensFacing).thenReturn(LensFacing.front);
     when(mockBackCameraInfoOne.lensFacing).thenReturn(LensFacing.back);
     when(mockBackCameraInfoTwo.lensFacing).thenReturn(LensFacing.back);
+    // An intrinsic zoom ratio of 1.0 identifies the default camera of a lens
+    // facing direction, which maps to CameraLensType.unknown.
+    when(mockFrontCameraInfo.getIntrinsicZoomRatio()).thenAnswer((_) async => 1.0);
+    when(mockBackCameraInfoOne.getIntrinsicZoomRatio()).thenAnswer((_) async => 1.0);
+    when(mockBackCameraInfoTwo.getIntrinsicZoomRatio()).thenAnswer((_) async => 1.0);
 
     // Mock/Detached objects for (typically attached) objects created by
     // createCamera.

--- a/packages/camera/camera_android_camerax/test/android_camera_camerax_test.mocks.dart
+++ b/packages/camera/camera_android_camerax/test/android_camera_camerax_test.mocks.dart
@@ -458,6 +458,15 @@ class MockCameraInfo extends _i1.Mock implements _i3.CameraInfo {
             returnValueForMissingStub: _FakeCameraInfo_8(this, Invocation.method(#pigeon_copy, [])),
           )
           as _i3.CameraInfo);
+
+  @override
+  _i5.Future<double> getIntrinsicZoomRatio() =>
+      (super.noSuchMethod(
+            Invocation.method(#getIntrinsicZoomRatio, []),
+            returnValue: _i5.Future<double>.value(0.0),
+            returnValueForMissingStub: _i5.Future<double>.value(0.0),
+          )
+          as _i5.Future<double>);
 }
 
 /// A class which mocks [CameraCharacteristicsKey].


### PR DESCRIPTION
Populates `CameraDescription.lensType` on Android, so that `availableCameras()`
reports whether each camera is an ultra wide or a telephoto lens instead of
always reporting `CameraLensType.unknown`.

This is the Android counterpart of the iOS implementation added in
flutter/packages#7653, and it consumes the `CameraLensType` enum and the
`CameraDescription.lensType` field that flutter/packages#8723 added to
`camera_platform_interface` (2.10.0). No platform interface change is needed —
this PR only fills in a field that already exists.

## Implementation

CameraX exposes [`CameraInfo.getIntrinsicZoomRatio()`][intrinsic], which is the
ratio of a camera's field of view to that of the default camera with the same
lens facing direction. That maps onto `CameraLensType` directly:

| Intrinsic zoom ratio | Reported lens type |
| --- | --- |
| `< 1.0` (wider field of view than the default camera) | `CameraLensType.ultraWide` |
| `> 1.0` (narrower field of view than the default camera) | `CameraLensType.telephoto` |
| `== 1.0` | `CameraLensType.unknown` |

`getIntrinsicZoomRatio()` is stable public API — it carries no experimental
marker in the `cameraxVersion` this plugin pins (1.6.1) — and is implemented by
the camera2 backend's `CameraInfoAdapter`.

The change is:

* `pigeons/camerax_library.dart`: adds `double getIntrinsicZoomRatio()` to the
  `CameraInfo` ProxyApi, plus the regenerated `camerax_library.g.dart` and
  `CameraXLibrary.g.kt`.
* `CameraInfoProxyApi.java`: delegates straight to
  `CameraInfo.getIntrinsicZoomRatio()`, with no added logic, per the plugin's
  [CONTRIBUTING][contributing] guidance for host API implementations.
* `android_camera_camerax.dart`: maps the ratio to a `CameraLensType` in
  `availableCameras()`.

### Why `1.0` is reported as `unknown` rather than `wide`

This is the one judgement call in the change, so it is worth spelling out.

CameraX's javadoc guarantees that the *default* camera of a lens facing
direction reports an intrinsic zoom ratio of `1.0`, which would make `1.0` look
like a reliable signal for `CameraLensType.wide`. It is not, because `1.0` is
overloaded three ways:

1. the default camera genuinely reports `1.0`;
2. `INTRINSIC_ZOOM_RATIO_UNKNOWN` is **defined as** `1.0f`, and is what is
   returned when the ratio cannot be computed; and
3. the default implementation of `CameraInfo.getIntrinsicZoomRatio()` also
   returns it.

Nothing in the returned value distinguishes those cases. Reporting `wide` would
therefore assert a specific lens role on the strength of a value that may simply
mean "I don't know", which is worse than reporting `unknown` — a caller can
handle `unknown` by falling back, but has no way to detect a wrong `wide`. So
`1.0` maps to `unknown`, and the rationale is recorded in a comment at the
mapping site so it is not "simplified" away later.

### Failure handling

Reporting a lens type is best effort. `getIntrinsicZoomRatio()` is called per
camera inside the `availableCameras()` loop, and a failure is caught and
reported as `CameraLensType.unknown` so that one camera refusing the query
cannot fail enumeration of the rest. Pigeon wraps every host-side `Throwable`,
as well as channel and codec failures, into a `PlatformException`, so catching
that one type covers every failure mode of the call.

The pigeon member is a **method** rather than an attached field for this reason:
an attached field is read eagerly when the `CameraInfo` instance is created, so
a throwing getter would break `CameraInfo` construction entirely rather than
degrading one field, and it would also change the generated
`CameraInfo.pigeon_detached` constructor signature.

## Tests

* Four new Dart tests in `android_camera_camerax_test.dart` covering the three
  ratio mappings and the error fallback.
* A new `CameraInfoTest.getIntrinsicZoomRatio_retrievesExpectedIntrinsicZoomRatio`
  native unit test covering the host API delegation.
* Two existing `availableCameras` tests gained a `getIntrinsicZoomRatio` stub.
  `MockCameraInfo` is a *nice* mock, so an unstubbed `Future<double>` returns
  `0.0`, which would have been reported as `ultraWide`. The stub supplies `1.0`
  — the realistic value for a default camera — which preserves each test's
  existing expectation unchanged. No assertion was modified.

## A note on flutter/flutter#178038

flutter/flutter#178038 ("CameraLensType.unknown returned on Android") was closed
as `not planned` on the basis that CameraX does not expose lens type data, which
made `CameraLensType.unknown` the expected value on Android rather than a bug.
`CameraInfo.getIntrinsicZoomRatio()` does expose enough to distinguish ultra wide
and telephoto lenses, so that premise no longer holds for those two cases —
though it remains true that CameraX offers no way to positively identify a `wide`
lens, which is the other half of why `1.0` is reported as `unknown` above.

Fixes flutter/flutter#91247

[intrinsic]: https://developer.android.com/reference/androidx/camera/core/CameraInfo#getIntrinsicZoomRatio()
[contributing]: https://github.com/flutter/packages/blob/main/packages/camera/camera_android_camerax/CONTRIBUTING.md

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [ ] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under[^1].
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [x] All existing and new tests are passing.

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[the version and CHANGELOG instructions]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version-and-changelog-updates
[semantic versioning]: https://dart.dev/tools/pub/versioning#semantic-versions
[repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
