### PR TITLE
Reset CupertinoScrollbar thumb thickness on canceled thumb drag

### DIFF
--- a/packages/cupertino_ui/lib/src/scrollbar.dart
+++ b/packages/cupertino_ui/lib/src/scrollbar.dart
@@ -231,6 +231,14 @@ class _CupertinoScrollbarState extends RawScrollbarState<CupertinoScrollbar> {
   }
 
   @override
+  void handleThumbPressCancel() {
+    // handleThumbPressEnd is not called when the gesture is canceled, so the
+    // thickness animation started by handleThumbPress has to be reverted here.
+    _thicknessAnimationController.reverse();
+    super.handleThumbPressCancel();
+  }
+
+  @override
   void handleTrackTapDown(TapDownDetails details) {
     // On iOS, tapping the track does not page towards the position of the tap.
     if (ScrollConfiguration.of(context).getPlatform(context) != TargetPlatform.iOS) {

--- a/packages/cupertino_ui/pending_changelogs/change_2026_08_25_port191691.yaml
+++ b/packages/cupertino_ui/pending_changelogs/change_2026_08_25_port191691.yaml
@@ -1,0 +1,3 @@
+changelog: |
+  - Fix `CupertinoScrollbar` thumb staying stuck at its dragging thickness when a thumb drag is canceled before it is accepted (e.g. a touch that starts inside the padded hit area but loses the gesture arena to the scroll view).
+version: patch

--- a/packages/cupertino_ui/test/scrollbar_test.dart
+++ b/packages/cupertino_ui/test/scrollbar_test.dart
@@ -1354,4 +1354,60 @@ void main() {
     );
     expect(tester.getSize(find.byType(CupertinoScrollbar)), Size.zero);
   });
+
+  testWidgets('CupertinoScrollbar thumb thickness is restored when the thumb drag is canceled', (
+    WidgetTester tester,
+  ) async {
+    // Regression test for https://github.com/flutter/flutter/issues/162747
+    final scrollController = ScrollController();
+    addTearDown(scrollController.dispose);
+    await tester.pumpWidget(
+      CupertinoApp(
+        home: PrimaryScrollController(
+          controller: scrollController,
+          child: CupertinoScrollbar(
+            thumbVisibility: true,
+            controller: scrollController,
+            child: ListView.builder(
+              controller: scrollController,
+              itemCount: 50,
+              itemBuilder: (BuildContext context, int index) =>
+                  const SizedBox(height: 50.0, child: Text('Item')),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    double thumbThickness() {
+      final CustomPaint customPaint = tester
+          .widgetList<CustomPaint>(
+            find.descendant(
+              of: find.byType(CupertinoScrollbar),
+              matching: find.byType(CustomPaint),
+            ),
+          )
+          .firstWhere((CustomPaint paint) => paint.foregroundPainter is ScrollbarPainter);
+      return (customPaint.foregroundPainter! as ScrollbarPainter).thickness;
+    }
+
+    expect(thumbThickness(), CupertinoScrollbar.defaultThickness);
+
+    // Touch the thumb close to, but not directly on top of, the scrollbar
+    // track. The touch is still within the thumb's padded hit test area, so
+    // the thumb drag gesture recognizer is notified, but the scrollable's own
+    // drag gesture recognizer also joins the gesture arena. Lifting the finger
+    // without moving it makes the thumb drag lose the arena, which cancels the
+    // gesture instead of ending it.
+    final TestGesture gesture = await tester.startGesture(const Offset(780.0, 74.0));
+    await tester.pump();
+    await tester.pump(kScrollbarResizeDuration);
+    expect(thumbThickness(), CupertinoScrollbar.defaultThicknessWhileDragging);
+
+    await gesture.up();
+    await tester.pump();
+    await tester.pump(kScrollbarResizeDuration);
+    expect(thumbThickness(), CupertinoScrollbar.defaultThickness);
+  });
 }


### PR DESCRIPTION
_CupertinoScrollbarState now overrides the new handleThumbPressCancel hook
to reverse the thickness animation controller, the same way
handleThumbPressEnd already does. Without this, a thumb drag that lost the
gesture arena to the scroll view's own drag recognizer (which can happen
when a touch lands inside the scrollbar's padded hit area but outside the
track) left the thumb stuck at thicknessWhileDragging until the next thumb
drag ended normally.

Depends on the RawScrollbarState.handleThumbPressCancel hook landed in
flutter/flutter (see
https://github.com/kaluli123123/flutter/tree/fix-rawscrollbar-thumbpresscancel-hook).

Ported from flutter/flutter#191691, which is blocked by the Cupertino code freeze.

Fixes https://github.com/flutter/flutter/issues/162747