### PR TITLE
[material_ui] Declare Flutter SDK dependencies in the pubspec.yaml for tool/gen_defaults

### DIFF
--- a/packages/material_ui/tool/gen_defaults/pubspec.yaml
+++ b/packages/material_ui/tool/gen_defaults/pubspec.yaml
@@ -5,9 +5,12 @@ version: 1.0.0
 
 environment:
   sdk: ^3.12.0
+  flutter: ">=3.44.0"
 
 dependencies:
   args: ^2.7.0
+  flutter:
+    sdk: flutter
   meta: ^1.18.0
   path: ^1.9.1
 


### PR DESCRIPTION
This is required for running the Dart analyzer within the tool/gen_defaults package.