### PR TITLE
Honor ThemeData.hintColor for Material 3 hint text

### DIFF
--- a/packages/material_ui/lib/src/input_decorator.dart
+++ b/packages/material_ui/lib/src/input_decorator.dart
@@ -2189,7 +2189,28 @@ class _InputDecoratorState extends State<InputDecorator> with TickerProviderStat
             : themeData.textTheme.titleMedium!)
         .merge(widget.baseStyle)
         .merge(defaultStyle)
+        .merge(_getThemeHintColorStyle(themeData))
         .merge(style);
+  }
+
+  // ThemeData.hintColor is a Material 2 property, but it is still honored for
+  // Material 3 when it has been set by the application, for backward
+  // compatibility. It is ignored when the input is disabled because the
+  // disabled color takes precedence, as it does for Material 2.
+  //
+  // ThemeData always resolves hintColor to a non-null value, so the only way to
+  // know whether it has been set is to compare it with the value that the
+  // ThemeData constructor defaults to.
+  // See https://github.com/flutter/flutter/issues/153219.
+  TextStyle? _getThemeHintColorStyle(ThemeData themeData) {
+    if (!themeData.useMaterial3 || widgetState.contains(WidgetState.disabled)) {
+      return null;
+    }
+    final Color defaultHintColor = switch (themeData.brightness) {
+      Brightness.dark => Colors.white60,
+      Brightness.light => Colors.black.withOpacity(0.6),
+    };
+    return themeData.hintColor == defaultHintColor ? null : TextStyle(color: themeData.hintColor);
   }
 
   TextStyle _getFloatingLabelStyle(ThemeData themeData, InputDecorationThemeData defaults) {

--- a/packages/material_ui/pending_changelogs/change_2026_08_25_port191695.yaml
+++ b/packages/material_ui/pending_changelogs/change_2026_08_25_port191695.yaml
@@ -1,0 +1,3 @@
+changelog: |
+  - Fix `ThemeData.hintColor` being ignored for hint text under Material 3; a customized `hintColor` is honored again while the Material 3 default (`ColorScheme.onSurfaceVariant`) is used when it is not customized.
+version: patch

--- a/packages/material_ui/test/input_decorator_test.dart
+++ b/packages/material_ui/test/input_decorator_test.dart
@@ -5387,6 +5387,78 @@ void main() {
       );
       expect(getHintRect(tester).right, expectedHintRight);
     });
+
+    // Regression test for https://github.com/flutter/flutter/issues/153219.
+    group('ThemeData.hintColor', () {
+      testWidgets('is used when it is set', (WidgetTester tester) async {
+        const hintColor = Color(0xFFFF0000);
+        await tester.pumpWidget(
+          buildInputDecorator(
+            isEmpty: true,
+            theme: ThemeData(hintColor: hintColor),
+            decoration: const InputDecoration(hintText: hintText),
+          ),
+        );
+
+        expect(getHintStyle(tester).color, hintColor);
+      });
+
+      testWidgets('is used when it is set on a dark theme', (WidgetTester tester) async {
+        const hintColor = Color(0xFFFF0000);
+        await tester.pumpWidget(
+          buildInputDecorator(
+            isEmpty: true,
+            theme: ThemeData(brightness: Brightness.dark, hintColor: hintColor),
+            decoration: const InputDecoration(hintText: hintText),
+          ),
+        );
+
+        expect(getHintStyle(tester).color, hintColor);
+      });
+
+      testWidgets('is ignored when it is not set', (WidgetTester tester) async {
+        final theme = ThemeData();
+        await tester.pumpWidget(
+          buildInputDecorator(
+            isEmpty: true,
+            theme: theme,
+            decoration: const InputDecoration(hintText: hintText),
+          ),
+        );
+
+        expect(getHintStyle(tester).color, theme.colorScheme.onSurfaceVariant);
+      });
+
+      testWidgets('is ignored when the field is disabled', (WidgetTester tester) async {
+        const hintColor = Color(0xFFFF0000);
+        final theme = ThemeData(hintColor: hintColor);
+        await tester.pumpWidget(
+          buildInputDecorator(
+            isEmpty: true,
+            theme: theme,
+            decoration: const InputDecoration(enabled: false, hintText: hintText),
+          ),
+        );
+
+        expect(getHintStyle(tester).color, theme.colorScheme.onSurface.withOpacity(0.38));
+      });
+
+      testWidgets('is overridden by InputDecoration.hintStyle', (WidgetTester tester) async {
+        const hintStyleColor = Color(0xFF00FF00);
+        await tester.pumpWidget(
+          buildInputDecorator(
+            isEmpty: true,
+            theme: ThemeData(hintColor: const Color(0xFFFF0000)),
+            decoration: const InputDecoration(
+              hintText: hintText,
+              hintStyle: TextStyle(color: hintStyleColor),
+            ),
+          ),
+        );
+
+        expect(getHintStyle(tester).color, hintStyleColor);
+      });
+    });
   });
 
   group('Material3 - InputDecoration helper/counter/error', () {


### PR DESCRIPTION
Since flutter/flutter#150278, InputDecorator uses the Material 3 default
hint color (ColorScheme.onSurfaceVariant) and ignores ThemeData.hintColor.
Apps that customized ThemeData.hintColor lost their hint text color when
they migrated to Flutter 3.24.

ThemeData resolves hintColor to a non-null default in its constructor, so
the only way to know whether an app has set it is to compare it with that
default. _InputDecoratorState now merges a TextStyle built from
ThemeData.hintColor into the inline hint style when the theme uses
Material 3 and hintColor differs from the ThemeData default. The Material 3
default is unchanged when hintColor is not customized, the disabled color
still takes precedence (as for Material 2), and InputDecoration.hintStyle
still overrides the theme.

Ported from flutter/flutter#191695, which is blocked by the Material code freeze.

Fixes https://github.com/flutter/flutter/issues/153219