### PR TITLE
[material_ui] Fix DropdownButtonFormField underline alignment at bottom

### DIFF
--- a/packages/material_ui/lib/src/dropdown.dart
+++ b/packages/material_ui/lib/src/dropdown.dart
@@ -1756,19 +1756,9 @@ class _DropdownButtonState<T> extends State<DropdownButton<T>> with WidgetsBindi
         ),
 
         // suffixIconGap: 0.0,
-        // InputDecorator does not expose vertical alignment for suffixIcon.
-        // Padding is the only stable way to force top alignment when expanded.
-        suffixIcon: LayoutBuilder(
-          builder: (context, constraints) {
-            final double bottomOffset = widget.isVerticallyExpanded
-                ? (constraints.maxHeight - widget.iconSize).clamp(0, constraints.maxHeight)
-                : 0;
-
-            return Padding(
-              padding: EdgeInsetsDirectional.only(bottom: bottomOffset, end: suffixIconEndMargin),
-              child: effectiveSuffixIcon,
-            );
-          },
+        suffixIcon: Padding(
+          padding: EdgeInsetsGeometry.directional(end: suffixIconEndMargin),
+          child: effectiveSuffixIcon,
         ),
       );
       if (_hasPrimaryFocus) {

--- a/packages/material_ui/lib/src/dropdown.dart
+++ b/packages/material_ui/lib/src/dropdown.dart
@@ -1802,6 +1802,13 @@ class _DropdownButtonState<T> extends State<DropdownButton<T>> with WidgetsBindi
           ),
         ),
       );
+
+      // When vertical expansion is disabled, wrap with Align
+      // to prevent the widget from stretching to fill the parent's
+      // available height.
+      if (!widget.isVerticallyExpanded) {
+        result = Align(alignment: Alignment.topCenter, heightFactor: 1.0, child: result);
+      }
     } else {
       result = InkWell(
         mouseCursor: effectiveMouseCursor,
@@ -1818,18 +1825,6 @@ class _DropdownButtonState<T> extends State<DropdownButton<T>> with WidgetsBindi
 
     final bool childHasButtonSemantic =
         hintIndex != null || (_selectedIndex != null && widget.selectedItemBuilder == null);
-
-    // When vertical expansion is disabled, wrap with UnconstrainedBox
-    // to prevent the widget from stretching to fill the parent's
-    // available height. Only the horizontal axis remains constrained,
-    // preserving the width defined by the parent.
-    if (!widget.isVerticallyExpanded) {
-      result = UnconstrainedBox(
-        constrainedAxis: Axis.horizontal, // Keep width constrained by parent
-        alignment: Alignment.topCenter,
-        child: result,
-      );
-    }
 
     return Semantics(
       button: !childHasButtonSemantic,

--- a/packages/material_ui/lib/src/dropdown.dart
+++ b/packages/material_ui/lib/src/dropdown.dart
@@ -1034,6 +1034,7 @@ class DropdownButton<T> extends StatefulWidget {
     this.barrierDismissible = true,
     this.mouseCursor,
     this.dropdownMenuItemMouseCursor,
+    this.isVerticallyExpanded = true,
     // When adding new arguments, consider adding similar arguments to
     // DropdownButtonFormField.
   }) : assert(
@@ -1085,6 +1086,7 @@ class DropdownButton<T> extends StatefulWidget {
     this.barrierDismissible = true,
     this.mouseCursor,
     this.dropdownMenuItemMouseCursor,
+    this.isVerticallyExpanded = false,
     required this._inputDecoration,
     required this._isEmpty,
   }) : assert(
@@ -1251,14 +1253,11 @@ class DropdownButton<T> extends StatefulWidget {
   /// its own decorations, like [InputDecorator].
   final bool isDense;
 
-  /// Controls whether the dropdown's inner contents expand to fill the
-  /// available space.
+  /// Set the dropdown's inner contents to horizontally fill its parent.
   ///
-  /// When `true`, the inner width and height of the dropdown are expanded
-  /// to match its parent container. By default, the inner width is only as
-  /// wide as its contents, and the height is minimal. Setting this to `true`
-  /// ensures that the dropdown's underline and items align properly within
-  /// its container.
+  /// By default this button's inner width is the minimum size of its contents.
+  /// If [isExpanded] is true, the inner width is expanded to fill its
+  /// surrounding container.
   final bool isExpanded;
 
   /// If null, then the menu item heights will vary according to each menu item's
@@ -1364,6 +1363,27 @@ class DropdownButton<T> extends StatefulWidget {
   ///
   /// If this property is null, [WidgetStateMouseCursor.adaptiveClickable] will be used.
   final MouseCursor? dropdownMenuItemMouseCursor;
+
+  /// Whether the dropdown's inner contents expand to fill the
+  /// available vertical space.
+  ///
+  /// When true, the inner height of the dropdown is expanded to match its
+  /// parent container. When false, the inner height is determined by the
+  /// height of the selected item (its intrinsic height).
+  ///
+  /// This is particularly useful when the dropdown is used inside a fixed-height
+  /// container, ensuring that the underline and items align properly within
+  /// the allocated space.
+  ///
+  /// Defaults to true for [DropdownButton] to maintain its standard behavior,
+  /// and false for [DropdownButtonFormField] to ensure the input decorator
+  /// handles the vertical constraints correctly by default.
+  ///
+  /// See also:
+  ///
+  ///  * [DropdownButton.isExpanded], which expands the inner width of the
+  ///    dropdown to fill the available horizontal space.
+  final bool isVerticallyExpanded;
 
   final InputDecoration? _inputDecoration;
 
@@ -1775,7 +1795,7 @@ class _DropdownButtonState<T> extends State<DropdownButton<T>> with WidgetsBindi
               isEmpty: widget._isEmpty,
               isFocused: _hasPrimaryFocus,
               isHovering: _isHovering,
-              expands: widget.isExpanded,
+              expands: widget.isVerticallyExpanded,
               child: widget.padding == null
                   ? result
                   : Padding(padding: widget.padding!, child: result),
@@ -1799,6 +1819,14 @@ class _DropdownButtonState<T> extends State<DropdownButton<T>> with WidgetsBindi
 
     final bool childHasButtonSemantic =
         hintIndex != null || (_selectedIndex != null && widget.selectedItemBuilder == null);
+
+    // When not vertically expanded, force the widget to its default height
+    // using heightFactor: 1.0. This prevents the item from expanding
+    // to fill the parent's available vertical space.
+    if (!widget.isVerticallyExpanded) {
+      result = Align(alignment: Alignment.topCenter, heightFactor: 1.0, child: result);
+    }
+
     return Semantics(
       button: !childHasButtonSemantic,
       expanded: _isMenuExpanded,
@@ -1872,6 +1900,7 @@ class DropdownButtonFormField<T> extends FormField<T> {
     this.barrierDismissible = true,
     this.mouseCursor,
     this.dropdownMenuItemMouseCursor,
+    bool isVerticallyExpanded = false,
     // When adding new arguments, consider adding similar arguments to
     // DropdownButton.
   }) : assert(
@@ -1968,6 +1997,7 @@ class DropdownButtonFormField<T> extends FormField<T> {
                  barrierDismissible: barrierDismissible,
                  mouseCursor: mouseCursor,
                  dropdownMenuItemMouseCursor: dropdownMenuItemMouseCursor,
+                 isVerticallyExpanded: isVerticallyExpanded,
                ),
              ),
            );

--- a/packages/material_ui/lib/src/dropdown.dart
+++ b/packages/material_ui/lib/src/dropdown.dart
@@ -1251,11 +1251,14 @@ class DropdownButton<T> extends StatefulWidget {
   /// its own decorations, like [InputDecorator].
   final bool isDense;
 
-  /// Set the dropdown's inner contents to horizontally fill its parent.
+  /// Controls whether the dropdown's inner contents expand to fill the
+  /// available space.
   ///
-  /// By default this button's inner width is the minimum size of its contents.
-  /// If [isExpanded] is true, the inner width is expanded to fill its
-  /// surrounding container.
+  /// When `true`, the inner width and height of the dropdown are expanded
+  /// to match its parent container. By default, the inner width is only as
+  /// wide as its contents, and the height is minimal. Setting this to `true`
+  /// ensures that the dropdown's underline and items align properly within
+  /// its container.
   final bool isExpanded;
 
   /// If null, then the menu item heights will vary according to each menu item's

--- a/packages/material_ui/lib/src/dropdown.dart
+++ b/packages/material_ui/lib/src/dropdown.dart
@@ -1034,7 +1034,6 @@ class DropdownButton<T> extends StatefulWidget {
     this.barrierDismissible = true,
     this.mouseCursor,
     this.dropdownMenuItemMouseCursor,
-    this.isVerticallyExpanded = true,
     // When adding new arguments, consider adding similar arguments to
     // DropdownButtonFormField.
   }) : assert(
@@ -1051,6 +1050,7 @@ class DropdownButton<T> extends StatefulWidget {
          'with the same value',
        ),
        assert(itemHeight == null || itemHeight >= kMinInteractiveDimension),
+       isVerticallyExpanded = true,
        _inputDecoration = null,
        _isEmpty = false;
 

--- a/packages/material_ui/lib/src/dropdown.dart
+++ b/packages/material_ui/lib/src/dropdown.dart
@@ -1796,9 +1796,7 @@ class _DropdownButtonState<T> extends State<DropdownButton<T>> with WidgetsBindi
               isFocused: _hasPrimaryFocus,
               isHovering: _isHovering,
               expands: widget.isVerticallyExpanded,
-              child: widget.padding == null
-                  ? result
-                  : Padding(padding: widget.padding!, child: result),
+              child: _buildAlignedChild(result),
             ),
           ),
         ),
@@ -1813,25 +1811,33 @@ class _DropdownButtonState<T> extends State<DropdownButton<T>> with WidgetsBindi
         autofocus: widget.autofocus,
         focusColor: widget.focusColor ?? Theme.of(context).focusColor,
         enableFeedback: false,
-        child: widget.padding == null ? result : Padding(padding: widget.padding!, child: result),
+        child: _buildAlignedChild(result),
       );
     }
 
     final bool childHasButtonSemantic =
         hintIndex != null || (_selectedIndex != null && widget.selectedItemBuilder == null);
 
-    // When not vertically expanded, force the widget to its default height
-    // using heightFactor: 1.0. This prevents the item from expanding
-    // to fill the parent's available vertical space.
-    if (!widget.isVerticallyExpanded) {
-      result = Align(alignment: Alignment.topCenter, heightFactor: 1.0, child: result);
-    }
-
     return Semantics(
       button: !childHasButtonSemantic,
       expanded: _isMenuExpanded,
       child: Actions(actions: _actionMap, child: result),
     );
+  }
+
+  Widget _buildAlignedChild(Widget result) {
+    Widget child = widget.padding == null
+        ? result
+        : Padding(padding: widget.padding!, child: result);
+
+    // When not vertically expanded, force the widget to its default height
+    // using heightFactor: 1.0. This prevents the item from expanding
+    // to fill the parent's available vertical space.
+    if (!widget.isVerticallyExpanded) {
+      child = Align(alignment: Alignment.topCenter, heightFactor: 1.0, child: child);
+    }
+
+    return child;
   }
 }
 

--- a/packages/material_ui/lib/src/dropdown.dart
+++ b/packages/material_ui/lib/src/dropdown.dart
@@ -1807,7 +1807,7 @@ class _DropdownButtonState<T> extends State<DropdownButton<T>> with WidgetsBindi
       // to prevent the widget from stretching to fill the parent's
       // available height.
       if (!widget.isVerticallyExpanded) {
-        result = Align(alignment: Alignment.topCenter, heightFactor: 1.0, child: result);
+        result = Align(alignment: AlignmentDirectional.topStart, heightFactor: 1.0, child: result);
       }
     } else {
       result = InkWell(

--- a/packages/material_ui/lib/src/dropdown.dart
+++ b/packages/material_ui/lib/src/dropdown.dart
@@ -1258,6 +1258,10 @@ class DropdownButton<T> extends StatefulWidget {
   /// By default this button's inner width is the minimum size of its contents.
   /// If [isExpanded] is true, the inner width is expanded to fill its
   /// surrounding container.
+  /// See also:
+  ///
+  ///  * [DropdownButton.isVerticallyExpanded], which expands the inner height of the
+  ///    dropdown to fill the available vertical space.
   final bool isExpanded;
 
   /// If null, then the menu item heights will vary according to each menu item's

--- a/packages/material_ui/lib/src/dropdown.dart
+++ b/packages/material_ui/lib/src/dropdown.dart
@@ -1034,7 +1034,7 @@ class DropdownButton<T> extends StatefulWidget {
     this.barrierDismissible = true,
     this.mouseCursor,
     this.dropdownMenuItemMouseCursor,
-    this.isVerticallyExpanded = true,
+    this.isVerticallyExpanded = false,
     // When adding new arguments, consider adding similar arguments to
     // DropdownButtonFormField.
   }) : assert(
@@ -1821,11 +1821,16 @@ class _DropdownButtonState<T> extends State<DropdownButton<T>> with WidgetsBindi
     final bool childHasButtonSemantic =
         hintIndex != null || (_selectedIndex != null && widget.selectedItemBuilder == null);
 
-    // When not vertically expanded, force the widget to its default height
-    // using heightFactor: 1.0. This prevents the item from expanding
-    // to fill the parent's available vertical space.
+    // When vertical expansion is disabled, wrap with UnconstrainedBox
+    // to prevent the widget from stretching to fill the parent's
+    // available height. Only the horizontal axis remains constrained,
+    // preserving the width defined by the parent.
     if (!widget.isVerticallyExpanded) {
-      result = Align(alignment: Alignment.topCenter, heightFactor: 1.0, child: result);
+      result = UnconstrainedBox(
+        constrainedAxis: Axis.horizontal, // Keep width constrained by parent
+        alignment: Alignment.topCenter,
+        child: result,
+      );
     }
 
     return Semantics(

--- a/packages/material_ui/lib/src/dropdown.dart
+++ b/packages/material_ui/lib/src/dropdown.dart
@@ -1034,7 +1034,7 @@ class DropdownButton<T> extends StatefulWidget {
     this.barrierDismissible = true,
     this.mouseCursor,
     this.dropdownMenuItemMouseCursor,
-    this.isVerticallyExpanded = false,
+    this.isVerticallyExpanded = true,
     // When adding new arguments, consider adding similar arguments to
     // DropdownButtonFormField.
   }) : assert(
@@ -1821,10 +1821,10 @@ class _DropdownButtonState<T> extends State<DropdownButton<T>> with WidgetsBindi
     final bool childHasButtonSemantic =
         hintIndex != null || (_selectedIndex != null && widget.selectedItemBuilder == null);
 
-    // When vertical expansion is disabled, wrap with UnconstrainedBox
-    // to prevent the widget from stretching to fill the parent's
-    // available height. Only the horizontal axis remains constrained,
-    // preserving the width defined by the parent.
+    // // When vertical expansion is disabled, wrap with UnconstrainedBox
+    // // to prevent the widget from stretching to fill the parent's
+    // // available height. Only the horizontal axis remains constrained,
+    // // preserving the width defined by the parent.
     if (!widget.isVerticallyExpanded) {
       result = UnconstrainedBox(
         constrainedAxis: Axis.horizontal, // Keep width constrained by parent

--- a/packages/material_ui/lib/src/dropdown.dart
+++ b/packages/material_ui/lib/src/dropdown.dart
@@ -1754,10 +1754,21 @@ class _DropdownButtonState<T> extends State<DropdownButton<T>> with WidgetsBindi
           minWidth: widget.iconSize + suffixIconEndMargin,
           minHeight: widget.iconSize,
         ),
+
         // suffixIconGap: 0.0,
-        suffixIcon: Padding(
-          padding: EdgeInsetsGeometry.directional(end: suffixIconEndMargin),
-          child: effectiveSuffixIcon,
+        // InputDecorator does not expose vertical alignment for suffixIcon.
+        // Padding is the only stable way to force top alignment when expanded.
+        suffixIcon: LayoutBuilder(
+          builder: (context, constraints) {
+            final double bottomOffset = widget.isVerticallyExpanded
+                ? (constraints.maxHeight - widget.iconSize).clamp(0, constraints.maxHeight)
+                : 0;
+
+            return Padding(
+              padding: EdgeInsetsDirectional.only(bottom: bottomOffset, end: suffixIconEndMargin),
+              child: effectiveSuffixIcon,
+            );
+          },
         ),
       );
       if (_hasPrimaryFocus) {
@@ -1796,7 +1807,9 @@ class _DropdownButtonState<T> extends State<DropdownButton<T>> with WidgetsBindi
               isFocused: _hasPrimaryFocus,
               isHovering: _isHovering,
               expands: widget.isVerticallyExpanded,
-              child: _buildAlignedChild(result),
+              child: widget.padding == null
+                  ? result
+                  : Padding(padding: widget.padding!, child: result),
             ),
           ),
         ),
@@ -1811,33 +1824,25 @@ class _DropdownButtonState<T> extends State<DropdownButton<T>> with WidgetsBindi
         autofocus: widget.autofocus,
         focusColor: widget.focusColor ?? Theme.of(context).focusColor,
         enableFeedback: false,
-        child: _buildAlignedChild(result),
+        child: widget.padding == null ? result : Padding(padding: widget.padding!, child: result),
       );
     }
 
     final bool childHasButtonSemantic =
         hintIndex != null || (_selectedIndex != null && widget.selectedItemBuilder == null);
 
+    // When not vertically expanded, force the widget to its default height
+    // using heightFactor: 1.0. This prevents the item from expanding
+    // to fill the parent's available vertical space.
+    if (!widget.isVerticallyExpanded) {
+      result = Align(alignment: Alignment.topCenter, heightFactor: 1.0, child: result);
+    }
+
     return Semantics(
       button: !childHasButtonSemantic,
       expanded: _isMenuExpanded,
       child: Actions(actions: _actionMap, child: result),
     );
-  }
-
-  Widget _buildAlignedChild(Widget result) {
-    Widget child = widget.padding == null
-        ? result
-        : Padding(padding: widget.padding!, child: result);
-
-    // When not vertically expanded, force the widget to its default height
-    // using heightFactor: 1.0. This prevents the item from expanding
-    // to fill the parent's available vertical space.
-    if (!widget.isVerticallyExpanded) {
-      child = Align(alignment: Alignment.topCenter, heightFactor: 1.0, child: child);
-    }
-
-    return child;
   }
 }
 

--- a/packages/material_ui/lib/src/dropdown.dart
+++ b/packages/material_ui/lib/src/dropdown.dart
@@ -1375,8 +1375,7 @@ class DropdownButton<T> extends StatefulWidget {
   /// container, ensuring that the underline and items align properly within
   /// the allocated space.
   ///
-  /// Defaults to true for [DropdownButton] to maintain its standard behavior,
-  /// and false for [DropdownButtonFormField] to ensure the input decorator
+  /// Defaults to false for [DropdownButtonFormField] to ensure the input decorator
   /// handles the vertical constraints correctly by default.
   ///
   /// See also:
@@ -1754,7 +1753,6 @@ class _DropdownButtonState<T> extends State<DropdownButton<T>> with WidgetsBindi
           minWidth: widget.iconSize + suffixIconEndMargin,
           minHeight: widget.iconSize,
         ),
-
         // suffixIconGap: 0.0,
         suffixIcon: Padding(
           padding: EdgeInsetsGeometry.directional(end: suffixIconEndMargin),
@@ -1821,10 +1819,10 @@ class _DropdownButtonState<T> extends State<DropdownButton<T>> with WidgetsBindi
     final bool childHasButtonSemantic =
         hintIndex != null || (_selectedIndex != null && widget.selectedItemBuilder == null);
 
-    // // When vertical expansion is disabled, wrap with UnconstrainedBox
-    // // to prevent the widget from stretching to fill the parent's
-    // // available height. Only the horizontal axis remains constrained,
-    // // preserving the width defined by the parent.
+    // When vertical expansion is disabled, wrap with UnconstrainedBox
+    // to prevent the widget from stretching to fill the parent's
+    // available height. Only the horizontal axis remains constrained,
+    // preserving the width defined by the parent.
     if (!widget.isVerticallyExpanded) {
       result = UnconstrainedBox(
         constrainedAxis: Axis.horizontal, // Keep width constrained by parent

--- a/packages/material_ui/lib/src/dropdown.dart
+++ b/packages/material_ui/lib/src/dropdown.dart
@@ -1772,6 +1772,7 @@ class _DropdownButtonState<T> extends State<DropdownButton<T>> with WidgetsBindi
               isEmpty: widget._isEmpty,
               isFocused: _hasPrimaryFocus,
               isHovering: _isHovering,
+              expands: widget.isExpanded,
               child: widget.padding == null
                   ? result
                   : Padding(padding: widget.padding!, child: result),

--- a/packages/material_ui/pending_changelogs/change_2026_08_25_1787659013745.yaml
+++ b/packages/material_ui/pending_changelogs/change_2026_08_25_1787659013745.yaml
@@ -1,0 +1,3 @@
+changelog: |
+  - Fix DropdownButtonFormField underline alignment at bottom.
+version: patch

--- a/packages/material_ui/test/dropdown_form_field_test.dart
+++ b/packages/material_ui/test/dropdown_form_field_test.dart
@@ -1056,7 +1056,12 @@ void main() {
     expect(find.text(currentValue), findsOneWidget);
 
     // Tap the DropdownButtonFormField widget
-    await tester.tap(find.byType(DropdownButton<String>));
+    await tester.tap(
+      find.descendant(
+        of: find.byType(DropdownButton<String>),
+        matching: find.byType(GestureDetector),
+      ),
+    );
     await tester.pumpAndSettle();
 
     // Tap the first dropdown menu item.

--- a/packages/material_ui/test/dropdown_form_field_test.dart
+++ b/packages/material_ui/test/dropdown_form_field_test.dart
@@ -1056,12 +1056,7 @@ void main() {
     expect(find.text(currentValue), findsOneWidget);
 
     // Tap the DropdownButtonFormField widget
-    await tester.tap(
-      find.descendant(
-        of: find.byType(DropdownButton<String>),
-        matching: find.byType(GestureDetector),
-      ),
-    );
+    await tester.tap(find.text(currentValue));
     await tester.pumpAndSettle();
 
     // Tap the first dropdown menu item.

--- a/packages/material_ui/test/dropdown_test.dart
+++ b/packages/material_ui/test/dropdown_test.dart
@@ -3970,7 +3970,6 @@ void main() {
         home: Material(
           child: DropdownButton<String>(
             key: menuKey,
-            isVerticallyExpanded: true,
             onChanged: (String? value) {},
             items: const <DropdownMenuItem<String>>[
               DropdownMenuItem<String>(
@@ -4094,7 +4093,6 @@ void main() {
           child: DropdownButton<String>(
             key: menuKey,
             mouseCursor: SystemMouseCursors.cell,
-            isVerticallyExpanded: true,
             dropdownMenuItemMouseCursor: SystemMouseCursors.grab,
             onChanged: (String? newValue) {},
             items: const <DropdownMenuItem<String>>[
@@ -4132,7 +4130,6 @@ void main() {
           child: DropdownButton<String>(
             key: menuKey,
             dropdownMenuItemMouseCursor: SystemMouseCursors.grab,
-            isVerticallyExpanded: true,
             onChanged: (String? newValue) {},
             items: const <DropdownMenuItem<String>>[
               DropdownMenuItem<String>(key: itemKey, value: 'One', child: Text('One')),

--- a/packages/material_ui/test/dropdown_test.dart
+++ b/packages/material_ui/test/dropdown_test.dart
@@ -4980,6 +4980,7 @@ void main() {
             height: containerHeight,
             child: DropdownButtonFormField<int>(
               isExpanded: true,
+              isVerticallyExpanded: true,
               items: const [DropdownMenuItem(value: 1, child: Text('Option 1'))],
               onChanged: (_) {},
             ),

--- a/packages/material_ui/test/dropdown_test.dart
+++ b/packages/material_ui/test/dropdown_test.dart
@@ -3970,6 +3970,7 @@ void main() {
         home: Material(
           child: DropdownButton<String>(
             key: menuKey,
+            isVerticallyExpanded: true,
             onChanged: (String? value) {},
             items: const <DropdownMenuItem<String>>[
               DropdownMenuItem<String>(
@@ -4093,6 +4094,7 @@ void main() {
           child: DropdownButton<String>(
             key: menuKey,
             mouseCursor: SystemMouseCursors.cell,
+            isVerticallyExpanded: true,
             dropdownMenuItemMouseCursor: SystemMouseCursors.grab,
             onChanged: (String? newValue) {},
             items: const <DropdownMenuItem<String>>[
@@ -4130,6 +4132,7 @@ void main() {
           child: DropdownButton<String>(
             key: menuKey,
             dropdownMenuItemMouseCursor: SystemMouseCursors.grab,
+            isVerticallyExpanded: true,
             onChanged: (String? newValue) {},
             items: const <DropdownMenuItem<String>>[
               DropdownMenuItem<String>(key: itemKey, value: 'One', child: Text('One')),

--- a/packages/material_ui/test/dropdown_test.dart
+++ b/packages/material_ui/test/dropdown_test.dart
@@ -4968,6 +4968,40 @@ void main() {
     );
   });
 
+  testWidgets('DropdownButtonFormField underline is at the bottom of the expanded height', (
+    WidgetTester tester,
+  ) async {
+    const containerHeight = 200.0;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: SizedBox(
+            height: containerHeight,
+            child: DropdownButtonFormField<int>(
+              isExpanded: true,
+              items: const [DropdownMenuItem(value: 1, child: Text('Option 1'))],
+              onChanged: (_) {},
+            ),
+          ),
+        ),
+      ),
+    );
+
+    final Finder decorator = find.byType(InputDecorator);
+
+    final RenderBox box = tester.renderObject(decorator);
+    final double width = box.size.width;
+
+    expect(
+      decorator,
+      paints..line(
+        p1: const Offset(0, containerHeight - 0.5),
+        p2: Offset(width, containerHeight - 0.5),
+      ),
+    );
+  });
+
   testWidgets(
     'DropdownButtonFormField asserts when both errorBuilder and decoration.errorText are provided',
     (WidgetTester tester) async {


### PR DESCRIPTION
This PR fixes the visual issue where the underline of a `DropdownButtonFormField` did not align at the bottom of its expanded container.

Fixes flutter/flutter#162350

Port of https://github.com/flutter/flutter/pull/181040.

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under[^1].
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[the version and CHANGELOG instructions]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version-and-changelog-updates
[semantic versioning]: https://dart.dev/tools/pub/versioning#semantic-versions
[repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
