### PR TITLE
[camera_android_camerax] Fix exposure offset setting error thrown when canceled by a new request

### DIFF
--- a/packages/camera/camera_android_camerax/CHANGELOG.md
+++ b/packages/camera/camera_android_camerax/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.7.4+7
+
+* Fix exposure offset slider freezing camera preview and fix setExposureOffset return value.
+
 ## 0.7.4+6
 
 * Adds explicit `androidx.concurrent:concurrent-futures:1.2.0` dependency to fix

--- a/packages/camera/camera_android_camerax/implementation_plan.md
+++ b/packages/camera/camera_android_camerax/implementation_plan.md
@@ -1,0 +1,121 @@
+## Goal Description
+The goal is to fix an issue in the `camera_android_camerax` package where rapidly changing the exposure offset (e.g., via a slider) causes the camera preview to freeze and throws an exception: `"Setting exposure compensation index was canceled due to the camera being closed or a new request being submitted."`
+
+### Issue Explanation
+When a user slides the exposure slider rapidly, multiple `setExposureOffset` calls are triggered in quick succession. The underlying CameraX Android library handles this by cancelling the previous pending request and processing the newest one. This cancellation surfaces as a `CameraControl.OperationCanceledException` in Java.
+
+The Java Pigeon wrapper (`CameraControlProxyApi.java`) handles this correctly by catching the exception and returning `null` to the Dart side to indicate a benign cancellation.
+
+However, in `android_camera_camerax.dart`, the Dart code misinterprets this `null` return value as a fatal camera error. It does two things:
+1. Throws a `CameraException` which crashes the local operation.
+2. Adds an error string to the global `cameraErrorStreamController`.
+
+Adding an error to `cameraErrorStreamController` notifies the frontend `CameraController` that the camera has encountered a critical, unrecoverable failure. This is what causes the app's camera preview to freeze and stop responding, as the app tears down the camera session in response to the global error.
+
+Additionally, we identified a secondary bug: when `setExposureOffset` succeeds, it currently returns the integer *index* instead of the calculated double *offset* (which violates the `Camera` platform interface contract).
+
+## User Review Required
+> [!NOTE]
+> The platform interface for `setExposureOffset` specifies that it should return the rounded offset value that was set. We will be fixing a bug where it previously returned the raw integer index from CameraX. This is technically a bug fix but alters the return value to what the platform interface actually specifies.
+
+## Open Questions
+None at this time.
+
+## Proposed Changes
+
+---
+
+### camera_android_camerax Package
+We will update `android_camera_camerax.dart` to handle cancellations gracefully and return the correct offset values. We will also prevent `_startFocusAndMetering` from adding benign cancellations to the global error stream.
+
+#### [MODIFY] `lib/src/android_camera_camerax.dart`
+```diff
+@@ -751,14 +751,9 @@
+       );
+
+       if (newIndex == null) {
+-        cameraErrorStreamController.add(
+-          'Setting exposure compensation index was canceled due to the camera being closed or a new request being submitted.',
+-        );
+-        throw CameraException(
+-          setExposureOffsetFailedErrorCode,
+-          'Setting exposure compensation index was canceled due to the camera being closed or a new request being submitted.',
+-        );
++        // Return the requested rounded offset if the operation was cancelled.
++        return roundedExposureCompensationIndex * exposureOffsetStepSize;
+       }
+
+-      return newIndex.toDouble();
++      return newIndex * exposureOffsetStepSize;
+     } on PlatformException catch (e) {
+@@ -1771,9 +1766,6 @@
+       );
+
+-      if (result == null) {
+-        cameraErrorStreamController.add(
+-          'Starting focus and metering was canceled due to the camera being closed or a new request being submitted.',
+-        );
+-      }
+
+       return result?.isFocusSuccessful ?? false;
+```
+
+#### [MODIFY] `test/android_camera_camerax_test.dart`
+We will update the tests to reflect the graceful handling of cancellations and the correct return value types.
+
+```diff
+@@ -4665,7 +4665,7 @@
+-    'setExposureOffset throws exception if exposure compensation could not be set due to camera being closed or newer value being set',
++    'setExposureOffset returns gracefully if exposure compensation could not be set due to camera being closed or newer value being set',
+     () async {
+       // ...
+-      expect(() => camera.setExposureOffset(cameraId, offset), throwsA(isA<CameraException>()));
++      expect(await camera.setExposureOffset(cameraId, offset), equals(5.0));
+     },
+   );
+
+@@ -4715,11 +4715,11 @@
+       when(
+         mockCameraControl.setExposureCompensationIndex(expectedExposureCompensationIndex),
+       ).thenAnswer(
+-        (_) async => Future<int>.value(
+-          (expectedExposureCompensationIndex * exposureState.exposureCompensationStep).round(),
+-        ),
++        (_) async => Future<int>.value(expectedExposureCompensationIndex),
+       );
+
+-      // Exposure index * exposure offset step size = exposure offset, i.e.
+-      // 15 * 0.2 = 3.
+-      expect(await camera.setExposureOffset(cameraId, offset), equals(3));
++      // Exposure index * exposure offset step size = exposure offset, i.e.
++      // 15 * 0.2 = 3.0
++      expect(await camera.setExposureOffset(cameraId, offset), equals(3.0));
+     },
+   );
+```
+
+We will also add a new test to ensure that cancelling `setFocusPoint` does not push an error to the global `cameraErrorStreamController`.
+
+## Verification Plan
+
+### Automated Tests
+The modified and newly added tests in `test/android_camera_camerax_test.dart` will initially fail with the current code, and pass once the proposed changes are implemented. These unit tests ensure we do not regress on video recording state by guaranteeing `cameraErrorStreamController` won't emit false errors that would otherwise tear down the camera pipeline.
+
+I will run the tests using:
+```bash
+dart run $REPO_ROOT/script/tool/bin/flutter_plugin_tools.dart dart-test --packages camera_android_camerax
+```
+
+### Manual Verification
+The user should manually verify the fix by running the example app:
+1. Run the `camera_android_camerax/example` app on an Android device.
+2. Tap on "Exposure mode" and drag the slider quickly back and forth.
+3. Observe that no exceptions are thrown, and the camera preview does not freeze.
+
+### Repository Standards
+I will ensure this PR meets the `flutter/packages` standards by doing the following:
+1. Validating the code formatting with `dart run $REPO_ROOT/script/tool/bin/flutter_plugin_tools.dart format --packages camera_android_camerax`.
+2. Validating static analysis with `dart run $REPO_ROOT/script/tool/bin/flutter_plugin_tools.dart analyze --packages camera_android_camerax`.
+3. Validating tests with `dart run $REPO_ROOT/script/tool/bin/flutter_plugin_tools.dart dart-test --packages camera_android_camerax`.
+4. Bumping the patch version and generating a `CHANGELOG.md` entry via `dart run $REPO_ROOT/script/tool/bin/flutter_plugin_tools.dart update-release-info --version=minimal --base-branch=origin/main --changelog="Fix exposure offset slider freezing camera preview."`
+5. Ensuring the pre-push checks via `.agents/skills/pre-push-skill/SKILL.md` are green.

--- a/packages/camera/camera_android_camerax/implementation_plan.md
+++ b/packages/camera/camera_android_camerax/implementation_plan.md
@@ -118,5 +118,5 @@ I will ensure this PR meets the `flutter/packages` standards by doing the follow
 1. Validating the code formatting with `dart run $REPO_ROOT/script/tool/bin/flutter_plugin_tools.dart format --packages camera_android_camerax`.
 2. Validating static analysis with `dart run $REPO_ROOT/script/tool/bin/flutter_plugin_tools.dart analyze --packages camera_android_camerax`.
 3. Validating tests with `dart run $REPO_ROOT/script/tool/bin/flutter_plugin_tools.dart dart-test --packages camera_android_camerax`.
-4. Bumping the patch version and generating a `CHANGELOG.md` entry via `dart run $REPO_ROOT/script/tool/bin/flutter_plugin_tools.dart update-release-info --version=minimal --base-branch=origin/main --changelog="Fix exposure offset slider freezing camera preview."`
+4. Bumping the patch version and generating a `CHANGELOG.md` entry via `dart run $REPO_ROOT/script/tool/bin/flutter_plugin_tools.dart update-release-info --version=minimal --base-branch=origin/main --changelog="Fix exposure offset slider freezing camera preview and fix setExposureOffset return value."`
 5. Ensuring the pre-push checks via `.agents/skills/pre-push-skill/SKILL.md` are green.

--- a/packages/camera/camera_android_camerax/implementation_plan.md
+++ b/packages/camera/camera_android_camerax/implementation_plan.md
@@ -14,21 +14,13 @@ Adding an error to `cameraErrorStreamController` notifies the frontend `CameraCo
 
 Additionally, we identified a secondary bug: when `setExposureOffset` succeeds, it currently returns the integer *index* instead of the calculated double *offset* (which violates the `Camera` platform interface contract).
 
-## User Review Required
+## Design Decisions
 > [!NOTE]
-> The platform interface for `setExposureOffset` specifies that it should return the rounded offset value that was set (e.g. `3.0`). We will be fixing a bug where it previously returned the raw integer index from CameraX (e.g. `15`). 
+> **Returning gracefully on cancellation instead of throwing an exception:** 
+> We have decided not to throw an exception when the operation is canceled. The cancellation is primarily caused by intermediate values being set between the old and desired value as the user rapidly scrubs the slider, which supersedes older requests. The only other relevant situation for a cancellation exception is when the camera is closed, in which case failing to set the exposure offset is not a real error. Returning the requested offset gracefully avoids crashing or cluttering the developer's console when these benign cancellations occur.
 > 
-> **Proof regarding the CameraX return value:**
-> The CameraX documentation for `CameraControl.setExposureCompensationIndex(int index)` states that it returns a `ListenableFuture<Integer>`, and that this integer is the index that was actually set. The native Pigeon wrapper in `CameraControlProxyApi.java` correctly returns this integer. However, the Dart code was directly returning `newIndex.toDouble()`, thus returning the index (e.g. `15.0`) instead of multiplying it by the `exposureOffsetStepSize` (e.g. `15 * 0.2 = 3.0`) as required by the `camera` platform interface.
-
-## Open Questions
-> [!IMPORTANT]
-> **Regarding your comment on notifying the developer:**
-> If we throw an exception when the request is canceled, it will bubble up to the `setExposureOffset` Future caller. Because canceling is expected behavior when a user drags a slider rapidly (the new request supersedes the old one), throwing an exception forces developers to catch and ignore it, and in the case of the example app, it surfaces an annoying snackbar error.
-> 
-> If we *don't* throw an exception, we can just return the rounded offset that they requested. Since a new request has already been submitted to replace this one, the slider will eventually settle on the final request's value. 
-> 
-> We could technically throw a `CameraException` with a specific code like `exposureOffsetCanceled`, but returning the requested value gracefully (which is what we currently propose) is usually the standard way to handle superseded rapid-fire requests without littering the developer's console/UI with errors. What do you prefer?
+> **Returning the correct offset value:** 
+> The platform interface for `setExposureOffset` specifies that it should return the rounded offset value that was set (e.g. `3.0`). We will be fixing a bug where it previously returned the raw integer index from CameraX (e.g. `15.0`). The CameraX documentation for `CameraControl.setExposureCompensationIndex(int index)` states that it returns a `ListenableFuture<Integer>`, and that this integer is the index that was actually set. The native Pigeon wrapper in `CameraControlProxyApi.java` correctly returns this integer. However, the Dart code was directly returning `newIndex.toDouble()`, thus returning the index instead of multiplying it by the `exposureOffsetStepSize` (e.g. `15 * 0.2 = 3.0`) as required by the `camera` platform interface.
 
 ## Proposed Changes
 

--- a/packages/camera/camera_android_camerax/implementation_plan.md
+++ b/packages/camera/camera_android_camerax/implementation_plan.md
@@ -16,10 +16,19 @@ Additionally, we identified a secondary bug: when `setExposureOffset` succeeds, 
 
 ## User Review Required
 > [!NOTE]
-> The platform interface for `setExposureOffset` specifies that it should return the rounded offset value that was set. We will be fixing a bug where it previously returned the raw integer index from CameraX. This is technically a bug fix but alters the return value to what the platform interface actually specifies.
+> The platform interface for `setExposureOffset` specifies that it should return the rounded offset value that was set (e.g. `3.0`). We will be fixing a bug where it previously returned the raw integer index from CameraX (e.g. `15`). 
+> 
+> **Proof regarding the CameraX return value:**
+> The CameraX documentation for `CameraControl.setExposureCompensationIndex(int index)` states that it returns a `ListenableFuture<Integer>`, and that this integer is the index that was actually set. The native Pigeon wrapper in `CameraControlProxyApi.java` correctly returns this integer. However, the Dart code was directly returning `newIndex.toDouble()`, thus returning the index (e.g. `15.0`) instead of multiplying it by the `exposureOffsetStepSize` (e.g. `15 * 0.2 = 3.0`) as required by the `camera` platform interface.
 
 ## Open Questions
-None at this time.
+> [!IMPORTANT]
+> **Regarding your comment on notifying the developer:**
+> If we throw an exception when the request is canceled, it will bubble up to the `setExposureOffset` Future caller. Because canceling is expected behavior when a user drags a slider rapidly (the new request supersedes the old one), throwing an exception forces developers to catch and ignore it, and in the case of the example app, it surfaces an annoying snackbar error.
+> 
+> If we *don't* throw an exception, we can just return the rounded offset that they requested. Since a new request has already been submitted to replace this one, the slider will eventually settle on the final request's value. 
+> 
+> We could technically throw a `CameraException` with a specific code like `exposureOffsetCanceled`, but returning the requested value gracefully (which is what we currently propose) is usually the standard way to handle superseded rapid-fire requests without littering the developer's console/UI with errors. What do you prefer?
 
 ## Proposed Changes
 

--- a/packages/camera/camera_android_camerax/lib/src/android_camera_camerax.dart
+++ b/packages/camera/camera_android_camerax/lib/src/android_camera_camerax.dart
@@ -751,16 +751,10 @@ class AndroidCameraCameraX extends CameraPlatform {
       );
 
       if (newIndex == null) {
-        cameraErrorStreamController.add(
-          'Setting exposure compensation index was canceled due to the camera being closed or a new request being submitted.',
-        );
-        throw CameraException(
-          setExposureOffsetFailedErrorCode,
-          'Setting exposure compensation index was canceled due to the camera being closed or a new request being submitted.',
-        );
+        return roundedExposureCompensationIndex * exposureOffsetStepSize;
       }
 
-      return newIndex.toDouble();
+      return newIndex * exposureOffsetStepSize;
     } on PlatformException catch (e) {
       cameraErrorStreamController.add(
         e.message ?? 'Setting the camera exposure compensation index failed.',
@@ -1769,12 +1763,6 @@ class AndroidCameraCameraX extends CameraPlatform {
       final FocusMeteringResult? result = await cameraControl.startFocusAndMetering(
         currentFocusMeteringAction!,
       );
-
-      if (result == null) {
-        cameraErrorStreamController.add(
-          'Starting focus and metering was canceled due to the camera being closed or a new request being submitted.',
-        );
-      }
 
       return result?.isFocusSuccessful ?? false;
     } on PlatformException catch (e) {

--- a/packages/camera/camera_android_camerax/pubspec.yaml
+++ b/packages/camera/camera_android_camerax/pubspec.yaml
@@ -2,7 +2,7 @@ name: camera_android_camerax
 description: Android implementation of the camera plugin using the CameraX library.
 repository: https://github.com/flutter/packages/tree/main/packages/camera/camera_android_camerax
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+camera%22
-version: 0.7.4+6
+version: 0.7.4+7
 
 environment:
   sdk: ^3.12.0

--- a/packages/camera/camera_android_camerax/test/android_camera_camerax_test.dart
+++ b/packages/camera/camera_android_camerax/test/android_camera_camerax_test.dart
@@ -4662,7 +4662,7 @@ void main() {
   );
 
   test(
-    'setExposureOffset throws exception if exposure compensation could not be set due to camera being closed or newer value being set',
+    'setExposureOffset returns gracefully if exposure compensation could not be set due to camera being closed or newer value being set',
     () async {
       final camera = AndroidCameraCameraX();
       const cameraId = 21;
@@ -4685,7 +4685,7 @@ void main() {
         mockCameraControl.setExposureCompensationIndex(expectedExposureCompensationIndex),
       ).thenAnswer((_) async => Future<int?>.value());
 
-      expect(() => camera.setExposureOffset(cameraId, offset), throwsA(isA<CameraException>()));
+      expect(await camera.setExposureOffset(cameraId, offset), equals(5.0));
     },
   );
 
@@ -4711,15 +4711,11 @@ void main() {
       when(mockCameraInfo.exposureState).thenReturn(exposureState);
       when(
         mockCameraControl.setExposureCompensationIndex(expectedExposureCompensationIndex),
-      ).thenAnswer(
-        (_) async => Future<int>.value(
-          (expectedExposureCompensationIndex * exposureState.exposureCompensationStep).round(),
-        ),
-      );
+      ).thenAnswer((_) async => Future<int>.value(expectedExposureCompensationIndex));
 
       // Exposure index * exposure offset step size = exposure offset, i.e.
-      // 15 * 0.2 = 3.
-      expect(await camera.setExposureOffset(cameraId, offset), equals(3));
+      // 15 * 0.2 = 3.0
+      expect(await camera.setExposureOffset(cameraId, offset), equals(3.0));
     },
   );
 
@@ -4805,6 +4801,48 @@ void main() {
       throwsA(isA<CameraException>()),
     );
   });
+
+  test(
+    'setFocusPoint does not add error to stream if focus and metering action is canceled',
+    () async {
+      final camera = AndroidCameraCameraX();
+      const cameraId = 23;
+      final mockCameraControl = MockCameraControl();
+      const focusPoint = Point<double>(0.5, 0.5);
+      final List<CameraEvent> errors = [];
+      camera.cameraEventStreamController.stream.listen(errors.add);
+
+      // Set directly for test versus calling createCamera.
+      camera.cameraControl = mockCameraControl;
+      camera.cameraInfo = MockCameraInfo();
+
+      final mockActionBuilder = MockFocusMeteringActionBuilder();
+      when(mockActionBuilder.build()).thenAnswer(
+        (_) async => FocusMeteringAction.pigeon_detached(
+          meteringPointsAe: const <MeteringPoint>[],
+          meteringPointsAf: const <MeteringPoint>[],
+          meteringPointsAwb: const <MeteringPoint>[],
+          isAutoCancelEnabled: false,
+        ),
+      );
+
+      setUpOverridesForExposureAndFocus(
+        withModeFocusMeteringActionBuilder:
+            ({required MeteringMode mode, required MeteringPoint point}) {
+              return mockActionBuilder;
+            },
+      );
+
+      when(
+        mockCameraControl.startFocusAndMetering(any),
+      ).thenAnswer((_) async => Future<FocusMeteringResult?>.value());
+
+      await camera.setFocusPoint(cameraId, focusPoint);
+
+      // Verify no errors were added to the stream.
+      expect(errors, isEmpty);
+    },
+  );
 
   test(
     'setFocusPoint adds new focus point to focus metering action to start as expected when previous metering points have been set',


### PR DESCRIPTION
Project One Shot Demonstration. WIP towards https://github.com/flutter/flutter/issues/148521 :)

Related (attempt without harness): https://github.com/flutter/packages/pull/12580

## Pre-Review Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [ ] I read the [Tree Hygiene] page, which explains my responsibilities.
- [ ] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [ ] I signed the [CLA].
- [ ] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I [linked to at least one issue that this PR fixes] in the description above.
- [ ] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under[^1].
- [ ] I updated/added any relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[the version and CHANGELOG instructions]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version-and-changelog-updates
[semantic versioning]: https://dart.dev/tools/pub/versioning#semantic-versions
[repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
