### PR TITLE
[material_ui] Add SliverAppBar showOnScreen semantics test coverage

### DIFF
--- a/packages/material_ui/test/app_bar_sliver_test.dart
+++ b/packages/material_ui/test/app_bar_sliver_test.dart
@@ -2079,17 +2079,20 @@ void main() {
   ) async {
     final semantics = SemanticsTester(tester); // enables semantics tree generation
 
-    const kItemHeight = 100.0;
+    const kItemHeight = 72.0;
+    const kInitialScrollOffset = 250.0;
     const kExpandedAppBarHeight = 256.0;
 
     final children = <Widget>[];
     final slivers = List<Widget>.generate(30, (int i) {
-      final Widget child = MergeSemantics(child: SizedBox(height: 72.0, child: Text('Item $i')));
+      final Widget child = MergeSemantics(
+        child: SizedBox(height: kItemHeight, child: Text('Item $i')),
+      );
       children.add(child);
       return SliverToBoxAdapter(child: child);
     });
 
-    final scrollController = ScrollController(initialScrollOffset: 2.5 * kItemHeight);
+    final scrollController = ScrollController(initialScrollOffset: kInitialScrollOffset);
     addTearDown(scrollController.dispose);
 
     await tester.pumpWidget(
@@ -2124,7 +2127,7 @@ void main() {
       ),
     );
 
-    expect(scrollController.offset, 2.5 * kItemHeight);
+    expect(scrollController.offset, kInitialScrollOffset);
 
     final int id0 = tester.renderObject(find.byWidget(children[0])).debugSemantics!.id;
     tester.binding.pipelineOwner.semanticsOwner!.performAction(id0, SemanticsAction.showOnScreen);

--- a/packages/material_ui/test/app_bar_sliver_test.dart
+++ b/packages/material_ui/test/app_bar_sliver_test.dart
@@ -2012,17 +2012,17 @@ void main() {
   ) async {
     final semantics = SemanticsTester(tester); // enables semantics tree generation
 
-    const kItemHeight = 100.0;
-    const kExpandedAppBarHeight = 56.0;
+    const itemHeight = 100.0;
+    const expandedAppBarHeight = 56.0;
 
     final containers = List<Widget>.generate(
       80,
       (int i) => MergeSemantics(
-        child: SizedBox(height: kItemHeight, child: Text('container $i')),
+        child: SizedBox(height: itemHeight, child: Text('container $i')),
       ),
     );
 
-    final scrollController = ScrollController(initialScrollOffset: kItemHeight / 2);
+    final scrollController = ScrollController(initialScrollOffset: itemHeight / 2);
     addTearDown(scrollController.dispose);
 
     await tester.pumpWidget(
@@ -2044,7 +2044,7 @@ void main() {
                   slivers: <Widget>[
                     const SliverAppBar(
                       pinned: true,
-                      expandedHeight: kExpandedAppBarHeight,
+                      expandedHeight: expandedAppBarHeight,
                       flexibleSpace: FlexibleSpaceBar(title: Text('App Bar')),
                     ),
                     SliverList.list(children: containers),
@@ -2057,7 +2057,7 @@ void main() {
       ),
     );
 
-    expect(scrollController.offset, kItemHeight / 2);
+    expect(scrollController.offset, itemHeight / 2);
 
     final int firstContainerId = tester
         .renderObject(find.byWidget(containers.first))
@@ -2067,9 +2067,8 @@ void main() {
       firstContainerId,
       SemanticsAction.showOnScreen,
     );
-    await tester.pump();
-    await tester.pump(const Duration(seconds: 5));
-    expect(tester.getTopLeft(find.byWidget(containers.first)).dy, kExpandedAppBarHeight);
+    await tester.pumpAndSettle();
+    expect(tester.getTopLeft(find.byWidget(containers.first)).dy, expandedAppBarHeight);
 
     semantics.dispose();
   });
@@ -2079,20 +2078,20 @@ void main() {
   ) async {
     final semantics = SemanticsTester(tester); // enables semantics tree generation
 
-    const kItemHeight = 72.0;
-    const kInitialScrollOffset = 250.0;
-    const kExpandedAppBarHeight = 256.0;
+    const itemHeight = 72.0;
+    const initialScrollOffset = 250.0;
+    const expandedAppBarHeight = 256.0;
 
     final children = <Widget>[];
     final slivers = List<Widget>.generate(30, (int i) {
       final Widget child = MergeSemantics(
-        child: SizedBox(height: kItemHeight, child: Text('Item $i')),
+        child: SizedBox(height: itemHeight, child: Text('Item $i')),
       );
       children.add(child);
       return SliverToBoxAdapter(child: child);
     });
 
-    final scrollController = ScrollController(initialScrollOffset: kInitialScrollOffset);
+    final scrollController = ScrollController(initialScrollOffset: initialScrollOffset);
     addTearDown(scrollController.dispose);
 
     await tester.pumpWidget(
@@ -2114,7 +2113,7 @@ void main() {
                   slivers: <Widget>[
                     const SliverAppBar(
                       pinned: true,
-                      expandedHeight: kExpandedAppBarHeight,
+                      expandedHeight: expandedAppBarHeight,
                       flexibleSpace: FlexibleSpaceBar(title: Text('App Bar')),
                     ),
                     ...slivers,
@@ -2127,12 +2126,11 @@ void main() {
       ),
     );
 
-    expect(scrollController.offset, kInitialScrollOffset);
+    expect(scrollController.offset, initialScrollOffset);
 
     final int id0 = tester.renderObject(find.byWidget(children[0])).debugSemantics!.id;
     tester.binding.pipelineOwner.semanticsOwner!.performAction(id0, SemanticsAction.showOnScreen);
-    await tester.pump();
-    await tester.pump(const Duration(seconds: 5));
+    await tester.pumpAndSettle();
     expect(tester.getTopLeft(find.byWidget(children[0])).dy, kToolbarHeight);
 
     semantics.dispose();

--- a/packages/material_ui/test/app_bar_sliver_test.dart
+++ b/packages/material_ui/test/app_bar_sliver_test.dart
@@ -2074,6 +2074,67 @@ void main() {
     semantics.dispose();
   });
 
+  testWidgets('showOnScreen works with pinned SliverAppBar and individual slivers', (
+    WidgetTester tester,
+  ) async {
+    final semantics = SemanticsTester(tester); // enables semantics tree generation
+
+    const kItemHeight = 100.0;
+    const kExpandedAppBarHeight = 256.0;
+
+    final children = <Widget>[];
+    final slivers = List<Widget>.generate(30, (int i) {
+      final Widget child = MergeSemantics(child: SizedBox(height: 72.0, child: Text('Item $i')));
+      children.add(child);
+      return SliverToBoxAdapter(child: child);
+    });
+
+    final scrollController = ScrollController(initialScrollOffset: 2.5 * kItemHeight);
+    addTearDown(scrollController.dispose);
+
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: MediaQuery(
+          data: const MediaQueryData(),
+          child: Localizations(
+            locale: const Locale('en', 'us'),
+            delegates: const <LocalizationsDelegate<dynamic>>[
+              DefaultWidgetsLocalizations.delegate,
+              DefaultMaterialLocalizations.delegate,
+            ],
+            child: Scrollable(
+              controller: scrollController,
+              viewportBuilder: (BuildContext context, ViewportOffset offset) {
+                return Viewport(
+                  offset: offset,
+                  slivers: <Widget>[
+                    const SliverAppBar(
+                      pinned: true,
+                      expandedHeight: kExpandedAppBarHeight,
+                      flexibleSpace: FlexibleSpaceBar(title: Text('App Bar')),
+                    ),
+                    ...slivers,
+                  ],
+                );
+              },
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(scrollController.offset, 2.5 * kItemHeight);
+
+    final int id0 = tester.renderObject(find.byWidget(children[0])).debugSemantics!.id;
+    tester.binding.pipelineOwner.semanticsOwner!.performAction(id0, SemanticsAction.showOnScreen);
+    await tester.pump();
+    await tester.pump(const Duration(seconds: 5));
+    expect(tester.getTopLeft(find.byWidget(children[0])).dy, kToolbarHeight);
+
+    semantics.dispose();
+  });
+
   testWidgets('Changing SliverAppBar snap from true to false', (WidgetTester tester) async {
     // Regression test for https://github.com/flutter/flutter/issues/17598
     const appBarHeight = 256.0;

--- a/packages/material_ui/test/app_bar_sliver_test.dart
+++ b/packages/material_ui/test/app_bar_sliver_test.dart
@@ -2007,6 +2007,73 @@ void main() {
     semantics.dispose();
   });
 
+  testWidgets('showOnScreen works with pinned SliverAppBar and sliver list', (
+    WidgetTester tester,
+  ) async {
+    final semantics = SemanticsTester(tester); // enables semantics tree generation
+
+    const kItemHeight = 100.0;
+    const kExpandedAppBarHeight = 56.0;
+
+    final containers = List<Widget>.generate(
+      80,
+      (int i) => MergeSemantics(
+        child: SizedBox(height: kItemHeight, child: Text('container $i')),
+      ),
+    );
+
+    final scrollController = ScrollController(initialScrollOffset: kItemHeight / 2);
+    addTearDown(scrollController.dispose);
+
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: Localizations(
+          locale: const Locale('en', 'us'),
+          delegates: const <LocalizationsDelegate<dynamic>>[
+            DefaultWidgetsLocalizations.delegate,
+            DefaultMaterialLocalizations.delegate,
+          ],
+          child: MediaQuery(
+            data: const MediaQueryData(),
+            child: Scrollable(
+              controller: scrollController,
+              viewportBuilder: (BuildContext context, ViewportOffset offset) {
+                return Viewport(
+                  offset: offset,
+                  slivers: <Widget>[
+                    const SliverAppBar(
+                      pinned: true,
+                      expandedHeight: kExpandedAppBarHeight,
+                      flexibleSpace: FlexibleSpaceBar(title: Text('App Bar')),
+                    ),
+                    SliverList.list(children: containers),
+                  ],
+                );
+              },
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(scrollController.offset, kItemHeight / 2);
+
+    final int firstContainerId = tester
+        .renderObject(find.byWidget(containers.first))
+        .debugSemantics!
+        .id;
+    tester.binding.pipelineOwner.semanticsOwner!.performAction(
+      firstContainerId,
+      SemanticsAction.showOnScreen,
+    );
+    await tester.pump();
+    await tester.pump(const Duration(seconds: 5));
+    expect(tester.getTopLeft(find.byWidget(containers.first)).dy, kExpandedAppBarHeight);
+
+    semantics.dispose();
+  });
+
   testWidgets('Changing SliverAppBar snap from true to false', (WidgetTester tester) async {
     // Regression test for https://github.com/flutter/flutter/issues/17598
     const appBarHeight = 256.0;

--- a/packages/material_ui/test/app_bar_sliver_test.dart
+++ b/packages/material_ui/test/app_bar_sliver_test.dart
@@ -2026,33 +2026,17 @@ void main() {
     addTearDown(scrollController.dispose);
 
     await tester.pumpWidget(
-      Directionality(
-        textDirection: TextDirection.ltr,
-        child: Localizations(
-          locale: const Locale('en', 'us'),
-          delegates: const <LocalizationsDelegate<dynamic>>[
-            DefaultWidgetsLocalizations.delegate,
-            DefaultMaterialLocalizations.delegate,
-          ],
-          child: MediaQuery(
-            data: const MediaQueryData(),
-            child: Scrollable(
-              controller: scrollController,
-              viewportBuilder: (BuildContext context, ViewportOffset offset) {
-                return Viewport(
-                  offset: offset,
-                  slivers: <Widget>[
-                    const SliverAppBar(
-                      pinned: true,
-                      expandedHeight: expandedAppBarHeight,
-                      flexibleSpace: FlexibleSpaceBar(title: Text('App Bar')),
-                    ),
-                    SliverList.list(children: containers),
-                  ],
-                );
-              },
+      MaterialApp(
+        home: CustomScrollView(
+          controller: scrollController,
+          slivers: <Widget>[
+            const SliverAppBar(
+              pinned: true,
+              expandedHeight: expandedAppBarHeight,
+              flexibleSpace: FlexibleSpaceBar(title: Text('App Bar')),
             ),
-          ),
+            SliverList.list(children: containers),
+          ],
         ),
       ),
     );
@@ -2095,33 +2079,17 @@ void main() {
     addTearDown(scrollController.dispose);
 
     await tester.pumpWidget(
-      Directionality(
-        textDirection: TextDirection.ltr,
-        child: MediaQuery(
-          data: const MediaQueryData(),
-          child: Localizations(
-            locale: const Locale('en', 'us'),
-            delegates: const <LocalizationsDelegate<dynamic>>[
-              DefaultWidgetsLocalizations.delegate,
-              DefaultMaterialLocalizations.delegate,
-            ],
-            child: Scrollable(
-              controller: scrollController,
-              viewportBuilder: (BuildContext context, ViewportOffset offset) {
-                return Viewport(
-                  offset: offset,
-                  slivers: <Widget>[
-                    const SliverAppBar(
-                      pinned: true,
-                      expandedHeight: expandedAppBarHeight,
-                      flexibleSpace: FlexibleSpaceBar(title: Text('App Bar')),
-                    ),
-                    ...slivers,
-                  ],
-                );
-              },
+      MaterialApp(
+        home: CustomScrollView(
+          controller: scrollController,
+          slivers: <Widget>[
+            const SliverAppBar(
+              pinned: true,
+              expandedHeight: expandedAppBarHeight,
+              flexibleSpace: FlexibleSpaceBar(title: Text('App Bar')),
             ),
-          ),
+            ...slivers,
+          ],
         ),
       ),
     );


### PR DESCRIPTION
Reopen of #12341, now that material_ui is accepting contributions (per flutter/flutter#188444).

Restores `showOnScreen` semantics coverage for a pinned `SliverAppBar` that was lost in flutter/flutter#186611, per flutter/flutter#189117. Companion framework-only PR: flutter/flutter#190410.

No version bump or CHANGELOG entry: test-only change, documented exemption.