### PR TITLE
Add CupertinoPicker regression test for duplicate selection leaders

### DIFF
--- a/packages/cupertino_ui/pending_changelogs/change_2026_08_25_port191677.yaml
+++ b/packages/cupertino_ui/pending_changelogs/change_2026_08_25_port191677.yaml
@@ -1,0 +1,3 @@
+changelog: |
+  - Add regression coverage for `CupertinoPicker` inside a `SelectableRegion` pushing duplicate selection handle leader layers, fixed in the framework's `RenderParagraph`.
+version: patch

--- a/packages/cupertino_ui/test/picker_test.dart
+++ b/packages/cupertino_ui/test/picker_test.dart
@@ -4,6 +4,7 @@
 
 import 'package:cupertino_ui/cupertino_ui.dart';
 import 'package:flutter/foundation.dart';
+import 'package:flutter/gestures.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -948,5 +949,49 @@ void main() {
       ),
     );
     expect(tester.getSize(find.byType(CupertinoPicker)), Size.zero);
+  });
+
+  testWidgets('CupertinoPicker in a SelectableRegion only pushes one selection handle leader layer per link', (
+    WidgetTester tester,
+  ) async {
+    // Regression test for https://github.com/flutter/flutter/issues/140543.
+    await tester.pumpWidget(
+      CupertinoApp(
+        home: Center(
+          child: SizedBox(
+            height: 300.0,
+            width: 300.0,
+            child: SelectableRegion(
+              selectionControls: cupertinoTextSelectionControls,
+              child: CupertinoPicker(
+                itemExtent: 50.0,
+                onSelectedItemChanged: (int index) {},
+                children: const <Widget>[Text('Element 1'), Text('Element 2')],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    // The item in the center of the wheel is painted twice in the same frame:
+    // once dimmed outside of the center rect and once at full opacity inside of
+    // it. Selecting it used to push a selection handle leader layer for each of
+    // those paints, leaving the handle layer links with more than one leader.
+    final Rect textRect = tester.getRect(find.text('Element 1'));
+    final TestGesture gesture = await tester.startGesture(
+      textRect.centerLeft + const Offset(2.0, 0.0),
+      kind: PointerDeviceKind.mouse,
+    );
+    addTearDown(gesture.removePointer);
+    await tester.pump();
+    await gesture.moveTo(textRect.centerRight - const Offset(2.0, 0.0));
+    await tester.pump();
+    await gesture.up();
+    await tester.pumpAndSettle();
+
+    expect(tester.takeException(), isNull);
+    // One leader layer for the toolbar and one for each selection handle.
+    expect(tester.layers.whereType<LeaderLayer>(), hasLength(3));
   });
 }


### PR DESCRIPTION
Regression test verifying a CupertinoPicker inside a SelectableRegion no
longer trips the LayerLink assertion when its centered item is painted
twice in the same frame (once for the magnifier, once for the dimmed
cylindrical part). Exercises the LayerHandle fix landed in flutter/flutter
(see https://github.com/kaluli123123/flutter/tree/fix-render-paragraph-duplicate-leaders).

Ported from flutter/flutter#191677, which is blocked by the Cupertino code freeze.

Fixes https://github.com/flutter/flutter/issues/140543