### PR TITLE
Label date picker icon buttons for screen readers

### DIFF
--- a/packages/material_ui/lib/src/calendar_date_picker.dart
+++ b/packages/material_ui/lib/src/calendar_date_picker.dart
@@ -25,6 +25,7 @@ import 'material.dart';
 import 'material_localizations.dart';
 import 'material_state.dart';
 import 'theme.dart';
+import 'tooltip_theme.dart';
 
 const Duration _monthScrollDuration = Duration(milliseconds: 200);
 
@@ -906,32 +907,35 @@ class _MonthPickerState extends State<_MonthPicker> {
             height: _subHeaderHeight,
             child: Padding(
               padding: const EdgeInsetsDirectional.only(start: 16, end: 4),
-              child: Row(
-                children: <Widget>[
-                  const Spacer(),
-                  IconButton(
-                    icon: Icon(
-                      Icons.chevron_left,
-                      semanticLabel: _isDisplayingFirstMonth
-                          ? _localizations.previousMonthTooltip
-                          : null,
+              // The tooltips of the month navigation buttons are excluded from
+              // semantics because the buttons already expose the same message as
+              // their semantics label. Screen readers that fold the tooltip into
+              // the accessible name would otherwise announce it twice.
+              child: TooltipTheme(
+                data: const TooltipThemeData(excludeFromSemantics: true),
+                child: Row(
+                  children: <Widget>[
+                    const Spacer(),
+                    IconButton(
+                      icon: Icon(
+                        Icons.chevron_left,
+                        semanticLabel: _localizations.previousMonthTooltip,
+                      ),
+                      color: subHeaderForegroundColor,
+                      tooltip: _isDisplayingFirstMonth ? null : _localizations.previousMonthTooltip,
+                      onPressed: _isDisplayingFirstMonth ? null : _handlePreviousMonth,
                     ),
-                    color: subHeaderForegroundColor,
-                    tooltip: _isDisplayingFirstMonth ? null : _localizations.previousMonthTooltip,
-                    onPressed: _isDisplayingFirstMonth ? null : _handlePreviousMonth,
-                  ),
-                  IconButton(
-                    icon: Icon(
-                      Icons.chevron_right,
-                      semanticLabel: _isDisplayingLastMonth
-                          ? _localizations.nextMonthTooltip
-                          : null,
+                    IconButton(
+                      icon: Icon(
+                        Icons.chevron_right,
+                        semanticLabel: _localizations.nextMonthTooltip,
+                      ),
+                      color: subHeaderForegroundColor,
+                      tooltip: _isDisplayingLastMonth ? null : _localizations.nextMonthTooltip,
+                      onPressed: _isDisplayingLastMonth ? null : _handleNextMonth,
                     ),
-                    color: subHeaderForegroundColor,
-                    tooltip: _isDisplayingLastMonth ? null : _localizations.nextMonthTooltip,
-                    onPressed: _isDisplayingLastMonth ? null : _handleNextMonth,
-                  ),
-                ],
+                  ],
+                ),
               ),
             ),
           ),

--- a/packages/material_ui/lib/src/date_picker.dart
+++ b/packages/material_ui/lib/src/date_picker.dart
@@ -38,6 +38,7 @@ import 'text_button.dart';
 import 'text_field.dart';
 import 'text_theme.dart';
 import 'theme.dart';
+import 'tooltip_theme.dart';
 
 // The M3 sizes are coming from the tokens, but are hand coded,
 // as the current token DB does not contain landscape versions.
@@ -702,13 +703,23 @@ class _DatePickerDialogState extends State<DatePickerDialog> with RestorationMix
     switch (_entryMode.value) {
       case DatePickerEntryMode.calendar:
         picker = calendarDatePicker();
-        entryModeButton = IconButton(
-          icon:
-              widget.switchToInputEntryModeIcon ??
-              Icon(useMaterial3 ? Icons.edit_outlined : Icons.edit),
-          color: headerForegroundColor,
-          tooltip: localizations.inputDateModeButtonLabel,
-          onPressed: _handleEntryModeToggle,
+        entryModeButton = TooltipTheme(
+          // The tooltip is excluded from the semantics tree because the button
+          // already exposes the same message as its semantics label. Screen
+          // readers that fold the tooltip into the accessible name would
+          // otherwise announce the message twice.
+          data: const TooltipThemeData(excludeFromSemantics: true),
+          child: IconButton(
+            icon: Semantics(
+              label: localizations.inputDateModeButtonLabel,
+              child:
+                  widget.switchToInputEntryModeIcon ??
+                  Icon(useMaterial3 ? Icons.edit_outlined : Icons.edit),
+            ),
+            color: headerForegroundColor,
+            tooltip: localizations.inputDateModeButtonLabel,
+            onPressed: _handleEntryModeToggle,
+          ),
         );
 
       case DatePickerEntryMode.calendarOnly:
@@ -717,11 +728,17 @@ class _DatePickerDialogState extends State<DatePickerDialog> with RestorationMix
 
       case DatePickerEntryMode.input:
         picker = inputDatePicker();
-        entryModeButton = IconButton(
-          icon: widget.switchToCalendarEntryModeIcon ?? const Icon(Icons.calendar_today),
-          color: headerForegroundColor,
-          tooltip: localizations.calendarModeButtonLabel,
-          onPressed: _handleEntryModeToggle,
+        entryModeButton = TooltipTheme(
+          data: const TooltipThemeData(excludeFromSemantics: true),
+          child: IconButton(
+            icon: Semantics(
+              label: localizations.calendarModeButtonLabel,
+              child: widget.switchToCalendarEntryModeIcon ?? const Icon(Icons.calendar_today),
+            ),
+            color: headerForegroundColor,
+            tooltip: localizations.calendarModeButtonLabel,
+            onPressed: _handleEntryModeToggle,
+          ),
         );
 
       case DatePickerEntryMode.inputOnly:
@@ -1659,13 +1676,19 @@ class _DateRangePickerDialogState extends State<DateRangePickerDialog> with Rest
           onConfirm: _hasSelectedDateRange ? _handleOk : null,
           onCancel: _handleCancel,
           entryModeButton: showEntryModeButton
-              ? IconButton(
-                  icon:
-                      widget.switchToInputEntryModeIcon ??
-                      Icon(useMaterial3 ? Icons.edit_outlined : Icons.edit),
-                  padding: EdgeInsets.zero,
-                  tooltip: localizations.inputDateModeButtonLabel,
-                  onPressed: _handleEntryModeToggle,
+              ? TooltipTheme(
+                  data: const TooltipThemeData(excludeFromSemantics: true),
+                  child: IconButton(
+                    icon: Semantics(
+                      label: localizations.inputDateModeButtonLabel,
+                      child:
+                          widget.switchToInputEntryModeIcon ??
+                          Icon(useMaterial3 ? Icons.edit_outlined : Icons.edit),
+                    ),
+                    padding: EdgeInsets.zero,
+                    tooltip: localizations.inputDateModeButtonLabel,
+                    onPressed: _handleEntryModeToggle,
+                  ),
                 )
               : null,
           confirmText:
@@ -1733,11 +1756,18 @@ class _DateRangePickerDialogState extends State<DateRangePickerDialog> with Rest
           onConfirm: _handleOk,
           onCancel: _handleCancel,
           entryModeButton: showEntryModeButton
-              ? IconButton(
-                  icon: widget.switchToCalendarEntryModeIcon ?? const Icon(Icons.calendar_today),
-                  padding: EdgeInsets.zero,
-                  tooltip: localizations.calendarModeButtonLabel,
-                  onPressed: _handleEntryModeToggle,
+              ? TooltipTheme(
+                  data: const TooltipThemeData(excludeFromSemantics: true),
+                  child: IconButton(
+                    icon: Semantics(
+                      label: localizations.calendarModeButtonLabel,
+                      child:
+                          widget.switchToCalendarEntryModeIcon ?? const Icon(Icons.calendar_today),
+                    ),
+                    padding: EdgeInsets.zero,
+                    tooltip: localizations.calendarModeButtonLabel,
+                    onPressed: _handleEntryModeToggle,
+                  ),
                 )
               : null,
           confirmText: widget.confirmText ?? localizations.okButtonLabel,

--- a/packages/material_ui/pending_changelogs/change_2026_08_25_port191694.yaml
+++ b/packages/material_ui/pending_changelogs/change_2026_08_25_port191694.yaml
@@ -1,0 +1,3 @@
+changelog: |
+  - Give date picker month-navigation and entry-mode-toggle icon buttons a real semantics label instead of relying on their tooltip, so screen readers announce them correctly.
+version: patch

--- a/packages/material_ui/test/calendar_date_picker_test.dart
+++ b/packages/material_ui/test/calendar_date_picker_test.dart
@@ -1012,7 +1012,7 @@ void main() {
         expect(
           tester.getSemantics(previousMonthIcon),
           matchesSemantics(
-            tooltip: 'Previous month',
+            label: 'Previous month',
             isButton: true,
             hasTapAction: true,
             hasFocusAction: true,
@@ -1024,7 +1024,7 @@ void main() {
         expect(
           tester.getSemantics(nextMonthIcon),
           matchesSemantics(
-            tooltip: 'Next month',
+            label: 'Next month',
             isButton: true,
             hasTapAction: true,
             hasFocusAction: true,
@@ -1448,6 +1448,44 @@ void main() {
             isButton: true,
           ),
         );
+        semantics.dispose();
+      });
+
+      testWidgets('Enabled next and previous month buttons have meaningful labels', (
+        WidgetTester tester,
+      ) async {
+        final SemanticsHandle semantics = tester.ensureSemantics();
+
+        await tester.pumpWidget(
+          calendarDatePicker(initialDate: DateTime(2016, DateTime.january, 15)),
+        );
+
+        // Prev/Next month buttons.
+        expect(
+          tester.getSemantics(previousMonthIcon),
+          matchesSemantics(
+            label: 'Previous month',
+            isButton: true,
+            hasTapAction: true,
+            hasFocusAction: true,
+            isEnabled: true,
+            hasEnabledState: true,
+            isFocusable: true,
+          ),
+        );
+        expect(
+          tester.getSemantics(nextMonthIcon),
+          matchesSemantics(
+            label: 'Next month',
+            isButton: true,
+            hasTapAction: true,
+            hasFocusAction: true,
+            isEnabled: true,
+            hasEnabledState: true,
+            isFocusable: true,
+          ),
+        );
+
         semantics.dispose();
       });
 

--- a/packages/material_ui/test/date_picker_test.dart
+++ b/packages/material_ui/test/date_picker_test.dart
@@ -1749,7 +1749,7 @@ void main() {
         expect(
           tester.getSemantics(switchToInputIcon),
           matchesSemantics(
-            tooltip: 'Switch to input',
+            label: 'Switch to input',
             isButton: true,
             hasTapAction: true,
             hasFocusAction: true,
@@ -1834,7 +1834,7 @@ void main() {
         expect(
           tester.getSemantics(switchToCalendarIcon),
           matchesSemantics(
-            tooltip: 'Switch to calendar',
+            label: 'Switch to calendar',
             isButton: true,
             hasTapAction: true,
             hasFocusAction: true,
@@ -1884,6 +1884,45 @@ void main() {
           tester.getSemantics(find.text('CANCEL')),
           matchesSemantics(
             label: 'CANCEL',
+            isButton: true,
+            hasTapAction: true,
+            hasFocusAction: true,
+            isEnabled: true,
+            hasEnabledState: true,
+            isFocusable: true,
+          ),
+        );
+      });
+      semantics.dispose();
+    });
+
+    // Regression test for https://github.com/flutter/flutter/issues/155224.
+    testWidgets('Entry mode toggle buttons are labeled instead of relying on their tooltip', (
+      WidgetTester tester,
+    ) async {
+      final SemanticsHandle semantics = tester.ensureSemantics();
+
+      await prepareDatePicker(tester, (Future<DateTime?> date) async {
+        expect(
+          tester.getSemantics(switchToInputIcon),
+          matchesSemantics(
+            label: 'Switch to input',
+            isButton: true,
+            hasTapAction: true,
+            hasFocusAction: true,
+            isEnabled: true,
+            hasEnabledState: true,
+            isFocusable: true,
+          ),
+        );
+
+        await tester.tap(switchToInputIcon);
+        await tester.pumpAndSettle();
+
+        expect(
+          tester.getSemantics(switchToCalendarIcon),
+          matchesSemantics(
+            label: 'Switch to calendar',
             isButton: true,
             hasTapAction: true,
             hasFocusAction: true,


### PR DESCRIPTION
The month navigation buttons and the entry mode toggle buttons of the
date pickers only described themselves through their tooltip. A semantics
node that carries a tooltip but no label has no accessible name, so
screen readers fall back to describing the icon itself (TalkBack
announces the detected icon) and desktop screen readers announce nothing
but 'button', because the tooltip is not mapped to the accessible name
there.

Give those buttons a real semantics label and keep their tooltip out of
the semantics tree, so the message is exposed as the accessible name
exactly once on every platform.

Ported from flutter/flutter#191694, which is blocked by the Material code freeze.

Fixes https://github.com/flutter/flutter/issues/155224