### PR TITLE
[material_ui] Fix FilledButton Material 3 default style docs

### DIFF
--- a/packages/material_ui/lib/src/filled_button.dart
+++ b/packages/material_ui/lib/src/filled_button.dart
@@ -400,13 +400,13 @@ class FilledButton extends ButtonStyleButton {
   /// * `textStyle` - Theme.textTheme.labelLarge
   /// * `backgroundColor`
   ///   * disabled - Theme.colorScheme.onSurface(0.12)
-  ///   * others - Theme.colorScheme.secondaryContainer
+  ///   * others - Theme.colorScheme.primary
   /// * `foregroundColor`
   ///   * disabled - Theme.colorScheme.onSurface(0.38)
-  ///   * others - Theme.colorScheme.onSecondaryContainer
+  ///   * others - Theme.colorScheme.onPrimary
   /// * `overlayColor`
-  ///   * hovered - Theme.colorScheme.onSecondaryContainer(0.08)
-  ///   * focused or pressed - Theme.colorScheme.onSecondaryContainer(0.1)
+  ///   * hovered - Theme.colorScheme.onPrimary(0.08)
+  ///   * focused or pressed - Theme.colorScheme.onPrimary(0.1)
   /// * `shadowColor` - Theme.colorScheme.shadow
   /// * `surfaceTintColor` - Colors.transparent
   /// * `elevation`

--- a/packages/material_ui/lib/src/filled_button.dart
+++ b/packages/material_ui/lib/src/filled_button.dart
@@ -400,13 +400,21 @@ class FilledButton extends ButtonStyleButton {
   /// * `textStyle` - Theme.textTheme.labelLarge
   /// * `backgroundColor`
   ///   * disabled - Theme.colorScheme.onSurface(0.12)
-  ///   * others - Theme.colorScheme.primary
+  ///   * others
+  ///     - Theme.colorScheme.primary in `FilledButton`
+  ///     - Theme.colorScheme.secondaryContainer in `FilledButton.tonal`
   /// * `foregroundColor`
   ///   * disabled - Theme.colorScheme.onSurface(0.38)
-  ///   * others - Theme.colorScheme.onPrimary
+  ///   * others
+  ///     - Theme.colorScheme.onPrimary in `FilledButton`
+  ///     - Theme.colorScheme.onSecondaryContainer in `FilledButton.tonal`
   /// * `overlayColor`
-  ///   * hovered - Theme.colorScheme.onPrimary(0.08)
-  ///   * focused or pressed - Theme.colorScheme.onPrimary(0.1)
+  ///   * hovered
+  ///     - Theme.colorScheme.onPrimary(0.08) in `FilledButton`
+  ///     - Theme.colorScheme.onSecondaryContainer(0.08) in `FilledButton.tonal`
+  ///   * focused or pressed
+  ///     - Theme.colorScheme.onPrimary(0.1) in `FilledButton`
+  ///     - Theme.colorScheme.onSecondaryContainer(0.1) in `FilledButton.tonal`
   /// * `shadowColor` - Theme.colorScheme.shadow
   /// * `surfaceTintColor` - Colors.transparent
   /// * `elevation`

--- a/packages/material_ui/pending_changelogs/change_2026_08_25_1787668928638.yaml
+++ b/packages/material_ui/pending_changelogs/change_2026_08_25_1787668928638.yaml
@@ -1,0 +1,3 @@
+changelog: |
+  - Corrects the Material 3 default style documentation for FilledButton to match its implementation.
+version: patch


### PR DESCRIPTION
Fixes flutter/flutter#191556

This is the port of flutter/flutter#191721 following the Material/Cupertino decoupling.

## Description

The Material 3 defaults documented in `FilledButton.defaultStyleOf` did not match the values used by `_FilledButtonDefaultsM3`.

The documentation described the tonal variant colors (`secondaryContainer` / `onSecondaryContainer`) and corresponding overlay colors, while the implementation uses `primary` / `onPrimary`.

This updates the Material 3 defaults documentation to match the existing implementation.

## Tests
- Ran `dart format packages/material_ui/lib/src/filled_button.dart`.
- No tests added as this is a documentation-only change.

Original Flutter PR: flutter/flutter#191721


## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under[^1].
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[the version and CHANGELOG instructions]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version-and-changelog-updates
[semantic versioning]: https://dart.dev/tools/pub/versioning#semantic-versions
[repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
