### PR TITLE
[in_app_purchase_android] Defer reconnect off the platform-message upcall to fix an uncatchable SIGABRT

### DIFF
--- a/packages/in_app_purchase/in_app_purchase_android/CHANGELOG.md
+++ b/packages/in_app_purchase/in_app_purchase_android/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.5.4
+
+* Fixes a rare uncatchable native crash (`SIGABRT` in
+  `FlutterViewHandlePlatformMessage`) on billing-service disconnect: the
+  reconnect no longer issues `startConnection` synchronously from inside the
+  `onBillingServiceDisconnected` platform-message callback.
+
 ## 0.5.3
 
 * Updates pigeon dev_dependency to ^27.3.2 for analyzer 14 compatibility.

--- a/packages/in_app_purchase/in_app_purchase_android/lib/src/billing_client_wrappers/billing_client_manager.dart
+++ b/packages/in_app_purchase/in_app_purchase_android/lib/src/billing_client_wrappers/billing_client_manager.dart
@@ -186,6 +186,19 @@ class BillingClientManager {
     }
     _isConnecting = true;
     _readyFuture = Future<void>.sync(() async {
+      // Yield to a macrotask before connecting. onBillingServiceDisconnected
+      // is delivered synchronously inside an inbound platform-message JNI
+      // upcall; issuing startConnection (an outbound platform message) from
+      // that same stack can turn a pending Java exception into an uncatchable
+      // native crash (SIGABRT in FlutterViewHandlePlatformMessage's
+      // FML_CHECK). A zero-duration timer escapes the upcall; a microtask
+      // would not, because microtasks drain before control returns to the
+      // engine. See https://github.com/flutter/flutter/issues/144954.
+      await Future<void>.delayed(Duration.zero);
+      if (_isDisposed) {
+        _isConnecting = false;
+        return;
+      }
       await client.startConnection(
         onBillingServiceDisconnected: _connect,
         billingChoiceMode: _billingChoiceMode,

--- a/packages/in_app_purchase/in_app_purchase_android/pubspec.yaml
+++ b/packages/in_app_purchase/in_app_purchase_android/pubspec.yaml
@@ -3,7 +3,7 @@ description: An implementation for the Android platform of the Flutter `in_app_p
 repository: https://github.com/flutter/packages/tree/main/packages/in_app_purchase/in_app_purchase_android
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+in_app_purchase%22
 
-version: 0.5.3
+version: 0.5.4
 
 environment:
   sdk: ^3.12.0

--- a/packages/in_app_purchase/in_app_purchase_android/test/billing_client_wrappers/billing_client_manager_test.dart
+++ b/packages/in_app_purchase/in_app_purchase_android/test/billing_client_wrappers/billing_client_manager_test.dart
@@ -19,7 +19,7 @@ void main() {
   late MockInAppPurchaseApi mockApi;
   late BillingClientManager manager;
 
-  setUp(() {
+  setUp(() async {
     WidgetsFlutterBinding.ensureInitialized();
     mockApi = MockInAppPurchaseApi();
     when(mockApi.startConnection(any, any, any)).thenAnswer(
@@ -33,6 +33,9 @@ void main() {
             UserSelectedAlternativeBillingListener? alternativeBillingListener,
           ) => BillingClient(listener, alternativeBillingListener, api: mockApi),
     );
+    // _connect defers the connection by one macrotask, so pump the event
+    // queue so the tests below start from an already-connected manager.
+    await pumpEventQueue();
   });
 
   group('BillingClientWrapper', () {
@@ -70,7 +73,28 @@ void main() {
       await manager.runWithClientNonRetryable((_) async {});
 
       manager.client.hostCallbackHandler.onBillingServiceDisconnected(0);
+      // The reconnect is deferred one macrotask; pump so it fires before
+      // verifying.
+      await pumpEventQueue();
       verify(mockApi.startConnection(any, any, any)).called(2);
+    });
+
+    test('reconnect is deferred off the disconnect callback (does not call '
+        'startConnection synchronously)', () async {
+      // Ensures all asynchronous connected code finishes.
+      await manager.runWithClientNonRetryable((_) async {});
+      clearInteractions(mockApi);
+
+      manager.client.hostCallbackHandler.onBillingServiceDisconnected(0);
+      // Regression test for https://github.com/flutter/flutter/issues/144954:
+      // the outbound startConnection platform message must NOT be sent
+      // synchronously on the inbound onBillingServiceDisconnected upcall —
+      // a pending Java exception at that moment aborts the process
+      // (uncatchable SIGABRT in FlutterViewHandlePlatformMessage).
+      verifyNever(mockApi.startConnection(any, any, any));
+
+      await pumpEventQueue();
+      verify(mockApi.startConnection(any, any, any)).called(1);
     });
 
     test('re-connects when host calls reconnectWithBillingChoiceMode', () async {
@@ -85,6 +109,9 @@ void main() {
 
       /// Fake the disconnect that we would expect from a endConnectionCall.
       manager.client.hostCallbackHandler.onBillingServiceDisconnected(0);
+      // The reconnect is deferred one macrotask; pump so it fires before
+      // verifying.
+      await pumpEventQueue();
       // Verify that after connection ended reconnect was called.
       final VerificationResult result = verify(mockApi.startConnection(any, captureAny, any));
       expect(result.captured.single, PlatformBillingChoiceMode.alternativeBillingOnly);
@@ -104,6 +131,9 @@ void main() {
 
       /// Fake the disconnect that we would expect from a endConnectionCall.
       manager.client.hostCallbackHandler.onBillingServiceDisconnected(0);
+      // The reconnect is deferred one macrotask; pump so it fires before
+      // verifying.
+      await pumpEventQueue();
       // Verify that after connection ended reconnect was called.
       final VerificationResult result = verify(mockApi.startConnection(any, any, captureAny));
       expect(

--- a/packages/in_app_purchase/in_app_purchase_android/test/in_app_purchase_android_platform_addition_test.dart
+++ b/packages/in_app_purchase/in_app_purchase_android/test/in_app_purchase_android_platform_addition_test.dart
@@ -24,7 +24,7 @@ void main() {
   late InAppPurchaseAndroidPlatformAddition iapAndroidPlatformAddition;
   late BillingClientManager manager;
 
-  setUp(() {
+  setUp(() async {
     widgets.WidgetsFlutterBinding.ensureInitialized();
     mockApi = MockInAppPurchaseApi();
     when(mockApi.startConnection(any, any, any)).thenAnswer(
@@ -39,6 +39,10 @@ void main() {
           ) => BillingClient(listener, alternativeBillingListener, api: mockApi),
     );
     iapAndroidPlatformAddition = InAppPurchaseAndroidPlatformAddition(manager);
+    // _connect defers the connection by one macrotask, so pump the event
+    // queue so the setBillingChoice tests below count startConnection calls
+    // from an already-completed initial connection.
+    await pumpEventQueue();
   });
 
   group('consume purchases', () {
@@ -84,6 +88,9 @@ void main() {
 
       // Fake the disconnect that we would expect from a endConnectionCall.
       manager.client.hostCallbackHandler.onBillingServiceDisconnected(0);
+      // The reconnect is deferred one macrotask; pump so it fires before
+      // verifying.
+      await pumpEventQueue();
       // Verify that after connection ended reconnect was called.
       final VerificationResult result = verify(mockApi.startConnection(any, captureAny, any));
       expect(result.callCount, equals(2));
@@ -96,6 +103,9 @@ void main() {
 
       // Fake the disconnect that we would expect from a endConnectionCall.
       manager.client.hostCallbackHandler.onBillingServiceDisconnected(0);
+      // The reconnect is deferred one macrotask; pump so it fires before
+      // verifying.
+      await pumpEventQueue();
       // Verify that after connection ended reconnect was called.
       final VerificationResult result = verify(mockApi.startConnection(any, captureAny, any));
       expect(result.callCount, equals(2));

--- a/packages/in_app_purchase/in_app_purchase_android/test/in_app_purchase_android_platform_test.dart
+++ b/packages/in_app_purchase/in_app_purchase_android/test/in_app_purchase_android_platform_test.dart
@@ -56,7 +56,7 @@ void main() {
   late MockInAppPurchaseApi mockApi;
   late InAppPurchaseAndroidPlatform iapAndroidPlatform;
 
-  setUp(() {
+  setUp(() async {
     widgets.WidgetsFlutterBinding.ensureInitialized();
 
     mockApi = MockInAppPurchaseApi();
@@ -74,6 +74,9 @@ void main() {
       ),
     );
     InAppPurchasePlatform.instance = iapAndroidPlatform;
+    // _connect defers the connection by one macrotask, so pump the event
+    // queue so the tests below start from an already-connected manager.
+    await pumpEventQueue();
   });
 
   group('connection management', () {
@@ -82,9 +85,12 @@ void main() {
       verify(mockApi.startConnection(any, any, any)).called(1);
     });
 
-    test('re-connects when client sends onBillingServiceDisconnected', () {
+    test('re-connects when client sends onBillingServiceDisconnected', () async {
       iapAndroidPlatform.billingClientManager.client.hostCallbackHandler
           .onBillingServiceDisconnected(0);
+      // The reconnect is deferred one macrotask; pump so it fires before
+      // verifying.
+      await pumpEventQueue();
       verify(mockApi.startConnection(any, any, any)).called(2);
     });
 


### PR DESCRIPTION
`BillingClientManager._connect` issues `startConnection` synchronously from
inside the `onBillingServiceDisconnected` callback. That callback runs inside
an inbound platform-message JNI upcall, so the outbound `startConnection` send
happens re-entrantly on the same stack. When the billing service is flapping,
the Java side has a pending exception when the engine runs
`FML_CHECK(CheckException(env))` in `FlutterViewHandlePlatformMessage`, and
the process aborts (`SIGABRT`) — uncatchable from Dart
(https://github.com/flutter/flutter/issues/144954).

This PR yields one macrotask (`await Future<void>.delayed(Duration.zero)`)
before the platform send, so `startConnection` always runs on a fresh task off
the upcall. A microtask would not suffice: microtasks drain before control
returns to the engine, so they do not escape the JNI upcall. `_readyFuture` is
still assigned synchronously, so `runWithClient` callers are unaffected aside
from a one-turn deferral; disposal during the deferral is re-checked before
sending.

Existing tests that asserted a synchronous reconnect now pump the event queue;
a new regression test asserts the send is not issued synchronously on the
disconnect callback.

*Developed with AI assistance; tested and verified by the submitter.*

Fixes https://github.com/flutter/flutter/issues/191831

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under[^1].
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [x] All existing and new tests are passing.

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[the version and CHANGELOG instructions]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version-and-changelog-updates
[semantic versioning]: https://dart.dev/tools/pub/versioning#semantic-versions
[repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests

