### PR TITLE
[cupertino_icons] Migrate to `cupertino_ui`

### DIFF
--- a/third_party/packages/cupertino_icons/CHANGELOG.md
+++ b/third_party/packages/cupertino_icons/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## NEXT
 
-* Updates minimum supported SDK version to Flutter 3.38/Dart 3.10.
+* Updates minimum supported SDK version to Flutter 3.44/Dart 3.12.
+* Migrates to use `cupertino_ui` instead of `flutter/cupertino.dart`.
 
 ## 1.0.9
 

--- a/third_party/packages/cupertino_icons/pubspec.yaml
+++ b/third_party/packages/cupertino_icons/pubspec.yaml
@@ -6,10 +6,11 @@ issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+
 version: 1.0.9
 
 environment:
-  sdk: ^3.10.0
+  sdk: ^3.12.0
 
 dev_dependencies:
   collection: ^1.18.0
+  cupertino_ui: ^1.0.0
   flutter:
     sdk: flutter
   flutter_test:

--- a/third_party/packages/cupertino_icons/test/cupertino_icons_golden_test.dart
+++ b/third_party/packages/cupertino_icons/test/cupertino_icons_golden_test.dart
@@ -5,7 +5,7 @@
 import 'dart:io' show File, Platform;
 
 import 'package:collection/collection.dart';
-import 'package:flutter/cupertino.dart';
+import 'package:cupertino_ui/cupertino_ui.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';

--- a/third_party/packages/cupertino_icons/test/cupertino_icons_test.dart
+++ b/third_party/packages/cupertino_icons/test/cupertino_icons_test.dart
@@ -5,17 +5,16 @@
 /// This test file is primarily here to serve as a source for code excerpts.
 library;
 
-import 'package:flutter/cupertino.dart';
-import 'package:flutter/material.dart';
+import 'package:cupertino_ui/cupertino_ui.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   testWidgets('Cupertino Icon Test', (WidgetTester tester) async {
     // #docregion CupertinoIcon
-    const icon = Icon(CupertinoIcons.heart_fill, color: Colors.pink, size: 24.0);
+    const icon = Icon(CupertinoIcons.heart_fill, color: CupertinoColors.systemPink, size: 24.0);
     // #enddocregion CupertinoIcon
 
-    await tester.pumpWidget(const MaterialApp(home: Scaffold(body: icon)));
+    await tester.pumpWidget(const CupertinoApp(home: icon));
 
     expect(find.byType(Icon), findsOne);
   });

--- a/third_party/packages/cupertino_icons/test/icons_list.dart
+++ b/third_party/packages/cupertino_icons/test/icons_list.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:flutter/cupertino.dart';
+import 'package:cupertino_ui/cupertino_ui.dart';
 
 int _compare(IconData a, IconData b) => a.codePoint.compareTo(b.codePoint);
 


### PR DESCRIPTION
Update `cupertino_icons` to use `cupertino_ui` instead of `flutter/cupertino`

Part of #https://github.com/flutter/flutter/issues/191322


## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under[^1].
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[the version and CHANGELOG instructions]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version-and-changelog-updates
[semantic versioning]: https://dart.dev/tools/pub/versioning#semantic-versions
[repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
