### PR TITLE
[material_ui] Cover arrow keys in a closed MenuAnchor

### DIFF
--- a/packages/material_ui/pending_changelogs/change_2026_08_25_port191688.yaml
+++ b/packages/material_ui/pending_changelogs/change_2026_08_25_port191688.yaml
@@ -1,0 +1,3 @@
+changelog: |
+  - Add regression coverage for arrow keys not moving the caret of a `TextField` in a `MenuAnchor` when the menu is closed, fixed in the framework's `RawMenuAnchor`.
+version: patch

--- a/packages/material_ui/test/menu_anchor_test.dart
+++ b/packages/material_ui/test/menu_anchor_test.dart
@@ -2478,6 +2478,106 @@ void main() {
       await tester.pump();
       expect(focusedMenu, equals('MenuItemButton(Text("Submenu item 1"))'));
     });
+
+    // Regression test for https://github.com/flutter/flutter/issues/163475.
+    testWidgets('Arrow keys move the caret of a TextField in the anchor when the menu is closed', (
+      WidgetTester tester,
+    ) async {
+      final textController = TextEditingController(text: 'text');
+      addTearDown(textController.dispose);
+      final textFieldFocusNode = FocusNode(debugLabel: 'TextField');
+      addTearDown(textFieldFocusNode.dispose);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: MenuAnchor(
+              controller: controller,
+              menuChildren: <Widget>[
+                MenuItemButton(child: Text(TestMenu.subMenu00.label), onPressed: () {}),
+              ],
+              builder: (BuildContext context, MenuController controller, Widget? child) {
+                return TextField(controller: textController, focusNode: textFieldFocusNode);
+              },
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.byType(TextField));
+      await tester.pump();
+
+      expect(textFieldFocusNode.hasFocus, isTrue);
+      expect(controller.isOpen, isFalse);
+
+      textController.selection = const TextSelection.collapsed(offset: 4);
+      await tester.pump();
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowLeft);
+      await tester.pump();
+
+      expect(textController.selection.baseOffset, 3);
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowRight);
+      await tester.pump();
+
+      expect(textController.selection.baseOffset, 4);
+    });
+
+    // Regression test for https://github.com/flutter/flutter/issues/163475.
+    testWidgets(
+      'Up and down arrow keys move the caret of a multiline TextField in the anchor when the menu is closed',
+      (WidgetTester tester) async {
+        final textController = TextEditingController(text: 'aaaa\nbbbb');
+        addTearDown(textController.dispose);
+        final textFieldFocusNode = FocusNode(debugLabel: 'TextField');
+        addTearDown(textFieldFocusNode.dispose);
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: MenuAnchor(
+                controller: controller,
+                menuChildren: <Widget>[
+                  MenuItemButton(child: Text(TestMenu.subMenu00.label), onPressed: () {}),
+                ],
+                builder: (BuildContext context, MenuController controller, Widget? child) {
+                  return TextField(
+                    controller: textController,
+                    focusNode: textFieldFocusNode,
+                    maxLines: 2,
+                  );
+                },
+              ),
+            ),
+          ),
+        );
+
+        await tester.tap(find.byType(TextField));
+        await tester.pump();
+
+        expect(textFieldFocusNode.hasFocus, isTrue);
+        expect(controller.isOpen, isFalse);
+
+        // Place the caret on the second line, between the second and third
+        // characters.
+        textController.selection = const TextSelection.collapsed(offset: 7);
+        await tester.pump();
+
+        await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
+        await tester.pump();
+
+        // The caret moved up to the first line instead of moving the focus.
+        expect(textController.selection.baseOffset, 2);
+        expect(textFieldFocusNode.hasFocus, isTrue);
+
+        await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+        await tester.pump();
+
+        expect(textController.selection.baseOffset, 7);
+        expect(textFieldFocusNode.hasFocus, isTrue);
+      },
+    );
   });
 
   group('Accelerators', () {


### PR DESCRIPTION
Add regression coverage for left/right and up/down arrow keys moving a TextField caret inside a closed MenuAnchor, rather than being consumed as menu traversal shortcuts.

Fixes https://github.com/flutter/flutter/issues/163475

## Framework dependency

This draft is not ready to merge. The corresponding RawMenuAnchor framework changes have not landed in the stock Flutter 3.47.0 SDK. The original framework PR https://github.com/flutter/flutter/pull/191688 was closed without merging; the previous description's claim that the fix had landed was incorrect.

After syncing packages main `364fc7d23873930db22a0ba9b28da9c29c69eab5`, both new regression cases still fail on stock Flutter 3.47.0: the horizontal caret remains at 4 instead of 3, and the vertical caret remains at 7 instead of 2. The tests retain those expectations to expose the dependency.

## Validation

- Resolved the menu test conflict while preserving main's `reduced-web-test-set` tag.
- Full `menu_anchor_test.dart`: 171 passed, 1 skipped, 2 failed as described above.
- Package analysis, Dart formatting, and whitespace checks passed.
- The synchronized repository tooling passed analysis and 1,248 tests.

The full material package suite and Windows/browser/device runs were not repeated for this dependency-blocked draft. Framework integration, current-head CI, and human review remain outstanding.
