### PR TITLE
[go_router_builder] Support analyzer 14

### DIFF
--- a/packages/go_router_builder/CHANGELOG.md
+++ b/packages/go_router_builder/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.4.1
+
+* Adds support for analyzer 14.
+
 ## 4.4.0
 
 - Adds `hasOverriddenOnExit` parameter to `GoRouteData.$route` and `RelativeGoRouteData.$route` helper methods for type-safe routes. When set to `true`, enables custom `onExit` callback invocation from route data classes extending `GoRouteData` or `RelativeGoRouteData` when the route is removed from the navigation stack.

--- a/packages/go_router_builder/pubspec.yaml
+++ b/packages/go_router_builder/pubspec.yaml
@@ -2,7 +2,7 @@ name: go_router_builder
 description: >-
   A builder that supports generated strongly-typed route helpers for
   package:go_router
-version: 4.4.0
+version: 4.4.1
 repository: https://github.com/flutter/packages/tree/main/packages/go_router_builder
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+go_router_builder%22
 
@@ -11,7 +11,7 @@ environment:
   flutter: ">=3.38.0"
 
 dependencies:
-  analyzer: ">=8.2.0 <14.0.0"
+  analyzer: ">=8.2.0 <15.0.0"
   async: ^2.8.0
   # TODO(piinks): Pin version once new stable rolls.
   build: ">=3.0.0 <5.0.0"


### PR DESCRIPTION
Updates `go_router_builder` dependency constraint for `analyzer` to `<15.0.0` to support Analyzer 14.