### PR TITLE
Show InputDecoration.errorText when the field is disabled in M2

### DIFF
--- a/packages/material_ui/lib/src/input_decorator.dart
+++ b/packages/material_ui/lib/src/input_decorator.dart
@@ -5930,9 +5930,9 @@ class _InputDecoratorDefaultsM2 extends InputDecorationThemeData {
   @override
   TextStyle? get errorStyle => WidgetStateTextStyle.resolveWith((Set<WidgetState> states) {
     final ThemeData themeData = Theme.of(context);
-    if (states.contains(WidgetState.disabled)) {
-      return themeData.textTheme.bodySmall!.copyWith(color: Colors.transparent);
-    }
+    // The error text is shown even when the field is disabled: the subtext
+    // space is allocated for it in any case, so hiding the text would only
+    // leave an unexplained gap below the field.
     return themeData.textTheme.bodySmall!.copyWith(color: themeData.colorScheme.error);
   });
 

--- a/packages/material_ui/pending_changelogs/change_2026_08_25_port191662.yaml
+++ b/packages/material_ui/pending_changelogs/change_2026_08_25_port191662.yaml
@@ -1,0 +1,3 @@
+changelog: |
+  - Fix `InputDecoration.errorText` not being visible when the field is disabled under Material 2.
+version: patch

--- a/packages/material_ui/test/input_decorator_test.dart
+++ b/packages/material_ui/test/input_decorator_test.dart
@@ -12066,6 +12066,19 @@ void main() {
       expect(find.text('errorText'), findsOneWidget);
     });
 
+    // Regression test for https://github.com/flutter/flutter/issues/67409.
+    testWidgets('InputDecorator shows error text when disabled', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        buildInputDecoratorM2(
+          decoration: const InputDecoration(enabled: false, errorText: errorText),
+        ),
+      );
+
+      final ThemeData theme = Theme.of(tester.element(findDecorator()));
+      expect(findError(), findsOneWidget);
+      expect(getErrorStyle(tester).color, theme.colorScheme.error);
+    });
+
     testWidgets('InputDecoration shows error border for errorText and error widget', (
       WidgetTester tester,
     ) async {

--- a/packages/material_ui/test/text_field_test.dart
+++ b/packages/material_ui/test/text_field_test.dart
@@ -7152,7 +7152,8 @@ void main() {
     expect(helperWidget.style!.color, isNot(equals(Colors.transparent)));
     expect(errorWidget.style!.color, isNot(equals(Colors.transparent)));
 
-    // When enabled is false, the helper/error and counter are not visible.
+    // When enabled is false, the helper and counter are not visible, but the
+    // error is still shown, see https://github.com/flutter/flutter/issues/67409.
     await tester.pumpWidget(buildFrame(false, false));
     helperWidget = tester.widget(find.text(helperText));
     counterWidget = tester.widget(find.text(counterText));
@@ -7162,7 +7163,7 @@ void main() {
     errorWidget = tester.widget(find.text(errorText));
     counterWidget = tester.widget(find.text(counterText));
     expect(counterWidget.style!.color, equals(Colors.transparent));
-    expect(errorWidget.style!.color, equals(Colors.transparent));
+    expect(errorWidget.style!.color, isNot(equals(Colors.transparent)));
   });
 
   testWidgets('Disabled text field has default M2 disabled text style for the input text', (

--- a/packages/material_ui/test/text_form_field_test.dart
+++ b/packages/material_ui/test/text_form_field_test.dart
@@ -625,7 +625,8 @@ void main() {
     expect(helperWidget.style!.color, isNot(equals(Colors.transparent)));
     expect(errorWidget.style!.color, isNot(equals(Colors.transparent)));
 
-    // When enabled is false, the helper/error and counter are not visible.
+    // When enabled is false, the helper and counter are not visible, but the
+    // error is still shown, see https://github.com/flutter/flutter/issues/67409.
     await tester.pumpWidget(buildFrame(false, false));
     helperWidget = tester.widget(find.text(helperText));
     counterWidget = tester.widget(find.text(counterText));
@@ -635,7 +636,7 @@ void main() {
     errorWidget = tester.widget(find.text(errorText));
     counterWidget = tester.widget(find.text(counterText));
     expect(counterWidget.style!.color, equals(Colors.transparent));
-    expect(errorWidget.style!.color, equals(Colors.transparent));
+    expect(errorWidget.style!.color, isNot(equals(Colors.transparent)));
   });
 
   testWidgets('passing a buildCounter shows returned widget', (WidgetTester tester) async {


### PR DESCRIPTION
Ports flutter/flutter#191662. Fixes https://github.com/flutter/flutter/issues/67409