### PR TITLE
[material_ui] Support custom date input formatters via CalendarDelegate

### DIFF
--- a/packages/material_ui/example/lib/date_picker/show_date_picker.2.dart
+++ b/packages/material_ui/example/lib/date_picker/show_date_picker.2.dart
@@ -1,0 +1,236 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+/// Flutter code sample showing how to use [showDatePicker] with a custom
+/// [DateInputCalendarDelegate] to support configurable text input formats.
+
+void main() => runApp(const DatePickerSampleApp());
+
+class DatePickerSampleApp extends StatelessWidget {
+  const DatePickerSampleApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const MaterialApp(home: DatePickerSample());
+  }
+}
+
+class DatePickerSample extends StatefulWidget {
+  const DatePickerSample({super.key});
+
+  @override
+  State<DatePickerSample> createState() => _DatePickerSampleState();
+}
+
+class _DatePickerSampleState extends State<DatePickerSample> {
+  DateTime? _selectedDate;
+
+  DateInputFormat _formatType = DateInputFormat.dayMonthYear;
+  DateSeparator _separator = DateSeparator.dot;
+
+  Future<void> _showPicker() async {
+    final DateTime? result = await showDatePicker(
+      context: context,
+      initialDate: _selectedDate ?? DateTime(2021, 7, 25),
+      firstDate: DateTime(2021),
+      lastDate: DateTime(2999, 7, 25),
+      initialEntryMode: DatePickerEntryMode.input,
+      calendarDelegate: ConfigurableDateDelegate(formatType: _formatType, separator: _separator),
+    );
+
+    if (result != null) {
+      setState(() {
+        _selectedDate = result;
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final String label = _selectedDate == null
+        ? 'No date selected'
+        : DateInputFormatter(formatType: _formatType, separator: _separator.value).format(_selectedDate!);
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('showDatePicker with input delegate')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: <Widget>[
+            Text(label),
+            const SizedBox(height: 24),
+            DropdownButtonFormField<DateInputFormat>(
+              initialValue: _formatType,
+              decoration: const InputDecoration(labelText: 'Date format'),
+              items: DateInputFormat.values
+                  .map((DateInputFormat format) => DropdownMenuItem(value: format, child: Text(format.patternLabel)))
+                  .toList(),
+              onChanged: (DateInputFormat? value) {
+                if (value != null) {
+                  setState(() => _formatType = value);
+                }
+              },
+            ),
+            const SizedBox(height: 16),
+            DropdownButtonFormField<DateSeparator>(
+              initialValue: _separator,
+              decoration: const InputDecoration(labelText: 'Separator'),
+              items: DateSeparator.values
+                  .map((DateSeparator sep) => DropdownMenuItem(value: sep, child: Text(sep.value)))
+                  .toList(),
+              onChanged: (DateSeparator? value) {
+                if (value != null) {
+                  setState(() => _separator = value);
+                }
+              },
+            ),
+
+            const SizedBox(height: 24),
+
+            OutlinedButton(onPressed: _showPicker, child: const Text('Select date')),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+enum DateInputFormat {
+  dayMonthYear(fieldLengths: [2, 2, 4], patternLabel: 'dd/mm/yyyy'),
+  monthDayYear(fieldLengths: [2, 2, 4], patternLabel: 'mm/dd/yyyy'),
+  yearMonthDay(fieldLengths: [4, 2, 2], patternLabel: 'yyyy/mm/dd');
+
+  const DateInputFormat({required this.fieldLengths, required this.patternLabel});
+
+  final List<int> fieldLengths;
+  final String patternLabel;
+
+  String pattern(String separator) => patternLabel.replaceAll('/', separator);
+}
+
+enum DateSeparator {
+  slash('/'),
+  dash('-'),
+  dot('.');
+
+  const DateSeparator(this.value);
+  final String value;
+}
+
+class DateInputFormatter extends TextInputFormatter {
+  const DateInputFormatter({required this.formatType, required this.separator});
+
+  final DateInputFormat formatType;
+  final String separator;
+
+  String get pattern => formatType.pattern(separator);
+
+  String format(DateTime date) {
+    final String day = date.day.toString().padLeft(2, '0');
+    final String month = date.month.toString().padLeft(2, '0');
+    final String year = date.year.toString().padLeft(4, '0');
+
+    return switch (formatType) {
+      DateInputFormat.dayMonthYear => '$day$separator$month$separator$year',
+      DateInputFormat.monthDayYear => '$month$separator$day$separator$year',
+      DateInputFormat.yearMonthDay => '$year$separator$month$separator$day',
+    };
+  }
+
+  DateTime? parse(String? input) {
+    if (input == null || input.isEmpty) {
+      return null;
+    }
+
+    final List<String> parts = input.split(separator);
+    if (parts.length != 3) {
+      return null;
+    }
+
+    final (String d, String m, String y) = switch (formatType) {
+      DateInputFormat.dayMonthYear => (parts[0], parts[1], parts[2]),
+      DateInputFormat.monthDayYear => (parts[1], parts[0], parts[2]),
+      DateInputFormat.yearMonthDay => (parts[2], parts[1], parts[0]),
+    };
+
+    final int? day = int.tryParse(d);
+    final int? month = int.tryParse(m);
+    final int? year = int.tryParse(y);
+
+    if (day == null || month == null || year == null) {
+      return null;
+    }
+    if (month < 1 || month > 12 || day < 1) {
+      return null;
+    }
+
+    final int lastDayOfMonth = DateTime(year, month + 1, 0).day;
+    if (day > lastDayOfMonth) {
+      return null;
+    }
+
+    return DateTime(year, month, day);
+  }
+
+  @override
+  TextEditingValue formatEditUpdate(TextEditingValue oldValue, TextEditingValue newValue) {
+    final String digits = newValue.text.replaceAll(RegExp(r'\D'), '');
+    final int maxLength = formatType.fieldLengths.fold<int>(0, (int a, int b) => a + b);
+
+    if (digits.length > maxLength) {
+      return oldValue;
+    }
+
+    final String formatted = _applyMask(digits);
+    return TextEditingValue(
+      text: formatted,
+      selection: TextSelection.collapsed(offset: formatted.length),
+    );
+  }
+
+  String _applyMask(String digits) {
+    final StringBuffer buffer = StringBuffer();
+    int offset = 0;
+
+    for (int i = 0; i < formatType.fieldLengths.length && offset < digits.length; i++) {
+      final int len = formatType.fieldLengths[i];
+      final int end = (offset + len).clamp(0, digits.length);
+      buffer.write(digits.substring(offset, end));
+      offset = end;
+
+      if (offset < digits.length && i < formatType.fieldLengths.length - 1) {
+        buffer.write(separator);
+      }
+    }
+    return buffer.toString();
+  }
+}
+
+class ConfigurableDateDelegate extends DateInputCalendarDelegate {
+  const ConfigurableDateDelegate({required this.formatType, this.separator = DateSeparator.slash});
+
+  final DateInputFormat formatType;
+  final DateSeparator separator;
+
+  DateInputFormatter get _formatter => DateInputFormatter(formatType: formatType, separator: separator.value);
+
+  @override
+  List<TextInputFormatter> get inputFormatters => <TextInputFormatter>[
+    FilteringTextInputFormatter.digitsOnly,
+    _formatter,
+  ];
+
+  @override
+  String dateHelpText(MaterialLocalizations localizations) => _formatter.pattern;
+
+  @override
+  String formatCompactDate(DateTime date, MaterialLocalizations localizations) => _formatter.format(date);
+
+  @override
+  DateTime? parseCompactDate(String? inputString, MaterialLocalizations localizations) => _formatter.parse(inputString);
+}

--- a/packages/material_ui/example/lib/date_picker/show_date_picker.2.dart
+++ b/packages/material_ui/example/lib/date_picker/show_date_picker.2.dart
@@ -103,9 +103,7 @@ class _DatePickerSampleState extends State<DatePickerSample> {
                 }
               },
             ),
-
             const SizedBox(height: 24),
-
             OutlinedButton(
               onPressed: _showPicker,
               child: const Text('Select date'),
@@ -142,6 +140,23 @@ enum DateSeparator {
   final String value;
 }
 
+/// A [TextInputFormatter] used by the input mode of [showDatePicker] to
+/// format and validate date text according to a specific [DateInputFormat].
+///
+/// This formatter is intended to be used when [DatePickerEntryMode.input]
+/// is enabled, ensuring that the manual date entry matches the same format
+/// expected by the picker.
+///
+/// It:
+/// - Restricts input to digits and automatically inserts the configured
+///   [separator].
+/// - Enforces the field order defined by [DateInputFormat]
+///   (e.g. day–month–year, month–day–year, year–month–day).
+/// - Provides utilities to format a [DateTime] into a string and to parse
+///   user input back into a [DateTime], returning `null` for invalid values.
+///
+/// This formatter is typically wired through a custom calendar delegate,
+/// such as [ConfigurableDateDelegate], rather than being attached directly.
 class DateInputFormatter extends TextInputFormatter {
   const DateInputFormatter({required this.formatType, required this.separator});
 
@@ -155,11 +170,13 @@ class DateInputFormatter extends TextInputFormatter {
     final String month = date.month.toString().padLeft(2, '0');
     final String year = date.year.toString().padLeft(4, '0');
 
-    return switch (formatType) {
-      DateInputFormat.dayMonthYear => '$day$separator$month$separator$year',
-      DateInputFormat.monthDayYear => '$month$separator$day$separator$year',
-      DateInputFormat.yearMonthDay => '$year$separator$month$separator$day',
+    final components = switch (formatType) {
+      DateInputFormat.dayMonthYear => [day, month, year],
+      DateInputFormat.monthDayYear => [month, day, year],
+      DateInputFormat.yearMonthDay => [year, month, day],
     };
+
+    return components.join(separator);
   }
 
   DateTime? parse(String? input) {

--- a/packages/material_ui/example/lib/date_picker/show_date_picker.2.dart
+++ b/packages/material_ui/example/lib/date_picker/show_date_picker.2.dart
@@ -39,7 +39,10 @@ class _DatePickerSampleState extends State<DatePickerSample> {
       firstDate: DateTime(2021),
       lastDate: DateTime(2999, 7, 25),
       initialEntryMode: DatePickerEntryMode.input,
-      calendarDelegate: ConfigurableDateDelegate(formatType: _formatType, separator: _separator),
+      calendarDelegate: ConfigurableDateDelegate(
+        formatType: _formatType,
+        separator: _separator,
+      ),
     );
 
     if (result != null) {
@@ -53,7 +56,10 @@ class _DatePickerSampleState extends State<DatePickerSample> {
   Widget build(BuildContext context) {
     final String label = _selectedDate == null
         ? 'No date selected'
-        : DateInputFormatter(formatType: _formatType, separator: _separator.value).format(_selectedDate!);
+        : DateInputFormatter(
+            formatType: _formatType,
+            separator: _separator.value,
+          ).format(_selectedDate!);
 
     return Scaffold(
       appBar: AppBar(title: const Text('showDatePicker with input delegate')),
@@ -68,7 +74,12 @@ class _DatePickerSampleState extends State<DatePickerSample> {
               initialValue: _formatType,
               decoration: const InputDecoration(labelText: 'Date format'),
               items: DateInputFormat.values
-                  .map((DateInputFormat format) => DropdownMenuItem(value: format, child: Text(format.patternLabel)))
+                  .map(
+                    (DateInputFormat format) => DropdownMenuItem(
+                      value: format,
+                      child: Text(format.patternLabel),
+                    ),
+                  )
                   .toList(),
               onChanged: (DateInputFormat? value) {
                 if (value != null) {
@@ -81,7 +92,10 @@ class _DatePickerSampleState extends State<DatePickerSample> {
               initialValue: _separator,
               decoration: const InputDecoration(labelText: 'Separator'),
               items: DateSeparator.values
-                  .map((DateSeparator sep) => DropdownMenuItem(value: sep, child: Text(sep.value)))
+                  .map(
+                    (DateSeparator sep) =>
+                        DropdownMenuItem(value: sep, child: Text(sep.value)),
+                  )
                   .toList(),
               onChanged: (DateSeparator? value) {
                 if (value != null) {
@@ -92,7 +106,10 @@ class _DatePickerSampleState extends State<DatePickerSample> {
 
             const SizedBox(height: 24),
 
-            OutlinedButton(onPressed: _showPicker, child: const Text('Select date')),
+            OutlinedButton(
+              onPressed: _showPicker,
+              child: const Text('Select date'),
+            ),
           ],
         ),
       ),
@@ -105,7 +122,10 @@ enum DateInputFormat {
   monthDayYear(fieldLengths: [2, 2, 4], patternLabel: 'mm/dd/yyyy'),
   yearMonthDay(fieldLengths: [4, 2, 2], patternLabel: 'yyyy/mm/dd');
 
-  const DateInputFormat({required this.fieldLengths, required this.patternLabel});
+  const DateInputFormat({
+    required this.fieldLengths,
+    required this.patternLabel,
+  });
 
   final List<int> fieldLengths;
   final String patternLabel;
@@ -178,9 +198,15 @@ class DateInputFormatter extends TextInputFormatter {
   }
 
   @override
-  TextEditingValue formatEditUpdate(TextEditingValue oldValue, TextEditingValue newValue) {
+  TextEditingValue formatEditUpdate(
+    TextEditingValue oldValue,
+    TextEditingValue newValue,
+  ) {
     final String digits = newValue.text.replaceAll(RegExp(r'\D'), '');
-    final int maxLength = formatType.fieldLengths.fold<int>(0, (int a, int b) => a + b);
+    final int maxLength = formatType.fieldLengths.fold<int>(
+      0,
+      (int a, int b) => a + b,
+    );
 
     if (digits.length > maxLength) {
       return oldValue;
@@ -197,7 +223,11 @@ class DateInputFormatter extends TextInputFormatter {
     final StringBuffer buffer = StringBuffer();
     int offset = 0;
 
-    for (int i = 0; i < formatType.fieldLengths.length && offset < digits.length; i++) {
+    for (
+      int i = 0;
+      i < formatType.fieldLengths.length && offset < digits.length;
+      i++
+    ) {
       final int len = formatType.fieldLengths[i];
       final int end = (offset + len).clamp(0, digits.length);
       buffer.write(digits.substring(offset, end));
@@ -212,12 +242,16 @@ class DateInputFormatter extends TextInputFormatter {
 }
 
 class ConfigurableDateDelegate extends DateInputCalendarDelegate {
-  const ConfigurableDateDelegate({required this.formatType, this.separator = DateSeparator.slash});
+  const ConfigurableDateDelegate({
+    required this.formatType,
+    this.separator = DateSeparator.slash,
+  });
 
   final DateInputFormat formatType;
   final DateSeparator separator;
 
-  DateInputFormatter get _formatter => DateInputFormatter(formatType: formatType, separator: separator.value);
+  DateInputFormatter get _formatter =>
+      DateInputFormatter(formatType: formatType, separator: separator.value);
 
   @override
   List<TextInputFormatter> get inputFormatters => <TextInputFormatter>[
@@ -226,11 +260,18 @@ class ConfigurableDateDelegate extends DateInputCalendarDelegate {
   ];
 
   @override
-  String dateHelpText(MaterialLocalizations localizations) => _formatter.pattern;
+  String dateHelpText(MaterialLocalizations localizations) =>
+      _formatter.pattern;
 
   @override
-  String formatCompactDate(DateTime date, MaterialLocalizations localizations) => _formatter.format(date);
+  String formatCompactDate(
+    DateTime date,
+    MaterialLocalizations localizations,
+  ) => _formatter.format(date);
 
   @override
-  DateTime? parseCompactDate(String? inputString, MaterialLocalizations localizations) => _formatter.parse(inputString);
+  DateTime? parseCompactDate(
+    String? inputString,
+    MaterialLocalizations localizations,
+  ) => _formatter.parse(inputString);
 }

--- a/packages/material_ui/example/lib/date_picker/show_date_picker.2.dart
+++ b/packages/material_ui/example/lib/date_picker/show_date_picker.2.dart
@@ -6,7 +6,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
 /// Flutter code sample showing how to use [showDatePicker] with a custom
-/// [DateInputCalendarDelegate] to support configurable text input formats.
+/// [DateInputGregorianCalendarDelegate] to support configurable text input formats.
 
 void main() => runApp(const DatePickerSampleApp());
 
@@ -258,7 +258,7 @@ class DateInputFormatter extends TextInputFormatter {
   }
 }
 
-class ConfigurableDateDelegate extends DateInputCalendarDelegate {
+class ConfigurableDateDelegate extends DateInputGregorianCalendarDelegate {
   const ConfigurableDateDelegate({
     required this.formatType,
     this.separator = DateSeparator.slash,

--- a/packages/material_ui/example/lib/date_picker/show_date_picker.2.dart
+++ b/packages/material_ui/example/lib/date_picker/show_date_picker.2.dart
@@ -257,7 +257,7 @@ class DateInputFormatter extends TextInputFormatter {
   }
 }
 
-class CustomDateInputDelegate extends DateInputDelegate {
+final class CustomDateInputDelegate extends DateInputDelegate {
   const CustomDateInputDelegate({
     required this.formatType,
     required this.separator,

--- a/packages/material_ui/example/lib/date_picker/show_date_picker.2.dart
+++ b/packages/material_ui/example/lib/date_picker/show_date_picker.2.dart
@@ -33,10 +33,8 @@ class _DatePickerSampleState extends State<DatePickerSample> {
   DateSeparator _separator = DateSeparator.dot;
 
   Future<void> _showPicker() async {
-    final DateInputDelegate dateInputDelegate = CustomDateInputDelegate(
-      formatType: _formatType,
-      separator: _separator,
-    );
+    final CustomDateInputDelegate customDateInputDelegate =
+        CustomDateInputDelegate(formatType: _formatType, separator: _separator);
 
     final DateTime? result = await showDatePicker(
       context: context,
@@ -44,7 +42,8 @@ class _DatePickerSampleState extends State<DatePickerSample> {
       firstDate: DateTime(2021),
       lastDate: DateTime(2999, 7, 25),
       initialEntryMode: DatePickerEntryMode.input,
-      dateInputDelegate: dateInputDelegate,
+      calendarDelegate: customDateInputDelegate,
+      inputFormatters: customDateInputDelegate.inputFormatters,
     );
 
     if (result != null) {
@@ -257,7 +256,7 @@ class DateInputFormatter extends TextInputFormatter {
   }
 }
 
-final class CustomDateInputDelegate extends DateInputDelegate {
+final class CustomDateInputDelegate extends GregorianCalendarDelegate {
   const CustomDateInputDelegate({
     required this.formatType,
     required this.separator,
@@ -269,20 +268,24 @@ final class CustomDateInputDelegate extends DateInputDelegate {
   DateInputFormatter get _formatter =>
       DateInputFormatter(formatType: formatType, separator: separator.value);
 
-  @override
   List<TextInputFormatter> get inputFormatters => <TextInputFormatter>[
     FilteringTextInputFormatter.digitsOnly,
     _formatter,
   ];
 
   @override
-  String helpText(MaterialLocalizations localizations) => _formatter.pattern;
+  String dateHelpText(MaterialLocalizations localizations) =>
+      _formatter.pattern;
 
   @override
-  String format(DateTime date, MaterialLocalizations localizations) =>
-      _formatter.format(date);
+  String formatCompactDate(
+    DateTime date,
+    MaterialLocalizations localizations,
+  ) => _formatter.format(date);
 
   @override
-  DateTime? parse(String? input, MaterialLocalizations localizations) =>
-      _formatter.parse(input);
+  DateTime? parseCompactDate(
+    String? inputString,
+    MaterialLocalizations localizations,
+  ) => _formatter.parse(inputString);
 }

--- a/packages/material_ui/example/lib/date_picker/show_date_picker.2.dart
+++ b/packages/material_ui/example/lib/date_picker/show_date_picker.2.dart
@@ -30,8 +30,8 @@ class DatePickerSample extends StatefulWidget {
 class _DatePickerSampleState extends State<DatePickerSample> {
   DateTime? _selectedDate;
 
-  DateInputFormat _formatType = DateInputFormat.dayMonthYear;
-  DateSeparator _separator = DateSeparator.dot;
+  DateInputFormat _formatType = .dayMonthYear;
+  DateSeparator _separator = .dot;
 
   Future<void> _showPicker() async {
     final CustomDateInputDelegate customDateInputDelegate =
@@ -63,55 +63,45 @@ class _DatePickerSampleState extends State<DatePickerSample> {
             separator: _separator.value,
           ).format(_selectedDate!);
 
+    final content = <Widget>[
+      Text(label),
+      const SizedBox(height: 24),
+      DropdownButtonFormField<DateInputFormat>(
+        initialValue: _formatType,
+        decoration: const InputDecoration(labelText: 'Date format'),
+        items: [
+          for (final format in DateInputFormat.values)
+            DropdownMenuItem(value: format, child: Text(format.patternLabel)),
+        ],
+        onChanged: (DateInputFormat? value) {
+          if (value != null) {
+            setState(() => _formatType = value);
+          }
+        },
+      ),
+      const SizedBox(height: 16),
+      DropdownButtonFormField<DateSeparator>(
+        initialValue: _separator,
+        decoration: const InputDecoration(labelText: 'Separator'),
+        items: [
+          for (final separator in DateSeparator.values)
+            DropdownMenuItem(value: separator, child: Text(separator.value)),
+        ],
+        onChanged: (DateSeparator? value) {
+          if (value != null) {
+            setState(() => _separator = value);
+          }
+        },
+      ),
+      const SizedBox(height: 24),
+      OutlinedButton(onPressed: _showPicker, child: const Text('Select date')),
+    ];
+
     return Scaffold(
       appBar: AppBar(title: const Text('showDatePicker with input delegate')),
       body: Padding(
         padding: const EdgeInsets.all(16),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: <Widget>[
-            Text(label),
-            const SizedBox(height: 24),
-            DropdownButtonFormField<DateInputFormat>(
-              initialValue: _formatType,
-              decoration: const InputDecoration(labelText: 'Date format'),
-              items: DateInputFormat.values
-                  .map(
-                    (DateInputFormat format) => DropdownMenuItem(
-                      value: format,
-                      child: Text(format.patternLabel),
-                    ),
-                  )
-                  .toList(),
-              onChanged: (DateInputFormat? value) {
-                if (value != null) {
-                  setState(() => _formatType = value);
-                }
-              },
-            ),
-            const SizedBox(height: 16),
-            DropdownButtonFormField<DateSeparator>(
-              initialValue: _separator,
-              decoration: const InputDecoration(labelText: 'Separator'),
-              items: DateSeparator.values
-                  .map(
-                    (DateSeparator sep) =>
-                        DropdownMenuItem(value: sep, child: Text(sep.value)),
-                  )
-                  .toList(),
-              onChanged: (DateSeparator? value) {
-                if (value != null) {
-                  setState(() => _separator = value);
-                }
-              },
-            ),
-            const SizedBox(height: 24),
-            OutlinedButton(
-              onPressed: _showPicker,
-              child: const Text('Select date'),
-            ),
-          ],
-        ),
+        child: Column(mainAxisSize: MainAxisSize.min, children: content),
       ),
     );
   }

--- a/packages/material_ui/example/lib/date_picker/show_date_picker.2.dart
+++ b/packages/material_ui/example/lib/date_picker/show_date_picker.2.dart
@@ -209,21 +209,36 @@ class DateInputFormatter extends TextInputFormatter {
     TextEditingValue newValue,
   ) {
     final String digits = newValue.text.replaceAll(RegExp(r'\D'), '');
-    final int maxLength = formatType.fieldLengths.fold<int>(
-      0,
-      (int a, int b) => a + b,
-    );
+    final int maxLength = formatType.fieldLengths.fold<int>(0, (a, b) => a + b);
 
     if (digits.length > maxLength) {
       return oldValue;
     }
 
     final String formatted = _applyMask(digits);
+
+    int digitsBefore = _countDigits(
+      newValue.text.substring(0, newValue.selection.baseOffset),
+    );
+
+    final digitIndices = <int>[];
+    for (int i = 0; i < formatted.length; i++) {
+      if (RegExp(r'\d').hasMatch(formatted[i])) digitIndices.add(i);
+    }
+
+    int newOffset = digitsBefore == 0 ? 0 : digitIndices[digitsBefore - 1] + 1;
+
+    if (newOffset < formatted.length && formatted[newOffset] == separator) {
+      newOffset++;
+    }
+
     return TextEditingValue(
       text: formatted,
-      selection: TextSelection.collapsed(offset: formatted.length),
+      selection: TextSelection.collapsed(offset: newOffset),
     );
   }
+
+  int _countDigits(String text) => text.replaceAll(RegExp(r'\D'), '').length;
 
   String _applyMask(String digits) {
     final StringBuffer buffer = StringBuffer();

--- a/packages/material_ui/example/lib/date_picker/show_date_picker.2.dart
+++ b/packages/material_ui/example/lib/date_picker/show_date_picker.2.dart
@@ -6,7 +6,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
 /// Flutter code sample showing how to use [showDatePicker] with a custom
-/// [DateInputGregorianCalendarDelegate] to support configurable text input formats.
+/// [DateInputDelegate] to support configurable text input formats.
 
 void main() => runApp(const DatePickerSampleApp());
 
@@ -33,16 +33,18 @@ class _DatePickerSampleState extends State<DatePickerSample> {
   DateSeparator _separator = DateSeparator.dot;
 
   Future<void> _showPicker() async {
+    final DateInputDelegate dateInputDelegate = CustomDateInputDelegate(
+      formatType: _formatType,
+      separator: _separator,
+    );
+
     final DateTime? result = await showDatePicker(
       context: context,
       initialDate: _selectedDate ?? DateTime(2021, 7, 25),
       firstDate: DateTime(2021),
       lastDate: DateTime(2999, 7, 25),
       initialEntryMode: DatePickerEntryMode.input,
-      calendarDelegate: ConfigurableDateDelegate(
-        formatType: _formatType,
-        separator: _separator,
-      ),
+      dateInputDelegate: dateInputDelegate,
     );
 
     if (result != null) {
@@ -154,9 +156,6 @@ enum DateSeparator {
 ///   (e.g. day–month–year, month–day–year, year–month–day).
 /// - Provides utilities to format a [DateTime] into a string and to parse
 ///   user input back into a [DateTime], returning `null` for invalid values.
-///
-/// This formatter is typically wired through a custom calendar delegate,
-/// such as [ConfigurableDateDelegate], rather than being attached directly.
 class DateInputFormatter extends TextInputFormatter {
   const DateInputFormatter({required this.formatType, required this.separator});
 
@@ -258,10 +257,10 @@ class DateInputFormatter extends TextInputFormatter {
   }
 }
 
-class ConfigurableDateDelegate extends DateInputGregorianCalendarDelegate {
-  const ConfigurableDateDelegate({
+class CustomDateInputDelegate extends DateInputDelegate {
+  const CustomDateInputDelegate({
     required this.formatType,
-    this.separator = DateSeparator.slash,
+    required this.separator,
   });
 
   final DateInputFormat formatType;
@@ -277,18 +276,13 @@ class ConfigurableDateDelegate extends DateInputGregorianCalendarDelegate {
   ];
 
   @override
-  String dateHelpText(MaterialLocalizations localizations) =>
-      _formatter.pattern;
+  String helpText(MaterialLocalizations localizations) => _formatter.pattern;
 
   @override
-  String formatCompactDate(
-    DateTime date,
-    MaterialLocalizations localizations,
-  ) => _formatter.format(date);
+  String format(DateTime date, MaterialLocalizations localizations) =>
+      _formatter.format(date);
 
   @override
-  DateTime? parseCompactDate(
-    String? inputString,
-    MaterialLocalizations localizations,
-  ) => _formatter.parse(inputString);
+  DateTime? parse(String? input, MaterialLocalizations localizations) =>
+      _formatter.parse(input);
 }

--- a/packages/material_ui/example/lib/date_picker/show_date_picker.2.dart
+++ b/packages/material_ui/example/lib/date_picker/show_date_picker.2.dart
@@ -6,7 +6,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
 /// Flutter code sample showing how to use [showDatePicker] with a custom
-/// [DateInputDelegate] to support configurable text input formats.
+/// [CalendarDelegate] and [InputDatePickerFormField.inputFormatters] to
+/// synchronize input masking with date parsing and validation.
 
 void main() => runApp(const DatePickerSampleApp());
 

--- a/packages/material_ui/example/lib/date_picker/show_date_picker.2.dart
+++ b/packages/material_ui/example/lib/date_picker/show_date_picker.2.dart
@@ -1,4 +1,4 @@
-// Copyright 2014 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/material_ui/example/lib/date_picker/show_date_picker.2.dart
+++ b/packages/material_ui/example/lib/date_picker/show_date_picker.2.dart
@@ -6,7 +6,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
 /// Flutter code sample showing how to use [showDatePicker] with a custom
-/// [CalendarDelegate] and [InputDatePickerFormField.inputFormatters] to
+/// [CalendarDelegate] and its [keyboardInputFormatters] to
 /// synchronize input masking with date parsing and validation.
 
 void main() => runApp(const DatePickerSampleApp());
@@ -44,7 +44,6 @@ class _DatePickerSampleState extends State<DatePickerSample> {
       lastDate: DateTime(2999, 7, 25),
       initialEntryMode: DatePickerEntryMode.input,
       calendarDelegate: customDateInputDelegate,
-      inputFormatters: customDateInputDelegate.inputFormatters,
     );
 
     if (result != null) {
@@ -274,10 +273,15 @@ final class CustomDateInputDelegate extends GregorianCalendarDelegate {
   DateInputFormatter get _formatter =>
       DateInputFormatter(formatType: formatType, separator: separator.value);
 
-  List<TextInputFormatter> get inputFormatters => <TextInputFormatter>[
-    FilteringTextInputFormatter.digitsOnly,
-    _formatter,
-  ];
+  @override
+  List<TextInputFormatter>? keyboardInputFormatters(
+    MaterialLocalizations localizations,
+  ) {
+    return <TextInputFormatter>[
+      FilteringTextInputFormatter.digitsOnly,
+      _formatter,
+    ];
+  }
 
   @override
   String dateHelpText(MaterialLocalizations localizations) =>

--- a/packages/material_ui/example/lib/date_picker/show_date_picker.2.dart
+++ b/packages/material_ui/example/lib/date_picker/show_date_picker.2.dart
@@ -2,11 +2,11 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:material_ui/material_ui.dart';
 
 /// Flutter code sample showing how to use [showDatePicker] with a custom
-/// [CalendarDelegate] and its [keyboardInputFormatters] to
+/// [CalendarDelegate] and its [CustomDateInputDelegate.keyboardInputFormatters] to
 /// synchronize input masking with date parsing and validation.
 
 void main() => runApp(const DatePickerSampleApp());

--- a/packages/material_ui/example/test/date_picker/show_date_picker.2_test.dart
+++ b/packages/material_ui/example/test/date_picker/show_date_picker.2_test.dart
@@ -1,3 +1,7 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 import 'package:flutter/material.dart';
 import 'package:flutter_api_samples/material/date_picker/show_date_picker.2.dart' as example;
 import 'package:flutter_test/flutter_test.dart';

--- a/packages/material_ui/example/test/date_picker/show_date_picker.2_test.dart
+++ b/packages/material_ui/example/test/date_picker/show_date_picker.2_test.dart
@@ -3,55 +3,65 @@
 // found in the LICENSE file.
 
 import 'package:flutter/material.dart';
-import 'package:flutter_api_samples/material/date_picker/show_date_picker.2.dart' as example;
+import 'package:flutter_api_samples/material/date_picker/show_date_picker.2.dart'
+    as example;
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
-  testWidgets('renders selected date text according to formatType and separator (input mode)', (
-    WidgetTester tester,
-  ) async {
-    await tester.pumpWidget(const MaterialApp(home: example.DatePickerSample()));
+  testWidgets(
+    'renders selected date text according to formatType and separator (input mode)',
+    (WidgetTester tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(home: example.DatePickerSample()),
+      );
 
-    expect(find.text('No date selected'), findsOneWidget);
+      expect(find.text('No date selected'), findsOneWidget);
 
-    // Open date picker.
-    await tester.tap(find.byType(OutlinedButton));
-    await tester.pumpAndSettle();
+      // Open date picker.
+      await tester.tap(find.byType(OutlinedButton));
+      await tester.pumpAndSettle();
 
-    final Finder textField = find.byType(TextField);
-    expect(textField, findsOneWidget);
+      final Finder textField = find.byType(TextField);
+      expect(textField, findsOneWidget);
 
-    // Enter date: 30/07/2021.
-    await tester.enterText(textField, '30072021');
-    await tester.pump();
+      // Enter date: 30/07/2021.
+      await tester.enterText(textField, '30072021');
+      await tester.pump();
 
-    await tester.tap(find.text('OK'));
-    await tester.pumpAndSettle();
+      await tester.tap(find.text('OK'));
+      await tester.pumpAndSettle();
 
-    expect(find.text('30.07.2021'), findsOneWidget);
+      expect(find.text('30.07.2021'), findsOneWidget);
 
-    // Change format to monthDayYear.
-    await tester.tap(find.byType(DropdownButtonFormField<example.DateInputFormat>));
-    await tester.pumpAndSettle();
-    await tester.tap(find.text('mm/dd/yyyy').last);
-    await tester.pumpAndSettle();
+      // Change format to monthDayYear.
+      await tester.tap(
+        find.byType(DropdownButtonFormField<example.DateInputFormat>),
+      );
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('mm/dd/yyyy').last);
+      await tester.pumpAndSettle();
 
-    expect(find.text('07.30.2021'), findsOneWidget);
+      expect(find.text('07.30.2021'), findsOneWidget);
 
-    // Change separator to dash.
-    await tester.tap(find.byType(DropdownButtonFormField<example.DateSeparator>));
-    await tester.pumpAndSettle();
-    await tester.tap(find.text('-').last);
-    await tester.pumpAndSettle();
+      // Change separator to dash.
+      await tester.tap(
+        find.byType(DropdownButtonFormField<example.DateSeparator>),
+      );
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('-').last);
+      await tester.pumpAndSettle();
 
-    expect(find.text('07-30-2021'), findsOneWidget);
+      expect(find.text('07-30-2021'), findsOneWidget);
 
-    // Change format to yearMonthDay.
-    await tester.tap(find.byType(DropdownButtonFormField<example.DateInputFormat>));
-    await tester.pumpAndSettle();
-    await tester.tap(find.text('yyyy/mm/dd').last);
-    await tester.pumpAndSettle();
+      // Change format to yearMonthDay.
+      await tester.tap(
+        find.byType(DropdownButtonFormField<example.DateInputFormat>),
+      );
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('yyyy/mm/dd').last);
+      await tester.pumpAndSettle();
 
-    expect(find.text('2021-07-30'), findsOneWidget);
-  });
+      expect(find.text('2021-07-30'), findsOneWidget);
+    },
+  );
 }

--- a/packages/material_ui/example/test/date_picker/show_date_picker.2_test.dart
+++ b/packages/material_ui/example/test/date_picker/show_date_picker.2_test.dart
@@ -1,0 +1,53 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_api_samples/material/date_picker/show_date_picker.2.dart' as example;
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('renders selected date text according to formatType and separator (input mode)', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(const MaterialApp(home: example.DatePickerSample()));
+
+    expect(find.text('No date selected'), findsOneWidget);
+
+    // Open date picker.
+    await tester.tap(find.byType(OutlinedButton));
+    await tester.pumpAndSettle();
+
+    final Finder textField = find.byType(TextField);
+    expect(textField, findsOneWidget);
+
+    // Enter date: 30/07/2021.
+    await tester.enterText(textField, '30072021');
+    await tester.pump();
+
+    await tester.tap(find.text('OK'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('30.07.2021'), findsOneWidget);
+
+    // Change format to monthDayYear.
+    await tester.tap(find.byType(DropdownButtonFormField<example.DateInputFormat>));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('mm/dd/yyyy').last);
+    await tester.pumpAndSettle();
+
+    expect(find.text('07.30.2021'), findsOneWidget);
+
+    // Change separator to dash.
+    await tester.tap(find.byType(DropdownButtonFormField<example.DateSeparator>));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('-').last);
+    await tester.pumpAndSettle();
+
+    expect(find.text('07-30-2021'), findsOneWidget);
+
+    // Change format to yearMonthDay.
+    await tester.tap(find.byType(DropdownButtonFormField<example.DateInputFormat>));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('yyyy/mm/dd').last);
+    await tester.pumpAndSettle();
+
+    expect(find.text('2021-07-30'), findsOneWidget);
+  });
+}

--- a/packages/material_ui/example/test/date_picker/show_date_picker.2_test.dart
+++ b/packages/material_ui/example/test/date_picker/show_date_picker.2_test.dart
@@ -2,10 +2,10 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:flutter/material.dart';
-import 'package:flutter_api_samples/material/date_picker/show_date_picker.2.dart'
-    as example;
+import 'package:material_ui/material_ui.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:material_ui_examples/date_picker/show_date_picker.2.dart'
+    as example;
 
 void main() {
   testWidgets(

--- a/packages/material_ui/example/test/date_picker/show_date_picker.2_test.dart
+++ b/packages/material_ui/example/test/date_picker/show_date_picker.2_test.dart
@@ -1,9 +1,9 @@
-// Copyright 2014 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:material_ui/material_ui.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:material_ui_examples/date_picker/show_date_picker.2.dart'
     as example;
 

--- a/packages/material_ui/lib/src/date.dart
+++ b/packages/material_ui/lib/src/date.dart
@@ -4,6 +4,7 @@
 
 /// @docImport 'calendar_date_picker.dart';
 /// @docImport 'date_picker.dart';
+/// @docImport 'input_date_picker_form_field.dart';
 /// @docImport 'text_field.dart';
 library;
 
@@ -11,8 +12,6 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 
-import 'date_picker.dart';
-import 'input_date_picker_form_field.dart';
 import 'material_localizations.dart';
 
 /// Controls the calendar system used in the date picker.

--- a/packages/material_ui/lib/src/date.dart
+++ b/packages/material_ui/lib/src/date.dart
@@ -8,7 +8,6 @@
 library;
 
 import 'package:flutter/foundation.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 
 import 'date_picker.dart';
@@ -485,45 +484,4 @@ class DateTimeRange<T extends DateTime> {
 
   @override
   String toString() => '$start - $end';
-}
-
-/// A delegate that manages the formatting, parsing, and input validation
-/// for date text fields within a date picker.
-///
-/// This delegate decouples the text input logic from the calendar system,
-/// allowing custom date formats, input masks (via [inputFormatters]), and
-/// parsing rules independent of the [CalendarDelegate].
-///
-/// See also:
-///
-///  * [CalendarDelegate], which handles the underlying calendar math and navigation.
-abstract base class DateInputDelegate {
-  /// Abstract const constructor. This constructor enables subclasses to provide
-  /// const constructors so that they can be used in const expressions.
-  const DateInputDelegate();
-
-  /// The formatters applied to the text field to guide and validate user input.
-  ///
-  /// These are typically used to provide input masks (e.g., adding slashes
-  /// automatically) or to limit the characters allowed in the field.
-  List<TextInputFormatter> get inputFormatters;
-
-  /// Returns the help text (e.g., "MM/DD/YYYY") used as a hint in the text
-  /// field to indicate the expected date format.
-  ///
-  /// The [localizations] parameter can be used to provide a locale-specific
-  /// format string.
-  String helpText(MaterialLocalizations localizations);
-
-  /// Formats the given [date] into a compact string representation to be
-  /// displayed in the text field's controller.
-  ///
-  /// This should be consistent with the logic in [parse].
-  String format(DateTime date, MaterialLocalizations localizations);
-
-  /// Converts the given [input] string back into a [DateTime] object.
-  ///
-  /// Returns null if the [input] string does not represent a valid date
-  /// according to this delegate's rules.
-  DateTime? parse(String? input, MaterialLocalizations localizations);
 }

--- a/packages/material_ui/lib/src/date.dart
+++ b/packages/material_ui/lib/src/date.dart
@@ -37,8 +37,6 @@ import 'material_localizations.dart';
 /// See also:
 ///
 ///  * [GregorianCalendarDelegate], the default implementation for the Gregorian calendar.
-///  * [DateInputGregorianCalendarDelegate], an interface for delegates that support
-///    customizing date text input and formatting.
 ///  * [CalendarDatePicker], which uses this delegate to manage calendar-specific behavior.
 abstract class CalendarDelegate<T extends DateTime> {
   /// Creates a calendar delegate.
@@ -252,19 +250,6 @@ class GregorianCalendarDelegate extends CalendarDelegate<DateTime> {
   String dateHelpText(MaterialLocalizations localizations) {
     return localizations.dateHelpText;
   }
-}
-
-/// A [GregorianCalendarDelegate] that synchronizes calendar operations with
-/// text input requirements, such as [inputFormatters].
-///
-/// Subclasses must provide the appropriate [inputFormatters] to ensure
-/// that user entry matches the parsing logic in [parseCompactDate].
-abstract class DateInputGregorianCalendarDelegate extends GregorianCalendarDelegate {
-  /// Creates a calendar delegate.
-  const DateInputGregorianCalendarDelegate();
-
-  /// The formatters applied to the text field to guide and validate user input.
-  List<TextInputFormatter> get inputFormatters;
 }
 
 /// Utility functions for working with dates.
@@ -500,4 +485,45 @@ class DateTimeRange<T extends DateTime> {
 
   @override
   String toString() => '$start - $end';
+}
+
+/// A delegate that manages the formatting, parsing, and input validation
+/// for date text fields within a date picker.
+///
+/// This delegate decouples the text input logic from the calendar system,
+/// allowing custom date formats, input masks (via [inputFormatters]), and
+/// parsing rules independent of the [CalendarDelegate].
+///
+/// See also:
+///
+///  * [CalendarDelegate], which handles the underlying calendar math and navigation.
+abstract class DateInputDelegate {
+  /// Abstract const constructor. This constructor enables subclasses to provide
+  /// const constructors so that they can be used in const expressions.
+  const DateInputDelegate();
+
+  /// The formatters applied to the text field to guide and validate user input.
+  ///
+  /// These are typically used to provide input masks (e.g., adding slashes
+  /// automatically) or to limit the characters allowed in the field.
+  List<TextInputFormatter> get inputFormatters;
+
+  /// Returns the help text (e.g., "MM/DD/YYYY") used as a hint in the text
+  /// field to indicate the expected date format.
+  ///
+  /// The [localizations] parameter can be used to provide a locale-specific
+  /// format string.
+  String helpText(MaterialLocalizations localizations);
+
+  /// Formats the given [date] into a compact string representation to be
+  /// displayed in the text field's controller.
+  ///
+  /// This should be consistent with the logic in [parse].
+  String format(DateTime date, MaterialLocalizations localizations);
+
+  /// Converts the given [input] string back into a [DateTime] object.
+  ///
+  /// Returns null if the [input] string does not represent a valid date
+  /// according to this delegate's rules.
+  DateTime? parse(String? input, MaterialLocalizations localizations);
 }

--- a/packages/material_ui/lib/src/date.dart
+++ b/packages/material_ui/lib/src/date.dart
@@ -37,7 +37,7 @@ import 'material_localizations.dart';
 /// See also:
 ///
 ///  * [GregorianCalendarDelegate], the default implementation for the Gregorian calendar.
-///  * [DateInputCalendarDelegate], an interface for delegates that support
+///  * [DateInputGregorianCalendarDelegate], an interface for delegates that support
 ///    customizing date text input and formatting.
 ///  * [CalendarDatePicker], which uses this delegate to manage calendar-specific behavior.
 abstract class CalendarDelegate<T extends DateTime> {
@@ -259,9 +259,9 @@ class GregorianCalendarDelegate extends CalendarDelegate<DateTime> {
 ///
 /// Subclasses must provide the appropriate [inputFormatters] to ensure
 /// that user entry matches the parsing logic in [parseCompactDate].
-abstract class DateInputCalendarDelegate extends GregorianCalendarDelegate {
+abstract class DateInputGregorianCalendarDelegate extends GregorianCalendarDelegate {
   /// Creates a calendar delegate.
-  const DateInputCalendarDelegate();
+  const DateInputGregorianCalendarDelegate();
 
   /// The formatters applied to the text field to guide and validate user input.
   List<TextInputFormatter> get inputFormatters;

--- a/packages/material_ui/lib/src/date.dart
+++ b/packages/material_ui/lib/src/date.dart
@@ -497,7 +497,7 @@ class DateTimeRange<T extends DateTime> {
 /// See also:
 ///
 ///  * [CalendarDelegate], which handles the underlying calendar math and navigation.
-abstract class DateInputDelegate {
+abstract base class DateInputDelegate {
   /// Abstract const constructor. This constructor enables subclasses to provide
   /// const constructors so that they can be used in const expressions.
   const DateInputDelegate();

--- a/packages/material_ui/lib/src/date.dart
+++ b/packages/material_ui/lib/src/date.dart
@@ -8,6 +8,7 @@
 library;
 
 import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 
 import 'date_picker.dart';
@@ -160,6 +161,15 @@ abstract class CalendarDelegate<T extends DateTime> {
   /// The help text used on an empty [InputDatePickerFormField] to indicate
   /// to the user the date format being asked for.
   String dateHelpText(MaterialLocalizations localizations);
+
+  /// Optional list of [TextInputFormatter]s applied to the date input field.
+  ///
+  /// These formatters control and restrict how the user enters text, such as
+  /// enforcing a specific date mask.
+  ///
+  /// The functionality of date input and validation relies on consistency between
+  /// these formatters and the [parseCompactDate] method.
+  List<TextInputFormatter>? keyboardInputFormatters(MaterialLocalizations localizations) => null;
 }
 
 /// A [CalendarDelegate] implementation for the Gregorian calendar system.

--- a/packages/material_ui/lib/src/date.dart
+++ b/packages/material_ui/lib/src/date.dart
@@ -8,8 +8,11 @@
 library;
 
 import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 
+import 'date_picker.dart';
+import 'input_date_picker_form_field.dart';
 import 'material_localizations.dart';
 
 /// Controls the calendar system used in the date picker.
@@ -34,6 +37,8 @@ import 'material_localizations.dart';
 /// See also:
 ///
 ///  * [GregorianCalendarDelegate], the default implementation for the Gregorian calendar.
+///  * [DateInputCalendarDelegate], an interface for delegates that support
+///    customizing date text input and formatting.
 ///  * [CalendarDatePicker], which uses this delegate to manage calendar-specific behavior.
 abstract class CalendarDelegate<T extends DateTime> {
   /// Creates a calendar delegate.
@@ -247,6 +252,19 @@ class GregorianCalendarDelegate extends CalendarDelegate<DateTime> {
   String dateHelpText(MaterialLocalizations localizations) {
     return localizations.dateHelpText;
   }
+}
+
+/// A [GregorianCalendarDelegate] that synchronizes calendar operations with
+/// text input requirements, such as [inputFormatters].
+///
+/// Subclasses must provide the appropriate [inputFormatters] to ensure
+/// that user entry matches the parsing logic in [parseCompactDate].
+abstract class DateInputCalendarDelegate extends GregorianCalendarDelegate {
+  /// Creates a calendar delegate.
+  const DateInputCalendarDelegate();
+
+  /// The formatters applied to the text field to guide and validate user input.
+  List<TextInputFormatter> get inputFormatters;
 }
 
 /// Utility functions for working with dates.

--- a/packages/material_ui/lib/src/date_picker.dart
+++ b/packages/material_ui/lib/src/date_picker.dart
@@ -124,7 +124,7 @@ const double _fontSizeToScale = 14.0;
 ///
 /// {@macro material_ui.calendar_date_picker.calendarDelegate}
 ///
-/// Use [DateInputDelegate] to customize how dates are entered and
+/// Use [inputFormatters] to customize how dates are entered and
 /// formatted in [DatePickerEntryMode.input].
 ///
 /// A custom delegate can define specific date input conventions, such as
@@ -134,7 +134,7 @@ const double _fontSizeToScale = 14.0;
 ///
 /// {@tool dartpad}
 /// This sample shows how to customize the text input behavior of
-/// [showDatePicker] using a [DateInputDelegate].
+/// [showDatePicker] using a [inputFormatters].
 ///
 /// ** See code in examples/api/lib/material/date_picker/show_date_picker.2.dart **
 /// {@end-tool}
@@ -250,8 +250,7 @@ Future<DateTime?> showDatePicker({
   Icon? switchToInputEntryModeIcon,
   Icon? switchToCalendarEntryModeIcon,
   CalendarDelegate<DateTime> calendarDelegate = const GregorianCalendarDelegate(),
-  DateInputDelegate? dateInputDelegate,
-
+  List<TextInputFormatter>? inputFormatters,
 }) async {
   initialDate = initialDate == null ? null : calendarDelegate.dateOnly(initialDate);
   firstDate = calendarDelegate.dateOnly(firstDate);
@@ -294,7 +293,7 @@ Future<DateTime?> showDatePicker({
     switchToInputEntryModeIcon: switchToInputEntryModeIcon,
     switchToCalendarEntryModeIcon: switchToCalendarEntryModeIcon,
     calendarDelegate: calendarDelegate,
-    dateInputDelegate: dateInputDelegate,
+    inputFormatters: inputFormatters,
   );
 
   if (textDirection != null) {
@@ -362,7 +361,7 @@ class DatePickerDialog extends StatefulWidget {
     this.switchToCalendarEntryModeIcon,
     this.insetPadding = const EdgeInsets.symmetric(horizontal: 16.0, vertical: 24.0),
     this.calendarDelegate = const GregorianCalendarDelegate(),
-    this.dateInputDelegate,
+    this.inputFormatters,
   }) : initialDate = initialDate == null ? null : calendarDelegate.dateOnly(initialDate),
        firstDate = calendarDelegate.dateOnly(firstDate),
        lastDate = calendarDelegate.dateOnly(lastDate),
@@ -491,9 +490,8 @@ class DatePickerDialog extends StatefulWidget {
   /// {@macro material_ui.calendar_date_picker.calendarDelegate}
   final CalendarDelegate<DateTime> calendarDelegate;
 
-  /// A delegate that manages the formatting, parsing, and input validation
-  /// for date text fields.
-  final DateInputDelegate? dateInputDelegate;
+  /// {@macro flutter.material.input_date_picker_form_field.inputFormatters}
+  final List<TextInputFormatter>? inputFormatters;
 
   @override
   State<DatePickerDialog> createState() => _DatePickerDialogState();
@@ -709,7 +707,7 @@ class _DatePickerDialogState extends State<DatePickerDialog> with RestorationMix
                         fieldLabelText: widget.fieldLabelText,
                         keyboardType: widget.keyboardType,
                         autofocus: true,
-                        dateInputDelegate: widget.dateInputDelegate,
+                        inputFormatters: widget.inputFormatters,
                       ),
                     ),
                   ),
@@ -1236,7 +1234,7 @@ Future<DateTimeRange?> showDateRangePicker({
   Icon? switchToCalendarEntryModeIcon,
   SelectableDayForRangePredicate? selectableDayPredicate,
   CalendarDelegate<DateTime> calendarDelegate = const GregorianCalendarDelegate(),
-  DateInputDelegate? dateInputDelegate,
+  final List<TextInputFormatter>? inputFormatters,
 }) async {
   initialDateRange = initialDateRange == null ? null : calendarDelegate.datesOnly(initialDateRange);
   firstDate = calendarDelegate.dateOnly(firstDate);
@@ -1302,7 +1300,7 @@ Future<DateTimeRange?> showDateRangePicker({
     switchToInputEntryModeIcon: switchToInputEntryModeIcon,
     switchToCalendarEntryModeIcon: switchToCalendarEntryModeIcon,
     calendarDelegate: calendarDelegate,
-    dateInputDelegate: dateInputDelegate,
+    inputFormatters: inputFormatters,
   );
 
   if (textDirection != null) {
@@ -1402,9 +1400,8 @@ class DateRangePickerDialog extends StatefulWidget {
     this.switchToCalendarEntryModeIcon,
     this.selectableDayPredicate,
     this.calendarDelegate = const GregorianCalendarDelegate(),
-    this.dateInputDelegate,
+    this.inputFormatters,
   });
-
 
   /// The date range that the date range picker starts with when it opens.
   ///
@@ -1542,9 +1539,8 @@ class DateRangePickerDialog extends StatefulWidget {
   /// {@macro material_ui.calendar_date_picker.calendarDelegate}
   final CalendarDelegate<DateTime> calendarDelegate;
 
-  /// A delegate that manages the formatting, parsing, and input validation
-  /// for date text fields.
-  final DateInputDelegate? dateInputDelegate;
+  /// {@macro flutter.material.input_date_picker_form_field.inputFormatters}
+  final List<TextInputFormatter>? inputFormatters;
 
   @override
   State<DateRangePickerDialog> createState() => _DateRangePickerDialogState();
@@ -1756,7 +1752,7 @@ class _DateRangePickerDialogState extends State<DateRangePickerDialog> with Rest
                     fieldStartLabelText: widget.fieldStartLabelText,
                     fieldEndLabelText: widget.fieldEndLabelText,
                     keyboardType: widget.keyboardType,
-                    dateInputDelegate: widget.dateInputDelegate,
+                    inputFormatters: widget.inputFormatters,
                   ),
                   const Spacer(),
                 ],
@@ -3294,7 +3290,7 @@ class _InputDateRangePicker extends StatefulWidget {
     this.autofocus = false,
     this.autovalidate = false,
     this.keyboardType = TextInputType.datetime,
-    this.dateInputDelegate,
+    this.inputFormatters,
   }) : initialStartDate = initialStartDate == null
            ? null
            : calendarDelegate.dateOnly(initialStartDate),
@@ -3364,9 +3360,8 @@ class _InputDateRangePicker extends StatefulWidget {
   /// {@macro material_ui.calendar_date_picker.calendarDelegate}
   final CalendarDelegate<DateTime> calendarDelegate;
 
-  /// A delegate that manages the formatting, parsing, and input validation
-  /// for date text fields.
-  final DateInputDelegate? dateInputDelegate;
+  /// {@macro flutter.material.input_date_picker_form_field.inputFormatters}
+  final List<TextInputFormatter>? inputFormatters;
 
   @override
   _InputDateRangePickerState createState() => _InputDateRangePickerState();
@@ -3405,20 +3400,15 @@ class _InputDateRangePickerState extends State<_InputDateRangePicker> {
   void didChangeDependencies() {
     super.didChangeDependencies();
     final MaterialLocalizations localizations = MaterialLocalizations.of(context);
-    final DateInputDelegate? dateInputDelegate = widget.dateInputDelegate;
     if (_startDate != null) {
-      _startInputText = dateInputDelegate != null
-          ? dateInputDelegate.format(_startDate!, localizations)
-          : widget.calendarDelegate.formatCompactDate(_startDate!, localizations);
+      _startInputText = widget.calendarDelegate.formatCompactDate(_startDate!, localizations);
       final bool selectText = widget.autofocus && !_autoSelected;
       _updateController(_startController, _startInputText, selectText);
       _autoSelected = selectText;
     }
 
     if (_endDate != null) {
-      _endInputText = dateInputDelegate != null
-          ? dateInputDelegate.format(_endDate!, localizations)
-          : widget.calendarDelegate.formatCompactDate(_endDate!, localizations);
+      _endInputText = widget.calendarDelegate.formatCompactDate(_endDate!, localizations);
       _updateController(_endController, _endInputText, false);
     }
   }
@@ -3447,11 +3437,7 @@ class _InputDateRangePickerState extends State<_InputDateRangePicker> {
 
   DateTime? _parseDate(String? text) {
     final MaterialLocalizations localizations = MaterialLocalizations.of(context);
-    final DateInputDelegate? dateInputDelegate = widget.dateInputDelegate;
 
-    if (dateInputDelegate != null) {
-      return dateInputDelegate.parse(text, localizations);
-    }
     return widget.calendarDelegate.parseCompactDate(text, localizations);
   }
 
@@ -3512,16 +3498,9 @@ class _InputDateRangePickerState extends State<_InputDateRangePicker> {
     final bool useMaterial3 = theme.useMaterial3;
     final MaterialLocalizations localizations = MaterialLocalizations.of(context);
     final InputDecorationThemeData inputTheme = InputDecorationTheme.of(context);
-    final DateInputDelegate? dateInputDelegate = widget.dateInputDelegate;
     final InputBorder inputBorder =
         inputTheme.border ??
         (useMaterial3 ? const OutlineInputBorder() : const UnderlineInputBorder());
-
-    final List<TextInputFormatter> effectiveFormatters =
-        dateInputDelegate?.inputFormatters ?? <TextInputFormatter>[];
-    final String effectiveHelpText =
-        dateInputDelegate?.helpText(localizations) ??
-        widget.calendarDelegate.dateHelpText(localizations);
 
     return Row(
       crossAxisAlignment: CrossAxisAlignment.start,
@@ -3532,14 +3511,15 @@ class _InputDateRangePickerState extends State<_InputDateRangePicker> {
             decoration: InputDecoration(
               border: inputBorder,
               filled: inputTheme.filled,
-              hintText: widget.fieldStartHintText ?? effectiveHelpText,
+              hintText:
+                  widget.fieldStartHintText ?? widget.calendarDelegate.dateHelpText(localizations),
               labelText: widget.fieldStartLabelText ?? localizations.dateRangeStartLabel,
               errorText: _startErrorText,
             ),
             keyboardType: widget.keyboardType,
             onChanged: _handleStartChanged,
             autofocus: widget.autofocus,
-            inputFormatters: effectiveFormatters,
+            inputFormatters: widget.inputFormatters,
           ),
         ),
         const SizedBox(width: 8),
@@ -3549,13 +3529,14 @@ class _InputDateRangePickerState extends State<_InputDateRangePicker> {
             decoration: InputDecoration(
               border: inputBorder,
               filled: inputTheme.filled,
-              hintText: widget.fieldEndHintText ?? effectiveHelpText,
+              hintText:
+                  widget.fieldEndHintText ?? widget.calendarDelegate.dateHelpText(localizations),
               labelText: widget.fieldEndLabelText ?? localizations.dateRangeEndLabel,
               errorText: _endErrorText,
             ),
             keyboardType: widget.keyboardType,
             onChanged: _handleEndChanged,
-            inputFormatters: effectiveFormatters,
+            inputFormatters: widget.inputFormatters,
           ),
         ),
       ],

--- a/packages/material_ui/lib/src/date_picker.dart
+++ b/packages/material_ui/lib/src/date_picker.dart
@@ -3512,15 +3512,16 @@ class _InputDateRangePickerState extends State<_InputDateRangePicker> {
     final bool useMaterial3 = theme.useMaterial3;
     final MaterialLocalizations localizations = MaterialLocalizations.of(context);
     final InputDecorationThemeData inputTheme = InputDecorationTheme.of(context);
-    final DateInputDelegate? config = widget.dateInputDelegate;
+    final DateInputDelegate? dateInputDelegate = widget.dateInputDelegate;
     final InputBorder inputBorder =
         inputTheme.border ??
         (useMaterial3 ? const OutlineInputBorder() : const UnderlineInputBorder());
 
     final List<TextInputFormatter> effectiveFormatters =
-        config?.inputFormatters ?? <TextInputFormatter>[];
+        dateInputDelegate?.inputFormatters ?? <TextInputFormatter>[];
     final String effectiveHelpText =
-        config?.helpText(localizations) ?? widget.calendarDelegate.dateHelpText(localizations);
+        dateInputDelegate?.helpText(localizations) ??
+        widget.calendarDelegate.dateHelpText(localizations);
 
     return Row(
       crossAxisAlignment: CrossAxisAlignment.start,

--- a/packages/material_ui/lib/src/date_picker.dart
+++ b/packages/material_ui/lib/src/date_picker.dart
@@ -124,7 +124,7 @@ const double _fontSizeToScale = 14.0;
 ///
 /// {@macro material_ui.calendar_date_picker.calendarDelegate}
 ///
-/// Use [DateInputGregorianCalendarDelegate] to customize how dates are entered and
+/// Use [DateInputDelegate] to customize how dates are entered and
 /// formatted in [DatePickerEntryMode.input].
 ///
 /// A custom delegate can define specific date input conventions, such as
@@ -134,7 +134,7 @@ const double _fontSizeToScale = 14.0;
 ///
 /// {@tool dartpad}
 /// This sample shows how to customize the text input behavior of
-/// [showDatePicker] using a [DateInputGregorianCalendarDelegate].
+/// [showDatePicker] using a [DateInputDelegate].
 ///
 /// ** See code in examples/api/lib/material/date_picker/show_date_picker.2.dart **
 /// {@end-tool}
@@ -250,6 +250,8 @@ Future<DateTime?> showDatePicker({
   Icon? switchToInputEntryModeIcon,
   Icon? switchToCalendarEntryModeIcon,
   CalendarDelegate<DateTime> calendarDelegate = const GregorianCalendarDelegate(),
+  DateInputDelegate? dateInputDelegate,
+
 }) async {
   initialDate = initialDate == null ? null : calendarDelegate.dateOnly(initialDate);
   firstDate = calendarDelegate.dateOnly(firstDate);
@@ -292,6 +294,7 @@ Future<DateTime?> showDatePicker({
     switchToInputEntryModeIcon: switchToInputEntryModeIcon,
     switchToCalendarEntryModeIcon: switchToCalendarEntryModeIcon,
     calendarDelegate: calendarDelegate,
+    dateInputDelegate: dateInputDelegate,
   );
 
   if (textDirection != null) {
@@ -359,6 +362,7 @@ class DatePickerDialog extends StatefulWidget {
     this.switchToCalendarEntryModeIcon,
     this.insetPadding = const EdgeInsets.symmetric(horizontal: 16.0, vertical: 24.0),
     this.calendarDelegate = const GregorianCalendarDelegate(),
+    this.dateInputDelegate,
   }) : initialDate = initialDate == null ? null : calendarDelegate.dateOnly(initialDate),
        firstDate = calendarDelegate.dateOnly(firstDate),
        lastDate = calendarDelegate.dateOnly(lastDate),
@@ -486,6 +490,9 @@ class DatePickerDialog extends StatefulWidget {
 
   /// {@macro material_ui.calendar_date_picker.calendarDelegate}
   final CalendarDelegate<DateTime> calendarDelegate;
+
+  ///
+  final DateInputDelegate? dateInputDelegate;
 
   @override
   State<DatePickerDialog> createState() => _DatePickerDialogState();
@@ -701,6 +708,7 @@ class _DatePickerDialogState extends State<DatePickerDialog> with RestorationMix
                         fieldLabelText: widget.fieldLabelText,
                         keyboardType: widget.keyboardType,
                         autofocus: true,
+                        dateInputDelegate: widget.dateInputDelegate,
                       ),
                     ),
                   ),
@@ -1227,6 +1235,7 @@ Future<DateTimeRange?> showDateRangePicker({
   Icon? switchToCalendarEntryModeIcon,
   SelectableDayForRangePredicate? selectableDayPredicate,
   CalendarDelegate<DateTime> calendarDelegate = const GregorianCalendarDelegate(),
+  DateInputDelegate? dateInputDelegate,
 }) async {
   initialDateRange = initialDateRange == null ? null : calendarDelegate.datesOnly(initialDateRange);
   firstDate = calendarDelegate.dateOnly(firstDate);
@@ -1292,6 +1301,7 @@ Future<DateTimeRange?> showDateRangePicker({
     switchToInputEntryModeIcon: switchToInputEntryModeIcon,
     switchToCalendarEntryModeIcon: switchToCalendarEntryModeIcon,
     calendarDelegate: calendarDelegate,
+    dateInputDelegate: dateInputDelegate,
   );
 
   if (textDirection != null) {
@@ -1391,7 +1401,9 @@ class DateRangePickerDialog extends StatefulWidget {
     this.switchToCalendarEntryModeIcon,
     this.selectableDayPredicate,
     this.calendarDelegate = const GregorianCalendarDelegate(),
+    this.dateInputDelegate,
   });
+
 
   /// The date range that the date range picker starts with when it opens.
   ///
@@ -1528,6 +1540,10 @@ class DateRangePickerDialog extends StatefulWidget {
 
   /// {@macro material_ui.calendar_date_picker.calendarDelegate}
   final CalendarDelegate<DateTime> calendarDelegate;
+
+  /// A delegate that manages the formatting, parsing, and input validation
+  /// for date text fields.
+  final DateInputDelegate? dateInputDelegate;
 
   @override
   State<DateRangePickerDialog> createState() => _DateRangePickerDialogState();
@@ -1739,6 +1755,7 @@ class _DateRangePickerDialogState extends State<DateRangePickerDialog> with Rest
                     fieldStartLabelText: widget.fieldStartLabelText,
                     fieldEndLabelText: widget.fieldEndLabelText,
                     keyboardType: widget.keyboardType,
+                    dateInputDelegate: widget.dateInputDelegate,
                   ),
                   const Spacer(),
                 ],
@@ -3276,6 +3293,7 @@ class _InputDateRangePicker extends StatefulWidget {
     this.autofocus = false,
     this.autovalidate = false,
     this.keyboardType = TextInputType.datetime,
+    this.dateInputDelegate,
   }) : initialStartDate = initialStartDate == null
            ? null
            : calendarDelegate.dateOnly(initialStartDate),
@@ -3345,6 +3363,8 @@ class _InputDateRangePicker extends StatefulWidget {
   /// {@macro material_ui.calendar_date_picker.calendarDelegate}
   final CalendarDelegate<DateTime> calendarDelegate;
 
+  final DateInputDelegate? dateInputDelegate;
+
   @override
   _InputDateRangePickerState createState() => _InputDateRangePickerState();
 }
@@ -3382,15 +3402,20 @@ class _InputDateRangePickerState extends State<_InputDateRangePicker> {
   void didChangeDependencies() {
     super.didChangeDependencies();
     final MaterialLocalizations localizations = MaterialLocalizations.of(context);
+    final DateInputDelegate? dateInputDelegate = widget.dateInputDelegate;
     if (_startDate != null) {
-      _startInputText = widget.calendarDelegate.formatCompactDate(_startDate!, localizations);
+      _startInputText = dateInputDelegate != null
+          ? dateInputDelegate.format(_startDate!, localizations)
+          : widget.calendarDelegate.formatCompactDate(_startDate!, localizations);
       final bool selectText = widget.autofocus && !_autoSelected;
       _updateController(_startController, _startInputText, selectText);
       _autoSelected = selectText;
     }
 
     if (_endDate != null) {
-      _endInputText = widget.calendarDelegate.formatCompactDate(_endDate!, localizations);
+      _endInputText = dateInputDelegate != null
+          ? dateInputDelegate.format(_endDate!, localizations)
+          : widget.calendarDelegate.formatCompactDate(_endDate!, localizations);
       _updateController(_endController, _endInputText, false);
     }
   }
@@ -3419,6 +3444,11 @@ class _InputDateRangePickerState extends State<_InputDateRangePicker> {
 
   DateTime? _parseDate(String? text) {
     final MaterialLocalizations localizations = MaterialLocalizations.of(context);
+    final DateInputDelegate? dateInputDelegate = widget.dateInputDelegate;
+
+    if (dateInputDelegate != null) {
+      return dateInputDelegate.parse(text, localizations);
+    }
     return widget.calendarDelegate.parseCompactDate(text, localizations);
   }
 
@@ -3479,9 +3509,15 @@ class _InputDateRangePickerState extends State<_InputDateRangePicker> {
     final bool useMaterial3 = theme.useMaterial3;
     final MaterialLocalizations localizations = MaterialLocalizations.of(context);
     final InputDecorationThemeData inputTheme = InputDecorationTheme.of(context);
+    final DateInputDelegate? config = widget.dateInputDelegate;
     final InputBorder inputBorder =
         inputTheme.border ??
         (useMaterial3 ? const OutlineInputBorder() : const UnderlineInputBorder());
+
+    final List<TextInputFormatter> effectiveFormatters =
+        config?.inputFormatters ?? <TextInputFormatter>[];
+    final String effectiveHelpText =
+        config?.helpText(localizations) ?? widget.calendarDelegate.dateHelpText(localizations);
 
     return Row(
       crossAxisAlignment: CrossAxisAlignment.start,
@@ -3492,15 +3528,14 @@ class _InputDateRangePickerState extends State<_InputDateRangePicker> {
             decoration: InputDecoration(
               border: inputBorder,
               filled: inputTheme.filled,
-              hintText:
-                  widget.fieldStartHintText ?? widget.calendarDelegate.dateHelpText(localizations),
+              hintText: widget.fieldStartHintText ?? effectiveHelpText,
               labelText: widget.fieldStartLabelText ?? localizations.dateRangeStartLabel,
               errorText: _startErrorText,
             ),
             keyboardType: widget.keyboardType,
             onChanged: _handleStartChanged,
             autofocus: widget.autofocus,
-            inputFormatters: [...?_textInputFormatter],
+            inputFormatters: effectiveFormatters,
           ),
         ),
         const SizedBox(width: 8),
@@ -3510,25 +3545,16 @@ class _InputDateRangePickerState extends State<_InputDateRangePicker> {
             decoration: InputDecoration(
               border: inputBorder,
               filled: inputTheme.filled,
-              hintText:
-                  widget.fieldEndHintText ?? widget.calendarDelegate.dateHelpText(localizations),
+              hintText: widget.fieldEndHintText ?? effectiveHelpText,
               labelText: widget.fieldEndLabelText ?? localizations.dateRangeEndLabel,
               errorText: _endErrorText,
             ),
             keyboardType: widget.keyboardType,
             onChanged: _handleEndChanged,
-            inputFormatters: [...?_textInputFormatter],
+            inputFormatters: effectiveFormatters,
           ),
         ),
       ],
     );
-  }
-
-  List<TextInputFormatter>? get _textInputFormatter {
-    return switch (widget.calendarDelegate) {
-      DateInputGregorianCalendarDelegate(:final List<TextInputFormatter>? inputFormatters) =>
-        inputFormatters,
-      _ => null,
-    };
   }
 }

--- a/packages/material_ui/lib/src/date_picker.dart
+++ b/packages/material_ui/lib/src/date_picker.dart
@@ -491,7 +491,8 @@ class DatePickerDialog extends StatefulWidget {
   /// {@macro material_ui.calendar_date_picker.calendarDelegate}
   final CalendarDelegate<DateTime> calendarDelegate;
 
-  ///
+  /// A delegate that manages the formatting, parsing, and input validation
+  /// for date text fields.
   final DateInputDelegate? dateInputDelegate;
 
   @override
@@ -3363,6 +3364,8 @@ class _InputDateRangePicker extends StatefulWidget {
   /// {@macro material_ui.calendar_date_picker.calendarDelegate}
   final CalendarDelegate<DateTime> calendarDelegate;
 
+  /// A delegate that manages the formatting, parsing, and input validation
+  /// for date text fields.
   final DateInputDelegate? dateInputDelegate;
 
   @override

--- a/packages/material_ui/lib/src/date_picker.dart
+++ b/packages/material_ui/lib/src/date_picker.dart
@@ -124,8 +124,8 @@ const double _fontSizeToScale = 14.0;
 ///
 /// {@macro material_ui.calendar_date_picker.calendarDelegate}
 ///
-/// Use [inputFormatters] to customize how dates are entered and
-/// formatted in [DatePickerEntryMode.input].
+/// Use a custom [CalendarDelegate.keyboardInputFormatters] to customize
+/// how dates are entered and formatted in [DatePickerEntryMode.input].
 ///
 /// A custom delegate can define specific date input conventions, such as
 /// ordering, separators, or formatting rules (for example, `dd.MM.yyyy`), and
@@ -134,7 +134,7 @@ const double _fontSizeToScale = 14.0;
 ///
 /// {@tool dartpad}
 /// This sample shows how to customize the text input behavior of
-/// [showDatePicker] using a [inputFormatters].
+/// [showDatePicker] using a custom [CalendarDelegate].
 ///
 /// ** See code in examples/api/lib/material/date_picker/show_date_picker.2.dart **
 /// {@end-tool}
@@ -293,7 +293,6 @@ Future<DateTime?> showDatePicker({
     switchToInputEntryModeIcon: switchToInputEntryModeIcon,
     switchToCalendarEntryModeIcon: switchToCalendarEntryModeIcon,
     calendarDelegate: calendarDelegate,
-    inputFormatters: inputFormatters,
   );
 
   if (textDirection != null) {
@@ -361,7 +360,6 @@ class DatePickerDialog extends StatefulWidget {
     this.switchToCalendarEntryModeIcon,
     this.insetPadding = const EdgeInsets.symmetric(horizontal: 16.0, vertical: 24.0),
     this.calendarDelegate = const GregorianCalendarDelegate(),
-    this.inputFormatters,
   }) : initialDate = initialDate == null ? null : calendarDelegate.dateOnly(initialDate),
        firstDate = calendarDelegate.dateOnly(firstDate),
        lastDate = calendarDelegate.dateOnly(lastDate),
@@ -489,9 +487,6 @@ class DatePickerDialog extends StatefulWidget {
 
   /// {@macro material_ui.calendar_date_picker.calendarDelegate}
   final CalendarDelegate<DateTime> calendarDelegate;
-
-  /// {@macro flutter.material.input_date_picker_form_field.inputFormatters}
-  final List<TextInputFormatter>? inputFormatters;
 
   @override
   State<DatePickerDialog> createState() => _DatePickerDialogState();
@@ -707,7 +702,6 @@ class _DatePickerDialogState extends State<DatePickerDialog> with RestorationMix
                         fieldLabelText: widget.fieldLabelText,
                         keyboardType: widget.keyboardType,
                         autofocus: true,
-                        inputFormatters: widget.inputFormatters,
                       ),
                     ),
                   ),
@@ -1234,7 +1228,6 @@ Future<DateTimeRange?> showDateRangePicker({
   Icon? switchToCalendarEntryModeIcon,
   SelectableDayForRangePredicate? selectableDayPredicate,
   CalendarDelegate<DateTime> calendarDelegate = const GregorianCalendarDelegate(),
-  final List<TextInputFormatter>? inputFormatters,
 }) async {
   initialDateRange = initialDateRange == null ? null : calendarDelegate.datesOnly(initialDateRange);
   firstDate = calendarDelegate.dateOnly(firstDate);
@@ -1300,7 +1293,6 @@ Future<DateTimeRange?> showDateRangePicker({
     switchToInputEntryModeIcon: switchToInputEntryModeIcon,
     switchToCalendarEntryModeIcon: switchToCalendarEntryModeIcon,
     calendarDelegate: calendarDelegate,
-    inputFormatters: inputFormatters,
   );
 
   if (textDirection != null) {
@@ -1539,9 +1531,6 @@ class DateRangePickerDialog extends StatefulWidget {
   /// {@macro material_ui.calendar_date_picker.calendarDelegate}
   final CalendarDelegate<DateTime> calendarDelegate;
 
-  /// {@macro flutter.material.input_date_picker_form_field.inputFormatters}
-  final List<TextInputFormatter>? inputFormatters;
-
   @override
   State<DateRangePickerDialog> createState() => _DateRangePickerDialogState();
 }
@@ -1752,7 +1741,6 @@ class _DateRangePickerDialogState extends State<DateRangePickerDialog> with Rest
                     fieldStartLabelText: widget.fieldStartLabelText,
                     fieldEndLabelText: widget.fieldEndLabelText,
                     keyboardType: widget.keyboardType,
-                    inputFormatters: widget.inputFormatters,
                   ),
                   const Spacer(),
                 ],
@@ -3290,7 +3278,6 @@ class _InputDateRangePicker extends StatefulWidget {
     this.autofocus = false,
     this.autovalidate = false,
     this.keyboardType = TextInputType.datetime,
-    this.inputFormatters,
   }) : initialStartDate = initialStartDate == null
            ? null
            : calendarDelegate.dateOnly(initialStartDate),
@@ -3359,9 +3346,6 @@ class _InputDateRangePicker extends StatefulWidget {
 
   /// {@macro material_ui.calendar_date_picker.calendarDelegate}
   final CalendarDelegate<DateTime> calendarDelegate;
-
-  /// {@macro flutter.material.input_date_picker_form_field.inputFormatters}
-  final List<TextInputFormatter>? inputFormatters;
 
   @override
   _InputDateRangePickerState createState() => _InputDateRangePickerState();
@@ -3519,7 +3503,7 @@ class _InputDateRangePickerState extends State<_InputDateRangePicker> {
             keyboardType: widget.keyboardType,
             onChanged: _handleStartChanged,
             autofocus: widget.autofocus,
-            inputFormatters: widget.inputFormatters,
+            inputFormatters: widget.calendarDelegate.keyboardInputFormatters(localizations),
           ),
         ),
         const SizedBox(width: 8),
@@ -3536,7 +3520,7 @@ class _InputDateRangePickerState extends State<_InputDateRangePicker> {
             ),
             keyboardType: widget.keyboardType,
             onChanged: _handleEndChanged,
-            inputFormatters: widget.inputFormatters,
+            inputFormatters: widget.calendarDelegate.keyboardInputFormatters(localizations),
           ),
         ),
       ],

--- a/packages/material_ui/lib/src/date_picker.dart
+++ b/packages/material_ui/lib/src/date_picker.dart
@@ -124,7 +124,7 @@ const double _fontSizeToScale = 14.0;
 ///
 /// {@macro material_ui.calendar_date_picker.calendarDelegate}
 ///
-/// Use [DateInputCalendarDelegate] to customize how dates are entered and
+/// Use [DateInputGregorianCalendarDelegate] to customize how dates are entered and
 /// formatted in [DatePickerEntryMode.input].
 ///
 /// A custom delegate can define specific date input conventions, such as
@@ -134,7 +134,7 @@ const double _fontSizeToScale = 14.0;
 ///
 /// {@tool dartpad}
 /// This sample shows how to customize the text input behavior of
-/// [showDatePicker] using a [DateInputCalendarDelegate].
+/// [showDatePicker] using a [DateInputGregorianCalendarDelegate].
 ///
 /// ** See code in examples/api/lib/material/date_picker/show_date_picker.2.dart **
 /// {@end-tool}
@@ -3526,7 +3526,7 @@ class _InputDateRangePickerState extends State<_InputDateRangePicker> {
 
   List<TextInputFormatter>? get _textInputFormatter {
     return switch (widget.calendarDelegate) {
-      DateInputCalendarDelegate(:final List<TextInputFormatter>? inputFormatters) =>
+      DateInputGregorianCalendarDelegate(:final List<TextInputFormatter>? inputFormatters) =>
         inputFormatters,
       _ => null,
     };

--- a/packages/material_ui/lib/src/date_picker.dart
+++ b/packages/material_ui/lib/src/date_picker.dart
@@ -250,7 +250,6 @@ Future<DateTime?> showDatePicker({
   Icon? switchToInputEntryModeIcon,
   Icon? switchToCalendarEntryModeIcon,
   CalendarDelegate<DateTime> calendarDelegate = const GregorianCalendarDelegate(),
-  List<TextInputFormatter>? inputFormatters,
 }) async {
   initialDate = initialDate == null ? null : calendarDelegate.dateOnly(initialDate);
   firstDate = calendarDelegate.dateOnly(firstDate);
@@ -1392,7 +1391,6 @@ class DateRangePickerDialog extends StatefulWidget {
     this.switchToCalendarEntryModeIcon,
     this.selectableDayPredicate,
     this.calendarDelegate = const GregorianCalendarDelegate(),
-    this.inputFormatters,
   });
 
   /// The date range that the date range picker starts with when it opens.
@@ -1530,9 +1528,6 @@ class DateRangePickerDialog extends StatefulWidget {
 
   /// {@macro material_ui.calendar_date_picker.calendarDelegate}
   final CalendarDelegate<DateTime> calendarDelegate;
-
-  /// Optional text input formatters.
-  final List<TextInputFormatter>? inputFormatters;
 
   @override
   State<DateRangePickerDialog> createState() => _DateRangePickerDialogState();

--- a/packages/material_ui/lib/src/date_picker.dart
+++ b/packages/material_ui/lib/src/date_picker.dart
@@ -124,6 +124,21 @@ const double _fontSizeToScale = 14.0;
 ///
 /// {@macro material_ui.calendar_date_picker.calendarDelegate}
 ///
+/// Use [DateInputCalendarDelegate] to customize how dates are entered and
+/// formatted in [DatePickerEntryMode.input].
+///
+/// A custom delegate can define specific date input conventions, such as
+/// ordering, separators, or formatting rules (for example, `dd.MM.yyyy`), and
+/// is responsible for keeping text input parsing and calendar selection
+/// synchronized.
+///
+/// {@tool dartpad}
+/// This sample shows how to customize the text input behavior of
+/// [showDatePicker] using a [DateInputCalendarDelegate].
+///
+/// ** See code in examples/api/lib/material/date_picker/show_date_picker.2.dart **
+/// {@end-tool}
+///
 /// The following optional string parameters allow you to override the default
 /// text used for various parts of the dialog:
 ///
@@ -3485,6 +3500,7 @@ class _InputDateRangePickerState extends State<_InputDateRangePicker> {
             keyboardType: widget.keyboardType,
             onChanged: _handleStartChanged,
             autofocus: widget.autofocus,
+            inputFormatters: [...?_textInputFormatter],
           ),
         ),
         const SizedBox(width: 8),
@@ -3501,9 +3517,18 @@ class _InputDateRangePickerState extends State<_InputDateRangePicker> {
             ),
             keyboardType: widget.keyboardType,
             onChanged: _handleEndChanged,
+            inputFormatters: [...?_textInputFormatter],
           ),
         ),
       ],
     );
+  }
+
+  List<TextInputFormatter>? get _textInputFormatter {
+    return switch (widget.calendarDelegate) {
+      DateInputCalendarDelegate(:final List<TextInputFormatter>? inputFormatters) =>
+        inputFormatters,
+      _ => null,
+    };
   }
 }

--- a/packages/material_ui/lib/src/date_picker.dart
+++ b/packages/material_ui/lib/src/date_picker.dart
@@ -1531,6 +1531,9 @@ class DateRangePickerDialog extends StatefulWidget {
   /// {@macro material_ui.calendar_date_picker.calendarDelegate}
   final CalendarDelegate<DateTime> calendarDelegate;
 
+  /// Optional text input formatters.
+  final List<TextInputFormatter>? inputFormatters;
+
   @override
   State<DateRangePickerDialog> createState() => _DateRangePickerDialogState();
 }

--- a/packages/material_ui/lib/src/input_date_picker_form_field.dart
+++ b/packages/material_ui/lib/src/input_date_picker_form_field.dart
@@ -6,6 +6,7 @@
 /// @docImport 'text_field.dart';
 library;
 
+import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 
 import 'date.dart';
@@ -284,7 +285,16 @@ class _InputDatePickerFormFieldState extends State<InputDatePickerFormField> {
         autofocus: widget.autofocus,
         controller: _controller,
         focusNode: widget.focusNode,
+        inputFormatters: [...?_textInputFormatter],
       ),
     );
+  }
+
+  List<TextInputFormatter>? get _textInputFormatter {
+    return switch (widget.calendarDelegate) {
+      DateInputCalendarDelegate(:final List<TextInputFormatter>? inputFormatters) =>
+        inputFormatters,
+      _ => null,
+    };
   }
 }

--- a/packages/material_ui/lib/src/input_date_picker_form_field.dart
+++ b/packages/material_ui/lib/src/input_date_picker_form_field.dart
@@ -292,7 +292,7 @@ class _InputDatePickerFormFieldState extends State<InputDatePickerFormField> {
 
   List<TextInputFormatter>? get _textInputFormatter {
     return switch (widget.calendarDelegate) {
-      DateInputCalendarDelegate(:final List<TextInputFormatter>? inputFormatters) =>
+      DateInputGregorianCalendarDelegate(:final List<TextInputFormatter>? inputFormatters) =>
         inputFormatters,
       _ => null,
     };

--- a/packages/material_ui/lib/src/input_date_picker_form_field.dart
+++ b/packages/material_ui/lib/src/input_date_picker_form_field.dart
@@ -159,12 +159,8 @@ class InputDatePickerFormField extends StatefulWidget {
   /// enforcing a specific date mask (e.g., `MM/dd/yyyy`), limiting allowed
   /// characters, or automatically inserting date separators.
   ///
-  /// For date input and validation to function correctly, these formatters
-  /// must be consistent with the [CalendarDelegate.dateHelpText],
-  /// [CalendarDelegate.formatCompactDate], and [CalendarDelegate.parseCompactDate]
-  /// methods. While [CalendarDelegate.dateHelpText] provides the hint text
-  /// orienting the user, [CalendarDelegate.formatCompactDate] defines how a
-  /// selected date is initially displayed in the text field.
+  /// The functionality of date input and validation relies on consistency between these formatters and the [CalendarDelegate] methods: [CalendarDelegate.dateHelpText],
+  /// [CalendarDelegate.formatCompactDate], and [CalendarDelegate.parseCompactDate].
   ///
   /// Input formatters only affect the visual entry of text and do not perform
   /// validation or parsing. The conversion of user-entered text depends

--- a/packages/material_ui/lib/src/input_date_picker_form_field.dart
+++ b/packages/material_ui/lib/src/input_date_picker_form_field.dart
@@ -64,6 +64,7 @@ class InputDatePickerFormField extends StatefulWidget {
     this.acceptEmptyDate = false,
     this.focusNode,
     this.calendarDelegate = const GregorianCalendarDelegate(),
+    this.dateInputDelegate,
   }) : initialDate = initialDate != null ? calendarDelegate.dateOnly(initialDate) : null,
        firstDate = calendarDelegate.dateOnly(firstDate),
        lastDate = calendarDelegate.dateOnly(lastDate) {
@@ -151,6 +152,10 @@ class InputDatePickerFormField extends StatefulWidget {
   /// {@macro material_ui.calendar_date_picker.calendarDelegate}
   final CalendarDelegate<DateTime> calendarDelegate;
 
+  /// A delegate that manages the formatting, parsing, and input validation
+  /// for date text fields.
+  final DateInputDelegate? dateInputDelegate;
+
   @override
   State<InputDatePickerFormField> createState() => _InputDatePickerFormFieldState();
 }
@@ -196,7 +201,10 @@ class _InputDatePickerFormFieldState extends State<InputDatePickerFormField> {
   void _updateValueForSelectedDate() {
     if (_selectedDate != null) {
       final MaterialLocalizations localizations = MaterialLocalizations.of(context);
-      _inputText = widget.calendarDelegate.formatCompactDate(_selectedDate!, localizations);
+      final DateInputDelegate? dateInputDelegate = widget.dateInputDelegate;
+      _inputText = dateInputDelegate != null
+          ? dateInputDelegate.format(_selectedDate!, localizations)
+          : widget.calendarDelegate.formatCompactDate(_selectedDate!, localizations);
       var textEditingValue = TextEditingValue(text: _inputText!);
       // Select the new text if we are auto focused and haven't selected the text before.
       if (widget.autofocus && !_autoSelected) {
@@ -214,6 +222,10 @@ class _InputDatePickerFormFieldState extends State<InputDatePickerFormField> {
 
   DateTime? _parseDate(String? text) {
     final MaterialLocalizations localizations = MaterialLocalizations.of(context);
+    final DateInputDelegate? dateInputDelegate = widget.dateInputDelegate;
+    if (dateInputDelegate != null) {
+      return dateInputDelegate.parse(text, localizations);
+    }
     return widget.calendarDelegate.parseCompactDate(text, localizations);
   }
 
@@ -266,12 +278,19 @@ class _InputDatePickerFormFieldState extends State<InputDatePickerFormField> {
         inputTheme.border ??
         (useMaterial3 ? const OutlineInputBorder() : const UnderlineInputBorder());
 
+    final DateInputDelegate? dateInputDelegate = widget.dateInputDelegate;
+    final List<TextInputFormatter> effectiveFormatters =
+        dateInputDelegate?.inputFormatters ?? <TextInputFormatter>[];
+    final String effectiveHelpText =
+        dateInputDelegate?.helpText(localizations) ??
+        widget.calendarDelegate.dateHelpText(localizations);
+
     return Semantics(
       container: true,
       child: TextFormField(
         decoration:
             InputDecoration(
-              hintText: widget.fieldHintText ?? widget.calendarDelegate.dateHelpText(localizations),
+              hintText: widget.fieldHintText ?? effectiveHelpText,
               labelText: widget.fieldLabelText ?? localizations.dateInputLabel,
             ).applyDefaults(
               inputTheme
@@ -285,16 +304,8 @@ class _InputDatePickerFormFieldState extends State<InputDatePickerFormField> {
         autofocus: widget.autofocus,
         controller: _controller,
         focusNode: widget.focusNode,
-        inputFormatters: [...?_textInputFormatter],
+        inputFormatters: effectiveFormatters,
       ),
     );
-  }
-
-  List<TextInputFormatter>? get _textInputFormatter {
-    return switch (widget.calendarDelegate) {
-      DateInputGregorianCalendarDelegate(:final List<TextInputFormatter>? inputFormatters) =>
-        inputFormatters,
-      _ => null,
-    };
   }
 }

--- a/packages/material_ui/lib/src/input_date_picker_form_field.dart
+++ b/packages/material_ui/lib/src/input_date_picker_form_field.dart
@@ -64,7 +64,7 @@ class InputDatePickerFormField extends StatefulWidget {
     this.acceptEmptyDate = false,
     this.focusNode,
     this.calendarDelegate = const GregorianCalendarDelegate(),
-    this.dateInputDelegate,
+    this.inputFormatters,
   }) : initialDate = initialDate != null ? calendarDelegate.dateOnly(initialDate) : null,
        firstDate = calendarDelegate.dateOnly(firstDate),
        lastDate = calendarDelegate.dateOnly(lastDate) {
@@ -152,9 +152,30 @@ class InputDatePickerFormField extends StatefulWidget {
   /// {@macro material_ui.calendar_date_picker.calendarDelegate}
   final CalendarDelegate<DateTime> calendarDelegate;
 
-  /// A delegate that manages the formatting, parsing, and input validation
-  /// for date text fields.
-  final DateInputDelegate? dateInputDelegate;
+  /// {@template flutter.material.input_date_picker_form_field.inputFormatters}
+  /// Optional list of [TextInputFormatter]s applied to the date input field.
+  ///
+  /// These formatters control and restrict how the user enters text, such as
+  /// enforcing a specific date mask (e.g., `MM/dd/yyyy`), limiting allowed
+  /// characters, or automatically inserting date separators.
+  ///
+  /// For date input and validation to function correctly, these formatters
+  /// must be consistent with the [CalendarDelegate.dateHelpText],
+  /// [CalendarDelegate.formatCompactDate], and [CalendarDelegate.parseCompactDate]
+  /// methods. While [CalendarDelegate.dateHelpText] provides the hint text
+  /// orienting the user, [CalendarDelegate.formatCompactDate] defines how a
+  /// selected date is initially displayed in the text field.
+  ///
+  /// Input formatters only affect the visual entry of text and do not perform
+  /// validation or parsing. The conversion of user-entered text depends
+  /// entirely on [CalendarDelegate.parseCompactDate]. If the formatters
+  /// impose a structure that is incompatible with the delegate's parsing
+  /// logic, the input field may fail validation even if the user follows
+  /// the provided mask.
+  ///
+  /// If null, no input formatting is applied.
+  /// {@endtemplate}
+  final List<TextInputFormatter>? inputFormatters;
 
   @override
   State<InputDatePickerFormField> createState() => _InputDatePickerFormFieldState();
@@ -201,10 +222,7 @@ class _InputDatePickerFormFieldState extends State<InputDatePickerFormField> {
   void _updateValueForSelectedDate() {
     if (_selectedDate != null) {
       final MaterialLocalizations localizations = MaterialLocalizations.of(context);
-      final DateInputDelegate? dateInputDelegate = widget.dateInputDelegate;
-      _inputText = dateInputDelegate != null
-          ? dateInputDelegate.format(_selectedDate!, localizations)
-          : widget.calendarDelegate.formatCompactDate(_selectedDate!, localizations);
+      _inputText = widget.calendarDelegate.formatCompactDate(_selectedDate!, localizations);
       var textEditingValue = TextEditingValue(text: _inputText!);
       // Select the new text if we are auto focused and haven't selected the text before.
       if (widget.autofocus && !_autoSelected) {
@@ -222,10 +240,7 @@ class _InputDatePickerFormFieldState extends State<InputDatePickerFormField> {
 
   DateTime? _parseDate(String? text) {
     final MaterialLocalizations localizations = MaterialLocalizations.of(context);
-    final DateInputDelegate? dateInputDelegate = widget.dateInputDelegate;
-    if (dateInputDelegate != null) {
-      return dateInputDelegate.parse(text, localizations);
-    }
+
     return widget.calendarDelegate.parseCompactDate(text, localizations);
   }
 
@@ -278,19 +293,12 @@ class _InputDatePickerFormFieldState extends State<InputDatePickerFormField> {
         inputTheme.border ??
         (useMaterial3 ? const OutlineInputBorder() : const UnderlineInputBorder());
 
-    final DateInputDelegate? dateInputDelegate = widget.dateInputDelegate;
-    final List<TextInputFormatter> effectiveFormatters =
-        dateInputDelegate?.inputFormatters ?? <TextInputFormatter>[];
-    final String effectiveHelpText =
-        dateInputDelegate?.helpText(localizations) ??
-        widget.calendarDelegate.dateHelpText(localizations);
-
     return Semantics(
       container: true,
       child: TextFormField(
         decoration:
             InputDecoration(
-              hintText: widget.fieldHintText ?? effectiveHelpText,
+              hintText: widget.fieldHintText ?? widget.calendarDelegate.dateHelpText(localizations),
               labelText: widget.fieldLabelText ?? localizations.dateInputLabel,
             ).applyDefaults(
               inputTheme
@@ -304,7 +312,7 @@ class _InputDatePickerFormFieldState extends State<InputDatePickerFormField> {
         autofocus: widget.autofocus,
         controller: _controller,
         focusNode: widget.focusNode,
-        inputFormatters: effectiveFormatters,
+        inputFormatters: widget.inputFormatters,
       ),
     );
   }

--- a/packages/material_ui/lib/src/input_date_picker_form_field.dart
+++ b/packages/material_ui/lib/src/input_date_picker_form_field.dart
@@ -6,7 +6,6 @@
 /// @docImport 'text_field.dart';
 library;
 
-import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 
 import 'date.dart';
@@ -64,7 +63,6 @@ class InputDatePickerFormField extends StatefulWidget {
     this.acceptEmptyDate = false,
     this.focusNode,
     this.calendarDelegate = const GregorianCalendarDelegate(),
-    this.inputFormatters,
   }) : initialDate = initialDate != null ? calendarDelegate.dateOnly(initialDate) : null,
        firstDate = calendarDelegate.dateOnly(firstDate),
        lastDate = calendarDelegate.dateOnly(lastDate) {
@@ -151,27 +149,6 @@ class InputDatePickerFormField extends StatefulWidget {
 
   /// {@macro material_ui.calendar_date_picker.calendarDelegate}
   final CalendarDelegate<DateTime> calendarDelegate;
-
-  /// {@template flutter.material.input_date_picker_form_field.inputFormatters}
-  /// Optional list of [TextInputFormatter]s applied to the date input field.
-  ///
-  /// These formatters control and restrict how the user enters text, such as
-  /// enforcing a specific date mask (e.g., `MM/dd/yyyy`), limiting allowed
-  /// characters, or automatically inserting date separators.
-  ///
-  /// The functionality of date input and validation relies on consistency between these formatters and the [CalendarDelegate] methods: [CalendarDelegate.dateHelpText],
-  /// [CalendarDelegate.formatCompactDate], and [CalendarDelegate.parseCompactDate].
-  ///
-  /// Input formatters only affect the visual entry of text and do not perform
-  /// validation or parsing. The conversion of user-entered text depends
-  /// entirely on [CalendarDelegate.parseCompactDate]. If the formatters
-  /// impose a structure that is incompatible with the delegate's parsing
-  /// logic, the input field may fail validation even if the user follows
-  /// the provided mask.
-  ///
-  /// If null, no input formatting is applied.
-  /// {@endtemplate}
-  final List<TextInputFormatter>? inputFormatters;
 
   @override
   State<InputDatePickerFormField> createState() => _InputDatePickerFormFieldState();
@@ -308,7 +285,7 @@ class _InputDatePickerFormFieldState extends State<InputDatePickerFormField> {
         autofocus: widget.autofocus,
         controller: _controller,
         focusNode: widget.focusNode,
-        inputFormatters: widget.inputFormatters,
+        inputFormatters: widget.calendarDelegate.keyboardInputFormatters(localizations),
       ),
     );
   }

--- a/packages/material_ui/pending_changelogs/change_2026_08_19_date_input_formatters.yaml
+++ b/packages/material_ui/pending_changelogs/change_2026_08_19_date_input_formatters.yaml
@@ -1,0 +1,5 @@
+changelog: |
+  - Adds support for customizing date input formatters via
+    `CalendarDelegate.keyboardInputFormatters`, allowing custom date input
+    behavior in the Material date picker.
+version: minor

--- a/packages/material_ui/test/date_picker_test.dart
+++ b/packages/material_ui/test/date_picker_test.dart
@@ -2776,11 +2776,6 @@ void main() {
   });
 
   group('Date TextInputFormatter', () {
-    final inputFormatters = <TextInputFormatter>[
-      FilteringTextInputFormatter.digitsOnly,
-      LengthLimitingTextInputFormatter(8),
-    ];
-
     DateTime? result;
 
     Widget buildApp(Widget child) {
@@ -2799,7 +2794,6 @@ void main() {
         lastDate: lastDate,
         initialEntryMode: DatePickerEntryMode.input,
         calendarDelegate: const _TestDateInputDelegate(),
-        inputFormatters: inputFormatters,
       );
     }
 
@@ -3026,5 +3020,13 @@ class _TestDateInputDelegate extends GregorianCalendarDelegate {
     }
 
     return null;
+  }
+
+  @override
+  List<TextInputFormatter>? keyboardInputFormatters(MaterialLocalizations localizations) {
+    return <TextInputFormatter>[
+      FilteringTextInputFormatter.digitsOnly,
+      LengthLimitingTextInputFormatter(8),
+    ];
   }
 }

--- a/packages/material_ui/test/date_picker_test.dart
+++ b/packages/material_ui/test/date_picker_test.dart
@@ -2775,7 +2775,7 @@ void main() {
     expect(tester.getSize(find.byType(DatePickerDialog)).isEmpty, isTrue);
   });
 
-  group('DateInputGregorianCalendarDelegate', () {
+  group('DateInputConfiguration', () {
     Widget buildApp() {
       return MaterialApp(
         home: Material(
@@ -2790,7 +2790,7 @@ void main() {
                     firstDate: firstDate,
                     lastDate: lastDate,
                     initialEntryMode: DatePickerEntryMode.input,
-                    calendarDelegate: const TestDateInputGregorianCalendarDelegate(),
+                    dateInputDelegate: const _TestDateInputDelegate(),
                   );
                 },
               );
@@ -2819,7 +2819,7 @@ void main() {
                       firstDate: firstDate,
                       lastDate: lastDate,
                       initialEntryMode: DatePickerEntryMode.input,
-                      calendarDelegate: const TestDateInputGregorianCalendarDelegate(),
+                      dateInputDelegate: const _TestDateInputDelegate(),
                     );
                   },
                 );
@@ -3011,23 +3011,47 @@ class TestCalendarDelegate extends GregorianCalendarDelegate {
   }
 }
 
-class TestDateInputGregorianCalendarDelegate extends DateInputGregorianCalendarDelegate {
-  const TestDateInputGregorianCalendarDelegate();
+class _TestDateInputDelegate extends DateInputDelegate {
+  const _TestDateInputDelegate();
 
   @override
   List<TextInputFormatter> get inputFormatters => <TextInputFormatter>[
     FilteringTextInputFormatter.digitsOnly,
+    LengthLimitingTextInputFormatter(8),
   ];
 
   @override
-  DateTime? parseCompactDate(String? inputString, MaterialLocalizations localizations) {
-    // yyyyMMdd
-    if (inputString == null || inputString.length != 8) {
+  String helpText(MaterialLocalizations localizations) {
+    return 'aaaammdd';
+  }
+
+  @override
+  String format(DateTime date, MaterialLocalizations localizations) {
+    final String year = date.year.toString().padLeft(4, '0');
+    final String month = date.month.toString().padLeft(2, '0');
+    final String day = date.day.toString().padLeft(2, '0');
+    return '$year$month$day';
+  }
+
+  @override
+  DateTime? parse(String? input, MaterialLocalizations localizations) {
+    if (input == null || input.length != 8) {
       return null;
     }
-    final int year = int.parse(inputString.substring(0, 4));
-    final int month = int.parse(inputString.substring(4, 6));
-    final int day = int.parse(inputString.substring(6, 8));
-    return DateTime(year, month, day);
+
+    try {
+      final int year = int.parse(input.substring(0, 4));
+      final int month = int.parse(input.substring(4, 6));
+      final int day = int.parse(input.substring(6, 8));
+
+      final date = DateTime(year, month, day);
+      if (date.year == year && date.month == month && date.day == day) {
+        return date;
+      }
+    } catch (e) {
+      return null;
+    }
+
+    return null;
   }
 }

--- a/packages/material_ui/test/date_picker_test.dart
+++ b/packages/material_ui/test/date_picker_test.dart
@@ -2775,7 +2775,7 @@ void main() {
     expect(tester.getSize(find.byType(DatePickerDialog)).isEmpty, isTrue);
   });
 
-  group('DateInputCalendarDelegate', () {
+  group('DateInputGregorianCalendarDelegate', () {
     Widget buildApp() {
       return MaterialApp(
         home: Material(
@@ -2790,7 +2790,7 @@ void main() {
                     firstDate: firstDate,
                     lastDate: lastDate,
                     initialEntryMode: DatePickerEntryMode.input,
-                    calendarDelegate: const TestDateInputCalendarDelegate(),
+                    calendarDelegate: const TestDateInputGregorianCalendarDelegate(),
                   );
                 },
               );
@@ -2819,7 +2819,7 @@ void main() {
                       firstDate: firstDate,
                       lastDate: lastDate,
                       initialEntryMode: DatePickerEntryMode.input,
-                      calendarDelegate: const TestDateInputCalendarDelegate(),
+                      calendarDelegate: const TestDateInputGregorianCalendarDelegate(),
                     );
                   },
                 );
@@ -3011,8 +3011,8 @@ class TestCalendarDelegate extends GregorianCalendarDelegate {
   }
 }
 
-class TestDateInputCalendarDelegate extends DateInputCalendarDelegate {
-  const TestDateInputCalendarDelegate();
+class TestDateInputGregorianCalendarDelegate extends DateInputGregorianCalendarDelegate {
+  const TestDateInputGregorianCalendarDelegate();
 
   @override
   List<TextInputFormatter> get inputFormatters => <TextInputFormatter>[

--- a/packages/material_ui/test/date_picker_test.dart
+++ b/packages/material_ui/test/date_picker_test.dart
@@ -2775,7 +2775,12 @@ void main() {
     expect(tester.getSize(find.byType(DatePickerDialog)).isEmpty, isTrue);
   });
 
-  group('DateInputConfiguration', () {
+  group('Date TextInputFormatter', () {
+    final inputFormatters = <TextInputFormatter>[
+      FilteringTextInputFormatter.digitsOnly,
+      LengthLimitingTextInputFormatter(8),
+    ];
+
     Widget buildApp() {
       return MaterialApp(
         home: Material(
@@ -2790,7 +2795,8 @@ void main() {
                     firstDate: firstDate,
                     lastDate: lastDate,
                     initialEntryMode: DatePickerEntryMode.input,
-                    dateInputDelegate: const _TestDateInputDelegate(),
+                    calendarDelegate: const _TestDateInputDelegate(),
+                    inputFormatters: inputFormatters,
                   );
                 },
               );
@@ -2819,7 +2825,8 @@ void main() {
                       firstDate: firstDate,
                       lastDate: lastDate,
                       initialEntryMode: DatePickerEntryMode.input,
-                      dateInputDelegate: const _TestDateInputDelegate(),
+                      calendarDelegate: const _TestDateInputDelegate(),
+                      inputFormatters: inputFormatters,
                     );
                   },
                 );
@@ -3011,22 +3018,16 @@ class TestCalendarDelegate extends GregorianCalendarDelegate {
   }
 }
 
-base class _TestDateInputDelegate extends DateInputDelegate {
+class _TestDateInputDelegate extends GregorianCalendarDelegate {
   const _TestDateInputDelegate();
 
   @override
-  List<TextInputFormatter> get inputFormatters => <TextInputFormatter>[
-    FilteringTextInputFormatter.digitsOnly,
-    LengthLimitingTextInputFormatter(8),
-  ];
-
-  @override
-  String helpText(MaterialLocalizations localizations) {
+  String dateHelpText(MaterialLocalizations localizations) {
     return 'yyyymmdd';
   }
 
   @override
-  String format(DateTime date, MaterialLocalizations localizations) {
+  String formatCompactDate(DateTime date, MaterialLocalizations localizations) {
     final String year = date.year.toString().padLeft(4, '0');
     final String month = date.month.toString().padLeft(2, '0');
     final String day = date.day.toString().padLeft(2, '0');
@@ -3034,15 +3035,15 @@ base class _TestDateInputDelegate extends DateInputDelegate {
   }
 
   @override
-  DateTime? parse(String? input, MaterialLocalizations localizations) {
-    if (input == null || input.length != 8) {
+  DateTime? parseCompactDate(String? inputString, MaterialLocalizations localizations) {
+    if (inputString == null || inputString.length != 8) {
       return null;
     }
 
     try {
-      final int year = int.parse(input.substring(0, 4));
-      final int month = int.parse(input.substring(4, 6));
-      final int day = int.parse(input.substring(6, 8));
+      final int year = int.parse(inputString.substring(0, 4));
+      final int month = int.parse(inputString.substring(4, 6));
+      final int day = int.parse(inputString.substring(6, 8));
 
       final date = DateTime(year, month, day);
       if (date.year == year && date.month == month && date.day == day) {

--- a/packages/material_ui/test/date_picker_test.dart
+++ b/packages/material_ui/test/date_picker_test.dart
@@ -3022,7 +3022,7 @@ class _TestDateInputDelegate extends DateInputDelegate {
 
   @override
   String helpText(MaterialLocalizations localizations) {
-    return 'aaaammdd';
+    return 'yyyymmdd';
   }
 
   @override

--- a/packages/material_ui/test/date_picker_test.dart
+++ b/packages/material_ui/test/date_picker_test.dart
@@ -17,6 +17,7 @@ import 'package:material_ui/material_ui.dart';
 
 import 'clipboard_utils.dart';
 
+
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
@@ -2773,6 +2774,111 @@ void main() {
     );
     expect(tester.getSize(find.byType(DatePickerDialog)).isEmpty, isTrue);
   });
+
+  group('DateInputCalendarDelegate', () {
+    Widget buildApp() {
+      return MaterialApp(
+        home: Material(
+          child: Builder(
+            builder: (BuildContext context) {
+              return ElevatedButton(
+                child: const Text('Open'),
+                onPressed: () {
+                  showDatePicker(
+                    context: context,
+                    initialDate: initialDate,
+                    firstDate: firstDate,
+                    lastDate: lastDate,
+                    initialEntryMode: DatePickerEntryMode.input,
+                    calendarDelegate: const TestDateInputCalendarDelegate(),
+                  );
+                },
+              );
+            },
+          ),
+        ),
+      );
+    }
+
+    testWidgets('applies inputFormatters and allows text entry parsing', (
+      WidgetTester tester,
+    ) async {
+      late DateTime? result;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Material(
+            child: Builder(
+              builder: (BuildContext context) {
+                return ElevatedButton(
+                  child: const Text('Open'),
+                  onPressed: () async {
+                    result = await showDatePicker(
+                      context: context,
+                      initialDate: initialDate,
+                      firstDate: firstDate,
+                      lastDate: lastDate,
+                      initialEntryMode: DatePickerEntryMode.input,
+                      calendarDelegate: const TestDateInputCalendarDelegate(),
+                    );
+                  },
+                );
+              },
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('Open'));
+      await tester.pumpAndSettle();
+
+      await tester.enterText(find.byType(TextField), '20240620');
+      await tester.pump();
+
+      await tester.tap(find.text('OK'));
+      await tester.pumpAndSettle();
+
+      expect(result, DateTime(2024, 6, 20));
+    });
+
+    testWidgets('filters non-digit input via inputFormatters', (WidgetTester tester) async {
+      await tester.pumpWidget(buildApp());
+
+      await tester.tap(find.text('Open'));
+      await tester.pump();
+
+      final Finder textField = find.byType(TextField);
+      expect(textField, findsOneWidget);
+
+      await tester.enterText(textField, '2024-06-20');
+      await tester.pump();
+
+      final TextField field = tester.widget<TextField>(textField);
+      final TextEditingController controller = field.controller!;
+      // Only digits should remain.
+      expect(controller.text, '20240620');
+    });
+
+    testWidgets('rejects alphabetic characters via inputFormatters', (WidgetTester tester) async {
+      await tester.pumpWidget(buildApp());
+
+      await tester.tap(find.text('Open'));
+      await tester.pump();
+
+      final Finder textField = find.byType(TextField);
+      expect(textField, findsOneWidget);
+
+      // Try to enter letters mixed with digits.
+      await tester.enterText(textField, '20ab24cd0620');
+      await tester.pump();
+
+      final TextField field = tester.widget<TextField>(textField);
+      final TextEditingController controller = field.controller!;
+
+      // Alphabetic characters should be filtered out.
+      expect(controller.text, '20240620');
+    });
+  });
 }
 
 class _RestorableDatePickerDialogTestWidget extends StatefulWidget {
@@ -2902,5 +3008,26 @@ class TestCalendarDelegate extends GregorianCalendarDelegate {
   @override
   int firstDayOffset(int year, int month, MaterialLocalizations localizations) {
     return 1;
+  }
+}
+
+class TestDateInputCalendarDelegate extends DateInputCalendarDelegate {
+  const TestDateInputCalendarDelegate();
+
+  @override
+  List<TextInputFormatter> get inputFormatters => <TextInputFormatter>[
+    FilteringTextInputFormatter.digitsOnly,
+  ];
+
+  @override
+  DateTime? parseCompactDate(String? inputString, MaterialLocalizations localizations) {
+    // yyyyMMdd
+    if (inputString == null || inputString.length != 8) {
+      return null;
+    }
+    final int year = int.parse(inputString.substring(0, 4));
+    final int month = int.parse(inputString.substring(4, 6));
+    final int day = int.parse(inputString.substring(6, 8));
+    return DateTime(year, month, day);
   }
 }

--- a/packages/material_ui/test/date_picker_test.dart
+++ b/packages/material_ui/test/date_picker_test.dart
@@ -17,7 +17,6 @@ import 'package:material_ui/material_ui.dart';
 
 import 'clipboard_utils.dart';
 
-
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 

--- a/packages/material_ui/test/date_picker_test.dart
+++ b/packages/material_ui/test/date_picker_test.dart
@@ -3011,7 +3011,7 @@ class TestCalendarDelegate extends GregorianCalendarDelegate {
   }
 }
 
-class _TestDateInputDelegate extends DateInputDelegate {
+base class _TestDateInputDelegate extends DateInputDelegate {
   const _TestDateInputDelegate();
 
   @override

--- a/packages/material_ui/test/date_picker_test.dart
+++ b/packages/material_ui/test/date_picker_test.dart
@@ -2781,59 +2781,33 @@ void main() {
       LengthLimitingTextInputFormatter(8),
     ];
 
-    Widget buildApp() {
+    DateTime? result;
+
+    Widget buildApp(Widget child) {
       return MaterialApp(
-        home: Material(
-          child: Builder(
-            builder: (BuildContext context) {
-              return ElevatedButton(
-                child: const Text('Open'),
-                onPressed: () {
-                  showDatePicker(
-                    context: context,
-                    initialDate: initialDate,
-                    firstDate: firstDate,
-                    lastDate: lastDate,
-                    initialEntryMode: DatePickerEntryMode.input,
-                    calendarDelegate: const _TestDateInputDelegate(),
-                    inputFormatters: inputFormatters,
-                  );
-                },
-              );
-            },
-          ),
-        ),
+        home: Scaffold(body: Center(child: child)),
+      );
+    }
+
+    Future<void> openPicker(WidgetTester tester) async {
+      final BuildContext context = tester.element(find.text('Open'));
+
+      result = await showDatePicker(
+        context: context,
+        initialDate: initialDate,
+        firstDate: firstDate,
+        lastDate: lastDate,
+        initialEntryMode: DatePickerEntryMode.input,
+        calendarDelegate: const _TestDateInputDelegate(),
+        inputFormatters: inputFormatters,
       );
     }
 
     testWidgets('applies inputFormatters and allows text entry parsing', (
       WidgetTester tester,
     ) async {
-      late DateTime? result;
-
       await tester.pumpWidget(
-        MaterialApp(
-          home: Material(
-            child: Builder(
-              builder: (BuildContext context) {
-                return ElevatedButton(
-                  child: const Text('Open'),
-                  onPressed: () async {
-                    result = await showDatePicker(
-                      context: context,
-                      initialDate: initialDate,
-                      firstDate: firstDate,
-                      lastDate: lastDate,
-                      initialEntryMode: DatePickerEntryMode.input,
-                      calendarDelegate: const _TestDateInputDelegate(),
-                      inputFormatters: inputFormatters,
-                    );
-                  },
-                );
-              },
-            ),
-          ),
-        ),
+        buildApp(ElevatedButton(onPressed: () => openPicker(tester), child: const Text('Open'))),
       );
 
       await tester.tap(find.text('Open'));
@@ -2849,41 +2823,39 @@ void main() {
     });
 
     testWidgets('filters non-digit input via inputFormatters', (WidgetTester tester) async {
-      await tester.pumpWidget(buildApp());
+      await tester.pumpWidget(
+        buildApp(ElevatedButton(onPressed: () => openPicker(tester), child: const Text('Open'))),
+      );
 
       await tester.tap(find.text('Open'));
+      await tester.pumpAndSettle();
+
+      final Finder textFieldFinder = find.byType(TextField);
+
+      await tester.enterText(textFieldFinder, '2024-06-20');
       await tester.pump();
 
-      final Finder textField = find.byType(TextField);
-      expect(textField, findsOneWidget);
-
-      await tester.enterText(textField, '2024-06-20');
-      await tester.pump();
-
-      final TextField field = tester.widget<TextField>(textField);
-      final TextEditingController controller = field.controller!;
-      // Only digits should remain.
-      expect(controller.text, '20240620');
+      final TextField textField = tester.widget<TextField>(textFieldFinder);
+      // Verify that hyphens were removed by the formatter.
+      expect(textField.controller!.text, '20240620');
     });
 
     testWidgets('rejects alphabetic characters via inputFormatters', (WidgetTester tester) async {
-      await tester.pumpWidget(buildApp());
+      await tester.pumpWidget(
+        buildApp(ElevatedButton(onPressed: () => openPicker(tester), child: const Text('Open'))),
+      );
 
       await tester.tap(find.text('Open'));
+      await tester.pumpAndSettle();
+
+      final Finder textFieldFinder = find.byType(TextField);
+
+      await tester.enterText(textFieldFinder, '20ab24cd0620');
       await tester.pump();
 
-      final Finder textField = find.byType(TextField);
-      expect(textField, findsOneWidget);
-
-      // Try to enter letters mixed with digits.
-      await tester.enterText(textField, '20ab24cd0620');
-      await tester.pump();
-
-      final TextField field = tester.widget<TextField>(textField);
-      final TextEditingController controller = field.controller!;
-
-      // Alphabetic characters should be filtered out.
-      expect(controller.text, '20240620');
+      final TextField textField = tester.widget<TextField>(textFieldFinder);
+      // Only digits should remain in the controller.
+      expect(textField.controller!.text, '20240620');
     });
   });
 }


### PR DESCRIPTION
This PR adds the `keyboardInputFormatters` method to `CalendarDelegate`.

Previously, date input was strictly coupled to `MaterialLocalizations`. This change allows developers to provide a list of `TextInputFormatter`s via a custom `CalendarDelegate` to enforce specific input masks (e.g., dd/MM/yyyy) or restrict character entry in date pickers (`showDatePicker`, `showDateRangePicker`, and `InputDatePickerFormField`).


Fixes flutter/flutter#83302
Fixes flutter/flutter#97134 
Fixes flutter/flutter#62401
Fixes flutter/flutter#181043
Fixes flutter/flutter#115151
Fixes flutter/flutter#191639
Fixes partially flutter/flutter#150611

Port of https://github.com/flutter/flutter/pull/181105

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under[^1].
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[the version and CHANGELOG instructions]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version-and-changelog-updates
[semantic versioning]: https://dart.dev/tools/pub/versioning#semantic-versions
[repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
