### PR TITLE
[repo] Update AGENTS.md with dependency allowance and versioning guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,6 +97,7 @@ dart run $REPO_ROOT/script/tool/bin/flutter_plugin_tools.dart update-dependency 
 
 ### Specialized Workflows
 
+- **Allowed Dependencies in `.repo_tool_config.yaml`**: The repository strictly enforces a whitelist of non-local dependencies. If you add or modify a dependency in any package's `pubspec.yaml` (including `dev_dependencies`), ensure the package is registered under `allowed_dependencies` (either `pinned` or `unpinned`) in `.repo_tool_config.yaml` at the repository root. Otherwise, `validate` will fail with `The following unexpected non-local dependencies were found`.
 - **Federated Plugin Development**: If you change multiple packages in a federated plugin that depend on each other, use `make-deps-path-based` to make their pubspec.yaml files use `path:` dependencies. This allows you to test them together locally.
   ```bash
   dart run $REPO_ROOT/script/tool/bin/flutter_plugin_tools.dart make-deps-path-based --target-dependencies=<changed_plugin_packages>
@@ -150,8 +151,10 @@ dart run $REPO_ROOT/script/tool/bin/flutter_plugin_tools.dart update-release-inf
   --changelog="A description of the changes."
 ```
 
-- `--version=minimal`: Bumps patch for bug fixes, and skips unchanged packages. This is usually the best option unless a new feature is being added.
+- `--version=minimal`: Bumps patch for bug fixes and non-breaking changes, and skips unchanged packages. This is usually the best option unless a new feature or breaking API change is being added.
   - When making public API changes, use `--version=minor` instead.
 - `--base-branch=origin/main`: Diffs against the `main` branch to find changed packages.
+
+If a change is strictly internal/exempt (e.g., repo-wide CI tooling) and should not bump package versions, explain the exemption in the PR description and request the `override: no versioning needed` and `override: no changelog needed` labels.
 
 If you update manually, follow semantic versioning and the [repository's CHANGELOG style](https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style).


### PR DESCRIPTION
Updates `AGENTS.md` to add guidance on common presubmit validation requirements:
- Clarifies that external or Google-owned dependencies in `pubspec.yaml` must be whitelisted in `.repo_tool_config.yaml` under `allowed_dependencies`.
- Clarifies that modifying non-exempt files (such as `pubspec.yaml` or tool configs) triggers version and `CHANGELOG.md` requirements during repository validation unless explicit override labels are requested.

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[the version and CHANGELOG instructions]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version-and-changelog-updates
[semantic versioning]: https://dart.dev/tools/pub/versioning#semantic-versions
[repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests