### PR TITLE
[in_app_purchase] Support StoreKit 2 introductory offer eligibility JWS

### DIFF
--- a/packages/in_app_purchase/in_app_purchase_storekit/CHANGELOG.md
+++ b/packages/in_app_purchase/in_app_purchase_storekit/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.4.12
+
+* Adds support for setting introductory offer eligibility from a server-signed
+  compact JWS via `Sk2PurchaseParam.introductoryOfferEligibilityCompactJWS`,
+  which is forwarded to StoreKit 2 as
+  `Product.PurchaseOption.introductoryOfferEligibility(compactJWS:)`.
+
 ## 0.4.11+2
 
 * Updates pigeon dev_dependency to ^27.3.2 for analyzer 14 compatibility.

--- a/packages/in_app_purchase/in_app_purchase_storekit/darwin/in_app_purchase_storekit/Sources/in_app_purchase_storekit/StoreKit2/InAppPurchasePlugin+StoreKit2.swift
+++ b/packages/in_app_purchase/in_app_purchase_storekit/darwin/in_app_purchase_storekit/Sources/in_app_purchase_storekit/StoreKit2/InAppPurchasePlugin+StoreKit2.swift
@@ -85,6 +85,13 @@ extension InAppPurchasePlugin: InAppPurchase2API {
           }
         }
 
+        // No availability check is needed: `introductoryOfferEligibility` is
+        // back deployed, so it is available on the same iOS 15 / macOS 12
+        // floor as the rest of this StoreKit 2 extension.
+        if let compactJWS = options?.introductoryOfferEligibilityCompactJWS {
+          purchaseOptions.insert(.introductoryOfferEligibility(compactJWS: compactJWS))
+        }
+
         for await verificationResult in Transaction.unfinished {
           switch verificationResult {
           case .verified(let transaction):

--- a/packages/in_app_purchase/in_app_purchase_storekit/darwin/in_app_purchase_storekit/Sources/in_app_purchase_storekit/StoreKit2/StoreKit2Messages.g.swift
+++ b/packages/in_app_purchase/in_app_purchase_storekit/darwin/in_app_purchase_storekit/Sources/in_app_purchase_storekit/StoreKit2/StoreKit2Messages.g.swift
@@ -640,6 +640,12 @@ struct SK2ProductPurchaseOptionsMessage: Hashable, CustomStringConvertible {
   var quantity: Int64? = nil
   var promotionalOffer: SK2SubscriptionOfferPurchaseMessage? = nil
   var winBackOfferId: String? = nil
+  /// A compact JWS, signed by the developer's server, that sets the customer's
+  /// eligibility for an introductory offer on this purchase.
+  ///
+  /// This is passed to StoreKit verbatim; it is never parsed or validated
+  /// client-side.
+  var introductoryOfferEligibilityCompactJWS: String? = nil
 
   // swift-format-ignore: AlwaysUseLowerCamelCase
   static func fromList(_ pigeonVar_list: [Any?]) -> SK2ProductPurchaseOptionsMessage? {
@@ -647,12 +653,14 @@ struct SK2ProductPurchaseOptionsMessage: Hashable, CustomStringConvertible {
     let quantity: Int64? = nilOrValue(pigeonVar_list[1])
     let promotionalOffer: SK2SubscriptionOfferPurchaseMessage? = nilOrValue(pigeonVar_list[2])
     let winBackOfferId: String? = nilOrValue(pigeonVar_list[3])
+    let introductoryOfferEligibilityCompactJWS: String? = nilOrValue(pigeonVar_list[4])
 
     return SK2ProductPurchaseOptionsMessage(
       appAccountToken: appAccountToken,
       quantity: quantity,
       promotionalOffer: promotionalOffer,
-      winBackOfferId: winBackOfferId
+      winBackOfferId: winBackOfferId,
+      introductoryOfferEligibilityCompactJWS: introductoryOfferEligibilityCompactJWS
     )
   }
   func toList() -> [Any?] {
@@ -661,6 +669,7 @@ struct SK2ProductPurchaseOptionsMessage: Hashable, CustomStringConvertible {
       quantity,
       promotionalOffer,
       winBackOfferId,
+      introductoryOfferEligibilityCompactJWS,
     ]
   }
   static func == (lhs: SK2ProductPurchaseOptionsMessage, rhs: SK2ProductPurchaseOptionsMessage)
@@ -673,6 +682,8 @@ struct SK2ProductPurchaseOptionsMessage: Hashable, CustomStringConvertible {
       && StoreKit2MessagesPigeonInternal.deepEquals(lhs.quantity, rhs.quantity)
       && StoreKit2MessagesPigeonInternal.deepEquals(lhs.promotionalOffer, rhs.promotionalOffer)
       && StoreKit2MessagesPigeonInternal.deepEquals(lhs.winBackOfferId, rhs.winBackOfferId)
+      && StoreKit2MessagesPigeonInternal.deepEquals(
+        lhs.introductoryOfferEligibilityCompactJWS, rhs.introductoryOfferEligibilityCompactJWS)
   }
 
   func hash(into hasher: inout Hasher) {
@@ -681,11 +692,13 @@ struct SK2ProductPurchaseOptionsMessage: Hashable, CustomStringConvertible {
     StoreKit2MessagesPigeonInternal.deepHash(value: quantity, hasher: &hasher)
     StoreKit2MessagesPigeonInternal.deepHash(value: promotionalOffer, hasher: &hasher)
     StoreKit2MessagesPigeonInternal.deepHash(value: winBackOfferId, hasher: &hasher)
+    StoreKit2MessagesPigeonInternal.deepHash(
+      value: introductoryOfferEligibilityCompactJWS, hasher: &hasher)
   }
 
   public var description: String {
     return
-      "SK2ProductPurchaseOptionsMessage(appAccountToken: \(String(describing: appAccountToken)), quantity: \(String(describing: quantity)), promotionalOffer: \(String(describing: promotionalOffer)), winBackOfferId: \(String(describing: winBackOfferId)))"
+      "SK2ProductPurchaseOptionsMessage(appAccountToken: \(String(describing: appAccountToken)), quantity: \(String(describing: quantity)), promotionalOffer: \(String(describing: promotionalOffer)), winBackOfferId: \(String(describing: winBackOfferId)), introductoryOfferEligibilityCompactJWS: \(String(describing: introductoryOfferEligibilityCompactJWS)))"
   }
 }
 

--- a/packages/in_app_purchase/in_app_purchase_storekit/example/shared/RunnerTests/InAppPurchaseStoreKit2PluginTests.swift
+++ b/packages/in_app_purchase/in_app_purchase_storekit/example/shared/RunnerTests/InAppPurchaseStoreKit2PluginTests.swift
@@ -389,6 +389,26 @@ final class InAppPurchase2PluginTests: XCTestCase {
     await fulfillment(of: [expectation], timeout: 5)
   }
 
+  func testPurchaseWithIntroductoryOfferEligibilityJWS() async throws {
+    let expectation = self.expectation(
+      description: "Purchase with an introductory offer eligibility JWS should complete")
+
+    // The plugin forwards this compact JWS to StoreKit verbatim, without
+    // parsing or validating it. The purchase is driven end to end to exercise
+    // that path; the callback is not asserted on a specific outcome because a
+    // locally generated JWS is not signed by App Store Connect.
+    let compactJWS = "eyJhbGciOiJFUzI1NiJ9.eyJhdWQiOiJ0ZXN0In0.c2ln"
+    let options = SK2ProductPurchaseOptionsMessage(
+      appAccountToken: nil, promotionalOffer: nil, winBackOfferId: nil,
+      introductoryOfferEligibilityCompactJWS: compactJWS)
+
+    plugin.purchase(id: "subscription_silver", options: options) { _ in
+      expectation.fulfill()
+    }
+
+    await fulfillment(of: [expectation], timeout: 5)
+  }
+
   func testRestoreProductSuccess() async throws {
     let purchaseExpectation = self.expectation(description: "Purchase request should succeed")
     let restoreExpectation = self.expectation(description: "Restore request should succeed")

--- a/packages/in_app_purchase/in_app_purchase_storekit/lib/src/in_app_purchase_storekit_platform.dart
+++ b/packages/in_app_purchase/in_app_purchase_storekit/lib/src/in_app_purchase_storekit_platform.dart
@@ -108,6 +108,8 @@ class InAppPurchaseStoreKitPlatform extends InAppPurchasePlatform {
   /// - [Sk2PurchaseParam] — to include StoreKit2-specific fields like:
   ///   - [winBackOfferId]: Applies a win-back offer.
   ///   - [promotionalOffer]: Applies a promotional offer (requires a valid signature).
+  ///   - [introductoryOfferEligibilityCompactJWS]: Sets introductory offer
+  ///     eligibility from a server-signed compact JWS.
   ///
   /// - [AppStorePurchaseParam] — for StoreKit1 flows using `SKPaymentQueue`.
   ///
@@ -163,6 +165,8 @@ class InAppPurchaseStoreKitPlatform extends InAppPurchasePlatform {
           quantity: purchaseParam.quantity,
           winBackOfferId: purchaseParam.winBackOfferId,
           promotionalOffer: _convertPromotionalOffer(purchaseParam.promotionalOffer),
+          introductoryOfferEligibilityCompactJWS:
+              purchaseParam.introductoryOfferEligibilityCompactJWS,
         );
       } else {
         options = SK2ProductPurchaseOptions(

--- a/packages/in_app_purchase/in_app_purchase_storekit/lib/src/sk2_pigeon.g.dart
+++ b/packages/in_app_purchase/in_app_purchase_storekit/lib/src/sk2_pigeon.g.dart
@@ -579,6 +579,7 @@ class SK2ProductPurchaseOptionsMessage {
     this.quantity = 1,
     this.promotionalOffer,
     this.winBackOfferId,
+    this.introductoryOfferEligibilityCompactJWS,
   });
 
   String? appAccountToken;
@@ -589,8 +590,21 @@ class SK2ProductPurchaseOptionsMessage {
 
   String? winBackOfferId;
 
+  /// A compact JWS, signed by the developer's server, that sets the customer's
+  /// eligibility for an introductory offer on this purchase.
+  ///
+  /// This is passed to StoreKit verbatim; it is never parsed or validated
+  /// client-side.
+  String? introductoryOfferEligibilityCompactJWS;
+
   List<Object?> _toList() {
-    return <Object?>[appAccountToken, quantity, promotionalOffer, winBackOfferId];
+    return <Object?>[
+      appAccountToken,
+      quantity,
+      promotionalOffer,
+      winBackOfferId,
+      introductoryOfferEligibilityCompactJWS,
+    ];
   }
 
   Object encode() {
@@ -604,6 +618,7 @@ class SK2ProductPurchaseOptionsMessage {
       quantity: result[1] as int?,
       promotionalOffer: result[2] as SK2SubscriptionOfferPurchaseMessage?,
       winBackOfferId: result[3] as String?,
+      introductoryOfferEligibilityCompactJWS: result[4] as String?,
     );
   }
 
@@ -619,7 +634,11 @@ class SK2ProductPurchaseOptionsMessage {
     return _deepEquals(appAccountToken, other.appAccountToken) &&
         _deepEquals(quantity, other.quantity) &&
         _deepEquals(promotionalOffer, other.promotionalOffer) &&
-        _deepEquals(winBackOfferId, other.winBackOfferId);
+        _deepEquals(winBackOfferId, other.winBackOfferId) &&
+        _deepEquals(
+          introductoryOfferEligibilityCompactJWS,
+          other.introductoryOfferEligibilityCompactJWS,
+        );
   }
 
   @override
@@ -628,7 +647,7 @@ class SK2ProductPurchaseOptionsMessage {
 
   @override
   String toString() {
-    return 'SK2ProductPurchaseOptionsMessage(appAccountToken: $appAccountToken, quantity: $quantity, promotionalOffer: $promotionalOffer, winBackOfferId: $winBackOfferId)';
+    return 'SK2ProductPurchaseOptionsMessage(appAccountToken: $appAccountToken, quantity: $quantity, promotionalOffer: $promotionalOffer, winBackOfferId: $winBackOfferId, introductoryOfferEligibilityCompactJWS: $introductoryOfferEligibilityCompactJWS)';
   }
 }
 

--- a/packages/in_app_purchase/in_app_purchase_storekit/lib/src/store_kit_2_wrappers/sk2_product_wrapper.dart
+++ b/packages/in_app_purchase/in_app_purchase_storekit/lib/src/store_kit_2_wrappers/sk2_product_wrapper.dart
@@ -289,6 +289,7 @@ class SK2ProductPurchaseOptions {
     this.quantity,
     this.promotionalOffer,
     this.winBackOfferId,
+    this.introductoryOfferEligibilityCompactJWS,
   });
 
   /// Sets a UUID to associate the purchase with an account in your system.
@@ -303,6 +304,12 @@ class SK2ProductPurchaseOptions {
   /// Sets a win back offer to a purchase.
   final String? winBackOfferId;
 
+  /// Sets the customer's introductory offer eligibility for this purchase,
+  /// as a compact JWS signed by your server.
+  ///
+  /// See [Sk2PurchaseParam.introductoryOfferEligibilityCompactJWS].
+  final String? introductoryOfferEligibilityCompactJWS;
+
   /// Convert to pigeon representation [SK2ProductPurchaseOptionsMessage].
   SK2ProductPurchaseOptionsMessage convertToPigeon() {
     return SK2ProductPurchaseOptionsMessage(
@@ -310,6 +317,7 @@ class SK2ProductPurchaseOptions {
       quantity: quantity,
       winBackOfferId: winBackOfferId,
       promotionalOffer: promotionalOffer,
+      introductoryOfferEligibilityCompactJWS: introductoryOfferEligibilityCompactJWS,
     );
   }
 }

--- a/packages/in_app_purchase/in_app_purchase_storekit/lib/src/types/sk2_purchase_param.dart
+++ b/packages/in_app_purchase/in_app_purchase_storekit/lib/src/types/sk2_purchase_param.dart
@@ -16,6 +16,7 @@ class Sk2PurchaseParam extends PurchaseParam {
     this.quantity = 1,
     this.winBackOfferId,
     this.promotionalOffer,
+    this.introductoryOfferEligibilityCompactJWS,
   });
 
   /// Creates a [Sk2PurchaseParam] from a [ProductDetails] and a [SK2SubscriptionOffer].
@@ -54,4 +55,32 @@ class Sk2PurchaseParam extends PurchaseParam {
 
   /// The promotional offer identifier to apply to the purchase.
   final SK2PromotionalOffer? promotionalOffer;
+
+  /// A compact JWS, signed by your server, that sets the customer's
+  /// eligibility for an introductory offer on this purchase.
+  ///
+  /// When non-null this is forwarded verbatim to StoreKit as
+  /// [`Product.PurchaseOption.introductoryOfferEligibility(compactJWS:)`](https://developer.apple.com/documentation/storekit/product/purchaseoption/introductoryoffereligibility(compactjws:)).
+  /// When null, no such purchase option is set and the App Store applies its
+  /// own default introductory offer eligibility.
+  ///
+  /// The JWS is signed on your server with an App Store Connect In-App
+  /// Purchase key; see
+  /// [Generating JWS to sign App Store requests](https://developer.apple.com/documentation/storekit/generating-jws-to-sign-app-store-requests).
+  /// Its `allowIntroductoryOffer` claim determines whether the customer is
+  /// eligible, and can both grant an introductory offer to a customer the App
+  /// Store would consider ineligible and block one for a customer it would
+  /// consider eligible.
+  ///
+  /// This value is passed through untouched: the plugin never generates,
+  /// parses, validates or inspects it.
+  ///
+  /// This is **not** the same as [InAppPurchaseStoreKitPlatformAddition.isIntroductoryOfferEligible],
+  /// which reports the App Store's *default* eligibility for a product. This
+  /// property is a pricing decision supplied by a trusted server, and is
+  /// neither entitlement nor purchase verification.
+  ///
+  /// Available on iOS 15.0+ and macOS 12.0+; the underlying StoreKit API is
+  /// back deployed, so no additional OS version check is required.
+  final String? introductoryOfferEligibilityCompactJWS;
 }

--- a/packages/in_app_purchase/in_app_purchase_storekit/pigeons/sk2_pigeon.dart
+++ b/packages/in_app_purchase/in_app_purchase_storekit/pigeons/sk2_pigeon.dart
@@ -154,12 +154,20 @@ class SK2ProductPurchaseOptionsMessage {
     this.quantity = 1,
     this.promotionalOffer,
     this.winBackOfferId,
+    this.introductoryOfferEligibilityCompactJWS,
   });
 
   final String? appAccountToken;
   final int? quantity;
   final SK2SubscriptionOfferPurchaseMessage? promotionalOffer;
   final String? winBackOfferId;
+
+  /// A compact JWS, signed by the developer's server, that sets the customer's
+  /// eligibility for an introductory offer on this purchase.
+  ///
+  /// This is passed to StoreKit verbatim; it is never parsed or validated
+  /// client-side.
+  final String? introductoryOfferEligibilityCompactJWS;
 }
 
 class SK2TransactionMessage {

--- a/packages/in_app_purchase/in_app_purchase_storekit/pubspec.yaml
+++ b/packages/in_app_purchase/in_app_purchase_storekit/pubspec.yaml
@@ -2,7 +2,7 @@ name: in_app_purchase_storekit
 description: An implementation for the iOS and macOS platforms of the Flutter `in_app_purchase` plugin. This uses the StoreKit Framework.
 repository: https://github.com/flutter/packages/tree/main/packages/in_app_purchase/in_app_purchase_storekit
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+in_app_purchase%22
-version: 0.4.11+2
+version: 0.4.12
 
 environment:
   sdk: ^3.10.0

--- a/packages/in_app_purchase/in_app_purchase_storekit/test/in_app_purchase_storekit_2_platform_test.dart
+++ b/packages/in_app_purchase/in_app_purchase_storekit/test/in_app_purchase_storekit_2_platform_test.dart
@@ -249,6 +249,79 @@ void main() {
       expect(lastPurchaseOptions.promotionalOffer, isNull);
     });
 
+    test('should not set introductory offer eligibility JWS when it is null', () async {
+      final purchaseParam = Sk2PurchaseParam(
+        productDetails: AppStoreProduct2Details.fromSK2Product(dummyProductWrapper),
+        applicationUserName: 'testUser',
+      );
+
+      await iapStoreKitPlatform.buyNonConsumable(purchaseParam: purchaseParam);
+
+      expect(
+        fakeStoreKit2Platform.lastPurchaseOptions!.introductoryOfferEligibilityCompactJWS,
+        isNull,
+      );
+    });
+
+    test('should forward introductory offer eligibility JWS unchanged', () async {
+      const compactJWS = 'eyJhbGciOiJFUzI1NiJ9.eyJhdWQiOiJ0ZXN0In0.c2ln';
+
+      final purchaseParam = Sk2PurchaseParam(
+        productDetails: AppStoreProduct2Details.fromSK2Product(dummyProductWrapper),
+        introductoryOfferEligibilityCompactJWS: compactJWS,
+      );
+
+      await iapStoreKitPlatform.buyNonConsumable(purchaseParam: purchaseParam);
+
+      expect(
+        fakeStoreKit2Platform.lastPurchaseOptions!.introductoryOfferEligibilityCompactJWS,
+        compactJWS,
+      );
+    });
+
+    test('should send introductory offer eligibility JWS alongside other options', () async {
+      final fakeSignature = SK2SubscriptionOfferSignature(
+        keyID: 'key123',
+        signature: 'signature123',
+        nonce: 'nonce123',
+        timestamp: 1234567890,
+      );
+
+      final purchaseParam = Sk2PurchaseParam(
+        productDetails: AppStoreProduct2Details.fromSK2Product(dummyProductWrapper),
+        applicationUserName: 'testUser',
+        quantity: 2,
+        winBackOfferId: 'winBack123',
+        promotionalOffer: SK2PromotionalOffer(signature: fakeSignature, offerId: 'promo123'),
+        introductoryOfferEligibilityCompactJWS: 'jws-value',
+      );
+
+      await iapStoreKitPlatform.buyNonConsumable(purchaseParam: purchaseParam);
+
+      final SK2ProductPurchaseOptionsMessage lastPurchaseOptions =
+          fakeStoreKit2Platform.lastPurchaseOptions!;
+
+      expect(lastPurchaseOptions.appAccountToken, 'testUser');
+      expect(lastPurchaseOptions.quantity, 2);
+      expect(lastPurchaseOptions.winBackOfferId, 'winBack123');
+      expect(lastPurchaseOptions.promotionalOffer!.promotionalOfferId, 'promo123');
+      expect(lastPurchaseOptions.introductoryOfferEligibilityCompactJWS, 'jws-value');
+    });
+
+    test('should not set introductory offer eligibility JWS for a generic PurchaseParam', () async {
+      final purchaseParam = PurchaseParam(
+        productDetails: AppStoreProduct2Details.fromSK2Product(dummyProductWrapper),
+        applicationUserName: 'testUser',
+      );
+
+      await iapStoreKitPlatform.buyNonConsumable(purchaseParam: purchaseParam);
+
+      expect(
+        fakeStoreKit2Platform.lastPurchaseOptions!.introductoryOfferEligibilityCompactJWS,
+        isNull,
+      );
+    });
+
     test('should pass quantity for consumable product with Sk2PurchaseParam', () async {
       final purchaseParam = Sk2PurchaseParam(
         productDetails: AppStoreProduct2Details.fromSK2Product(dummyProductWrapper),


### PR DESCRIPTION
Adds an optional StoreKit 2-specific field to `Sk2PurchaseParam` that forwards a server-signed compact JWS to [`Product.PurchaseOption.introductoryOfferEligibility(compactJWS:)`](https://developer.apple.com/documentation/storekit/product/purchaseoption/introductoryoffereligibility(compactjws:)).

Fixes flutter/flutter#191668

## Problem

StoreKit 2 lets an app's own server decide, per purchase, whether an introductory offer applies. The app receives a compact JWS signed with an App Store Connect In-App Purchase key ([Generating JWS to sign App Store requests](https://developer.apple.com/documentation/storekit/generating-jws-to-sign-app-store-requests)) whose `allowIntroductoryOffer` claim Apple documents as "a Boolean value, `true` or `false`, that determines whether the customer is eligible for an introductory offer".

The plugin did not expose this purchase option, so apps whose eligibility rules live on their own server could not use the plugin's purchase path.

This is distinct from the existing `isIntroductoryOfferEligible(productId)`, which wraps `Product.SubscriptionInfo.isEligibleForIntroOffer` and **reads** the App Store's *default* eligibility. That read cannot express a server-signed per-purchase decision.

## Implementation

```dart
Sk2PurchaseParam(
  productDetails: productDetails,
  introductoryOfferEligibilityCompactJWS: compactJWSFromMyServer,
);
```

The value flows through `SK2ProductPurchaseOptions` and the Pigeon message to the Swift purchase-option builder:

```swift
if let compactJWS = options?.introductoryOfferEligibilityCompactJWS {
  purchaseOptions.insert(.introductoryOfferEligibility(compactJWS: compactJWS))
}
```

The JWS is opaque to the plugin: it is never generated, signed, parsed, validated or inspected.

Generated Pigeon files were regenerated with the repository's canonical `dart run pigeon --input pigeons/sk2_pigeon.dart`.

## Availability

No `#available` gate is required. `introductoryOfferEligibility(compactJWS:)` is declared `@backDeployed(before: iOS 18.4, macOS 15.4, tvOS 18.4, watchOS 11.4, visionOS 2.4)` with availability iOS 15.0+ / macOS 12.0+, which is the same floor as the existing `@available(iOS 15.0, macOS 12.0, *)` StoreKit 2 extension it is added to.

## Backwards compatibility

Not breaking:

- the field is optional and null by default
- when null, no purchase option is added and the App Store applies its own default eligibility, so existing apps behave identically
- the new Pigeon field is appended, so existing encoded payloads decode unchanged
- StoreKit 1 is untouched
- `isIntroductoryOfferEligible`, promotional offers, win-back offers, `appAccountToken` and `quantity` are unchanged and continue to work alongside the new option

## Tests

Dart (`in_app_purchase_storekit_2_platform_test.dart`), all passing:

- null JWS -> no option is sent
- non-null JWS -> forwarded unchanged
- JWS coexists with `appAccountToken`, `quantity`, `promotionalOffer` and `winBackOfferId`
- a generic `PurchaseParam` sends no JWS

Native (`InAppPurchaseStoreKit2PluginTests.swift`):

- `testPurchaseWithIntroductoryOfferEligibilityJWS` drives a purchase with the option set and passes.

## Known limitation in local native verification

I could not run the full `RunnerTests` suite locally. It crashes in `StoreKit2TranslatorTests.setUp()` (`StoreKit2TranslatorTests.swift:69`) with `EXC_BREAKPOINT`/`SIGTRAP`, and the existing purchase-success tests fail with `PigeonError` plus an asynchronous timeout.

This is independent of this change: I reproduced the identical crash signature and the identical purchase-test failure on the unmodified upstream base (9f595f3e96f53d7786ea0ebaf13bb4c574ecfe8a) under the same Xcode 26.6 / iOS 26.5 simulator. It matches flutter/flutter#184678, including the same file and line and the same `SKTestSession` `SKInternalErrorDomain Code=3` symptom.

To be precise about what was verified locally: the patch-specific native test passes, and `dart format`, `flutter analyze`, the 106 Dart unit tests and `swift-format lint --strict` are all clean. I am **not** claiming the full native suite passes. Because product lookup fails in that environment, the native test exercises the call path but cannot by itself assert the option reached StoreKit; the deterministic assertions for that are the Dart tests above, and the Swift call site was additionally verified with `swiftc -typecheck` against the iOS 15 target.

No unrelated upstream test was modified or worked around.

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA]. **Not yet signed — signing now; the `cla/google` check is currently failing and I will re-run it once signed.**
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under[^1].
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [ ] All existing and new tests are passing.

[^1]: See "Known limitation in local native verification" above regarding the pre-existing native suite failure tracked in flutter/flutter#184678.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[the version and CHANGELOG instructions]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version-and-changelog-updates
[semantic versioning]: https://dart.dev/tools/pub/versioning#semantic-versions
[repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
