### PR TITLE
[go_router] Support nested parentheses, groups, and lookaround assertions in path parameters

### DIFF
--- a/packages/go_router/lib/src/path_utils.dart
+++ b/packages/go_router/lib/src/path_utils.dart
@@ -5,7 +5,95 @@
 import 'misc/errors.dart';
 import 'route.dart';
 
-final RegExp _parameterRegExp = RegExp(r':(\w+)(\((?:\\.|[^\\()])+\))?');
+final RegExp _parameterNameRegExp = RegExp(r':(\w+)');
+
+/// A `:name` occurrence in a path pattern, with its optional constraint.
+class _PathParameter {
+  const _PathParameter({
+    required this.start,
+    required this.end,
+    required this.name,
+    this.constraint,
+  });
+
+  /// Index of the leading `:`.
+  final int start;
+
+  /// Exclusive end of the whole occurrence, constraint included.
+  final int end;
+
+  final String name;
+
+  /// The parenthesised regular expression constraining this parameter, parens
+  /// included (`(\d+)`), or null when the parameter is unconstrained.
+  final String? constraint;
+}
+
+/// Scans [pattern] for `:name` occurrences, each optionally followed by a
+/// `(...)` constraint.
+List<_PathParameter> _pathParametersOf(String pattern) {
+  final parameters = <_PathParameter>[];
+  RegExpMatch? match = _parameterNameRegExp.firstMatch(pattern);
+  while (match != null) {
+    final int closingParen = _closingParenIndex(pattern, match.end);
+    final int end = closingParen != -1 ? closingParen + 1 : match.end;
+    final String? name = match[1];
+
+    if (name != null) {
+      parameters.add(
+        _PathParameter(
+          start: match.start,
+          end: end,
+          name: name,
+          constraint: closingParen != -1 ? pattern.substring(match.end, end) : null,
+        ),
+      );
+    }
+    match = _parameterNameRegExp.allMatches(pattern, end).firstOrNull;
+  }
+  return parameters;
+}
+
+/// The index of the `)` that closes the `(` at [start], or -1 when [start] is
+/// not a `(` or the group is never closed.
+///
+/// Escaped characters and character classes never open or close a group, so
+/// `(\()` and `([()])` are both single groups.
+int _closingParenIndex(String pattern, int start) {
+  if (start >= pattern.length || pattern[start] != '(') {
+    return -1;
+  }
+
+  var depth = 0;
+  var inCharacterClass = false;
+  for (var currentIndex = start; currentIndex < pattern.length; currentIndex++) {
+    final String character = pattern[currentIndex];
+    if (character == r'\') {
+      // The next character is a literal: skip it together with the backslash.
+      currentIndex++;
+      continue;
+    }
+    if (inCharacterClass) {
+      if (character == ']') {
+        inCharacterClass = false;
+      }
+      continue;
+    }
+    switch (character) {
+      case '[':
+        inCharacterClass = true;
+      case '(':
+        depth++;
+      case ')':
+        depth--;
+        if (depth == 0) {
+          return currentIndex;
+        }
+    }
+  }
+
+  return -1;
+}
 
 /// Converts a [pattern] such as `/user/:id` into [RegExp].
 ///
@@ -26,18 +114,14 @@ final RegExp _parameterRegExp = RegExp(r':(\w+)(\((?:\\.|[^\\()])+\))?');
 RegExp patternToRegExp(String pattern, List<String> parameters, {required bool caseSensitive}) {
   final buffer = StringBuffer('^');
   var start = 0;
-  for (final RegExpMatch match in _parameterRegExp.allMatches(pattern)) {
-    if (match.start > start) {
-      buffer.write(RegExp.escape(pattern.substring(start, match.start)));
+  for (final _PathParameter parameter in _pathParametersOf(pattern)) {
+    if (parameter.start > start) {
+      buffer.write(RegExp.escape(pattern.substring(start, parameter.start)));
     }
-    final String name = match[1]!;
-    final String? optionalPattern = match[2];
-    final String regex = optionalPattern != null
-        ? _escapeGroup(optionalPattern, name)
-        : '(?<$name>[^/]+)';
-    buffer.write(regex);
-    parameters.add(name);
-    start = match.end;
+
+    buffer.write('(?<${parameter.name}>${parameter.constraint ?? '[^/]+'})');
+    parameters.add(parameter.name);
+    start = parameter.end;
   }
 
   if (start < pattern.length) {
@@ -48,17 +132,6 @@ RegExp patternToRegExp(String pattern, List<String> parameters, {required bool c
     buffer.write(r'(?=/|$)');
   }
   return RegExp(buffer.toString(), caseSensitive: caseSensitive);
-}
-
-String _escapeGroup(String group, [String? name]) {
-  final String escapedGroup = group.replaceFirstMapped(
-    RegExp(r'[:=!]'),
-    (Match match) => '\\${match[0]}',
-  );
-  if (name != null) {
-    return '(?<$name>$escapedGroup)';
-  }
-  return escapedGroup;
 }
 
 /// Reconstructs the full path from a [pattern] and path parameters.
@@ -76,13 +149,12 @@ String _escapeGroup(String group, [String? name]) {
 String patternToPath(String pattern, Map<String, String> pathParameters) {
   final buffer = StringBuffer();
   var start = 0;
-  for (final RegExpMatch match in _parameterRegExp.allMatches(pattern)) {
-    if (match.start > start) {
-      buffer.write(pattern.substring(start, match.start));
+  for (final _PathParameter parameter in _pathParametersOf(pattern)) {
+    if (parameter.start > start) {
+      buffer.write(pattern.substring(start, parameter.start));
     }
-    final String name = match[1]!;
-    buffer.write(pathParameters[name]);
-    start = match.end;
+    buffer.write(pathParameters[parameter.name]);
+    start = parameter.end;
   }
 
   if (start < pattern.length) {

--- a/packages/go_router/pending_changelogs/fix_lookahead_path_params.yaml
+++ b/packages/go_router/pending_changelogs/fix_lookahead_path_params.yaml
@@ -1,3 +1,3 @@
 changelog: |
-  - Fixes a bug that prevented path params regexp from using internal parenthesis (e.g. `:id((?!FOO).*)`)
+  - Fixes path parameter regex parsing to support nested parentheses, grouping constructs, and lookahead assertions in GoRoute paths.
 version: patch

--- a/packages/go_router/pending_changelogs/fix_lookahead_path_params.yaml
+++ b/packages/go_router/pending_changelogs/fix_lookahead_path_params.yaml
@@ -1,0 +1,3 @@
+changelog: |
+  - Fixes a bug that prevented path params regexp from using internal parenthesis (e.g. `:id((?!FOO).*)`)
+version: patch

--- a/packages/go_router/test/path_utils_test.dart
+++ b/packages/go_router/test/path_utils_test.dart
@@ -40,6 +40,54 @@ void main() {
     expect(regex.hasMatch('/'), isFalse);
   });
 
+  test('patternToRegExp with a nested group in the parameter pattern', () async {
+    const pattern = r'/user/:id((?!(?:0|1)(?:/|$))[^/]+)';
+    final pathParameter = <String>[];
+    final RegExp regex = patternToRegExp(pattern, pathParameter, caseSensitive: true);
+    expect(pathParameter, <String>['id']);
+
+    final RegExpMatch? match = regex.firstMatch('/user/12');
+    expect(match, isNotNull);
+    expect(extractPathParameters(pathParameter, match!)['id'], '12');
+
+    expect(regex.hasMatch('/user/0'), isFalse);
+    expect(regex.hasMatch('/user/0/edit'), isFalse);
+    expect(regex.hasMatch('/user/1'), isFalse);
+    expect(regex.hasMatch('/user/13'), isTrue);
+  });
+
+  test('patternToRegExp keeps group constructs in the parameter pattern', () async {
+    final pathParameter = <String>[];
+    final RegExp regex = patternToRegExp(
+      r'/user/:id((?:0x)?\d+)',
+      pathParameter,
+      caseSensitive: true,
+    );
+    expect(pathParameter, <String>['id']);
+    expect(regex.hasMatch('/user/0x42'), isTrue);
+    expect(regex.hasMatch('/user/42'), isTrue);
+    expect(regex.hasMatch('/user/abc'), isFalse);
+  });
+
+  test('patternToRegExp with parentheses in a character class', () async {
+    final pathParameter = <String>[];
+    final RegExp regex = patternToRegExp(r'/a/:x([()])', pathParameter, caseSensitive: true);
+    expect(pathParameter, <String>['x']);
+
+    final RegExpMatch? match = regex.firstMatch('/a/(');
+    expect(match, isNotNull);
+    expect(extractPathParameters(pathParameter, match!)['x'], '(');
+  });
+
+  test('patternToPath with a nested group in the parameter pattern', () async {
+    expect(
+      patternToPath(r'/tags/:slug((?!(?:admin|new)(?:/|$))[^/]+)', const <String, String>{
+        'slug': 'flutter',
+      }),
+      '/tags/flutter',
+    );
+  });
+
   test('patternToPath without path parameter', () async {
     const pattern = '/settings/detail';
     final pathParameter = <String>[];

--- a/packages/go_router/test/path_utils_test.dart
+++ b/packages/go_router/test/path_utils_test.dart
@@ -79,6 +79,27 @@ void main() {
     expect(extractPathParameters(pathParameter, match!)['x'], '(');
   });
 
+  test('patternToRegExp with a nested group containing an alternation', () async {
+    final pathParameter = <String>[];
+    final RegExp regex = patternToRegExp(
+      r'/details/:id((FOO|BAR)[0-9a-zA-Z]{10})',
+      pathParameter,
+      caseSensitive: true,
+    );
+    expect(pathParameter, <String>['id']);
+
+    final RegExpMatch? matchFoo = regex.firstMatch('/details/FOO0123456789');
+    expect(matchFoo, isNotNull);
+    expect(extractPathParameters(pathParameter, matchFoo!)['id'], 'FOO0123456789');
+
+    final RegExpMatch? matchBar = regex.firstMatch('/details/BAR0123456789');
+    expect(matchBar, isNotNull);
+    expect(extractPathParameters(pathParameter, matchBar!)['id'], 'BAR0123456789');
+
+    final RegExpMatch? matchBaz = regex.firstMatch('/details/BAZ0123456789');
+    expect(matchBaz, isNull);
+  });
+
   test('patternToPath with a nested group in the parameter pattern', () async {
     expect(
       patternToPath(r'/tags/:slug((?!(?:admin|new)(?:/|$))[^/]+)', const <String, String>{


### PR DESCRIPTION
* Fixes https://github.com/flutter/flutter/issues/117307
* Fixes an issue that prevented developers to use all kinds of groups in regexp patterns

Example:
`/tags/:slug((?!politics|economy)[^/]+)` should match `/tags/culture` and not match `/tags/politics`, but the current behavior is that the internal parenthesis are unhandled and the pattern is then used _literally_ :

* `/tags/flutter` -> No match
* `/tags/politics` -> No match
* `/tags/flutter((?!politics|economy))[^/]+)` -> Match, slug="flutter"

Disclosure: I did the investigation and fix using AI, which i carefully reviewed and tried to improve as much as I could according to the AI contribution guidelines. I think it's still better to mention it

A few things to note:
* Not a big fan of the "string-scanner" to find the closing parenthesis, but this is unachievable with a regex and needed for the fix to work as expected, and it's tested
* You might be wondering why the `_escapeGroup` function is completely gone (and why it was there in the first place if we can just remove it like that). The AI retraces this to when the repository transitioned from using the `path_to_regexp` package to having the functions in the codebase. This package seems to be using positional group matching, whereas go_router relies on named group matching, so escaping characters like :,- or ! is unnecessary as they can't disrupt the matching from working as expected.

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under[^1].
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [x] All existing and new tests are passing.