### PR TITLE
[material_ui] Add day and weekday builders to CalendarDatePicker and showDatePicker

### DIFF
--- a/packages/material_ui/lib/src/calendar_date_picker.dart
+++ b/packages/material_ui/lib/src/calendar_date_picker.dart
@@ -71,6 +71,28 @@ const double _kDayPickerGridLandscapeMaxScaleFactor = 1.5;
 // 14 is a common font size used to compute the effective text scale.
 const double _fontSizeToScale = 14.0;
 
+/// The signature of a function that builds a widget for a day in a
+/// [CalendarDatePicker].
+///
+/// The [day] is the date represented by the widget. The [states] are the
+/// current [WidgetState]s of the day, such as [WidgetState.disabled],
+/// [WidgetState.selected], or [WidgetState.hovered]. The [child] is the
+/// default widget built by the date picker.
+///
+/// The date picker's semantics, focus, and tap handling are applied to the
+/// widget returned by this function.
+typedef CalendarDatePickerDayBuilder =
+    Widget Function(BuildContext context, DateTime day, Set<WidgetState> states, Widget child);
+
+/// The signature of a function that builds a weekday header in a
+/// [CalendarDatePicker].
+///
+/// The [weekday] uses the same numbering as [DateTime.weekday], from
+/// [DateTime.monday] through [DateTime.sunday]. The [child] is the default
+/// localized weekday header built by the date picker.
+typedef CalendarDatePickerWeekdayBuilder =
+    Widget Function(BuildContext context, int weekday, Widget child);
+
 /// Displays a grid of days for a given month and allows the user to select a
 /// date.
 ///
@@ -117,6 +139,10 @@ class CalendarDatePicker extends StatefulWidget {
   /// If [selectableDayPredicate] and [initialDate] are both non-null,
   /// [selectableDayPredicate] must return `true` for the [initialDate].
   ///
+  /// The [dayBuilder] and [weekdayBuilder] can be used to customize the days and
+  /// weekday headers in the calendar's day grid. They are only used when the
+  /// picker is displaying the day selection interface.
+  ///
   /// {@template material_ui.calendar_date_picker.calendarDelegate}
   /// The [calendarDelegate] controls date interpretation, formatting, and
   /// navigation within the picker. By providing a custom implementation,
@@ -133,6 +159,8 @@ class CalendarDatePicker extends StatefulWidget {
     this.onDisplayedMonthChanged,
     this.initialCalendarMode = DatePickerMode.day,
     this.selectableDayPredicate,
+    this.dayBuilder,
+    this.weekdayBuilder,
     this.calendarDelegate = const GregorianCalendarDelegate(),
   }) : initialDate = initialDate == null ? null : calendarDelegate.dateOnly(initialDate),
        firstDate = calendarDelegate.dateOnly(firstDate),
@@ -191,6 +219,18 @@ class CalendarDatePicker extends StatefulWidget {
 
   /// Function to provide full control over which dates in the calendar can be selected.
   final SelectableDayPredicate? selectableDayPredicate;
+
+  /// An optional builder for the individual days in the calendar's day grid.
+  ///
+  /// The builder is only used when the picker is displaying the day selection
+  /// interface.
+  final CalendarDatePickerDayBuilder? dayBuilder;
+
+  /// An optional builder for the weekday headers in the calendar's day grid.
+  ///
+  /// The builder is only used when the picker is displaying the day selection
+  /// interface.
+  final CalendarDatePickerWeekdayBuilder? weekdayBuilder;
 
   /// {@macro material_ui.calendar_date_picker.calendarDelegate}
   final CalendarDelegate<DateTime> calendarDelegate;
@@ -359,6 +399,8 @@ class _CalendarDatePickerState extends State<CalendarDatePicker> {
           onChanged: _handleDayChanged,
           onDisplayedMonthChanged: _handleMonthChanged,
           selectableDayPredicate: widget.selectableDayPredicate,
+          dayBuilder: widget.dayBuilder,
+          weekdayBuilder: widget.weekdayBuilder,
         );
       case DatePickerMode.year:
         return Padding(
@@ -570,6 +612,8 @@ class _MonthPicker extends StatefulWidget {
     required this.onDisplayedMonthChanged,
     required this.calendarDelegate,
     this.selectableDayPredicate,
+    this.dayBuilder,
+    this.weekdayBuilder,
   }) : assert(!firstDate.isAfter(lastDate)),
        assert(selectedDate == null || !selectedDate.isBefore(firstDate)),
        assert(selectedDate == null || !selectedDate.isAfter(lastDate));
@@ -610,6 +654,12 @@ class _MonthPicker extends StatefulWidget {
 
   /// Optional user supplied predicate function to customize selectable days.
   final SelectableDayPredicate? selectableDayPredicate;
+
+  /// An optional builder for the individual days in the calendar's day grid.
+  final CalendarDatePickerDayBuilder? dayBuilder;
+
+  /// An optional builder for the weekday headers in the calendar's day grid.
+  final CalendarDatePickerWeekdayBuilder? weekdayBuilder;
 
   /// {@macro material_ui.calendar_date_picker.calendarDelegate}
   final CalendarDelegate<DateTime> calendarDelegate;
@@ -882,6 +932,8 @@ class _MonthPickerState extends State<_MonthPicker> {
       lastDate: widget.lastDate,
       displayedMonth: month,
       selectableDayPredicate: widget.selectableDayPredicate,
+      dayBuilder: widget.dayBuilder,
+      weekdayBuilder: widget.weekdayBuilder,
     );
   }
 
@@ -1003,6 +1055,8 @@ class _DayPicker extends StatefulWidget {
     required this.onChanged,
     required this.calendarDelegate,
     this.selectableDayPredicate,
+    this.dayBuilder,
+    this.weekdayBuilder,
   }) : assert(!firstDate.isAfter(lastDate)),
        assert(selectedDate == null || !selectedDate.isBefore(firstDate)),
        assert(selectedDate == null || !selectedDate.isAfter(lastDate));
@@ -1033,6 +1087,12 @@ class _DayPicker extends StatefulWidget {
 
   /// Optional user supplied predicate function to customize selectable days.
   final SelectableDayPredicate? selectableDayPredicate;
+
+  /// An optional builder for the individual days in the calendar's day grid.
+  final CalendarDatePickerDayBuilder? dayBuilder;
+
+  /// An optional builder for the weekday headers in the calendar's day grid.
+  final CalendarDatePickerWeekdayBuilder? weekdayBuilder;
 
   /// {@macro material_ui.calendar_date_picker.calendarDelegate}
   final CalendarDelegate<DateTime> calendarDelegate;
@@ -1094,7 +1154,11 @@ class _DayPickerState extends State<_DayPicker> {
   ///     _ _ _ _ 1 2 3
   ///     4 5 6 7 8 9 10
   ///
-  List<Widget> _dayHeaders(TextStyle? headerStyle, MaterialLocalizations localizations) {
+  List<Widget> _dayHeaders(
+    BuildContext context,
+    TextStyle? headerStyle,
+    MaterialLocalizations localizations,
+  ) {
     final result = <Widget>[];
     for (
       int i = localizations.firstDayOfWeekIndex;
@@ -1102,9 +1166,18 @@ class _DayPickerState extends State<_DayPicker> {
       i = (i + 1) % DateTime.daysPerWeek
     ) {
       final String weekday = localizations.narrowWeekdays[i];
+      final int dateTimeWeekday = (i == 0 ? DateTime.sunday : i);
+      final child = Text(weekday);
+
+      final Widget weekdayWidget =
+          widget.weekdayBuilder?.call(context, dateTimeWeekday, child) ?? child;
+
       result.add(
         ExcludeSemantics(
-          child: Center(child: Text(weekday, style: headerStyle)),
+          child: DefaultTextStyle.merge(
+            style: headerStyle,
+            child: Center(child: weekdayWidget),
+          ),
         ),
       );
     }
@@ -1127,7 +1200,7 @@ class _DayPickerState extends State<_DayPicker> {
     final int daysInMonth = widget.calendarDelegate.getDaysInMonth(year, month);
     final int dayOffset = widget.calendarDelegate.firstDayOffset(year, month, localizations);
 
-    final List<Widget> dayItems = _dayHeaders(weekdayStyle, localizations);
+    final List<Widget> dayItems = _dayHeaders(context, weekdayStyle, localizations);
     // 1-based day of month, e.g. 1-31 for January, and 1-29 for February on
     // a leap year.
     int day = -dayOffset;
@@ -1157,6 +1230,7 @@ class _DayPickerState extends State<_DayPicker> {
             onChanged: widget.onChanged,
             focusNode: _dayFocusNodes[day - 1],
             calendarDelegate: widget.calendarDelegate,
+            dayBuilder: widget.dayBuilder,
           ),
         );
       }
@@ -1192,6 +1266,7 @@ class _Day extends StatefulWidget {
     required this.onChanged,
     required this.focusNode,
     required this.calendarDelegate,
+    this.dayBuilder,
   });
 
   final DateTime day;
@@ -1201,6 +1276,7 @@ class _Day extends StatefulWidget {
   final ValueChanged<DateTime> onChanged;
   final FocusNode focusNode;
   final CalendarDelegate<DateTime> calendarDelegate;
+  final CalendarDatePickerDayBuilder? dayBuilder;
 
   @override
   State<_Day> createState() => _DayState();
@@ -1271,12 +1347,27 @@ class _DayState extends State<_Day> {
 
     Widget dayWidget = Ink(
       decoration: decoration,
-      child: Center(
-        child: Text(
-          localizations.formatDecimal(widget.day.day),
-          style: dayStyle?.apply(color: dayForegroundColor),
-        ),
-      ),
+      child: Center(child: Text(localizations.formatDecimal(widget.day.day))),
+    );
+
+    if (widget.dayBuilder != null) {
+      dayWidget = ListenableBuilder(
+        listenable: _statesController,
+        builder: (BuildContext context, Widget? child) {
+          return widget.dayBuilder!(
+            context,
+            widget.day,
+            Set<WidgetState>.unmodifiable(_statesController.value),
+            child!,
+          );
+        },
+        child: dayWidget,
+      );
+    }
+
+    dayWidget = DefaultTextStyle.merge(
+      style: dayStyle?.apply(color: dayForegroundColor),
+      child: dayWidget,
     );
 
     // Adds padding as per M3 guidelines for portrait mode. Not applied in landscape

--- a/packages/material_ui/lib/src/calendar_date_picker.dart
+++ b/packages/material_ui/lib/src/calendar_date_picker.dart
@@ -1166,20 +1166,28 @@ class _DayPickerState extends State<_DayPicker> {
       i = (i + 1) % DateTime.daysPerWeek
     ) {
       final String weekday = localizations.narrowWeekdays[i];
-      final int dateTimeWeekday = (i == 0 ? DateTime.sunday : i);
-      final child = Text(weekday);
-
-      final Widget weekdayWidget =
-          widget.weekdayBuilder?.call(context, dateTimeWeekday, child) ?? child;
-
-      result.add(
-        ExcludeSemantics(
-          child: DefaultTextStyle.merge(
-            style: headerStyle,
-            child: Center(child: weekdayWidget),
+      if (widget.weekdayBuilder != null) {
+        final int dateTimeWeekday = (i == 0 ? DateTime.sunday : i);
+        final Widget weekdayWidget = widget.weekdayBuilder!(
+          context,
+          dateTimeWeekday,
+          Text(weekday),
+        );
+        result.add(
+          ExcludeSemantics(
+            child: DefaultTextStyle.merge(
+              style: headerStyle,
+              child: Center(child: weekdayWidget),
+            ),
           ),
-        ),
-      );
+        );
+      } else {
+        result.add(
+          ExcludeSemantics(
+            child: Center(child: Text(weekday, style: headerStyle)),
+          ),
+        );
+      }
     }
     return result;
   }
@@ -1345,12 +1353,12 @@ class _DayState extends State<_Day> {
           )
         : ShapeDecoration(color: dayBackgroundColor, shape: dayShape);
 
-    Widget dayWidget = Ink(
-      decoration: decoration,
-      child: Center(child: Text(localizations.formatDecimal(widget.day.day))),
-    );
-
+    Widget dayWidget;
     if (widget.dayBuilder != null) {
+      dayWidget = Ink(
+        decoration: decoration,
+        child: Center(child: Text(localizations.formatDecimal(widget.day.day))),
+      );
       dayWidget = ListenableBuilder(
         listenable: _statesController,
         builder: (BuildContext context, Widget? child) {
@@ -1363,12 +1371,21 @@ class _DayState extends State<_Day> {
         },
         child: dayWidget,
       );
+      dayWidget = DefaultTextStyle.merge(
+        style: dayStyle?.apply(color: dayForegroundColor),
+        child: dayWidget,
+      );
+    } else {
+      dayWidget = Ink(
+        decoration: decoration,
+        child: Center(
+          child: Text(
+            localizations.formatDecimal(widget.day.day),
+            style: dayStyle?.apply(color: dayForegroundColor),
+          ),
+        ),
+      );
     }
-
-    dayWidget = DefaultTextStyle.merge(
-      style: dayStyle?.apply(color: dayForegroundColor),
-      child: dayWidget,
-    );
 
     // Adds padding as per M3 guidelines for portrait mode. Not applied in landscape
     // mode currently due to unclear specifications.

--- a/packages/material_ui/lib/src/date_picker.dart
+++ b/packages/material_ui/lib/src/date_picker.dart
@@ -122,6 +122,10 @@ const double _fontSizeToScale = 14.0;
 /// this can be used to only allow weekdays for selection. If provided, it must
 /// return true for [initialDate].
 ///
+/// The [dayBuilder] and [weekdayBuilder] can be used to customize the days and
+/// weekday headers in the calendar's day grid. They are only used when the
+/// picker is displaying the day selection interface.
+///
 /// {@macro material_ui.calendar_date_picker.calendarDelegate}
 ///
 /// The following optional string parameters allow you to override the default
@@ -234,6 +238,8 @@ Future<DateTime?> showDatePicker({
   ValueChanged<DatePickerEntryMode>? onDatePickerModeChange,
   Icon? switchToInputEntryModeIcon,
   Icon? switchToCalendarEntryModeIcon,
+  CalendarDatePickerDayBuilder? dayBuilder,
+  CalendarDatePickerWeekdayBuilder? weekdayBuilder,
   CalendarDelegate<DateTime> calendarDelegate = const GregorianCalendarDelegate(),
 }) async {
   initialDate = initialDate == null ? null : calendarDelegate.dateOnly(initialDate);
@@ -276,6 +282,8 @@ Future<DateTime?> showDatePicker({
     onDatePickerModeChange: onDatePickerModeChange,
     switchToInputEntryModeIcon: switchToInputEntryModeIcon,
     switchToCalendarEntryModeIcon: switchToCalendarEntryModeIcon,
+    dayBuilder: dayBuilder,
+    weekdayBuilder: weekdayBuilder,
     calendarDelegate: calendarDelegate,
   );
 
@@ -343,6 +351,8 @@ class DatePickerDialog extends StatefulWidget {
     this.switchToInputEntryModeIcon,
     this.switchToCalendarEntryModeIcon,
     this.insetPadding = const EdgeInsets.symmetric(horizontal: 16.0, vertical: 24.0),
+    this.dayBuilder,
+    this.weekdayBuilder,
     this.calendarDelegate = const GregorianCalendarDelegate(),
   }) : initialDate = initialDate == null ? null : calendarDelegate.dateOnly(initialDate),
        firstDate = calendarDelegate.dateOnly(firstDate),
@@ -468,6 +478,18 @@ class DatePickerDialog extends StatefulWidget {
   ///
   /// Defaults to `EdgeInsets.symmetric(horizontal: 16.0, vertical: 24.0)`.
   final EdgeInsets insetPadding;
+
+  /// An optional builder for the individual days in the calendar's day grid.
+  ///
+  /// The builder is only used when the picker is displaying the day selection
+  /// interface.
+  final CalendarDatePickerDayBuilder? dayBuilder;
+
+  /// An optional builder for the weekday headers in the calendar's day grid.
+  ///
+  /// The builder is only used when the picker is displaying the day selection
+  /// interface.
+  final CalendarDatePickerWeekdayBuilder? weekdayBuilder;
 
   /// {@macro material_ui.calendar_date_picker.calendarDelegate}
   final CalendarDelegate<DateTime> calendarDelegate;
@@ -651,6 +673,8 @@ class _DatePickerDialogState extends State<DatePickerDialog> with RestorationMix
         onDateChanged: _handleDateChanged,
         selectableDayPredicate: widget.selectableDayPredicate,
         initialCalendarMode: widget.initialCalendarMode,
+        dayBuilder: widget.dayBuilder,
+        weekdayBuilder: widget.weekdayBuilder,
       );
     }
 

--- a/packages/material_ui/pending_changelogs/change_2026_09_03_1788396131061.yaml
+++ b/packages/material_ui/pending_changelogs/change_2026_09_03_1788396131061.yaml
@@ -1,0 +1,3 @@
+changelog: |
+  - Adds `dayBuilder` and `weekdayBuilder` callbacks to `CalendarDatePicker`, `DatePickerDialog`, and `showDatePicker`.
+version: minor

--- a/packages/material_ui/test/calendar_date_picker_test.dart
+++ b/packages/material_ui/test/calendar_date_picker_test.dart
@@ -37,6 +37,8 @@ void main() {
     ValueChanged<DateTime>? onDisplayedMonthChanged,
     DatePickerMode initialCalendarMode = DatePickerMode.day,
     SelectableDayPredicate? selectableDayPredicate,
+    CalendarDatePickerDayBuilder? dayBuilder,
+    CalendarDatePickerWeekdayBuilder? weekdayBuilder,
     TextDirection textDirection = TextDirection.ltr,
     ThemeData? theme,
     bool? useMaterial3,
@@ -56,6 +58,8 @@ void main() {
             onDisplayedMonthChanged: onDisplayedMonthChanged,
             initialCalendarMode: initialCalendarMode,
             selectableDayPredicate: selectableDayPredicate,
+            dayBuilder: dayBuilder,
+            weekdayBuilder: weekdayBuilder,
           ),
         ),
       ),
@@ -468,6 +472,57 @@ void main() {
       await tester.tap(find.text('2018'));
       await tester.pumpAndSettle();
       expect(find.text('January 2018'), findsOneWidget);
+    });
+
+    testWidgets('dayBuilder customizes days', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        calendarDatePicker(
+          dayBuilder: (BuildContext context, DateTime day, Set<WidgetState> states, Widget child) {
+            return day.day == 1 ? const Text('Custom day 1') : child;
+          },
+        ),
+      );
+
+      expect(find.text('Custom day 1'), findsOneWidget);
+    });
+
+    testWidgets('dayBuilder receives day states', (WidgetTester tester) async {
+      final statesForDay = <DateTime, Set<WidgetState>>{};
+
+      await tester.pumpWidget(
+        calendarDatePicker(
+          initialDate: DateTime(2016, DateTime.january, 15),
+          selectableDayPredicate: (DateTime day) => day.day != 10,
+          dayBuilder: (BuildContext context, DateTime day, Set<WidgetState> states, Widget child) {
+            statesForDay[day] = Set<WidgetState>.of(states);
+            return child;
+          },
+        ),
+      );
+
+      expect(statesForDay[DateTime(2016, DateTime.january, 10)], contains(WidgetState.disabled));
+      expect(statesForDay[DateTime(2016, DateTime.january, 15)], contains(WidgetState.selected));
+
+      final TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
+      addTearDown(gesture.removePointer);
+      await gesture.addPointer(location: Offset.zero);
+      await gesture.moveTo(tester.getCenter(find.text('12')));
+      await tester.pump();
+      expect(statesForDay[DateTime(2016, DateTime.january, 12)], contains(WidgetState.hovered));
+    });
+
+    testWidgets('weekdayBuilder customizes headers and uses DateTime weekday values', (
+      WidgetTester tester,
+    ) async {
+      await tester.pumpWidget(
+        calendarDatePicker(
+          weekdayBuilder: (BuildContext context, int weekday, Widget child) {
+            return weekday == DateTime.sunday ? const Text('Custom Sunday') : child;
+          },
+        ),
+      );
+
+      expect(find.text('Custom Sunday'), findsOneWidget);
     });
 
     testWidgets('Material2 - currentDate is highlighted', (WidgetTester tester) async {

--- a/packages/material_ui/test/date_picker_test.dart
+++ b/packages/material_ui/test/date_picker_test.dart
@@ -81,6 +81,8 @@ void main() {
     bool useMaterial3 = false,
     ThemeData? theme,
     TextScaler textScaler = TextScaler.noScaling,
+    CalendarDatePickerDayBuilder? dayBuilder,
+    CalendarDatePickerWeekdayBuilder? weekdayBuilder,
   }) async {
     late BuildContext buttonContext;
     await tester.pumpWidget(
@@ -127,6 +129,8 @@ void main() {
       onDatePickerModeChange: (DatePickerEntryMode value) {
         currentMode = value;
       },
+      dayBuilder: dayBuilder,
+      weekdayBuilder: weekdayBuilder,
       builder: (BuildContext context, Widget? child) {
         return Directionality(textDirection: textDirection, child: child ?? const SizedBox());
       },
@@ -150,6 +154,24 @@ void main() {
   }
 
   group('showDatePicker Dialog', () {
+    testWidgets('forwards dayBuilder and weekdayBuilder to the calendar', (
+      WidgetTester tester,
+    ) async {
+      await prepareDatePicker(
+        tester,
+        (Future<DateTime?> date) async {
+          expect(find.text('Custom day 1'), findsOneWidget);
+          expect(find.text('Custom Sunday'), findsOneWidget);
+        },
+        dayBuilder: (BuildContext context, DateTime day, Set<WidgetState> states, Widget child) {
+          return day.day == 1 ? const Text('Custom day 1') : child;
+        },
+        weekdayBuilder: (BuildContext context, int weekday, Widget child) {
+          return weekday == DateTime.sunday ? const Text('Custom Sunday') : child;
+        },
+      );
+    });
+
     testWidgets('Default dialog size', (WidgetTester tester) async {
       Future<void> showPicker(WidgetTester tester, Size size) async {
         tester.view.physicalSize = size;


### PR DESCRIPTION
`CalendarDatePicker` does not provide a way to customize individual day cells or weekday headers while retaining the default picker behavior.

This PR adds `dayBuilder` and `weekdayBuilder` callbacks for customizing individual day cells and weekday headers.

The callbacks are exposed through `CalendarDatePicker`, `DatePickerDialog`, and `showDatePicker`. The day builder receives the current widget states while the picker retains its semantics, focus, and tap handling.

Tests cover customized days and weekday headers, day widget states, and `showDatePicker` parameter forwarding.

Fixes https://github.com/flutter/flutter/issues/68106

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under[^1].
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[the version and CHANGELOG instructions]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version-and-changelog-updates
[semantic versioning]: https://dart.dev/tools/pub/versioning#semantic-versions
[repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
