### PR TITLE
Ignore time of day in CupertinoDatePicker date mode bounds

### DIFF
--- a/packages/cupertino_ui/lib/src/date_picker.dart
+++ b/packages/cupertino_ui/lib/src/date_picker.dart
@@ -348,13 +348,13 @@ class CupertinoDatePicker extends StatefulWidget {
        assert(
          (mode != CupertinoDatePickerMode.date && mode != CupertinoDatePickerMode.monthYear) ||
              minimumDate == null ||
-             !minimumDate.isAfter(initialDateTime ?? DateTime.now()),
+             !_dateOnly(minimumDate).isAfter(_dateOnly(initialDateTime ?? DateTime.now())),
          'initial date ${initialDateTime ?? DateTime.now()} is not greater than or equal to minimumDate $minimumDate',
        ),
        assert(
          (mode != CupertinoDatePickerMode.date && mode != CupertinoDatePickerMode.monthYear) ||
              maximumDate == null ||
-             !maximumDate.isBefore(initialDateTime ?? DateTime.now()),
+             !_dateOnly(maximumDate).isBefore(_dateOnly(initialDateTime ?? DateTime.now())),
          'initial date ${initialDateTime ?? DateTime.now()} is not less than or equal to maximumDate $maximumDate',
        ),
        assert(
@@ -549,6 +549,14 @@ class CupertinoDatePicker extends StatefulWidget {
       CupertinoDatePickerMode.monthYear => _CupertinoDatePickerMonthYearState(dateOrder: dateOrder),
     };
   }
+
+  // Strips the time of day from `date`.
+  //
+  // In [CupertinoDatePickerMode.date] and [CupertinoDatePickerMode.monthYear]
+  // modes the picker only selects a date, and the entire day of [minimumDate]
+  // and [maximumDate] is selectable, so the time of day of these values must be
+  // ignored when they are validated against [initialDateTime].
+  static DateTime _dateOnly(DateTime date) => DateTime(date.year, date.month, date.day);
 
   // Estimate the minimum width that each column needs to layout its content.
   static double _getColumnWidth(

--- a/packages/cupertino_ui/pending_changelogs/change_2026_08_25_port191659.yaml
+++ b/packages/cupertino_ui/pending_changelogs/change_2026_08_25_port191659.yaml
@@ -1,0 +1,3 @@
+changelog: |
+  - Fix `CupertinoDatePicker` incorrectly throwing an assertion when `initialDateTime` matches the day of `minimumDate`/`maximumDate` but not the exact time, in `date` and `monthYear` mode.
+version: patch

--- a/packages/cupertino_ui/test/date_picker_test.dart
+++ b/packages/cupertino_ui/test/date_picker_test.dart
@@ -407,6 +407,76 @@ void main() {
       }, throwsAssertionError);
     });
 
+    // Regression test for https://github.com/flutter/flutter/issues/63196
+    test('date and monthYear modes ignore the time of day of minimumDate & maximumDate', () {
+      for (final mode in <CupertinoDatePickerMode>[
+        CupertinoDatePickerMode.date,
+        CupertinoDatePickerMode.monthYear,
+      ]) {
+        // The whole day of minimumDate/maximumDate is selectable in these modes,
+        // so the time of day must not make the initial date invalid.
+        expect(() {
+          CupertinoDatePicker(
+            mode: mode,
+            onDateTimeChanged: (DateTime d) {},
+            initialDateTime: DateTime(2020, 8, 8),
+            minimumDate: DateTime(2020, 8, 8, 8),
+          );
+        }, returnsNormally);
+
+        expect(() {
+          CupertinoDatePicker(
+            mode: mode,
+            onDateTimeChanged: (DateTime d) {},
+            initialDateTime: DateTime(2020, 8, 8, 12),
+            maximumDate: DateTime(2020, 8, 8, 8),
+          );
+        }, returnsNormally);
+
+        // Bounds that fall on a different day are still validated.
+        expect(() {
+          CupertinoDatePicker(
+            mode: mode,
+            onDateTimeChanged: (DateTime d) {},
+            initialDateTime: DateTime(2020, 8, 8),
+            minimumDate: DateTime(2020, 8, 9),
+          );
+        }, throwsAssertionError);
+
+        expect(() {
+          CupertinoDatePicker(
+            mode: mode,
+            onDateTimeChanged: (DateTime d) {},
+            initialDateTime: DateTime(2020, 8, 8),
+            maximumDate: DateTime(2020, 8, 7, 23, 59),
+          );
+        }, throwsAssertionError);
+      }
+    });
+
+    testWidgets('date mode builds with a minimumDate later in the initial day', (
+      WidgetTester tester,
+    ) async {
+      await tester.pumpWidget(
+        CupertinoApp(
+          home: Center(
+            child: SizedBox.square(
+              dimension: 400.0,
+              child: CupertinoDatePicker(
+                mode: CupertinoDatePickerMode.date,
+                onDateTimeChanged: (DateTime d) {},
+                initialDateTime: DateTime(2020, 8, 8),
+                minimumDate: DateTime(2020, 8, 8, 8),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      expect(tester.takeException(), isNull);
+      expect(find.text('8'), findsOneWidget);
+    });
+
     testWidgets('changing initialDateTime after first build does not do anything', (
       WidgetTester tester,
     ) async {


### PR DESCRIPTION
In CupertinoDatePickerMode.date and CupertinoDatePickerMode.monthYear the picker only selects a date, and the whole day of minimumDate/maximumDate is selectable at runtime. The constructor asserts however compared the full DateTime values, so a minimumDate such as DateTime(2020, 8, 8, 8) threw an assertion for an initialDateTime of DateTime(2020, 8, 8), even though that date is selectable once the picker is built.

The asserts now strip the time of day from initialDateTime, minimumDate and maximumDate before comparing them, which matches the day granularity used by _isCurrentDateValid. Bounds that fall on a different day are still rejected.

Ported from flutter/flutter#191659, which is blocked by the Cupertino code freeze.

Fixes https://github.com/flutter/flutter/issues/63196

*Replace this paragraph with a description of what this PR is changing or adding, and why. Consider including before/after screenshots.*

*List which issues are fixed by this PR. You must list at least one issue.*

## Pre-Review Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [ ] I read the [Tree Hygiene] page, which explains my responsibilities.
- [ ] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [ ] I signed the [CLA].
- [ ] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I [linked to at least one issue that this PR fixes] in the description above.
- [ ] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under[^1].
- [ ] I updated/added any relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[the version and CHANGELOG instructions]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version-and-changelog-updates
[semantic versioning]: https://dart.dev/tools/pub/versioning#semantic-versions
[repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
