### PR TITLE
Use input entry mode by default in landscape date picker

### DIFF
--- a/packages/material_ui/example/test/date_picker/date_picker_theme_day_shape.0_test.dart
+++ b/packages/material_ui/example/test/date_picker/date_picker_theme_day_shape.0_test.dart
@@ -28,6 +28,12 @@ void main() {
             as ShapeDecoration?;
       }
 
+      // The date picker defaults to the calendar entry mode in portrait
+      // orientation only.
+      tester.view.physicalSize = const Size(1080.0, 2400.0);
+      tester.view.devicePixelRatio = 3.0;
+      addTearDown(tester.view.reset);
+
       await tester.pumpWidget(const example.DatePickerApp());
 
       await tester.tap(find.text('Open Date Picker'));

--- a/packages/material_ui/example/test/date_picker/show_date_picker.1_test.dart
+++ b/packages/material_ui/example/test/date_picker/show_date_picker.1_test.dart
@@ -12,6 +12,12 @@ void main() {
     const String datePickerTitle = 'Select date';
     const String initialDate = 'Sun, Jul 25';
 
+    // The date picker defaults to the calendar entry mode in portrait
+    // orientation only.
+    tester.view.physicalSize = const Size(1080.0, 2400.0);
+    tester.view.devicePixelRatio = 3.0;
+    addTearDown(tester.view.reset);
+
     await tester.pumpWidget(const example.DatePickerApp());
 
     // The date picker is not shown initially.

--- a/packages/material_ui/lib/src/date_picker.dart
+++ b/packages/material_ui/lib/src/date_picker.dart
@@ -98,7 +98,11 @@ const double _fontSizeToScale = 14.0;
 /// An optional [initialEntryMode] argument can be used to display the date
 /// picker in the [DatePickerEntryMode.calendar] (a calendar month grid)
 /// or [DatePickerEntryMode.input] (a text input field) mode.
-/// It defaults to [DatePickerEntryMode.calendar].
+/// If it is null, [DatePickerEntryMode.calendar] is used in portrait
+/// orientation and [DatePickerEntryMode.input] is used in landscape
+/// orientation. This is because the calendar grid can't respect the minimum
+/// touch target size recommended by the accessibility guidelines when the
+/// available height is as small as it is in landscape orientation.
 ///
 /// {@template material_ui.date_picker.switchToInputEntryModeIcon}
 /// An optional [switchToInputEntryModeIcon] argument can be used to
@@ -211,7 +215,7 @@ Future<DateTime?> showDatePicker({
   required DateTime firstDate,
   required DateTime lastDate,
   DateTime? currentDate,
-  DatePickerEntryMode initialEntryMode = DatePickerEntryMode.calendar,
+  DatePickerEntryMode? initialEntryMode,
   SelectableDayPredicate? selectableDayPredicate,
   String? helpText,
   String? cancelText,
@@ -257,12 +261,25 @@ Future<DateTime?> showDatePicker({
   );
   assert(debugCheckHasMaterialLocalizations(context));
 
+  // The calendar day grid can't respect the minimum touch target size
+  // recommended by the accessibility guidelines in landscape orientation,
+  // because the dialog height is too small to lay out 7 rows of 48 logical
+  // pixels. The input entry mode is used instead, as recommended by the
+  // Material Design guidelines for constrained viewports. The user can still
+  // switch to the calendar entry mode with the entry mode button.
+  final DatePickerEntryMode effectiveInitialEntryMode =
+      initialEntryMode ??
+      switch (MediaQuery.orientationOf(context)) {
+        Orientation.portrait => DatePickerEntryMode.calendar,
+        Orientation.landscape => DatePickerEntryMode.input,
+      };
+
   Widget dialog = DatePickerDialog(
     initialDate: initialDate,
     firstDate: firstDate,
     lastDate: lastDate,
     currentDate: currentDate,
-    initialEntryMode: initialEntryMode,
+    initialEntryMode: effectiveInitialEntryMode,
     selectableDayPredicate: selectableDayPredicate,
     helpText: helpText,
     cancelText: cancelText,

--- a/packages/material_ui/pending_changelogs/change_2026_08_25_port191686.yaml
+++ b/packages/material_ui/pending_changelogs/change_2026_08_25_port191686.yaml
@@ -1,0 +1,3 @@
+changelog: |
+  - `showDatePicker` now defaults to `DatePickerEntryMode.input` in landscape orientation, where the calendar grid would otherwise shrink day buttons below the recommended touch target size. Portrait orientation is unaffected, and an explicit `initialEntryMode` still overrides the default.
+version: patch

--- a/packages/material_ui/pending_changelogs/change_2026_08_25_port191686.yaml
+++ b/packages/material_ui/pending_changelogs/change_2026_08_25_port191686.yaml
@@ -1,3 +1,3 @@
 changelog: |
   - `showDatePicker` now defaults to `DatePickerEntryMode.input` in landscape orientation, where the calendar grid would otherwise shrink day buttons below the recommended touch target size. Portrait orientation is unaffected, and an explicit `initialEntryMode` still overrides the default.
-version: patch
+version: minor

--- a/packages/material_ui/test/date_picker_test.dart
+++ b/packages/material_ui/test/date_picker_test.dart
@@ -178,6 +178,67 @@ void main() {
       expect(dialogContainerSize, calendarPortraitDialogSizeM3);
     });
 
+    // Regression test for https://github.com/flutter/flutter/issues/170786.
+    testWidgets('Default entry mode depends on the orientation', (WidgetTester tester) async {
+      Future<void> showPicker(Size size) async {
+        tester.view.physicalSize = size;
+        tester.view.devicePixelRatio = 1.0;
+        addTearDown(tester.view.reset);
+        late BuildContext buttonContext;
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Material(
+              child: Builder(
+                builder: (BuildContext context) {
+                  return ElevatedButton(
+                    onPressed: () {
+                      buttonContext = context;
+                    },
+                    child: const Text('Go'),
+                  );
+                },
+              ),
+            ),
+          ),
+        );
+        await tester.tap(find.text('Go'));
+        showDatePicker(
+          context: buttonContext,
+          initialDate: initialDate,
+          firstDate: firstDate,
+          lastDate: lastDate,
+        );
+        await tester.pumpAndSettle();
+      }
+
+      // In portrait, the calendar day grid has enough room to respect the
+      // minimum touch target size, so the calendar entry mode is used.
+      await showPicker(narrowWindowSize);
+      expect(find.byType(CalendarDatePicker), findsOneWidget);
+      expect(find.byType(InputDatePickerFormField), findsNothing);
+
+      // Close the dialog.
+      await tester.tap(find.text('Cancel'));
+      await tester.pumpAndSettle();
+
+      // In landscape, the calendar day grid can't respect the minimum touch
+      // target size, so the input entry mode is used.
+      await showPicker(wideWindowSize);
+      expect(find.byType(CalendarDatePicker), findsNothing);
+      expect(find.byType(InputDatePickerFormField), findsOneWidget);
+    });
+
+    testWidgets('Explicit initialEntryMode is not overridden by the orientation', (
+      WidgetTester tester,
+    ) async {
+      tester.view.physicalSize = wideWindowSize;
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.reset);
+      await prepareDatePicker(tester, (Future<DateTime?> date) async {
+        expect(find.byType(CalendarDatePicker), findsOneWidget);
+      }, useMaterial3: true);
+    });
+
     testWidgets('Default dialog properties', (WidgetTester tester) async {
       final theme = ThemeData();
       await prepareDatePicker(tester, (Future<DateTime?> date) async {
@@ -743,6 +804,7 @@ void main() {
                       firstDate: DateTime(2018),
                       lastDate: DateTime(2030),
                       switchToInputEntryModeIcon: switchToInputEntryModeIcon,
+                      initialEntryMode: DatePickerEntryMode.calendar,
                     );
                   },
                 );

--- a/packages/material_ui/test/date_picker_test.dart
+++ b/packages/material_ui/test/date_picker_test.dart
@@ -202,11 +202,13 @@ void main() {
           ),
         );
         await tester.tap(find.text('Go'));
-        showDatePicker(
-          context: buttonContext,
-          initialDate: initialDate,
-          firstDate: firstDate,
-          lastDate: lastDate,
+        unawaited(
+          showDatePicker(
+            context: buttonContext,
+            initialDate: initialDate,
+            firstDate: firstDate,
+            lastDate: lastDate,
+          ),
         );
         await tester.pumpAndSettle();
       }


### PR DESCRIPTION
In landscape orientation the date picker dialog is only 346 logical pixels
high, so the calendar day grid shrinks each day button well below the 48
logical pixel minimum touch target size recommended by the accessibility
guidelines. There is no Material specification for a landscape calendar
layout, and the Material Design guidelines recommend using the input mode
when the viewport is constrained.

showDatePicker now takes a nullable initialEntryMode. When it is not
provided, the entry mode defaults to DatePickerEntryMode.calendar in
portrait orientation and to DatePickerEntryMode.input in landscape
orientation. Callers that pass an explicit entry mode are not affected, and
the user can still switch to the calendar with the entry mode button.

Ported from flutter/flutter#191686, which is blocked by the Material code
freeze. The original PR also updated packages/flutter_localizations tests
to pin the previous calendar-mode default; that change is not applicable
here since flutter_localizations tests against flutter/flutter's own
(frozen, unchanged) date_picker.dart, not this package.

Fixes https://github.com/flutter/flutter/issues/170786