### PR TITLE
[material_ui] Make onChanged optional and add enabled to DropdownButtonFormField

### DIFF
--- a/packages/material_ui/lib/fix_data/fix_dropdown_button.yaml
+++ b/packages/material_ui/lib/fix_data/fix_dropdown_button.yaml
@@ -38,7 +38,11 @@ transforms:
       constructor: ''
       inClass: "DropdownButton"
     oneOf:
-      - if: "onChanged == 'null'"
+      - if: "onChanged == 'null' && enabled == 'false'"
+        changes:
+          - kind: "removeParameter"
+            name: "onChanged"
+      - if: "onChanged == 'null' && enabled == ''"
         changes:
           - kind: "addParameter"
             index: 0
@@ -65,7 +69,11 @@ transforms:
       constructor: ''
       inClass: "DropdownButtonFormField"
     oneOf:
-      - if: "onChanged == 'null'"
+      - if: "onChanged == 'null' && enabled == 'false'"
+        changes:
+          - kind: "removeParameter"
+            name: "onChanged"
+      - if: "onChanged == 'null' && enabled == ''"
         changes:
           - kind: "addParameter"
             index: 0

--- a/packages/material_ui/lib/fix_data/fix_dropdown_button.yaml
+++ b/packages/material_ui/lib/fix_data/fix_dropdown_button.yaml
@@ -30,4 +30,58 @@ transforms:
         oldName: 'value'
         newName: 'initialValue'
 
+  # Changes made in https://github.com/flutter/flutter/pull/182419.
+  - title: "Migrate to 'enabled: false'"
+    date: 2026-02-14
+    element:
+      uris: [ 'material.dart' ]
+      constructor: ''
+      inClass: "DropdownButton"
+    oneOf:
+      - if: "onChanged == 'null'"
+        changes:
+          - kind: "addParameter"
+            index: 0
+            name: "enabled"
+            style: "optional_named"
+            argumentValue:
+              expression: "false"
+              requiredIf: "onChanged == 'null'"
+          - kind: "removeParameter"
+            name: "onChanged"
+    variables:
+      onChanged:
+        kind: "fragment"
+        value: "arguments[onChanged]"
+      enabled:
+        kind: "fragment"
+        value: "arguments[enabled]"
+
+  # Changes made in https://github.com/flutter/flutter/pull/182419.
+  - title: "Migrate to 'enabled: false'"
+    date: 2026-02-14
+    element:
+      uris: [ 'material.dart' ]
+      constructor: ''
+      inClass: "DropdownButtonFormField"
+    oneOf:
+      - if: "onChanged == 'null'"
+        changes:
+          - kind: "addParameter"
+            index: 0
+            name: "enabled"
+            style: "optional_named"
+            argumentValue:
+              expression: "false"
+              requiredIf: "onChanged == 'null'"
+          - kind: "removeParameter"
+            name: "onChanged"
+    variables:
+      onChanged:
+        kind: "fragment"
+        value: "arguments[onChanged]"
+      enabled:
+        kind: "fragment"
+        value: "arguments[enabled]"
+
 # Before adding a new fix: read instructions at the top of this file.

--- a/packages/material_ui/lib/fix_data/fix_dropdown_button.yaml
+++ b/packages/material_ui/lib/fix_data/fix_dropdown_button.yaml
@@ -38,10 +38,19 @@ transforms:
       constructor: ''
       inClass: "DropdownButton"
     oneOf:
-      - if: "onChanged == 'null' && enabled == 'false'"
+      - if: "onChanged == 'null' && enabled != ''"
         changes:
           - kind: "removeParameter"
             name: "onChanged"
+          - kind: "removeParameter"
+            name: "enabled"
+          - kind: "addParameter"
+            index: 0
+            name: "enabled"
+            style: "optional_named"
+            argumentValue:
+              expression: "false"
+              requiredIf: "onChanged == 'null'"
       - if: "onChanged == 'null' && enabled == ''"
         changes:
           - kind: "addParameter"
@@ -69,10 +78,19 @@ transforms:
       constructor: ''
       inClass: "DropdownButtonFormField"
     oneOf:
-      - if: "onChanged == 'null' && enabled == 'false'"
+      - if: "onChanged == 'null' && enabled != ''"
         changes:
           - kind: "removeParameter"
             name: "onChanged"
+          - kind: "removeParameter"
+            name: "enabled"
+          - kind: "addParameter"
+            index: 0
+            name: "enabled"
+            style: "optional_named"
+            argumentValue:
+              expression: "false"
+              requiredIf: "onChanged == 'null'"
       - if: "onChanged == 'null' && enabled == ''"
         changes:
           - kind: "addParameter"

--- a/packages/material_ui/lib/src/dropdown.dart
+++ b/packages/material_ui/lib/src/dropdown.dart
@@ -1143,6 +1143,9 @@ class DropdownButton<T> extends StatefulWidget {
   ///
   /// The dropdown button is enabled when [enabled] is true.
   ///
+  /// If [enabled] is null, then the dropdown button will be enabled if
+  /// [onChanged] is provided, and disabled otherwise.
+  ///
   /// If [enabled] is false, or the list of [DropdownButton.items] is null or empty,
   /// then the dropdown button will be disabled. When disabled, the arrow is
   /// displayed in grey and the button does not respond to input.

--- a/packages/material_ui/lib/src/dropdown.dart
+++ b/packages/material_ui/lib/src/dropdown.dart
@@ -1139,12 +1139,16 @@ class DropdownButton<T> extends StatefulWidget {
   /// {@template material_ui.dropdownButton.onChanged}
   /// Called when the user selects an item.
   ///
-  /// If the [onChanged] callback is null or the list of [DropdownButton.items]
-  /// is null then the dropdown button will be disabled, i.e. its arrow will be
-  /// displayed in grey and it will not respond to input. A disabled button
-  /// will display the [DropdownButton.disabledHint] widget if it is non-null.
-  /// If [DropdownButton.disabledHint] is also null but [DropdownButton.hint] is
-  /// non-null, [DropdownButton.hint] will instead be displayed.
+  /// The dropdown button is enabled when [enabled] is true.
+  ///
+  /// If [enabled] is false or the list of [DropdownButton.items] is null,
+  /// then the dropdown button will be disabled. When disabled, the arrow is
+  /// displayed in grey and the button does not respond to input.
+  ///
+  /// A disabled button will display the [DropdownButton.disabledHint] widget if
+  /// it is non-null. If [DropdownButton.disabledHint] is also null but
+  /// [DropdownButton.hint] is non-null, [DropdownButton.hint] will instead be
+  /// displayed.
   /// {@endtemplate}
   final ValueChanged<T?>? onChanged;
 

--- a/packages/material_ui/lib/src/dropdown.dart
+++ b/packages/material_ui/lib/src/dropdown.dart
@@ -1132,7 +1132,7 @@ class DropdownButton<T> extends StatefulWidget {
 
   /// A preferred placeholder widget that is displayed when the dropdown is disabled.
   ///
-  /// If [value] is null, the dropdown is disabled ([items] or [onChanged] is null),
+  /// If the dropdown is disabled ([items] is null or empty, or [enabled] is false),
   /// this widget is displayed as a placeholder for the dropdown button's value.
   final Widget? disabledHint;
 
@@ -1141,7 +1141,7 @@ class DropdownButton<T> extends StatefulWidget {
   ///
   /// The dropdown button is enabled when [enabled] is true.
   ///
-  /// If [enabled] is false or the list of [DropdownButton.items] is null,
+  /// If [enabled] is false or the list of [DropdownButton.items] is null or empty,
   /// then the dropdown button will be disabled. When disabled, the arrow is
   /// displayed in grey and the button does not respond to input.
   ///

--- a/packages/material_ui/lib/src/dropdown.dart
+++ b/packages/material_ui/lib/src/dropdown.dart
@@ -1034,6 +1034,7 @@ class DropdownButton<T> extends StatefulWidget {
     this.barrierDismissible = true,
     this.mouseCursor,
     this.dropdownMenuItemMouseCursor,
+    this.enabled = true,
     // When adding new arguments, consider adding similar arguments to
     // DropdownButtonFormField.
   }) : assert(
@@ -1060,7 +1061,7 @@ class DropdownButton<T> extends StatefulWidget {
     this.value,
     this.hint,
     this.disabledHint,
-    required this.onChanged,
+    this.onChanged,
     this.onTap,
     this.elevation = 8,
     this.style,
@@ -1087,6 +1088,7 @@ class DropdownButton<T> extends StatefulWidget {
     this.dropdownMenuItemMouseCursor,
     required this._inputDecoration,
     required this._isEmpty,
+    this.enabled = true,
   }) : assert(
          items == null ||
              items.isEmpty ||
@@ -1362,6 +1364,14 @@ class DropdownButton<T> extends StatefulWidget {
   /// If this property is null, [WidgetStateMouseCursor.adaptiveClickable] will be used.
   final MouseCursor? dropdownMenuItemMouseCursor;
 
+  /// Whether the [DropdownButton] is enabled.
+  ///
+  /// When set to false, the field is disabled and does not allow user
+  /// interaction or value changes, regardless of the `onChanged` callback.
+  ///
+  /// Defaults to true.
+  final bool enabled;
+
   final InputDecoration? _inputDecoration;
 
   final bool _isEmpty;
@@ -1574,7 +1584,7 @@ class _DropdownButtonState<T> extends State<DropdownButton<T>> with WidgetsBindi
     }
   }
 
-  bool get _enabled => widget.items != null && widget.items!.isNotEmpty && widget.onChanged != null;
+  bool get _enabled => widget.items != null && widget.items!.isNotEmpty && widget.enabled;
 
   Orientation _getOrientation(BuildContext context) {
     Orientation? result = MediaQuery.maybeOrientationOf(context);
@@ -1839,7 +1849,7 @@ class DropdownButtonFormField<T> extends FormField<T> {
     T? initialValue,
     Widget? hint,
     Widget? disabledHint,
-    required this.onChanged,
+    this.onChanged,
     VoidCallback? onTap,
     int elevation = 8,
     TextStyle? style,
@@ -1859,6 +1869,7 @@ class DropdownButtonFormField<T> extends FormField<T> {
     super.validator,
     super.errorBuilder,
     super.forceErrorText,
+    super.enabled,
     AutovalidateMode? autovalidateMode,
     double? menuMaxHeight,
     bool? enableFeedback,
@@ -1900,7 +1911,7 @@ class DropdownButtonFormField<T> extends FormField<T> {
            final bool showSelectedItem =
                items != null &&
                items.where((DropdownMenuItem<T> item) => item.value == state.value).isNotEmpty;
-           final bool isDropdownEnabled = onChanged != null && items != null && items.isNotEmpty;
+           final bool isDropdownEnabled = enabled && items != null && items.isNotEmpty;
            // If decoration hintText is provided, use it as the default value for both hint and disabledHint.
            final Widget? decorationHint = effectiveDecoration.hintText != null
                ? Text(effectiveDecoration.hintText!)
@@ -1939,7 +1950,7 @@ class DropdownButtonFormField<T> extends FormField<T> {
                  value: state.value,
                  hint: effectiveHint,
                  disabledHint: effectiveDisabledHint,
-                 onChanged: onChanged == null ? null : state.didChange,
+                 onChanged: state.didChange,
                  onTap: onTap,
                  elevation: elevation,
                  style: style,
@@ -1964,6 +1975,7 @@ class DropdownButtonFormField<T> extends FormField<T> {
                  barrierDismissible: barrierDismissible,
                  mouseCursor: mouseCursor,
                  dropdownMenuItemMouseCursor: dropdownMenuItemMouseCursor,
+                 enabled: isDropdownEnabled,
                ),
              ),
            );

--- a/packages/material_ui/lib/src/dropdown.dart
+++ b/packages/material_ui/lib/src/dropdown.dart
@@ -1954,7 +1954,7 @@ class DropdownButtonFormField<T> extends FormField<T> {
                  value: state.value,
                  hint: effectiveHint,
                  disabledHint: effectiveDisabledHint,
-                 onChanged: state.didChange,
+                 onChanged: onChanged == null ? null : state.didChange,
                  onTap: onTap,
                  elevation: elevation,
                  style: style,

--- a/packages/material_ui/lib/src/dropdown.dart
+++ b/packages/material_ui/lib/src/dropdown.dart
@@ -988,9 +988,9 @@ class DropdownButton<T> extends StatefulWidget {
   /// Creates a dropdown button.
   ///
   /// The [items] must have distinct values. If [value] isn't null then it
-  /// must be equal to one of the [DropdownMenuItem] values. If [items] or
-  /// [onChanged] is null, the button will be disabled, the down arrow
-  /// will be greyed out.
+  /// must be equal to one of the [DropdownMenuItem] values. If [items] is
+  /// null or empty, or [enabled] is false, the button will be disabled,
+  /// the down arrow will be greyed out.
   ///
   /// If [value] is null and the button is enabled, [hint] will be displayed
   /// if it is non-null.
@@ -1034,10 +1034,11 @@ class DropdownButton<T> extends StatefulWidget {
     this.barrierDismissible = true,
     this.mouseCursor,
     this.dropdownMenuItemMouseCursor,
-    this.enabled = true,
+    bool? enabled,
     // When adding new arguments, consider adding similar arguments to
     // DropdownButtonFormField.
-  }) : assert(
+  }) : enabled = enabled ?? onChanged != null,
+       assert(
          items == null ||
              items.isEmpty ||
              value == null ||
@@ -1088,8 +1089,9 @@ class DropdownButton<T> extends StatefulWidget {
     this.dropdownMenuItemMouseCursor,
     required this._inputDecoration,
     required this._isEmpty,
-    this.enabled = true,
-  }) : assert(
+    bool? enabled,
+  }) : enabled = enabled ?? onChanged != null,
+       assert(
          items == null ||
              items.isEmpty ||
              value == null ||
@@ -1106,7 +1108,7 @@ class DropdownButton<T> extends StatefulWidget {
 
   /// The list of items the user can select.
   ///
-  /// If the [onChanged] callback is null or the list of items is null
+  /// If [enabled] is false or the list of items is null or empty
   /// then the dropdown button will be disabled, i.e. its arrow will be
   /// displayed in grey and it will not respond to input.
   final List<DropdownMenuItem<T>>? items;
@@ -1141,7 +1143,7 @@ class DropdownButton<T> extends StatefulWidget {
   ///
   /// The dropdown button is enabled when [enabled] is true.
   ///
-  /// If [enabled] is false or the list of [DropdownButton.items] is null or empty,
+  /// If [enabled] is false, or the list of [DropdownButton.items] is null or empty,
   /// then the dropdown button will be disabled. When disabled, the arrow is
   /// displayed in grey and the button does not respond to input.
   ///
@@ -1229,7 +1231,7 @@ class DropdownButton<T> extends StatefulWidget {
   final Widget? icon;
 
   /// The color of any [Icon] descendant of [icon] if this button is disabled,
-  /// i.e. if [onChanged] is null.
+  /// i.e. if [enabled] is false.
   ///
   /// Defaults to [MaterialColor.shade400] of [Colors.grey] when the theme's
   /// [ThemeData.brightness] is [Brightness.light] and to
@@ -1237,7 +1239,7 @@ class DropdownButton<T> extends StatefulWidget {
   final Color? iconDisabledColor;
 
   /// The color of any [Icon] descendant of [icon] if this button is enabled,
-  /// i.e. if [onChanged] is defined.
+  /// i.e. if [enabled] is true.
   ///
   /// Defaults to [MaterialColor.shade700] of [Colors.grey] when the theme's
   /// [ThemeData.brightness] is [Brightness.light] and to
@@ -1370,10 +1372,12 @@ class DropdownButton<T> extends StatefulWidget {
 
   /// Whether the [DropdownButton] is enabled.
   ///
-  /// When set to false, the field is disabled and does not allow user
-  /// interaction or value changes, regardless of the `onChanged` callback.
+  /// When [enabled] is false, the field is disabled and does not allow user
+  /// interaction or value changes, regardless of the [onChanged] callback.
   ///
-  /// Defaults to true.
+  /// If the `enabled` argument is not explicitly provided in the constructor,
+  /// this property falls back to true if [onChanged] is not null, and
+  /// false otherwise.
   final bool enabled;
 
   final InputDecoration? _inputDecoration;
@@ -1873,7 +1877,7 @@ class DropdownButtonFormField<T> extends FormField<T> {
     super.validator,
     super.errorBuilder,
     super.forceErrorText,
-    super.enabled,
+    bool? enabled,
     AutovalidateMode? autovalidateMode,
     double? menuMaxHeight,
     bool? enableFeedback,
@@ -1907,6 +1911,7 @@ class DropdownButtonFormField<T> extends FormField<T> {
        super(
          initialValue: initialValue ?? value,
          autovalidateMode: autovalidateMode ?? AutovalidateMode.disabled,
+         enabled: enabled ?? onChanged != null,
          builder: (FormFieldState<T> field) {
            final state = field as _DropdownButtonFormFieldState<T>;
            InputDecoration effectiveDecoration = (decoration ?? const InputDecoration())
@@ -1915,7 +1920,7 @@ class DropdownButtonFormField<T> extends FormField<T> {
            final bool showSelectedItem =
                items != null &&
                items.where((DropdownMenuItem<T> item) => item.value == state.value).isNotEmpty;
-           final bool isDropdownEnabled = enabled && items != null && items.isNotEmpty;
+           final bool isDropdownEnabled = items != null && items.isNotEmpty && field.widget.enabled;
            // If decoration hintText is provided, use it as the default value for both hint and disabledHint.
            final Widget? decorationHint = effectiveDecoration.hintText != null
                ? Text(effectiveDecoration.hintText!)

--- a/packages/material_ui/pending_changelogs/change_2026_08_25_1787661550818.yaml
+++ b/packages/material_ui/pending_changelogs/change_2026_08_25_1787661550818.yaml
@@ -1,0 +1,3 @@
+changelog: |
+  - Make onChanged optional and add enabled property to DropdownButton and DropdownButtonFormField.
+version: minor

--- a/packages/material_ui/test/dropdown_form_field_test.dart
+++ b/packages/material_ui/test/dropdown_form_field_test.dart
@@ -36,6 +36,7 @@ Widget buildFormFrame({
   Alignment alignment = Alignment.center,
   TextDirection textDirection = TextDirection.ltr,
   AlignmentGeometry buttonAlignment = AlignmentDirectional.centerStart,
+  bool enabled = true,
 }) {
   return TestApp(
     textDirection: textDirection,
@@ -66,6 +67,7 @@ Widget buildFormFrame({
               );
             }).toList(),
             alignment: buttonAlignment,
+            enabled: enabled,
           ),
         ),
       ),
@@ -188,7 +190,7 @@ void main() {
           child: DropdownButtonFormField<int?>(
             decoration: const InputDecoration(labelText: 'labelText'),
             initialValue: value,
-            onChanged: null, // this disables the menu and shows the disabledHint.
+            enabled: false,
             disabledHint: const Text('disabledHint'),
             items: const <DropdownMenuItem<int?>>[
               DropdownMenuItem<int?>(value: 1, child: Text('One')),
@@ -320,7 +322,6 @@ void main() {
             decoration: const InputDecoration(labelText: 'labelText'),
             initialValue: value,
             hint: const Text('hint'),
-            onChanged: null, // disabled
             disabledHint: const Text('disabledHint'),
             items: const <DropdownMenuItem<int?>>[
               DropdownMenuItem<int?>(value: 1, child: Text('One')),
@@ -755,6 +756,7 @@ void main() {
         onChanged: onChanged,
         hint: const Text('enabled'),
         disabledHint: const Text('disabled'),
+        enabled: false,
       );
     }
 
@@ -1183,7 +1185,6 @@ void main() {
               ) {
                 return DropdownMenuItem<String>(value: value, child: Text(value));
               }).toList(),
-              onChanged: null,
             ),
           ),
         ),
@@ -1315,7 +1316,6 @@ void main() {
                         items: menuItems.map((String value) {
                           return DropdownMenuItem<String>(value: value, child: Text(value));
                         }).toList(),
-                        onChanged: null,
                         autovalidateMode: AutovalidateMode.disabled,
                       ),
                       DropdownButtonFormField<String>(
@@ -1364,7 +1364,6 @@ void main() {
                     }).toList(),
                     decoration: const InputDecoration(errorText: decorationErrorText),
                     forceErrorText: forceErrorText,
-                    onChanged: null,
                   ),
                 ),
               ),

--- a/packages/material_ui/test/dropdown_test.dart
+++ b/packages/material_ui/test/dropdown_test.dart
@@ -63,6 +63,7 @@ Widget buildDropdown({
   double? menuMaxHeight,
   EdgeInsetsGeometry? padding,
   InputDecoration? decoration,
+  bool enabled = true,
 }) {
   final List<DropdownMenuItem<String>>? listItems = items?.map<DropdownMenuItem<String>>((
     String item,
@@ -70,6 +71,7 @@ Widget buildDropdown({
     return DropdownMenuItem<String>(
       key: ValueKey<String>(item),
       value: item,
+      enabled: enabled,
       child: Text(item, key: ValueKey<String>('${item}Text')),
     );
   }).toList();
@@ -101,6 +103,7 @@ Widget buildDropdown({
         menuMaxHeight: menuMaxHeight,
         padding: padding,
         decoration: decoration,
+        enabled: enabled,
       ),
     );
   }
@@ -129,6 +132,7 @@ Widget buildDropdown({
     alignment: alignment,
     menuMaxHeight: menuMaxHeight,
     padding: padding,
+    enabled: enabled,
   );
 }
 
@@ -164,6 +168,7 @@ Widget buildFrame({
   bool? useMaterial3,
   InputDecoration? decoration,
   InputDecorationThemeData? localInputDecorationTheme,
+  bool enabled = true,
 }) {
   return Theme(
     data: ThemeData(useMaterial3: useMaterial3),
@@ -203,6 +208,7 @@ Widget buildFrame({
                 menuMaxHeight: menuMaxHeight,
                 padding: padding,
                 decoration: decoration,
+                enabled: enabled,
               ),
             ),
           ),
@@ -867,7 +873,7 @@ void main() {
     expect(enabledRichText.text.style!.color, Colors.grey.shade700);
 
     // test for disabled color
-    await tester.pumpWidget(buildFrame(icon: customIcon));
+    await tester.pumpWidget(buildFrame(icon: customIcon, enabled: false));
 
     final RichText disabledRichText = tester.widget<RichText>(_iconRichText(iconKey));
     expect(disabledRichText.text.style!.color, Colors.grey.shade400);
@@ -904,6 +910,7 @@ void main() {
         iconSize: 30.0,
         iconEnabledColor: Colors.pink,
         iconDisabledColor: Colors.orange,
+        enabled: false,
       ),
     );
 
@@ -1612,34 +1619,36 @@ void main() {
   testWidgets('disabledHint displays on empty items or onChanged', (WidgetTester tester) async {
     final Key buttonKey = UniqueKey();
 
-    Widget build({List<String>? items, ValueChanged<String?>? onChanged}) => buildFrame(
-      items: items,
-      onChanged: onChanged,
-      buttonKey: buttonKey,
-      initialValue: null,
-      hint: const Text('enabled'),
-      disabledHint: const Text('disabled'),
-    );
+    Widget build({List<String>? items, ValueChanged<String?>? onChanged, required bool enabled}) =>
+        buildFrame(
+          items: items,
+          onChanged: onChanged,
+          buttonKey: buttonKey,
+          initialValue: null,
+          hint: const Text('enabled'),
+          disabledHint: const Text('disabled'),
+          enabled: enabled,
+        );
 
     // [disabledHint] should display when [items] is null
-    await tester.pumpWidget(build(onChanged: onChanged));
+    await tester.pumpWidget(build(onChanged: onChanged, enabled: false));
     expect(find.text('enabled'), findsNothing);
     expect(find.text('disabled'), findsOneWidget);
 
     // [disabledHint] should display when [items] is an empty list.
-    await tester.pumpWidget(build(items: <String>[], onChanged: onChanged));
+    await tester.pumpWidget(build(items: <String>[], onChanged: onChanged, enabled: true));
     expect(find.text('enabled'), findsNothing);
     expect(find.text('disabled'), findsOneWidget);
 
     // [disabledHint] should display when [onChanged] is null
-    await tester.pumpWidget(build(items: menuItems));
+    await tester.pumpWidget(build(items: menuItems, enabled: false));
     expect(find.text('enabled'), findsNothing);
     expect(find.text('disabled'), findsOneWidget);
     final RenderBox disabledHintBox = tester.renderObject<RenderBox>(find.byKey(buttonKey));
 
     // A Dropdown button with a disabled hint should be the same size as a
     // one with a regular enabled hint.
-    await tester.pumpWidget(build(items: menuItems, onChanged: onChanged));
+    await tester.pumpWidget(build(items: menuItems, onChanged: onChanged, enabled: true));
     expect(find.text('disabled'), findsNothing);
     expect(find.text('enabled'), findsOneWidget);
     final RenderBox enabledHintBox = tester.renderObject<RenderBox>(find.byKey(buttonKey));
@@ -1658,16 +1667,18 @@ void main() {
       String? value,
       Widget? hint,
       Widget? disabledHint,
+      required bool enabled,
     }) => buildFrame(
       items: items,
       onChanged: onChanged,
       initialValue: value,
       hint: hint,
       disabledHint: disabledHint,
+      enabled: enabled,
     );
 
     // The selected value should be displayed when the button is disabled.
-    await tester.pumpWidget(build(items: menuItems, value: 'two'));
+    await tester.pumpWidget(build(items: menuItems, value: 'two', enabled: false));
     // The dropdown icon and the selected menu item are vertically aligned.
     expect(tester.getCenter(find.text('two')).dy, tester.getCenter(find.byType(Icon)).dy);
 
@@ -1678,18 +1689,24 @@ void main() {
         onChanged: onChanged,
         hint: const Text('hint'),
         disabledHint: const Text('disabledHint'),
+        enabled: true,
       ),
     );
     expect(tester.getCenter(find.text('hint')).dy, tester.getCenter(find.byType(Icon)).dy);
 
     // If [value] is null, the button is disabled, [disabledHint] is displayed when [disabledHint] is non-null.
     await tester.pumpWidget(
-      build(items: menuItems, hint: const Text('hint'), disabledHint: const Text('disabledHint')),
+      build(
+        items: menuItems,
+        hint: const Text('hint'),
+        disabledHint: const Text('disabledHint'),
+        enabled: false,
+      ),
     );
     expect(tester.getCenter(find.text('disabledHint')).dy, tester.getCenter(find.byType(Icon)).dy);
 
     // If [value] is null, the button is disabled, [hint] is displayed when [disabledHint] is null.
-    await tester.pumpWidget(build(items: menuItems, hint: const Text('hint')));
+    await tester.pumpWidget(build(items: menuItems, hint: const Text('hint'), enabled: false));
     expect(tester.getCenter(find.text('hint')).dy, tester.getCenter(find.byType(Icon)).dy);
 
     int? getIndex() {
@@ -1698,11 +1715,11 @@ void main() {
     }
 
     // If [value], [hint] and [disabledHint] are null, the button is disabled, nothing displayed.
-    await tester.pumpWidget(build(items: menuItems));
+    await tester.pumpWidget(build(items: menuItems, enabled: false));
     expect(getIndex(), null);
 
     // If [value], [hint] and [disabledHint] are null, the button is enabled, nothing displayed.
-    await tester.pumpWidget(build(items: menuItems, onChanged: onChanged));
+    await tester.pumpWidget(build(items: menuItems, onChanged: onChanged, enabled: true));
     expect(getIndex(), null);
   });
 
@@ -1712,6 +1729,7 @@ void main() {
       String? value,
       Widget? hint,
       Widget? disabledHint,
+      required bool enabled,
     }) {
       return MaterialApp(
         theme: ThemeData(disabledColor: Colors.pink),
@@ -1729,6 +1747,7 @@ void main() {
                   ],
                   initialValue: value,
                   onChanged: onChanged,
+                  enabled: enabled,
                 ),
               ],
             ),
@@ -1742,7 +1761,7 @@ void main() {
     }
 
     // The selected value should be displayed when the button is enabled.
-    await tester.pumpWidget(build(onChanged: onChanged, value: 'two'));
+    await tester.pumpWidget(build(onChanged: onChanged, value: 'two', enabled: true));
     // The dropdown icon and the selected menu item are vertically aligned.
     expect(tester.getCenter(find.text('two')).dy, tester.getCenter(find.byType(Icon)).dy);
     // Selected item has a normal color from [DropdownButtonFormField.style]
@@ -1750,7 +1769,7 @@ void main() {
     expect(textColor('two'), Colors.yellow);
 
     // The selected value should be displayed when the button is disabled.
-    await tester.pumpWidget(build(value: 'two'));
+    await tester.pumpWidget(build(value: 'two', enabled: false));
     expect(tester.getCenter(find.text('two')).dy, tester.getCenter(find.byType(Icon)).dy);
     // Selected item has a disabled color from [theme.disabledColor]
     // when the button is disable.
@@ -1986,6 +2005,7 @@ void main() {
           disabledHint: const SizedBox(height: 50, width: 50, child: Text('hint')),
           items: items,
           itemHeight: null,
+          enabled: false,
           selectedItemBuilder: (BuildContext context) => [
             for (final item in items)
               SizedBox.square(
@@ -2019,6 +2039,7 @@ void main() {
           disabledHint: const SizedBox(height: 125, width: 125, child: Text('hint')),
           items: items,
           itemHeight: null,
+          enabled: false,
           selectedItemBuilder: (BuildContext context) => [
             for (final item in items)
               SizedBox.square(
@@ -2861,6 +2882,7 @@ void main() {
         focusNode: focusNode,
         autofocus: true,
         focusColor: const Color(0xff00ff00),
+        enabled: false,
       ),
     );
     await tester.pump(); // Pump a frame for autofocus to take effect (although it shouldn't).
@@ -4628,6 +4650,7 @@ void main() {
           disabledHint: const Text(disabledHintText),
           isFormField: true,
           decoration: const InputDecoration(hintText: decorationHintText),
+          enabled: false,
         ),
       );
 

--- a/packages/material_ui/test/dropdown_test.dart
+++ b/packages/material_ui/test/dropdown_test.dart
@@ -5008,4 +5008,50 @@ void main() {
       );
     },
   );
+
+  testWidgets('DropdownButton enabled property fallback behavior', (WidgetTester tester) async {
+    Widget buildDropdown({bool? enabled, ValueChanged<int?>? onChanged}) {
+      return MaterialApp(
+        home: Material(
+          child: DropdownButton<int>(
+            value: 1,
+            items: const <DropdownMenuItem<int>>[
+              DropdownMenuItem<int>(value: 1, child: Text('one')),
+              DropdownMenuItem<int>(value: 2, child: Text('two')),
+            ],
+            onChanged: onChanged,
+            enabled: enabled,
+          ),
+        ),
+      );
+    }
+
+    // 1. If enabled is false, it is disabled even with onChanged provided.
+    await tester.pumpWidget(buildDropdown(enabled: false, onChanged: (int? v) {}));
+    await tester.tap(find.text('one'));
+    await tester.pumpAndSettle();
+    expect(find.text('two'), findsNothing); // Menu did not open
+
+    // 2. If enabled is true, it is enabled even without onChanged.
+    await tester.pumpWidget(buildDropdown(enabled: true));
+    await tester.tap(find.text('one'));
+    await tester.pumpAndSettle();
+    expect(find.text('two'), findsOneWidget); // Menu opened
+
+    // Close the previous menu first by tapping the item.
+    await tester.tap(find.text('one').last);
+    await tester.pumpAndSettle();
+
+    // 3. If enabled is null, it falls back to checking if onChanged is provided (disabled).
+    await tester.pumpWidget(buildDropdown());
+    await tester.tap(find.text('one'));
+    await tester.pumpAndSettle();
+    expect(find.text('two'), findsNothing); // Menu did not open
+
+    // 4. If enabled is null, it falls back to checking if onChanged is provided (enabled).
+    await tester.pumpWidget(buildDropdown(onChanged: (int? v) {}));
+    await tester.tap(find.text('one'));
+    await tester.pumpAndSettle();
+    expect(find.text('two'), findsOneWidget); // Menu opened
+  });
 }

--- a/packages/material_ui/test/dropdown_test.dart
+++ b/packages/material_ui/test/dropdown_test.dart
@@ -5009,7 +5009,9 @@ void main() {
     },
   );
 
-  testWidgets('DropdownButton enabled property fallback behavior', (WidgetTester tester) async {
+  testWidgets('DropdownButton is disabled when enabled is false even with onChanged provided', (
+    WidgetTester tester,
+  ) async {
     Widget buildDropdown({bool? enabled, ValueChanged<int?>? onChanged}) {
       return MaterialApp(
         home: Material(
@@ -5026,32 +5028,85 @@ void main() {
       );
     }
 
-    // 1. If enabled is false, it is disabled even with onChanged provided.
     await tester.pumpWidget(buildDropdown(enabled: false, onChanged: (int? v) {}));
     await tester.tap(find.text('one'));
     await tester.pumpAndSettle();
     expect(find.text('two'), findsNothing); // Menu did not open
+  });
 
-    // 2. If enabled is true, it is enabled even without onChanged.
+  testWidgets('DropdownButton is enabled when enabled is true even without onChanged', (
+    WidgetTester tester,
+  ) async {
+    Widget buildDropdown({bool? enabled, ValueChanged<int?>? onChanged}) {
+      return MaterialApp(
+        home: Material(
+          child: DropdownButton<int>(
+            value: 1,
+            items: const <DropdownMenuItem<int>>[
+              DropdownMenuItem<int>(value: 1, child: Text('one')),
+              DropdownMenuItem<int>(value: 2, child: Text('two')),
+            ],
+            onChanged: onChanged,
+            enabled: enabled,
+          ),
+        ),
+      );
+    }
+
     await tester.pumpWidget(buildDropdown(enabled: true));
     await tester.tap(find.text('one'));
     await tester.pumpAndSettle();
     expect(find.text('two'), findsOneWidget); // Menu opened
+  });
 
-    // Close the previous menu first by tapping the item.
-    await tester.tap(find.text('one').last);
-    await tester.pumpAndSettle();
+  testWidgets('DropdownButton falls back to disabled when enabled is null and onChanged is null', (
+    WidgetTester tester,
+  ) async {
+    Widget buildDropdown({bool? enabled, ValueChanged<int?>? onChanged}) {
+      return MaterialApp(
+        home: Material(
+          child: DropdownButton<int>(
+            value: 1,
+            items: const <DropdownMenuItem<int>>[
+              DropdownMenuItem<int>(value: 1, child: Text('one')),
+              DropdownMenuItem<int>(value: 2, child: Text('two')),
+            ],
+            onChanged: onChanged,
+            enabled: enabled,
+          ),
+        ),
+      );
+    }
 
-    // 3. If enabled is null, it falls back to checking if onChanged is provided (disabled).
     await tester.pumpWidget(buildDropdown());
     await tester.tap(find.text('one'));
     await tester.pumpAndSettle();
     expect(find.text('two'), findsNothing); // Menu did not open
-
-    // 4. If enabled is null, it falls back to checking if onChanged is provided (enabled).
-    await tester.pumpWidget(buildDropdown(onChanged: (int? v) {}));
-    await tester.tap(find.text('one'));
-    await tester.pumpAndSettle();
-    expect(find.text('two'), findsOneWidget); // Menu opened
   });
+
+  testWidgets(
+    'DropdownButton falls back to enabled when enabled is null and onChanged is provided',
+    (WidgetTester tester) async {
+      Widget buildDropdown({bool? enabled, ValueChanged<int?>? onChanged}) {
+        return MaterialApp(
+          home: Material(
+            child: DropdownButton<int>(
+              value: 1,
+              items: const <DropdownMenuItem<int>>[
+                DropdownMenuItem<int>(value: 1, child: Text('one')),
+                DropdownMenuItem<int>(value: 2, child: Text('two')),
+              ],
+              onChanged: onChanged,
+              enabled: enabled,
+            ),
+          ),
+        );
+      }
+
+      await tester.pumpWidget(buildDropdown(onChanged: (int? v) {}));
+      await tester.tap(find.text('one'));
+      await tester.pumpAndSettle();
+      expect(find.text('two'), findsOneWidget); // Menu opened
+    },
+  );
 }

--- a/packages/material_ui/test/dropdown_test.dart
+++ b/packages/material_ui/test/dropdown_test.dart
@@ -1631,7 +1631,7 @@ void main() {
         );
 
     // [disabledHint] should display when [items] is null
-    await tester.pumpWidget(build(onChanged: onChanged, enabled: false));
+    await tester.pumpWidget(build(onChanged: onChanged, enabled: true));
     expect(find.text('enabled'), findsNothing);
     expect(find.text('disabled'), findsOneWidget);
 
@@ -1640,7 +1640,7 @@ void main() {
     expect(find.text('enabled'), findsNothing);
     expect(find.text('disabled'), findsOneWidget);
 
-    // [disabledHint] should display when [onChanged] is null
+    // [disabledHint] should display when [enabled] is false.
     await tester.pumpWidget(build(items: menuItems, enabled: false));
     expect(find.text('enabled'), findsNothing);
     expect(find.text('disabled'), findsOneWidget);
@@ -4082,6 +4082,7 @@ void main() {
           child: DropdownButton<String>(
             key: key,
             onChanged: null,
+            enabled: false,
             items: <String>['One', 'Two', 'Three', 'Four'].map<DropdownMenuItem<String>>((
               String value,
             ) {

--- a/packages/material_ui/test_fixes/dropdown_button.dart
+++ b/packages/material_ui/test_fixes/dropdown_button.dart
@@ -16,4 +16,19 @@ void main() {
 
   // Changes made in https://github.com/flutter/flutter/pull/182419.
   DropdownButton(onChanged: (String? v) {});
+
+  // Changes made in https://github.com/flutter/flutter/pull/182419.
+  DropdownButtonFormField(onChanged: (String? v) {});
+
+  // Changes made in https://github.com/flutter/flutter/pull/182419.
+  DropdownButton(onChanged: null, enabled: true);
+
+  // Changes made in https://github.com/flutter/flutter/pull/182419.
+  DropdownButtonFormField(onChanged: null, enabled: true);
+
+  // Changes made in https://github.com/flutter/flutter/pull/182419.
+  DropdownButton(onChanged: null, enabled: false);
+
+  // Changes made in https://github.com/flutter/flutter/pull/182419.
+  DropdownButtonFormField(onChanged: null, enabled: false);
 }

--- a/packages/material_ui/test_fixes/dropdown_button.dart
+++ b/packages/material_ui/test_fixes/dropdown_button.dart
@@ -31,4 +31,10 @@ void main() {
 
   // Changes made in https://github.com/flutter/flutter/pull/182419.
   DropdownButtonFormField(onChanged: null, enabled: false);
+
+  // Changes made in https://github.com/flutter/flutter/pull/182419.
+  DropdownButton(onChanged: null);
+
+  // Changes made in https://github.com/flutter/flutter/pull/182419.
+  DropdownButtonFormField(onChanged: null);
 }

--- a/packages/material_ui/test_fixes/dropdown_button.dart
+++ b/packages/material_ui/test_fixes/dropdown_button.dart
@@ -7,4 +7,13 @@ import 'package:material_ui/material_ui.dart';
 void main() {
   // Changes made in https://github.com/flutter/flutter/pull/170805.
   DropdownButtonFormField(value: 'one');
+
+  // Changes made in https://github.com/flutter/flutter/pull/182419.
+  DropdownButton(onChanged: null);
+
+  // Changes made in https://github.com/flutter/flutter/pull/182419.
+  DropdownButtonFormField(onChanged: null);
+
+  // Changes made in https://github.com/flutter/flutter/pull/182419.
+  DropdownButton(onChanged: (String? v) {});
 }

--- a/packages/material_ui/test_fixes/dropdown_button.dart.expect
+++ b/packages/material_ui/test_fixes/dropdown_button.dart.expect
@@ -16,4 +16,19 @@ void main() {
 
   // Changes made in https://github.com/flutter/flutter/pull/182419.
   DropdownButton(onChanged: (String? v) {});
+
+  // Changes made in https://github.com/flutter/flutter/pull/182419.
+  DropdownButtonFormField(onChanged: (String? v) {});
+
+  // Changes made in https://github.com/flutter/flutter/pull/182419.
+  DropdownButton(onChanged: null, enabled: true);
+
+  // Changes made in https://github.com/flutter/flutter/pull/182419.
+  DropdownButtonFormField(onChanged: null, enabled: true);
+
+  // Changes made in https://github.com/flutter/flutter/pull/182419.
+  DropdownButton(enabled: false);
+
+  // Changes made in https://github.com/flutter/flutter/pull/182419.
+  DropdownButtonFormField(enabled: false);
 }

--- a/packages/material_ui/test_fixes/dropdown_button.dart.expect
+++ b/packages/material_ui/test_fixes/dropdown_button.dart.expect
@@ -21,10 +21,16 @@ void main() {
   DropdownButtonFormField(onChanged: (String? v) {});
 
   // Changes made in https://github.com/flutter/flutter/pull/182419.
-  DropdownButton(onChanged: null, enabled: true);
+  DropdownButton(enabled: false);
 
   // Changes made in https://github.com/flutter/flutter/pull/182419.
-  DropdownButtonFormField(onChanged: null, enabled: true);
+  DropdownButtonFormField(enabled: false);
+
+  // Changes made in https://github.com/flutter/flutter/pull/182419.
+  DropdownButton(enabled: false);
+
+  // Changes made in https://github.com/flutter/flutter/pull/182419.
+  DropdownButtonFormField(enabled: false);
 
   // Changes made in https://github.com/flutter/flutter/pull/182419.
   DropdownButton(enabled: false);

--- a/packages/material_ui/test_fixes/dropdown_button.dart.expect
+++ b/packages/material_ui/test_fixes/dropdown_button.dart.expect
@@ -7,4 +7,13 @@ import 'package:material_ui/material_ui.dart';
 void main() {
   // Changes made in https://github.com/flutter/flutter/pull/170805.
   DropdownButtonFormField(initialValue: 'one');
+
+  // Changes made in https://github.com/flutter/flutter/pull/182419.
+  DropdownButton(enabled: false);
+
+  // Changes made in https://github.com/flutter/flutter/pull/182419.
+  DropdownButtonFormField(enabled: false);
+
+  // Changes made in https://github.com/flutter/flutter/pull/182419.
+  DropdownButton(onChanged: (String? v) {});
 }


### PR DESCRIPTION
Made `onChanged` optional and introduced the `enabled` parameter in `DropdownButtonFormField`, allowing proper disabled/read-only usage without dummy callbacks.

**Breaking change**

Previously, setting `onChanged: null` disabled the widget. This is no longer the case. The disabled state must now be controlled via the `enabled` property.

Most simple usages are handled by the automated fix tool. Code that conditionally relied on `onChanged` being null to disable the widget must be updated to use `enabled`.

If not migrated, the widget will remain interactive but will not trigger a callback.

Closes https://github.com/flutter/flutter/issues/57953.

Port of https://github.com/flutter/flutter/pull/182419.

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under[^1].
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[the version and CHANGELOG instructions]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version-and-changelog-updates
[semantic versioning]: https://dart.dev/tools/pub/versioning#semantic-versions
[repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests

