### PR TITLE
[material_ui] Fix GridTile crash when the incoming constraints are unbounded

### DIFF
--- a/packages/material_ui/lib/src/grid_tile.dart
+++ b/packages/material_ui/lib/src/grid_tile.dart
@@ -46,9 +46,14 @@ class GridTile extends StatelessWidget {
       return child;
     }
 
+    // The tile sizes itself to its child so that it can be used where the
+    // incoming constraints are unbounded, e.g. in a horizontally scrolling
+    // ListView. A Stack whose children are all positioned would try to expand
+    // to the biggest allowed size, which is infinite in that case.
     return Stack(
+      fit: StackFit.passthrough,
       children: <Widget>[
-        Positioned.fill(child: child),
+        child,
         if (header != null) Positioned(top: 0.0, left: 0.0, right: 0.0, child: header!),
         if (footer != null) Positioned(left: 0.0, bottom: 0.0, right: 0.0, child: footer!),
       ],

--- a/packages/material_ui/pending_changelogs/change_2026_08_25_port191656.yaml
+++ b/packages/material_ui/pending_changelogs/change_2026_08_25_port191656.yaml
@@ -1,0 +1,3 @@
+changelog: |
+  - Fix `GridTile` crash when the incoming constraints are unbounded (e.g. inside a horizontally scrolling `ListView`).
+version: patch

--- a/packages/material_ui/test/grid_title_test.dart
+++ b/packages/material_ui/test/grid_title_test.dart
@@ -59,6 +59,62 @@ void main() {
     expect(tester.getSize(find.byType(GridTile)), Size.zero);
   });
 
+  // Regression test for https://github.com/flutter/flutter/issues/82055
+  testWidgets('GridTile with header and footer sizes itself to its child when unconstrained', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Center(
+          child: SizedBox(
+            height: 100.0,
+            child: ListView.builder(
+              scrollDirection: Axis.horizontal,
+              itemCount: 1,
+              itemBuilder: (BuildContext context, int index) {
+                return GridTile(
+                  header: const Text('Header'),
+                  footer: const Text('Footer'),
+                  child: Container(height: 100.0, width: 80.0, color: Colors.red),
+                );
+              },
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(tester.takeException(), isNull);
+    expect(tester.getSize(find.byType(GridTile)), const Size(80.0, 100.0));
+    expect(find.text('Header'), findsOneWidget);
+    expect(find.text('Footer'), findsOneWidget);
+  });
+
+  testWidgets('GridTile child fills the tile when the constraints are tight', (
+    WidgetTester tester,
+  ) async {
+    final Key childKey = UniqueKey();
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Center(
+          child: SizedBox(
+            width: 200.0,
+            height: 150.0,
+            child: GridTile(
+              header: const Text('Header'),
+              footer: const Text('Footer'),
+              child: ColoredBox(key: childKey, color: Colors.red),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(tester.getSize(find.byType(GridTile)), const Size(200.0, 150.0));
+    expect(tester.getSize(find.byKey(childKey)), const Size(200.0, 150.0));
+  });
+
   testWidgets('GridTileBar does not crash at zero area', (WidgetTester tester) async {
     await tester.pumpWidget(
       const MaterialApp(


### PR DESCRIPTION
Ports flutter/flutter#191656, which is blocked by the Material/Cupertino code freeze in flutter/flutter (see https://github.com/flutter/flutter/issues/188444).

## Original description

`GridTile` placed every child of its `Stack` in a `Positioned` widget, including the tile content. A `Stack` without any non-positioned child sizes itself to the biggest allowed size, which is infinite along the main axis of an unbounded parent such as a horizontally scrolling `ListView`. `RenderStack` then failed its `size.isFinite` assertion.

The tile content is now a non-positioned child of the `Stack`, and the `Stack` uses `StackFit.passthrough` so the content still receives the constraints the tile receives. The tile keeps filling the available space when the incoming constraints are tight (the `GridView` case), and shrink-wraps its content when they are unbounded instead of crashing.

Fixes https://github.com/flutter/flutter/issues/82055

## Test plan

- [x] `flutter test test/grid_title_test.dart`
- [x] `flutter test`
- [x] `flutter analyze`
- [x] `dart format --output=none --set-exit-if-changed packages/material_ui/lib/src/grid_tile.dart packages/material_ui/test/grid_title_test.dart`

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under[^1].
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [x] All existing and new tests are passing.

The change uses the repository's pending changelog workflow (`packages/material_ui/pending_changelogs/change_2026_08_25_port191656.yaml`). No public API documentation change is needed.

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[the version and CHANGELOG instructions]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version-and-changelog-updates
[semantic versioning]: https://dart.dev/tools/pub/versioning#semantic-versions
[repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
