### PR TITLE
Read TextFormField value from its controller

### DIFF
--- a/packages/material_ui/lib/src/text_form_field.dart
+++ b/packages/material_ui/lib/src/text_form_field.dart
@@ -364,6 +364,16 @@ class _TextFormFieldState extends FormFieldState<String> {
 
   TextFormField get _textFormField => super.widget as TextFormField;
 
+  // The text editing controller is the source of truth for this field's value.
+  //
+  // Reading the value from the controller rather than from the value cached by
+  // [FormFieldState] guarantees that validators (and [FormField.onSaved]) see
+  // the current text even when they run before this state has been notified of
+  // a controller change, for example when [FormState.validate] is called from
+  // a controller listener that was registered before this field's own listener.
+  @override
+  String? get value => _effectiveController.text;
+
   @override
   void restoreState(RestorationBucket? oldBucket, bool initialRestore) {
     super.restoreState(oldBucket, initialRestore);
@@ -458,7 +468,7 @@ class _TextFormFieldState extends FormFieldState<String> {
     // notifications for changes originating from within this class -- for
     // example, the reset() method. In such cases, the FormField value will
     // already have been set.
-    if (_effectiveController.text != value) {
+    if (_effectiveController.text != super.value) {
       didChange(_effectiveController.text);
     }
   }

--- a/packages/material_ui/pending_changelogs/change_2026_08_25_port191658.yaml
+++ b/packages/material_ui/pending_changelogs/change_2026_08_25_port191658.yaml
@@ -1,0 +1,3 @@
+changelog: |
+  - Fix `TextFormField` validators sometimes seeing a stale value when `FormState.validate()` runs from a `TextEditingController` listener registered before the field's own listener.
+version: patch

--- a/packages/material_ui/test/text_form_field_test.dart
+++ b/packages/material_ui/test/text_form_field_test.dart
@@ -1942,4 +1942,58 @@ void main() {
 
     expect(controller.text, 'Initial Value');
   });
+
+  // Regression test for https://github.com/flutter/flutter/issues/40494.
+  testWidgets(
+    'validator receives the up-to-date value when validate() is called from a controller listener',
+    (WidgetTester tester) async {
+      final formKey = GlobalKey<FormState>();
+      final controller = TextEditingController();
+      addTearDown(controller.dispose);
+
+      final controllerTexts = <String>[];
+      final validatedValues = <String?>[];
+      final fieldValues = <String?>[];
+
+      // This listener is added before the TextFormField adds its own listener,
+      // so it is notified first, while the TextFormField has not had a chance
+      // to update its value yet.
+      controller.addListener(() {
+        final FormState? formState = formKey.currentState;
+        if (formState == null) {
+          return;
+        }
+        controllerTexts.add(controller.text);
+        formState.validate();
+        fieldValues.add(formState.fields.single.value as String?);
+      });
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Material(
+            child: Form(
+              key: formKey,
+              child: TextFormField(
+                controller: controller,
+                validator: (String? value) {
+                  validatedValues.add(value);
+                  return null;
+                },
+              ),
+            ),
+          ),
+        ),
+      );
+
+      await tester.enterText(find.byType(TextFormField), 'a');
+      await tester.pump();
+
+      expect(controller.text, 'a');
+      expect(controllerTexts, contains('a'));
+      // The validator and the field value must always agree with the value the
+      // controller is notifying about.
+      expect(validatedValues, controllerTexts);
+      expect(fieldValues, controllerTexts);
+    },
+  );
 }


### PR DESCRIPTION
_TextFormFieldState now overrides FormFieldState.value to read
_effectiveController.text directly instead of relying on the cached
value FormFieldState tracks internally. This guarantees validators (and
FormField.onSaved) see the current text even when they run before this
state has been notified of a controller change, for example when
FormState.validate() is called from a controller listener that was
registered before this field's own listener.

Depends on the FormFieldState.isValid/validate() fix in flutter/flutter,
which reads through the value getter instead of the private cached field.

Ported from flutter/flutter#191658, which is blocked by the Material code freeze.

Fixes https://github.com/flutter/flutter/issues/40494