### PR TITLE
[go_router_builder] Fixes text golden test to ignore platform specific newline

### DIFF
--- a/packages/go_router_builder/tool/run_tests.dart
+++ b/packages/go_router_builder/tool/run_tests.dart
@@ -53,20 +53,20 @@ Future<void> main() async {
       try {
         generator.generateForAnnotation(reader, results, <String>{});
       } on InvalidGenerationSourceError catch (e) {
-        expectWithNormalizedNewline(e.message.trim(), expectResult);
+        expectWithNormalizedNewlines(e.message.trim(), expectResult);
         return;
       }
 
       // Apply consistent formatting to both generated and expected code for comparison.
       final String generated = formatter.format(results.join('\n\n').trim());
       final String expected = formatter.format(expectResult);
-      expectWithNormalizedNewline(generated, expected);
+      expectWithNormalizedNewlines(generated, expected);
     }, timeout: const Timeout(Duration(seconds: 100)));
   }
 }
 
 /// Compares two strings after normalizing CRLF line endings to LF.
-void expectWithNormalizedNewline(String actual, String expected) {
+void expectWithNormalizedNewlines(String actual, String expected) {
   expect(
     actual.replaceAll('\r\n', '\n'),
     equals(expected.replaceAll('\r\n', '\n')),

--- a/packages/go_router_builder/tool/run_tests.dart
+++ b/packages/go_router_builder/tool/run_tests.dart
@@ -53,20 +53,20 @@ Future<void> main() async {
       try {
         generator.generateForAnnotation(reader, results, <String>{});
       } on InvalidGenerationSourceError catch (e) {
-        expectWithNormalizedNewlines(e.message.trim(), expectResult);
+        _expectWithNormalizedNewlines(e.message.trim(), expectResult);
         return;
       }
 
       // Apply consistent formatting to both generated and expected code for comparison.
       final String generated = formatter.format(results.join('\n\n').trim());
       final String expected = formatter.format(expectResult);
-      expectWithNormalizedNewlines(generated, expected);
+      _expectWithNormalizedNewlines(generated, expected);
     }, timeout: const Timeout(Duration(seconds: 100)));
   }
 }
 
 /// Compares two strings after normalizing CRLF line endings to LF.
-void expectWithNormalizedNewlines(String actual, String expected) {
+void _expectWithNormalizedNewlines(String actual, String expected) {
   expect(
     actual.replaceAll('\r\n', '\n'),
     equals(expected.replaceAll('\r\n', '\n')),

--- a/packages/go_router_builder/tool/run_tests.dart
+++ b/packages/go_router_builder/tool/run_tests.dart
@@ -53,16 +53,24 @@ Future<void> main() async {
       try {
         generator.generateForAnnotation(reader, results, <String>{});
       } on InvalidGenerationSourceError catch (e) {
-        expect(expectResult, e.message.trim());
+        expectWithNormalizedNewline(e.message.trim(), expectResult);
         return;
       }
 
       // Apply consistent formatting to both generated and expected code for comparison.
       final String generated = formatter.format(results.join('\n\n').trim());
-      final String expected = formatter.format(expectResult.trim());
-      expect(generated, equals(expected));
+      final String expected = formatter.format(expectResult);
+      expectWithNormalizedNewline(generated, expected);
     }, timeout: const Timeout(Duration(seconds: 100)));
   }
+}
+
+/// Compares two strings after normalizing CRLF line endings to LF.
+void expectWithNormalizedNewline(String actual, String expected) {
+  expect(
+    actual.replaceAll('\r\n', '\n'),
+    equals(expected.replaceAll('\r\n', '\n')),
+  );
 }
 
 Future<Version> _packageVersion() async {

--- a/packages/go_router_builder/tool/run_tests.dart
+++ b/packages/go_router_builder/tool/run_tests.dart
@@ -67,10 +67,7 @@ Future<void> main() async {
 
 /// Compares two strings after normalizing CRLF line endings to LF.
 void _expectWithNormalizedNewlines(String actual, String expected) {
-  expect(
-    actual.replaceAll('\r\n', '\n'),
-    equals(expected.replaceAll('\r\n', '\n')),
-  );
+  expect(actual.replaceAll('\r\n', '\n'), equals(expected.replaceAll('\r\n', '\n')));
 }
 
 Future<Version> _packageVersion() async {


### PR DESCRIPTION
fixes https://github.com/flutter/flutter/issues/191892

## Pre-Review Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [ ] I read the [Tree Hygiene] page, which explains my responsibilities.
- [ ] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [ ] I signed the [CLA].
- [ ] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I [linked to at least one issue that this PR fixes] in the description above.
- [ ] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under[^1].
- [ ] I updated/added any relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[the version and CHANGELOG instructions]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version-and-changelog-updates
[semantic versioning]: https://dart.dev/tools/pub/versioning#semantic-versions
[repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
