### PR TITLE
[material_ui] Let TabBarThemeData.indicator satisfy the indicatorWeight assert

### DIFF
--- a/packages/material_ui/lib/src/tabs.dart
+++ b/packages/material_ui/lib/src/tabs.dart
@@ -1066,8 +1066,7 @@ class TabBar extends StatefulWidget implements PreferredSizeWidget {
     this.tabAlignment,
     this.textScaler,
     this.indicatorAnimation,
-  }) : _isPrimary = true,
-       assert(indicator != null || (indicatorWeight > 0.0));
+  }) : _isPrimary = true;
 
   /// Creates a Material Design secondary tab bar.
   ///
@@ -1128,8 +1127,7 @@ class TabBar extends StatefulWidget implements PreferredSizeWidget {
     this.tabAlignment,
     this.textScaler,
     this.indicatorAnimation,
-  }) : _isPrimary = false,
-       assert(indicator != null || (indicatorWeight > 0.0));
+  }) : _isPrimary = false;
 
   /// Typically a list of two or more [Tab] widgets.
   ///
@@ -1173,7 +1171,8 @@ class TabBar extends StatefulWidget implements PreferredSizeWidget {
 
   /// The thickness of the line that appears below the selected tab.
   ///
-  /// The value of this parameter must be greater than zero.
+  /// The value of this parameter must be greater than zero, unless an indicator
+  /// is provided by [indicator] or [TabBarThemeData.indicator].
   ///
   /// If [ThemeData.useMaterial3] is true and [TabBar] is used to create a
   /// primary tab bar, the default value is 3.0. If the provided value is less
@@ -1644,6 +1643,13 @@ class _TabBarState extends State<TabBar> {
     if (tabBarTheme.indicator != null) {
       return tabBarTheme.indicator!;
     }
+
+    assert(
+      widget.indicatorWeight > 0.0,
+      'The indicatorWeight must be greater than zero when the TabBar draws its '
+      'default underline indicator, i.e. when no indicator is provided by the '
+      'TabBar or by TabBarThemeData.indicator.',
+    );
 
     Color color = widget.indicatorColor ?? tabBarTheme.indicatorColor ?? _defaults.indicatorColor!;
     // ThemeData tries to avoid this by having indicatorColor avoid being the

--- a/packages/material_ui/pending_changelogs/change_2026_08_28_tab_bar_indicator_weight.yaml
+++ b/packages/material_ui/pending_changelogs/change_2026_08_28_tab_bar_indicator_weight.yaml
@@ -1,0 +1,3 @@
+changelog: |
+  - Fixes `TabBar` asserting on construction when `indicatorWeight` is zero and the indicator is provided by `TabBarThemeData.indicator`.
+version: patch

--- a/packages/material_ui/test/tabs_test.dart
+++ b/packages/material_ui/test/tabs_test.dart
@@ -3160,6 +3160,75 @@ void main() {
     );
   });
 
+  // Regression test for https://github.com/flutter/flutter/issues/188837.
+  testWidgets('TabBar.indicatorWeight can be zero when the indicator comes from the theme', (
+    WidgetTester tester,
+  ) async {
+    const indicatorColor = Color(0xFF00FF00);
+    const tabBarTheme = TabBarThemeData(
+      indicator: BoxDecoration(color: indicatorColor),
+      indicatorSize: TabBarIndicatorSize.tab,
+    );
+
+    final tabs = List<Widget>.generate(2, (int index) => Tab(text: 'Tab $index'));
+
+    Widget buildTabBar({bool secondaryTabBar = false}) {
+      final TabController controller = createTabController(
+        vsync: const TestVSync(),
+        length: tabs.length,
+      );
+      return boilerplate(
+        useMaterial3: false,
+        tabBarTheme: tabBarTheme,
+        child: Container(
+          alignment: Alignment.topLeft,
+          child: secondaryTabBar
+              ? TabBar.secondary(indicatorWeight: 0.0, controller: controller, tabs: tabs)
+              : TabBar(indicatorWeight: 0.0, controller: controller, tabs: tabs),
+        ),
+      );
+    }
+
+    await tester.pumpWidget(buildTabBar());
+    expect(tester.takeException(), isNull);
+
+    RenderBox tabBarBox = tester.firstRenderObject<RenderBox>(find.byType(TabBar));
+    // 46 = _kTabHeight(46) + indicatorWeight(0.0)
+    expect(tabBarBox.size.height, 46.0);
+    expect(
+      tabBarBox,
+      paints..rect(rect: const Rect.fromLTRB(0.0, 0.0, 400.0, 46.0), color: indicatorColor),
+    );
+
+    await tester.pumpWidget(buildTabBar(secondaryTabBar: true));
+    expect(tester.takeException(), isNull);
+
+    tabBarBox = tester.firstRenderObject<RenderBox>(find.byType(TabBar));
+    expect(tabBarBox.size.height, 46.0);
+    expect(
+      tabBarBox,
+      paints..rect(rect: const Rect.fromLTRB(0.0, 0.0, 400.0, 46.0), color: indicatorColor),
+    );
+  });
+
+  testWidgets('TabBar asserts when indicatorWeight is zero and no indicator is provided', (
+    WidgetTester tester,
+  ) async {
+    final tabs = List<Widget>.generate(2, (int index) => Tab(text: 'Tab $index'));
+    final TabController controller = createTabController(
+      vsync: const TestVSync(),
+      length: tabs.length,
+    );
+
+    await tester.pumpWidget(
+      boilerplate(
+        child: TabBar(indicatorWeight: 0.0, controller: controller, tabs: tabs),
+      ),
+    );
+
+    expect(tester.takeException(), isAssertionError);
+  });
+
   testWidgets('TabBar with indicatorWeight, indicatorPadding (LTR)', (WidgetTester tester) async {
     const indicatorColor = Color(0xFF00FF00);
     const indicatorWeight = 8.0;


### PR DESCRIPTION
`TabBar` and `TabBar.secondary` asserted `indicator != null || (indicatorWeight > 0.0)` in their
constructors. A constructor has no `BuildContext`, so that check can only see the widget-level
`indicator` and is blind to `TabBarThemeData.indicator`. As a result, an app that supplies its
indicator app-wide through the theme cannot also pass `indicatorWeight: 0` to suppress the default
underline thickness — the only workarounds are an epsilon weight, or moving the indicator to the
widget, which then overrides the themed one.

This contradicts the documented behavior of `indicatorWeight`, which already states:

> If `indicator` is specified or provided from `TabBarThemeData`, this property is ignored.

This PR moves the check to `_TabBarState._getIndicator`, which runs after both the widget-level and
the theme-level indicator have been ruled out, so it now fires only when the `TabBar` actually draws
its default underline indicator. This matches the direction suggested by @dkwingsmt in
https://github.com/flutter/flutter/issues/188837#issuecomment-4859851938.

The `indicatorWeight` doc comment is updated to describe the relaxed constraint.

Fixes https://github.com/flutter/flutter/issues/188837

## Tests

Two tests are added to `packages/material_ui/test/tabs_test.dart`; both fail before this change:

- `TabBar.indicatorWeight can be zero when the indicator comes from the theme` — a regression test
  covering both `TabBar` and `TabBar.secondary`, verifying that the widget builds and paints the
  themed indicator.
- `TabBar asserts when indicatorWeight is zero and no indicator is provided` — verifies the check is
  still enforced when the `TabBar` falls back to its default underline indicator.

`material_ui` is a batch-release package, so the changelog entry is a new file under
`pending_changelogs/` with `version: patch` rather than a direct `CHANGELOG.md`/`pubspec.yaml` edit.

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under[^1].
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [x] All existing and new tests are passing.

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[the version and CHANGELOG instructions]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version-and-changelog-updates
[semantic versioning]: https://dart.dev/tools/pub/versioning#semantic-versions
[repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
