### PR TITLE
[in_app_purchase_android] Guard async billing callbacks against duplicate listener responses

### DIFF
--- a/packages/in_app_purchase/in_app_purchase_android/CHANGELOG.md
+++ b/packages/in_app_purchase/in_app_purchase_android/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.5.4
+
+* Fixes a crash (`IllegalStateException: Reply already submitted`) when the
+  Play Billing library invokes a response listener more than once for a single
+  call.
+
 ## 0.5.3
 
 * Updates pigeon dev_dependency to ^27.3.2 for analyzer 14 compatibility.

--- a/packages/in_app_purchase/in_app_purchase_android/android/src/main/java/io/flutter/plugins/inapppurchase/MethodCallHandlerImpl.java
+++ b/packages/in_app_purchase/in_app_purchase_android/android/src/main/java/io/flutter/plugins/inapppurchase/MethodCallHandlerImpl.java
@@ -39,6 +39,7 @@ import com.android.billingclient.api.QueryPurchasesParams;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
 import kotlin.Result;
 import kotlin.Unit;
 import kotlin.jvm.functions.Function1;
@@ -117,7 +118,9 @@ class MethodCallHandlerImpl implements Application.ActivityLifecycleCallbacks, I
 
   @Override
   public void showAlternativeBillingOnlyInformationDialog(
-      @NonNull Function1<? super Result<PlatformBillingResult>, Unit> callback) {
+      @NonNull Function1<? super Result<PlatformBillingResult>, Unit> rawCallback) {
+    final Function1<? super Result<PlatformBillingResult>, Unit> callback =
+        replyOnce("showAlternativeBillingOnlyInformationDialog", rawCallback);
     if (billingClient == null) {
       ResultUtilsKt.completeWithError(callback, getNullBillingClientError());
       return;
@@ -141,7 +144,9 @@ class MethodCallHandlerImpl implements Application.ActivityLifecycleCallbacks, I
   public void createAlternativeBillingOnlyReportingDetailsAsync(
       @NonNull
           Function1<? super Result<PlatformAlternativeBillingOnlyReportingDetailsResponse>, Unit>
-              callback) {
+              rawCallback) {
+    final Function1<? super Result<PlatformAlternativeBillingOnlyReportingDetailsResponse>, Unit>
+        callback = replyOnce("createAlternativeBillingOnlyReportingDetailsAsync", rawCallback);
     if (billingClient == null) {
       ResultUtilsKt.completeWithError(callback, getNullBillingClientError());
       return;
@@ -161,7 +166,9 @@ class MethodCallHandlerImpl implements Application.ActivityLifecycleCallbacks, I
 
   @Override
   public void isAlternativeBillingOnlyAvailableAsync(
-      @NonNull Function1<? super Result<PlatformBillingResult>, Unit> callback) {
+      @NonNull Function1<? super Result<PlatformBillingResult>, Unit> rawCallback) {
+    final Function1<? super Result<PlatformBillingResult>, Unit> callback =
+        replyOnce("isAlternativeBillingOnlyAvailableAsync", rawCallback);
     if (billingClient == null) {
       ResultUtilsKt.completeWithError(callback, getNullBillingClientError());
       return;
@@ -179,7 +186,9 @@ class MethodCallHandlerImpl implements Application.ActivityLifecycleCallbacks, I
   public void showInAppMessages(
       @NotNull
           Function1<? super @NotNull Result<@NotNull PlatformInAppMessageResult>, @NotNull Unit>
-              callback) {
+              rawCallback) {
+    final Function1<? super Result<PlatformInAppMessageResult>, Unit> callback =
+        replyOnce("showInAppMessages", rawCallback);
     if (billingClient == null) {
       ResultUtilsKt.completeWithError(callback, getNullBillingClientError());
       return;
@@ -204,7 +213,9 @@ class MethodCallHandlerImpl implements Application.ActivityLifecycleCallbacks, I
 
   @Override
   public void getBillingConfigAsync(
-      @NonNull Function1<? super Result<PlatformBillingConfigResponse>, Unit> callback) {
+      @NonNull Function1<? super Result<PlatformBillingConfigResponse>, Unit> rawCallback) {
+    final Function1<? super Result<PlatformBillingConfigResponse>, Unit> callback =
+        replyOnce("getBillingConfigAsync", rawCallback);
     if (billingClient == null) {
       ResultUtilsKt.completeWithError(callback, getNullBillingClientError());
       return;
@@ -243,7 +254,9 @@ class MethodCallHandlerImpl implements Application.ActivityLifecycleCallbacks, I
   @Override
   public void queryProductDetailsAsync(
       @NonNull List<PlatformQueryProduct> products,
-      @NonNull Function1<? super Result<PlatformProductDetailsResponse>, Unit> callback) {
+      @NonNull Function1<? super Result<PlatformProductDetailsResponse>, Unit> rawCallback) {
+    final Function1<? super Result<PlatformProductDetailsResponse>, Unit> callback =
+        replyOnce("queryProductDetailsAsync", rawCallback);
     if (billingClient == null) {
       ResultUtilsKt.completeWithError(callback, getNullBillingClientError());
       return;
@@ -384,7 +397,9 @@ class MethodCallHandlerImpl implements Application.ActivityLifecycleCallbacks, I
   @Override
   public void consumeAsync(
       @NonNull String purchaseToken,
-      @NonNull Function1<? super Result<PlatformBillingResult>, Unit> callback) {
+      @NonNull Function1<? super Result<PlatformBillingResult>, Unit> rawCallback) {
+    final Function1<? super Result<PlatformBillingResult>, Unit> callback =
+        replyOnce("consumeAsync", rawCallback);
     if (billingClient == null) {
       ResultUtilsKt.completeWithError(callback, getNullBillingClientError());
       return;
@@ -408,7 +423,9 @@ class MethodCallHandlerImpl implements Application.ActivityLifecycleCallbacks, I
   @Override
   public void queryPurchasesAsync(
       @NonNull PlatformProductType productType,
-      @NonNull Function1<? super Result<PlatformPurchasesResponse>, Unit> callback) {
+      @NonNull Function1<? super Result<PlatformPurchasesResponse>, Unit> rawCallback) {
+    final Function1<? super Result<PlatformPurchasesResponse>, Unit> callback =
+        replyOnce("queryPurchasesAsync", rawCallback);
     if (billingClient == null) {
       ResultUtilsKt.completeWithError(callback, getNullBillingClientError());
       return;
@@ -487,7 +504,9 @@ class MethodCallHandlerImpl implements Application.ActivityLifecycleCallbacks, I
   @Override
   public void acknowledgePurchase(
       @NonNull String purchaseToken,
-      @NonNull Function1<? super Result<PlatformBillingResult>, Unit> callback) {
+      @NonNull Function1<? super Result<PlatformBillingResult>, Unit> rawCallback) {
+    final Function1<? super Result<PlatformBillingResult>, Unit> callback =
+        replyOnce("acknowledgePurchase", rawCallback);
     if (billingClient == null) {
       ResultUtilsKt.completeWithError(callback, getNullBillingClientError());
       return;
@@ -512,6 +531,28 @@ class MethodCallHandlerImpl implements Application.ActivityLifecycleCallbacks, I
     for (ProductDetails productDetails : productDetailsList) {
       cachedProducts.put(productDetails.getProductId(), productDetails);
     }
+  }
+
+  // The Play Billing library can invoke a response listener more than once for
+  // a single call (e.g. via its internal watchdog/timeout path). The pigeon
+  // reply may only be submitted once; a second completion throws
+  // "IllegalStateException: Reply already submitted" on the main thread and
+  // crashes the app (https://github.com/flutter/flutter/issues/103432).
+  // startConnection already guards this with its own alreadyFinished flag;
+  // this wraps the other async methods' callbacks so the first completion wins
+  // and duplicates are dropped. Call sites bind the pigeon parameter as
+  // rawCallback and rebind `callback` to this wrapper, keeping the method
+  // bodies otherwise unchanged.
+  private static <T> @NonNull Function1<? super Result<T>, Unit> replyOnce(
+      @NonNull String methodName, @NonNull Function1<? super Result<T>, Unit> callback) {
+    final AtomicBoolean replied = new AtomicBoolean(false);
+    return result -> {
+      if (replied.getAndSet(true)) {
+        Log.d(TAG, "Ignoring duplicate billing response for " + methodName + ".");
+        return Unit.INSTANCE;
+      }
+      return callback.invoke(result);
+    };
   }
 
   private @NonNull FlutterError getNullBillingClientError() {

--- a/packages/in_app_purchase/in_app_purchase_android/android/src/test/java/io/flutter/plugins/inapppurchase/MethodCallHandlerTest.java
+++ b/packages/in_app_purchase/in_app_purchase_android/android/src/test/java/io/flutter/plugins/inapppurchase/MethodCallHandlerTest.java
@@ -635,6 +635,48 @@ public class MethodCallHandlerTest {
     assertTrue(Objects.requireNonNull(flutterError.getMessage()).contains("BillingClient"));
   }
 
+  // Regression test for https://github.com/flutter/flutter/issues/103432: the
+  // Play Billing library can invoke a response listener twice for one call
+  // (its internal watchdog/timeout path); the second pigeon reply must be
+  // dropped instead of throwing "Reply already submitted".
+  @Test
+  public void queryProductDetailsAsync_duplicateListenerResponseIsIgnored() {
+    establishConnectedBillingClient();
+    final List<PlatformQueryProduct> productList =
+        buildProductList(asList("id1", "id2"), PlatformProductType.INAPP);
+
+    methodChannelHandler.queryProductDetailsAsync(
+        productList, platformProductDetailsResult.asCallback());
+
+    ArgumentCaptor<ProductDetailsResponseListener> listenerCaptor =
+        ArgumentCaptor.forClass(ProductDetailsResponseListener.class);
+    verify(mockBillingClient).queryProductDetailsAsync(any(), listenerCaptor.capture());
+
+    List<ProductDetails> firstProducts = singletonList(buildProductDetails("foo"));
+    BillingResult firstResult = buildBillingResult();
+    QueryProductDetailsResult firstDetailsResult = mock(QueryProductDetailsResult.class);
+    when(firstDetailsResult.getProductDetailsList()).thenReturn(firstProducts);
+    when(firstDetailsResult.getUnfetchedProductList())
+        .thenReturn(java.util.Collections.emptyList());
+
+    BillingResult secondResult = buildBillingResult(200);
+    QueryProductDetailsResult secondDetailsResult = mock(QueryProductDetailsResult.class);
+    when(secondDetailsResult.getProductDetailsList())
+        .thenReturn(singletonList(buildProductDetails("bar")));
+    when(secondDetailsResult.getUnfetchedProductList())
+        .thenReturn(java.util.Collections.emptyList());
+
+    listenerCaptor.getValue().onProductDetailsResponse(firstResult, firstDetailsResult);
+    // The second (watchdog) invocation of the SAME listener must not reach the
+    // pigeon callback. (updateCachedProducts still runs, by design.)
+    listenerCaptor.getValue().onProductDetailsResponse(secondResult, secondDetailsResult);
+
+    assertEquals(1, platformProductDetailsResult.callCount);
+    PlatformProductDetailsResponse resultData = platformProductDetailsResult.result.getOrNull();
+    assertResultsMatch(resultData.getBillingResult(), firstResult);
+    assertDetailListsMatch(firstProducts, resultData.getProductDetails());
+  }
+
   // Test launchBillingFlow not crash if `accountId` is `null`
   // Ideally, we should check if the `accountId` is null in the parameter; however,
   // since PBL 3.0, the `accountId` variable is not public.
@@ -1021,6 +1063,32 @@ public class MethodCallHandlerTest {
     assertResultsMatch(platformBillingResult.result.getOrNull(), billingResult);
   }
 
+  // Same duplicate-listener-response scenario as
+  // queryProductDetailsAsync_duplicateListenerResponseIsIgnored, for a
+  // listener that carries only a BillingResult.
+  @Test
+  public void acknowledgePurchase_duplicateListenerResponseIsIgnored() {
+    establishConnectedBillingClient();
+    final String purchaseToken = "mockToken";
+    ArgumentCaptor<AcknowledgePurchaseResponseListener> listenerCaptor =
+        ArgumentCaptor.forClass(AcknowledgePurchaseResponseListener.class);
+
+    methodChannelHandler.acknowledgePurchase(purchaseToken, platformBillingResult.asCallback());
+
+    AcknowledgePurchaseParams params =
+        AcknowledgePurchaseParams.newBuilder().setPurchaseToken(purchaseToken).build();
+
+    verify(mockBillingClient).acknowledgePurchase(refEq(params), listenerCaptor.capture());
+
+    BillingResult firstResult = buildBillingResult();
+    BillingResult secondResult = buildBillingResult(200);
+    listenerCaptor.getValue().onAcknowledgePurchaseResponse(firstResult);
+    listenerCaptor.getValue().onAcknowledgePurchaseResponse(secondResult);
+
+    assertEquals(1, platformBillingResult.callCount);
+    assertResultsMatch(platformBillingResult.result.getOrNull(), firstResult);
+  }
+
   @Test
   public void endConnection_if_activity_detached() {
     InAppPurchasePlugin plugin = new InAppPurchasePlugin();
@@ -1226,11 +1294,16 @@ public class MethodCallHandlerTest {
   private static class TestResult<T> implements Function1<ResultCompat<T>, Unit> {
     ResultCompat<T> result;
     boolean called = false;
+    // Lets the duplicate-listener-response regression tests assert that the
+    // pigeon callback completed exactly once (result alone only stores the
+    // last value).
+    int callCount = 0;
 
     @Override
     public Unit invoke(ResultCompat<T> reply) {
       this.result = reply;
       this.called = true;
+      this.callCount++;
       return Unit.INSTANCE;
     }
 

--- a/packages/in_app_purchase/in_app_purchase_android/pubspec.yaml
+++ b/packages/in_app_purchase/in_app_purchase_android/pubspec.yaml
@@ -3,7 +3,7 @@ description: An implementation for the Android platform of the Flutter `in_app_p
 repository: https://github.com/flutter/packages/tree/main/packages/in_app_purchase/in_app_purchase_android
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+in_app_purchase%22
 
-version: 0.5.3
+version: 0.5.4
 
 environment:
   sdk: ^3.12.0


### PR DESCRIPTION
The Play Billing library can invoke the response listener of a single async
call more than once (observed in production via its internal watchdog/timeout
path, `zzaf.run → zzan.run`, with the real response also arriving). A pigeon
reply may only be submitted once; the second completion throws
`IllegalStateException: Reply already submitted` on the main thread and kills
the process.

`startConnection` already guards against a double `onBillingSetupFinished`
with its `alreadyFinished` flag; this PR extends the same protection to the
other 9 async methods via a `replyOnce(methodName, callback)` wrapper — an
`AtomicBoolean.getAndSet(true)` single-shot around the pigeon callback. The
first completion wins; duplicates are dropped with a `Log.d`. Call sites bind
the pigeon parameter as `rawCallback` and rebind `callback` to the wrapper, so
the method bodies are otherwise unchanged and every completion path
(null-client error, null-activity error, listener response, RuntimeException
catch) is single-shot. Listener side effects (`updateCachedProducts`) still
run on dropped duplicates, so if an error response lands first and the real
one second, the product cache still receives real data for a later
`launchBillingFlow`.

Two JUnit regression tests fire a captured listener twice with distinct
results and assert exactly one pigeon completion holding the first result.

*Developed with AI assistance; tested and verified by the submitter.*

Fixes https://github.com/flutter/flutter/issues/191832
Related: https://github.com/flutter/flutter/issues/103432, https://github.com/flutter/flutter/issues/134967

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under[^1].
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [x] All existing and new tests are passing.

Note: this PR and #12639 both bump the package to 0.5.3; whichever lands
second will be rebased and re-bumped.

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[the version and CHANGELOG instructions]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version-and-changelog-updates
[semantic versioning]: https://dart.dev/tools/pub/versioning#semantic-versions
[repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests

