### PR TITLE
[githooks] Add pre-push hook to prevent pushing evaluation test commits

### DIFF
--- a/.ci/scripts/analyze_repo_tools.sh
+++ b/.ci/scripts/analyze_repo_tools.sh
@@ -5,7 +5,9 @@
 set -e
 
 cd script/tool
+dart pub get
 dart analyze --fatal-infos
 
 cd ../githooks
+dart pub get
 dart analyze --fatal-infos

--- a/.ci/scripts/githooks_tests.sh
+++ b/.ci/scripts/githooks_tests.sh
@@ -5,4 +5,5 @@
 set -e
 
 cd script/githooks
+dart pub get
 dart test

--- a/.ci/scripts/githooks_tests.sh
+++ b/.ci/scripts/githooks_tests.sh
@@ -4,8 +4,5 @@
 # found in the LICENSE file.
 set -e
 
-cd script/tool
-dart analyze --fatal-infos
-
-cd ../githooks
-dart analyze --fatal-infos
+cd script/githooks
+dart test

--- a/.ci/scripts/prepare_tool.sh
+++ b/.ci/scripts/prepare_tool.sh
@@ -11,5 +11,8 @@ git branch main origin/main
 cd script/tool
 dart pub get
 
+cd ../githooks
+dart pub get
+
 cd ../flutter_goldens
 flutter pub get

--- a/.ci/targets/repo_tools_tests.yaml
+++ b/.ci/targets/repo_tools_tests.yaml
@@ -4,5 +4,7 @@ tasks:
     infra_step: true # Note infra steps failing prevents "always" from running.
   - name: tool unit tests
     script: .ci/scripts/plugin_tools_tests.sh
+  - name: githooks unit tests
+    script: .ci/scripts/githooks_tests.sh
   - name: flutter_goldens unit tests
     script: .ci/scripts/flutter_goldens_tests.sh

--- a/packages/camera/camera_android_camerax/.agents/skills/check-readiness/lib/check_readiness.dart
+++ b/packages/camera/camera_android_camerax/.agents/skills/check-readiness/lib/check_readiness.dart
@@ -146,6 +146,17 @@ class ReadinessChecker {
       return false;
     }
 
+    final String? repoRoot = _findRepoRoot(workspaceRoot);
+    if (repoRoot != null) {
+      final File prePushFile = _fileSystem.file(
+        _fileSystem.path.join(repoRoot, 'script', 'githooks', 'pre-push'),
+      );
+      if (!prePushFile.existsSync()) {
+        _log('Error: Git pre-push hook is missing at "${prePushFile.path}".');
+        return false;
+      }
+    }
+
     _log('Git hooks are configured correctly.');
     return true;
   }
@@ -186,7 +197,7 @@ class ReadinessChecker {
       return false;
     }
     final ProcessResult activateResult = await _processManager.run(
-      [
+      <String>[
         'dart',
         'pub',
         'global',

--- a/packages/camera/camera_android_camerax/.agents/skills/check-readiness/test/check_test.dart
+++ b/packages/camera/camera_android_camerax/.agents/skills/check-readiness/test/check_test.dart
@@ -18,9 +18,9 @@ import 'package:test/test.dart';
 import '../tool/check.dart';
 
 class FakeProcessManager implements ProcessManager {
-  final Map<String, bool> canRunMock = <String, bool>{};
-  final Map<String, ProcessResult> runMock = <String, ProcessResult>{};
-  final List<List<String>> runInvocations = <List<String>>[];
+  final Map<String, bool> canRunMock = {};
+  final Map<String, ProcessResult> runMock = {};
+  final List<List<String>> runInvocations = [];
 
   @override
   bool canRun(dynamic executable, {String? workingDirectory}) {
@@ -56,7 +56,7 @@ void main() {
   late FakeProcessManager processManager;
   late ReadinessChecker checker;
   late String workspaceRoot;
-  final List<String> printLogs = <String>[];
+  final List<String> printLogs = [];
 
   setUp(() {
     fileSystem = MemoryFileSystem.test();
@@ -95,12 +95,42 @@ void main() {
     expect(printLogs, contains('Environment is fully ready!'));
   });
 
+  test('fails when a broken symlink is present', () async {
+    final Directory skillsDir = fileSystem
+        .directory(fileSystem.path.join(workspaceRoot, '.agents', 'skills'))
+      ..createSync(recursive: true);
+
+    // MemoryFileSystem supports links
+    final Link link = fileSystem.link(fileSystem.path.join(skillsDir.path, 'broken_link'));
+    link.createSync('non_existent_target');
+
+    final bool result = await runChecker();
+    expect(result, isFalse);
+    expect(
+        printLogs.any((line) => line.contains('Found broken symlinks in .agents/skills:')), isTrue);
+  });
+
+  test('fails when git is dirty', () async {
+    fileSystem
+        .directory(fileSystem.path.join(workspaceRoot, '.agents', 'skills'))
+        .createSync(recursive: true);
+
+    processManager.runMock['git status --porcelain'] = ProcessResult(0, 0, ' M file.txt\n', '');
+
+    final bool result = await runChecker();
+    expect(result, isFalse);
+    expect(
+        printLogs,
+        contains(
+            'Error: Git working directory is not clean. Please commit or stash your changes before starting new work.'));
+  });
+
   test('fails when git hooks are not configured', () async {
     fileSystem
         .directory(fileSystem.path.join(workspaceRoot, '.agents', 'skills'))
         .createSync(recursive: true);
 
-    processManager.runMock['git config --get core.hooksPath'] = ProcessResult(0, 1, '', 'not set');
+    processManager.runMock['git config --get core.hooksPath'] = ProcessResult(0, 1, '', '');
 
     final bool result = await runChecker();
     expect(result, isFalse);
@@ -108,20 +138,22 @@ void main() {
       printLogs.any((line) => line.contains('Git hooks are not configured correctly')),
       isTrue,
     );
-    expect(printLogs.any((line) => line.contains('dart run bin/install_hooks.dart')), isTrue);
   });
 
-  test('fails when git hooks path is wrong', () async {
+  test('fails when git hooks point to incorrect path', () async {
     fileSystem
         .directory(fileSystem.path.join(workspaceRoot, '.agents', 'skills'))
         .createSync(recursive: true);
 
     processManager.runMock['git config --get core.hooksPath'] =
-        ProcessResult(0, 0, '.git/hooks\n', '');
+        ProcessResult(0, 0, 'other/hooks\n', '');
 
     final bool result = await runChecker();
     expect(result, isFalse);
-    expect(printLogs.any((line) => line.contains('expected "script/githooks"')), isTrue);
+    expect(
+      printLogs.any((line) => line.contains('Git hooks are not configured correctly')),
+      isTrue,
+    );
   });
 
   test('fails when pre-push hook file is missing', () async {
@@ -136,40 +168,6 @@ void main() {
     final bool result = await runChecker();
     expect(result, isFalse);
     expect(printLogs.any((line) => line.contains('Git pre-push hook is missing')), isTrue);
-  });
-
-  test('fails when a broken symlink is present', () async {
-    final Directory skillsDir = fileSystem
-        .directory(fileSystem.path.join(workspaceRoot, '.agents', 'skills'))
-      ..createSync(recursive: true);
-
-    // MemoryFileSystem supports links
-    final Link link = fileSystem.link(fileSystem.path.join(skillsDir.path, 'broken_link'));
-    link.createSync('non_existent_target');
-
-    final bool result = await runChecker();
-    expect(result, isFalse);
-    expect(
-      printLogs.any((line) => line.contains('Found broken symlinks in .agents/skills:')),
-      isTrue,
-    );
-  });
-
-  test('fails when git is dirty', () async {
-    fileSystem
-        .directory(fileSystem.path.join(workspaceRoot, '.agents', 'skills'))
-        .createSync(recursive: true);
-
-    processManager.runMock['git status --porcelain'] = ProcessResult(0, 0, ' M file.txt\n', '');
-
-    final bool result = await runChecker();
-    expect(result, isFalse);
-    expect(
-      printLogs,
-      contains(
-        'Error: Git working directory is not clean. Please commit or stash your changes before starting new work.',
-      ),
-    );
   });
 
   test('fails when flutter is missing', () async {
@@ -209,26 +207,24 @@ void main() {
     expect(printLogs, contains('Error: Failed to resolve dependencies.'));
   });
 
-  test(
-    'does not return early and reports multiple failures if git is dirty and tools are missing',
-    () async {
-      fileSystem
-          .directory(fileSystem.path.join(workspaceRoot, '.agents', 'skills'))
-          .createSync(recursive: true);
+  test('does not return early and reports multiple failures if git is dirty and tools are missing',
+      () async {
+    fileSystem
+        .directory(fileSystem.path.join(workspaceRoot, '.agents', 'skills'))
+        .createSync(recursive: true);
 
-      // Git returns dirty
-      processManager.runMock['git status --porcelain'] = ProcessResult(0, 0, ' M file.txt\n', '');
-      // Flutter is missing
-      processManager.canRunMock['flutter'] = false;
+    // Git returns dirty
+    processManager.runMock['git status --porcelain'] = ProcessResult(0, 0, ' M file.txt\n', '');
+    // Flutter is missing
+    processManager.canRunMock['flutter'] = false;
 
-      final bool result = await runChecker();
-      expect(result, isFalse);
+    final bool result = await runChecker();
+    expect(result, isFalse);
 
-      // Both errors should be printed
-      expect(printLogs.any((line) => line.contains('Git working directory is not clean')), isTrue);
-      expect(printLogs.any((line) => line.contains("'flutter' is not on the PATH")), isTrue);
-    },
-  );
+    // Both errors should be printed
+    expect(printLogs.any((line) => line.contains('Git working directory is not clean')), isTrue);
+    expect(printLogs.any((line) => line.contains("'flutter' is not on the PATH")), isTrue);
+  });
 
   group('Windows style', () {
     late MemoryFileSystem winFileSystem;
@@ -249,18 +245,7 @@ void main() {
       winFileSystem
           .file(winFileSystem.path.join(winWorkspaceRoot, 'script', 'githooks', 'pre-push'))
           .createSync(recursive: true);
-      processManager.runMock['git config --get core.hooksPath'] =
-          ProcessResult(0, 0, r'script\githooks' '\n', '');
       printLogs.clear();
-    });
-
-    test('passes when core.hooksPath uses backslashes on Windows', () async {
-      winFileSystem
-          .directory(winFileSystem.path.join(winWorkspaceRoot, '.agents', 'skills'))
-          .createSync(recursive: true);
-
-      final bool result = await winChecker.checkReadiness(winWorkspaceRoot);
-      expect(result, isTrue);
     });
 
     test('fails when a broken symlink is present on Windows', () async {
@@ -273,10 +258,18 @@ void main() {
 
       final bool result = await winChecker.checkReadiness(winWorkspaceRoot);
       expect(result, isFalse);
-      expect(
-        printLogs.any((line) => line.contains('Found broken symlinks in .agents/skills:')),
-        isTrue,
-      );
+      expect(printLogs.any((line) => line.contains('Found broken symlinks in .agents/skills:')),
+          isTrue);
+    });
+
+    test('passes when git hooks use Windows backslashes', () async {
+      processManager.runMock['git config --get core.hooksPath'] =
+          ProcessResult(0, 0, r'script\githooks' '\n', '');
+      processManager.runMock['git status --porcelain'] = ProcessResult(0, 0, '', '');
+
+      final bool result = await winChecker.checkReadiness(winWorkspaceRoot);
+      expect(result, isTrue);
+      expect(printLogs, contains('Git hooks are configured correctly.'));
     });
   });
 

--- a/packages/camera/camera_android_camerax/.agents/skills/check-readiness/test/check_test.dart
+++ b/packages/camera/camera_android_camerax/.agents/skills/check-readiness/test/check_test.dart
@@ -18,9 +18,9 @@ import 'package:test/test.dart';
 import '../tool/check.dart';
 
 class FakeProcessManager implements ProcessManager {
-  final Map<String, bool> canRunMock = {};
-  final Map<String, ProcessResult> runMock = {};
-  final List<List<String>> runInvocations = [];
+  final Map<String, bool> canRunMock = <String, bool>{};
+  final Map<String, ProcessResult> runMock = <String, ProcessResult>{};
+  final List<List<String>> runInvocations = <List<String>>[];
 
   @override
   bool canRun(dynamic executable, {String? workingDirectory}) {
@@ -56,7 +56,7 @@ void main() {
   late FakeProcessManager processManager;
   late ReadinessChecker checker;
   late String workspaceRoot;
-  final List<String> printLogs = [];
+  final List<String> printLogs = <String>[];
 
   setUp(() {
     fileSystem = MemoryFileSystem.test();
@@ -68,6 +68,9 @@ void main() {
     );
     workspaceRoot = fileSystem.path.absolute('workspace');
     fileSystem.file(fileSystem.path.join(workspaceRoot, '.git')).createSync(recursive: true);
+    fileSystem
+        .file(fileSystem.path.join(workspaceRoot, 'script', 'githooks', 'pre-push'))
+        .createSync(recursive: true);
     processManager.runMock['git config --get core.hooksPath'] =
         ProcessResult(0, 0, 'script/githooks\n', '');
     printLogs.clear();
@@ -92,6 +95,49 @@ void main() {
     expect(printLogs, contains('Environment is fully ready!'));
   });
 
+  test('fails when git hooks are not configured', () async {
+    fileSystem
+        .directory(fileSystem.path.join(workspaceRoot, '.agents', 'skills'))
+        .createSync(recursive: true);
+
+    processManager.runMock['git config --get core.hooksPath'] = ProcessResult(0, 1, '', 'not set');
+
+    final bool result = await runChecker();
+    expect(result, isFalse);
+    expect(
+      printLogs.any((line) => line.contains('Git hooks are not configured correctly')),
+      isTrue,
+    );
+    expect(printLogs.any((line) => line.contains('dart run bin/install_hooks.dart')), isTrue);
+  });
+
+  test('fails when git hooks path is wrong', () async {
+    fileSystem
+        .directory(fileSystem.path.join(workspaceRoot, '.agents', 'skills'))
+        .createSync(recursive: true);
+
+    processManager.runMock['git config --get core.hooksPath'] =
+        ProcessResult(0, 0, '.git/hooks\n', '');
+
+    final bool result = await runChecker();
+    expect(result, isFalse);
+    expect(printLogs.any((line) => line.contains('expected "script/githooks"')), isTrue);
+  });
+
+  test('fails when pre-push hook file is missing', () async {
+    fileSystem
+        .directory(fileSystem.path.join(workspaceRoot, '.agents', 'skills'))
+        .createSync(recursive: true);
+
+    fileSystem
+        .file(fileSystem.path.join(workspaceRoot, 'script', 'githooks', 'pre-push'))
+        .deleteSync();
+
+    final bool result = await runChecker();
+    expect(result, isFalse);
+    expect(printLogs.any((line) => line.contains('Git pre-push hook is missing')), isTrue);
+  });
+
   test('fails when a broken symlink is present', () async {
     final Directory skillsDir = fileSystem
         .directory(fileSystem.path.join(workspaceRoot, '.agents', 'skills'))
@@ -104,7 +150,9 @@ void main() {
     final bool result = await runChecker();
     expect(result, isFalse);
     expect(
-        printLogs.any((line) => line.contains('Found broken symlinks in .agents/skills:')), isTrue);
+      printLogs.any((line) => line.contains('Found broken symlinks in .agents/skills:')),
+      isTrue,
+    );
   });
 
   test('fails when git is dirty', () async {
@@ -117,39 +165,10 @@ void main() {
     final bool result = await runChecker();
     expect(result, isFalse);
     expect(
-        printLogs,
-        contains(
-            'Error: Git working directory is not clean. Please commit or stash your changes before starting new work.'));
-  });
-
-  test('fails when git hooks are not configured', () async {
-    fileSystem
-        .directory(fileSystem.path.join(workspaceRoot, '.agents', 'skills'))
-        .createSync(recursive: true);
-
-    processManager.runMock['git config --get core.hooksPath'] = ProcessResult(0, 1, '', '');
-
-    final bool result = await runChecker();
-    expect(result, isFalse);
-    expect(
-      printLogs.any((line) => line.contains('Git hooks are not configured correctly')),
-      isTrue,
-    );
-  });
-
-  test('fails when git hooks point to incorrect path', () async {
-    fileSystem
-        .directory(fileSystem.path.join(workspaceRoot, '.agents', 'skills'))
-        .createSync(recursive: true);
-
-    processManager.runMock['git config --get core.hooksPath'] =
-        ProcessResult(0, 0, 'other/hooks\n', '');
-
-    final bool result = await runChecker();
-    expect(result, isFalse);
-    expect(
-      printLogs.any((line) => line.contains('Git hooks are not configured correctly')),
-      isTrue,
+      printLogs,
+      contains(
+        'Error: Git working directory is not clean. Please commit or stash your changes before starting new work.',
+      ),
     );
   });
 
@@ -190,24 +209,26 @@ void main() {
     expect(printLogs, contains('Error: Failed to resolve dependencies.'));
   });
 
-  test('does not return early and reports multiple failures if git is dirty and tools are missing',
-      () async {
-    fileSystem
-        .directory(fileSystem.path.join(workspaceRoot, '.agents', 'skills'))
-        .createSync(recursive: true);
+  test(
+    'does not return early and reports multiple failures if git is dirty and tools are missing',
+    () async {
+      fileSystem
+          .directory(fileSystem.path.join(workspaceRoot, '.agents', 'skills'))
+          .createSync(recursive: true);
 
-    // Git returns dirty
-    processManager.runMock['git status --porcelain'] = ProcessResult(0, 0, ' M file.txt\n', '');
-    // Flutter is missing
-    processManager.canRunMock['flutter'] = false;
+      // Git returns dirty
+      processManager.runMock['git status --porcelain'] = ProcessResult(0, 0, ' M file.txt\n', '');
+      // Flutter is missing
+      processManager.canRunMock['flutter'] = false;
 
-    final bool result = await runChecker();
-    expect(result, isFalse);
+      final bool result = await runChecker();
+      expect(result, isFalse);
 
-    // Both errors should be printed
-    expect(printLogs.any((line) => line.contains('Git working directory is not clean')), isTrue);
-    expect(printLogs.any((line) => line.contains("'flutter' is not on the PATH")), isTrue);
-  });
+      // Both errors should be printed
+      expect(printLogs.any((line) => line.contains('Git working directory is not clean')), isTrue);
+      expect(printLogs.any((line) => line.contains("'flutter' is not on the PATH")), isTrue);
+    },
+  );
 
   group('Windows style', () {
     late MemoryFileSystem winFileSystem;
@@ -225,7 +246,21 @@ void main() {
       winFileSystem
           .file(winFileSystem.path.join(winWorkspaceRoot, '.git'))
           .createSync(recursive: true);
+      winFileSystem
+          .file(winFileSystem.path.join(winWorkspaceRoot, 'script', 'githooks', 'pre-push'))
+          .createSync(recursive: true);
+      processManager.runMock['git config --get core.hooksPath'] =
+          ProcessResult(0, 0, r'script\githooks' '\n', '');
       printLogs.clear();
+    });
+
+    test('passes when core.hooksPath uses backslashes on Windows', () async {
+      winFileSystem
+          .directory(winFileSystem.path.join(winWorkspaceRoot, '.agents', 'skills'))
+          .createSync(recursive: true);
+
+      final bool result = await winChecker.checkReadiness(winWorkspaceRoot);
+      expect(result, isTrue);
     });
 
     test('fails when a broken symlink is present on Windows', () async {
@@ -238,18 +273,10 @@ void main() {
 
       final bool result = await winChecker.checkReadiness(winWorkspaceRoot);
       expect(result, isFalse);
-      expect(printLogs.any((line) => line.contains('Found broken symlinks in .agents/skills:')),
-          isTrue);
-    });
-
-    test('passes when git hooks use Windows backslashes', () async {
-      processManager.runMock['git config --get core.hooksPath'] =
-          ProcessResult(0, 0, r'script\githooks' '\n', '');
-      processManager.runMock['git status --porcelain'] = ProcessResult(0, 0, '', '');
-
-      final bool result = await winChecker.checkReadiness(winWorkspaceRoot);
-      expect(result, isTrue);
-      expect(printLogs, contains('Git hooks are configured correctly.'));
+      expect(
+        printLogs.any((line) => line.contains('Found broken symlinks in .agents/skills:')),
+        isTrue,
+      );
     });
   });
 

--- a/script/githooks/README.md
+++ b/script/githooks/README.md
@@ -54,10 +54,11 @@ rm .git/hooks/pre-commit
 
 ### Bypass Hooks Temporarily
 
-To skip running hooks for a single action, pass the `--no-verify` flag. For example, to bypass the pre-commit hook during a commit:
+To skip running hooks for a single action, pass the `--no-verify` flag. For example, to bypass the pre-commit hook during a commit or pre-push hook during a push:
 
 ```bash
 git commit --no-verify
+git push --no-verify
 ```
 
 ## Available Hooks
@@ -73,4 +74,14 @@ If either check fails, it aborts the commit. To bypass the hook (for a WIP commi
 
 ```bash
 git commit -m "WIP" --no-verify
+```
+
+### pre-push
+
+The `pre-push` hook runs automatically when you run `git push` and inspects the last 20 commits to ensure that no commits authored or committed using evaluation credentials (`Eval Author` or `eval-author@example.com`) are pushed.
+
+If an evaluation commit is found, it aborts the push. To bypass the hook, use `--no-verify`:
+
+```bash
+git push --no-verify
 ```

--- a/script/githooks/lib/githooks.dart
+++ b/script/githooks/lib/githooks.dart
@@ -5,11 +5,13 @@
 import 'package:args/command_runner.dart';
 
 import 'src/pre_commit_command.dart';
+import 'src/pre_push_command.dart';
 
 /// Runs the githooks command line utility.
 Future<int> run(List<String> args) async {
   final runner = CommandRunner<bool>('githooks', 'Git hooks for flutter/packages')
-    ..addCommand(PreCommitCommand());
+    ..addCommand(PreCommitCommand())
+    ..addCommand(PrePushCommand());
 
   final bool success = await runner.run(args) ?? false;
   return success ? 0 : 1;

--- a/script/githooks/lib/src/pre_push_command.dart
+++ b/script/githooks/lib/src/pre_push_command.dart
@@ -13,7 +13,15 @@ const String evalAuthorName = 'Eval Author';
 /// The author email used in evaluation test commits.
 const String evalAuthorEmail = 'eval-author@example.com';
 
-/// The command that implements the pre-push githook.
+/// The command that implements the `pre-push` Git hook.
+///
+/// It inspects the last 20 commits in git history to ensure no commits
+/// were authored or committed using evaluation test credentials (`Eval Author`
+/// or `eval-author@example.com`).
+///
+/// Checking the last 20 commits keeps the hook simple and deterministic,
+/// avoiding complex diff calculations against arbitrary remote branches or
+/// tracking whether a branch has an open pull request under review.
 class PrePushCommand extends Command<bool> {
   /// Creates a [PrePushCommand].
   PrePushCommand({
@@ -48,7 +56,7 @@ class PrePushCommand extends Command<bool> {
       'log',
       '-n',
       '20',
-      '--format=%h | Author: %an <%ae> | Committer: %cn <%ce> | %s',
+      '--format=%h%x00%an%x00%ae%x00%cn%x00%ce%x00%s',
     ]);
 
     if (logResult.exitCode != 0) {
@@ -60,25 +68,35 @@ class PrePushCommand extends Command<bool> {
     }
 
     final stdoutStr = logResult.stdout as String;
-    final List<String> commitLines = stdoutStr
+    final List<String> commitEntries = stdoutStr
         .split('\n')
         .map((String line) => line.trim())
         .where((String line) => line.isNotEmpty)
         .toList();
 
-    final forbiddenIdentities = <String>[evalAuthorEmail, evalAuthorName];
+    for (final entry in commitEntries) {
+      final List<String> fields = entry.split('\u0000');
+      if (fields.length < 6) {
+        continue;
+      }
+      final String sha = fields[0];
+      final String authorName = fields[1];
+      final String authorEmail = fields[2];
+      final String committerName = fields[3];
+      final String committerEmail = fields[4];
+      final String subject = fields[5];
 
-    for (final commitLine in commitLines) {
-      for (final forbiddenIdentity in forbiddenIdentities) {
-        if (commitLine.contains(forbiddenIdentity)) {
-          print('''
+      if (authorName == evalAuthorName ||
+          authorEmail == evalAuthorEmail ||
+          committerName == evalAuthorName ||
+          committerEmail == evalAuthorEmail) {
+        print('''
 Pre-push check failed: Found commit(s) authored or committed with evaluation test credentials:
-  $commitLine
+  $sha | Author: $authorName <$authorEmail> | Committer: $committerName <$committerEmail> | $subject
 
 Evaluation test commits must not be pushed. Clean or rebase your branch before pushing.
 To bypass this check, push with --no-verify.''');
-          return false;
-        }
+        return false;
       }
     }
 

--- a/script/githooks/lib/src/pre_push_command.dart
+++ b/script/githooks/lib/src/pre_push_command.dart
@@ -1,0 +1,88 @@
+// Copyright 2013 The Flutter Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// ignore_for_file: avoid_print
+
+import 'dart:io';
+import 'package:args/command_runner.dart';
+
+/// The author name used in evaluation test commits.
+const String evalAuthorName = 'Eval Author';
+
+/// The author email used in evaluation test commits.
+const String evalAuthorEmail = 'eval-author@example.com';
+
+/// The command that implements the pre-push githook.
+class PrePushCommand extends Command<bool> {
+  /// Creates a [PrePushCommand].
+  PrePushCommand({
+    Future<ProcessResult> Function(
+      String executable,
+      List<String> arguments, {
+      String? workingDirectory,
+    })?
+    processRunner,
+  }) : processRunner = processRunner ?? Process.run;
+
+  /// The process runner injected for testing.
+  final Future<ProcessResult> Function(
+    String executable,
+    List<String> arguments, {
+    String? workingDirectory,
+  })
+  processRunner;
+
+  @override
+  final String name = 'pre-push';
+
+  @override
+  final String description =
+      'Validates that recent commits do not contain evaluation test credentials before "git push"';
+
+  @override
+  Future<bool> run() async {
+    print('Running pre-push validation...');
+
+    final ProcessResult logResult = await processRunner('git', <String>[
+      'log',
+      '-n',
+      '20',
+      '--format=%h | Author: %an <%ae> | Committer: %cn <%ce> | %s',
+    ]);
+
+    if (logResult.exitCode != 0) {
+      print('Failed to check git commit history.');
+      if (logResult.stderr.toString().isNotEmpty) {
+        print(logResult.stderr);
+      }
+      return false;
+    }
+
+    final stdoutStr = logResult.stdout as String;
+    final List<String> commitLines = stdoutStr
+        .split('\n')
+        .map((String line) => line.trim())
+        .where((String line) => line.isNotEmpty)
+        .toList();
+
+    final forbiddenIdentities = <String>[evalAuthorEmail, evalAuthorName];
+
+    for (final commitLine in commitLines) {
+      for (final forbiddenIdentity in forbiddenIdentities) {
+        if (commitLine.contains(forbiddenIdentity)) {
+          print('''
+Pre-push check failed: Found commit(s) authored or committed with evaluation test credentials:
+  $commitLine
+
+Evaluation test commits must not be pushed. Clean or rebase your branch before pushing.
+To bypass this check, push with --no-verify.''');
+          return false;
+        }
+      }
+    }
+
+    print('Pre-push validation passed.');
+    return true;
+  }
+}

--- a/script/githooks/lib/src/pre_push_command.dart
+++ b/script/githooks/lib/src/pre_push_command.dart
@@ -61,13 +61,14 @@ class PrePushCommand extends Command<bool> {
 
     if (logResult.exitCode != 0) {
       print('Failed to check git commit history.');
-      if (logResult.stderr.toString().isNotEmpty) {
-        print(logResult.stderr);
+      final String stderr = logResult.stderr?.toString().trim() ?? '';
+      if (stderr.isNotEmpty) {
+        print(stderr);
       }
       return false;
     }
 
-    final stdoutStr = logResult.stdout as String;
+    final String stdoutStr = logResult.stdout?.toString() ?? '';
     final List<String> commitEntries = stdoutStr
         .split('\n')
         .map((String line) => line.trim())

--- a/script/githooks/pre-push
+++ b/script/githooks/pre-push
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -e
+
+HOOKS_DIR="$(dirname "$0")"
+exec dart "$HOOKS_DIR/bin/main.dart" pre-push "$@"

--- a/script/githooks/test/pre_commit_command_test.dart
+++ b/script/githooks/test/pre_commit_command_test.dart
@@ -10,13 +10,7 @@ import 'package:test/test.dart';
 
 void main() {
   final String repoRoot = p.joinAll(<String>['mock', 'repo', 'root']);
-  final String toolScript = p.join(
-    repoRoot,
-    'script',
-    'tool',
-    'bin',
-    'flutter_plugin_tools.dart',
-  );
+  final String toolScript = p.join(repoRoot, 'script', 'tool', 'bin', 'flutter_plugin_tools.dart');
 
   group('pre-commit hook', () {
     test('passes when both format and analyze succeed', () async {

--- a/script/githooks/test/pre_commit_command_test.dart
+++ b/script/githooks/test/pre_commit_command_test.dart
@@ -5,11 +5,18 @@
 import 'dart:io';
 
 import 'package:githooks/src/pre_commit_command.dart';
+import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
 
 void main() {
-  const repoRoot = '/mock/repo/root';
-  const toolScript = '$repoRoot/script/tool/bin/flutter_plugin_tools.dart';
+  final String repoRoot = p.joinAll(<String>['mock', 'repo', 'root']);
+  final String toolScript = p.join(
+    repoRoot,
+    'script',
+    'tool',
+    'bin',
+    'flutter_plugin_tools.dart',
+  );
 
   group('pre-commit hook', () {
     test('passes when both format and analyze succeed', () async {

--- a/script/githooks/test/pre_push_command_test.dart
+++ b/script/githooks/test/pre_push_command_test.dart
@@ -1,0 +1,152 @@
+// Copyright 2013 The Flutter Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:io';
+
+import 'package:githooks/src/pre_push_command.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('pre-push hook', () {
+    test('passes when recent commits contain no evaluation credentials', () async {
+      final List<List<String>> executedArguments = <List<String>>[];
+      final command = PrePushCommand(
+        processRunner: (String executable, List<String> arguments, {String? workingDirectory}) async {
+          executedArguments.add(arguments);
+          if (executable == 'git' && arguments.contains('log')) {
+            return ProcessResult(
+              0,
+              0,
+              'abc1234 | Author: Alice <alice@google.com> | Committer: Alice <alice@google.com> | Fix feature\n'
+                  'def5678 | Author: Bob <bob@example.com> | Committer: Bob <bob@example.com> | Add unit tests\n',
+              '',
+            );
+          }
+          return ProcessResult(0, 0, 'Success', '');
+        },
+      );
+
+      final bool result = await command.run();
+      expect(result, isTrue);
+
+      expect(
+        executedArguments,
+        anyElement(
+          equals(<String>[
+            'log',
+            '-n',
+            '20',
+            '--format=%h | Author: %an <%ae> | Committer: %cn <%ce> | %s',
+          ]),
+        ),
+      );
+    });
+
+    test('fails when recent commit is authored by Eval Author', () async {
+      final command = PrePushCommand(
+        processRunner: (String executable, List<String> arguments, {String? workingDirectory}) async {
+          if (executable == 'git' && arguments.contains('log')) {
+            return ProcessResult(
+              0,
+              0,
+              'abc1234 | Author: Eval Author <contributor@example.com> | Committer: Contributor <contributor@example.com> | Eval change\n',
+              '',
+            );
+          }
+          return ProcessResult(0, 0, 'Success', '');
+        },
+      );
+
+      final bool result = await command.run();
+      expect(result, isFalse);
+    });
+
+    test('fails when recent commit is authored by eval-author@example.com', () async {
+      final command = PrePushCommand(
+        processRunner: (String executable, List<String> arguments, {String? workingDirectory}) async {
+          if (executable == 'git' && arguments.contains('log')) {
+            return ProcessResult(
+              0,
+              0,
+              'abc1234 | Author: Contributor <eval-author@example.com> | Committer: Contributor <contributor@example.com> | Eval change\n',
+              '',
+            );
+          }
+          return ProcessResult(0, 0, 'Success', '');
+        },
+      );
+
+      final bool result = await command.run();
+      expect(result, isFalse);
+    });
+
+    test('fails when recent commit is committed by Eval Author', () async {
+      final command = PrePushCommand(
+        processRunner: (String executable, List<String> arguments, {String? workingDirectory}) async {
+          if (executable == 'git' && arguments.contains('log')) {
+            return ProcessResult(
+              0,
+              0,
+              'abc1234 | Author: Contributor <contributor@example.com> | Committer: Eval Author <contributor@example.com> | Eval change\n',
+              '',
+            );
+          }
+          return ProcessResult(0, 0, 'Success', '');
+        },
+      );
+
+      final bool result = await command.run();
+      expect(result, isFalse);
+    });
+
+    test('fails when recent commit is committed by eval-author@example.com', () async {
+      final command = PrePushCommand(
+        processRunner: (String executable, List<String> arguments, {String? workingDirectory}) async {
+          if (executable == 'git' && arguments.contains('log')) {
+            return ProcessResult(
+              0,
+              0,
+              'abc1234 | Author: Contributor <contributor@example.com> | Committer: Contributor <eval-author@example.com> | Eval change\n',
+              '',
+            );
+          }
+          return ProcessResult(0, 0, 'Success', '');
+        },
+      );
+
+      final bool result = await command.run();
+      expect(result, isFalse);
+    });
+
+    test('fails when git log execution fails', () async {
+      final command = PrePushCommand(
+        processRunner:
+            (String executable, List<String> arguments, {String? workingDirectory}) async {
+              if (executable == 'git' && arguments.contains('log')) {
+                return ProcessResult(0, 1, '', 'Git fatal error');
+              }
+              return ProcessResult(0, 0, 'Success', '');
+            },
+      );
+
+      final bool result = await command.run();
+      expect(result, isFalse);
+    });
+
+    test('passes when git log returns empty output', () async {
+      final command = PrePushCommand(
+        processRunner:
+            (String executable, List<String> arguments, {String? workingDirectory}) async {
+              if (executable == 'git' && arguments.contains('log')) {
+                return ProcessResult(0, 0, '', '');
+              }
+              return ProcessResult(0, 0, 'Success', '');
+            },
+      );
+
+      final bool result = await command.run();
+      expect(result, isTrue);
+    });
+  });
+}

--- a/script/githooks/test/pre_push_command_test.dart
+++ b/script/githooks/test/pre_push_command_test.dart
@@ -12,7 +12,7 @@ void main() {
     PrePushCommand createCommand(
       String gitLogOutput, {
       int exitCode = 0,
-      String stderr = '',
+      dynamic stderr = '',
       List<List<String>>? capturedArgs,
     }) {
       return PrePushCommand(
@@ -100,6 +100,13 @@ void main() {
 
     test('fails when git log execution fails', () async {
       final PrePushCommand command = createCommand('', exitCode: 1, stderr: 'Git fatal error');
+
+      final bool result = await command.run();
+      expect(result, isFalse);
+    });
+
+    test('fails when git log execution fails with null stderr', () async {
+      final PrePushCommand command = createCommand('', exitCode: 1, stderr: null);
 
       final bool result = await command.run();
       expect(result, isFalse);

--- a/script/githooks/test/pre_push_command_test.dart
+++ b/script/githooks/test/pre_push_command_test.dart
@@ -12,7 +12,7 @@ void main() {
     PrePushCommand createCommand(
       String gitLogOutput, {
       int exitCode = 0,
-      dynamic stderr = '',
+      String? stderr = '',
       List<List<String>>? capturedArgs,
     }) {
       return PrePushCommand(

--- a/script/githooks/test/pre_push_command_test.dart
+++ b/script/githooks/test/pre_push_command_test.dart
@@ -9,22 +9,41 @@ import 'package:test/test.dart';
 
 void main() {
   group('pre-push hook', () {
+    PrePushCommand createCommand(
+      String gitLogOutput, {
+      int exitCode = 0,
+      String stderr = '',
+      List<List<String>>? capturedArgs,
+    }) {
+      return PrePushCommand(
+        processRunner:
+            (String executable, List<String> arguments, {String? workingDirectory}) async {
+              capturedArgs?.add(arguments);
+              if (executable == 'git' && arguments.contains('log')) {
+                return ProcessResult(0, exitCode, gitLogOutput, stderr);
+              }
+              return ProcessResult(0, 0, 'Success', '');
+            },
+      );
+    }
+
+    String formatCommit({
+      String sha = 'abc1234',
+      String authorName = 'Alice',
+      String authorEmail = 'alice@google.com',
+      String committerName = 'Alice',
+      String committerEmail = 'alice@google.com',
+      String subject = 'Valid commit',
+    }) {
+      return '$sha\u0000$authorName\u0000$authorEmail\u0000$committerName\u0000$committerEmail\u0000$subject\n';
+    }
+
     test('passes when recent commits contain no evaluation credentials', () async {
-      final List<List<String>> executedArguments = <List<String>>[];
-      final command = PrePushCommand(
-        processRunner: (String executable, List<String> arguments, {String? workingDirectory}) async {
-          executedArguments.add(arguments);
-          if (executable == 'git' && arguments.contains('log')) {
-            return ProcessResult(
-              0,
-              0,
-              'abc1234 | Author: Alice <alice@google.com> | Committer: Alice <alice@google.com> | Fix feature\n'
-                  'def5678 | Author: Bob <bob@example.com> | Committer: Bob <bob@example.com> | Add unit tests\n',
-              '',
-            );
-          }
-          return ProcessResult(0, 0, 'Success', '');
-        },
+      final executedArguments = <List<String>>[];
+      final PrePushCommand command = createCommand(
+        '${formatCommit(subject: 'Fix feature')}'
+        '${formatCommit(sha: 'def5678', authorName: 'Bob', authorEmail: 'bob@example.com', committerName: 'Bob', committerEmail: 'bob@example.com', subject: 'Add unit tests')}',
+        capturedArgs: executedArguments,
       );
 
       final bool result = await command.run();
@@ -33,48 +52,30 @@ void main() {
       expect(
         executedArguments,
         anyElement(
-          equals(<String>[
-            'log',
-            '-n',
-            '20',
-            '--format=%h | Author: %an <%ae> | Committer: %cn <%ce> | %s',
-          ]),
+          equals(<String>['log', '-n', '20', '--format=%h%x00%an%x00%ae%x00%cn%x00%ce%x00%s']),
         ),
       );
     });
 
-    test('fails when recent commit is authored by Eval Author', () async {
-      final command = PrePushCommand(
-        processRunner: (String executable, List<String> arguments, {String? workingDirectory}) async {
-          if (executable == 'git' && arguments.contains('log')) {
-            return ProcessResult(
-              0,
-              0,
-              'abc1234 | Author: Eval Author <contributor@example.com> | Committer: Contributor <contributor@example.com> | Eval change\n',
-              '',
-            );
-          }
-          return ProcessResult(0, 0, 'Success', '');
-        },
+    test('passes when commit message contains eval credentials in subject', () async {
+      final PrePushCommand command = createCommand(
+        formatCommit(subject: 'Fix bug with eval-author@example.com and Eval Author'),
       );
+
+      final bool result = await command.run();
+      expect(result, isTrue);
+    });
+
+    test('fails when recent commit is authored by Eval Author', () async {
+      final PrePushCommand command = createCommand(formatCommit(authorName: 'Eval Author'));
 
       final bool result = await command.run();
       expect(result, isFalse);
     });
 
     test('fails when recent commit is authored by eval-author@example.com', () async {
-      final command = PrePushCommand(
-        processRunner: (String executable, List<String> arguments, {String? workingDirectory}) async {
-          if (executable == 'git' && arguments.contains('log')) {
-            return ProcessResult(
-              0,
-              0,
-              'abc1234 | Author: Contributor <eval-author@example.com> | Committer: Contributor <contributor@example.com> | Eval change\n',
-              '',
-            );
-          }
-          return ProcessResult(0, 0, 'Success', '');
-        },
+      final PrePushCommand command = createCommand(
+        formatCommit(authorEmail: 'eval-author@example.com'),
       );
 
       final bool result = await command.run();
@@ -82,37 +83,15 @@ void main() {
     });
 
     test('fails when recent commit is committed by Eval Author', () async {
-      final command = PrePushCommand(
-        processRunner: (String executable, List<String> arguments, {String? workingDirectory}) async {
-          if (executable == 'git' && arguments.contains('log')) {
-            return ProcessResult(
-              0,
-              0,
-              'abc1234 | Author: Contributor <contributor@example.com> | Committer: Eval Author <contributor@example.com> | Eval change\n',
-              '',
-            );
-          }
-          return ProcessResult(0, 0, 'Success', '');
-        },
-      );
+      final PrePushCommand command = createCommand(formatCommit(committerName: 'Eval Author'));
 
       final bool result = await command.run();
       expect(result, isFalse);
     });
 
     test('fails when recent commit is committed by eval-author@example.com', () async {
-      final command = PrePushCommand(
-        processRunner: (String executable, List<String> arguments, {String? workingDirectory}) async {
-          if (executable == 'git' && arguments.contains('log')) {
-            return ProcessResult(
-              0,
-              0,
-              'abc1234 | Author: Contributor <contributor@example.com> | Committer: Contributor <eval-author@example.com> | Eval change\n',
-              '',
-            );
-          }
-          return ProcessResult(0, 0, 'Success', '');
-        },
+      final PrePushCommand command = createCommand(
+        formatCommit(committerEmail: 'eval-author@example.com'),
       );
 
       final bool result = await command.run();
@@ -120,30 +99,14 @@ void main() {
     });
 
     test('fails when git log execution fails', () async {
-      final command = PrePushCommand(
-        processRunner:
-            (String executable, List<String> arguments, {String? workingDirectory}) async {
-              if (executable == 'git' && arguments.contains('log')) {
-                return ProcessResult(0, 1, '', 'Git fatal error');
-              }
-              return ProcessResult(0, 0, 'Success', '');
-            },
-      );
+      final PrePushCommand command = createCommand('', exitCode: 1, stderr: 'Git fatal error');
 
       final bool result = await command.run();
       expect(result, isFalse);
     });
 
     test('passes when git log returns empty output', () async {
-      final command = PrePushCommand(
-        processRunner:
-            (String executable, List<String> arguments, {String? workingDirectory}) async {
-              if (executable == 'git' && arguments.contains('log')) {
-                return ProcessResult(0, 0, '', '');
-              }
-              return ProcessResult(0, 0, 'Success', '');
-            },
-      );
+      final PrePushCommand command = createCommand('');
 
       final bool result = await command.run();
       expect(result, isTrue);


### PR DESCRIPTION
This work was pulled out of https://github.com/flutter/packages/pull/12624#discussion_r3866530532 because we decided that a pre push git hook was a better tool than using an eval and skill. 

- @reidbaker 
---
Agent authored description. 
Adds a deterministic `pre-push` Git hook under `script/githooks` that inspects the last 20 commits for evaluation credentials (`Eval Author` and `eval-author@example.com`) and aborts the push if detected.

Also updates the `check-readiness` skill to verify that the `pre-push` hook script exists in `script/githooks`.

## Pre-launch Checklist
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides].
- [x] I signed the [CLA].
- [x] The title of the PR matches the expected standard.
- [x] All existing and new tests are passing.