### PR TITLE
[go_router] Preserve nested pushes during config updates

### DIFF
--- a/packages/go_router/lib/src/configuration.dart
+++ b/packages/go_router/lib/src/configuration.dart
@@ -22,6 +22,16 @@ typedef GoRouterRedirect = FutureOr<String?> Function(BuildContext context, GoRo
 
 typedef _NamedPath = ({String path, bool caseSensitive});
 
+Iterable<ImperativeRouteMatch> _imperativeMatches(List<RouteMatchBase> matches) sync* {
+  for (final match in matches) {
+    if (match is ImperativeRouteMatch) {
+      yield match;
+    } else if (match is ShellRouteMatch) {
+      yield* _imperativeMatches(match.matches);
+    }
+  }
+}
+
 /// The route configuration for GoRouter configured by the app.
 class RouteConfiguration {
   /// Constructs a [RouteConfiguration].
@@ -340,8 +350,7 @@ class RouteConfiguration {
   RouteMatchList reparse(RouteMatchList matchList) {
     RouteMatchList result = findMatch(matchList.uri, extra: matchList.extra);
 
-    for (final ImperativeRouteMatch imperativeMatch
-        in matchList.matches.whereType<ImperativeRouteMatch>()) {
+    for (final ImperativeRouteMatch imperativeMatch in _imperativeMatches(matchList.matches)) {
       final match = ImperativeRouteMatch(
         pageKey: imperativeMatch.pageKey,
         matches: findMatch(imperativeMatch.matches.uri, extra: imperativeMatch.matches.extra),

--- a/packages/go_router/lib/src/configuration.dart
+++ b/packages/go_router/lib/src/configuration.dart
@@ -22,16 +22,6 @@ typedef GoRouterRedirect = FutureOr<String?> Function(BuildContext context, GoRo
 
 typedef _NamedPath = ({String path, bool caseSensitive});
 
-Iterable<ImperativeRouteMatch> _imperativeMatches(List<RouteMatchBase> matches) sync* {
-  for (final match in matches) {
-    if (match is ImperativeRouteMatch) {
-      yield match;
-    } else if (match is ShellRouteMatch) {
-      yield* _imperativeMatches(match.matches);
-    }
-  }
-}
-
 /// The route configuration for GoRouter configured by the app.
 class RouteConfiguration {
   /// Constructs a [RouteConfiguration].
@@ -350,14 +340,18 @@ class RouteConfiguration {
   RouteMatchList reparse(RouteMatchList matchList) {
     RouteMatchList result = findMatch(matchList.uri, extra: matchList.extra);
 
-    for (final ImperativeRouteMatch imperativeMatch in _imperativeMatches(matchList.matches)) {
-      final match = ImperativeRouteMatch(
-        pageKey: imperativeMatch.pageKey,
-        matches: findMatch(imperativeMatch.matches.uri, extra: imperativeMatch.matches.extra),
-        completer: imperativeMatch.completer,
-      );
-      result = result.push(match);
-    }
+    matchList.visitRouteMatches((RouteMatchBase match) {
+      if (match is ImperativeRouteMatch) {
+        result = result.push(
+          ImperativeRouteMatch(
+            pageKey: match.pageKey,
+            matches: findMatch(match.matches.uri, extra: match.matches.extra),
+            completer: match.completer,
+          ),
+        );
+      }
+      return true;
+    });
     return result;
   }
 

--- a/packages/go_router/pending_changelogs/preserve_nested_pushes_on_reparse.yaml
+++ b/packages/go_router/pending_changelogs/preserve_nested_pushes_on_reparse.yaml
@@ -1,0 +1,2 @@
+changelog: Fixes pushed routes nested within a shell being lost when a dynamic routing configuration changes.
+version: patch

--- a/packages/go_router/test/routing_config_test.dart
+++ b/packages/go_router/test/routing_config_test.dart
@@ -2,7 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:cupertino_ui/cupertino_ui.dart';
+import 'dart:async';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
 import 'package:material_ui/material_ui.dart';
@@ -134,6 +135,64 @@ void main() {
     );
     await tester.pumpAndSettle();
     expect(key.currentState!.value == 1, isTrue);
+  });
+
+  testWidgets('routing config preserves pushed shell routes', (WidgetTester tester) async {
+    final branchANavigatorKey = GlobalKey<NavigatorState>(debugLabel: 'branch-a');
+    final branchBNavigatorKey = GlobalKey<NavigatorState>(debugLabel: 'branch-b');
+    RoutingConfig createConfig({required List<RouteBase> additionalRoutes}) {
+      return RoutingConfig(
+        routes: <RouteBase>[
+          GoRoute(path: '/top', builder: (_, _) => const Text('Top-level route')),
+          StatefulShellRoute.indexedStack(
+            branches: <StatefulShellBranch>[
+              StatefulShellBranch(
+                navigatorKey: branchANavigatorKey,
+                routes: <RouteBase>[
+                  GoRoute(path: '/a', builder: (_, _) => const Text('Screen A')),
+                  ...additionalRoutes,
+                ],
+              ),
+              StatefulShellBranch(
+                navigatorKey: branchBNavigatorKey,
+                routes: <RouteBase>[
+                  GoRoute(
+                    path: '/b',
+                    builder: (_, _) => const Text('Screen B'),
+                    routes: <RouteBase>[
+                      GoRoute(path: 'details', builder: (_, _) => const Text('Screen B Detail')),
+                    ],
+                  ),
+                ],
+              ),
+            ],
+            pageBuilder: (_, _, StatefulNavigationShell navigationShell) =>
+                MaterialPage<void>(child: navigationShell),
+          ),
+        ],
+      );
+    }
+
+    final config = ValueNotifier<RoutingConfig>(createConfig(additionalRoutes: <RouteBase>[]));
+    addTearDown(config.dispose);
+    final GoRouter router = await createRouterWithRoutingConfig(
+      config,
+      tester,
+      initialLocation: '/a',
+    );
+    unawaited(router.push('/b/details'));
+    await tester.pumpAndSettle();
+    unawaited(router.push('/top'));
+    await tester.pumpAndSettle();
+
+    config.value = createConfig(
+      additionalRoutes: <RouteBase>[GoRoute(path: '/c', builder: (_, _) => const Text('Screen C'))],
+    );
+    await tester.pumpAndSettle();
+    router.pop();
+    await tester.pumpAndSettle();
+
+    expect(find.text('Screen B Detail'), findsOneWidget);
   });
 
   testWidgets(


### PR DESCRIPTION
`RouteConfiguration.reparse` currently restores only imperative matches at the root of the match list. Imperative matches created by pushing a route owned by a `StatefulShellRoute` branch are nested inside `ShellRouteMatch.matches`, so a dynamic `RoutingConfig` update silently drops them.

This change recursively enumerates imperative matches within shell matches and replays them against the new routing configuration. Rebuilding each match preserves the pushed navigation stack without retaining stale route objects from the previous configuration.

The regression test covers this sequence using the go_router test suite's standard A/B route naming:

1. Start at `/a`.
2. Push `/b/details` into another shell branch.
3. Push `/top` above the shell.
4. Update the routing configuration.
5. Pop `/top` and verify that `Screen B Detail` is restored.

Fixes flutter/flutter#167344.

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under[^1].
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [x] All existing and new tests are passing.

This is a draft pending the author's review of the contribution, AI-assistance, Tree Hygiene, and CLA requirements above.

### Local verification

- `flutter_plugin_tools format --packages go_router`
- `flutter_plugin_tools analyze --packages go_router`
- `flutter_plugin_tools test --packages go_router`
- `flutter_plugin_tools validate --check-for-missing-changes --packages go_router`

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[the version and CHANGELOG instructions]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version-and-changelog-updates
[semantic versioning]: https://dart.dev/tools/pub/versioning#semantic-versions
[repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.
