### PR TITLE
[two_dimensional_scrollables] Exclude trailing pinned spans from the non-pinned range

### DIFF
--- a/packages/two_dimensional_scrollables/CHANGELOG.md
+++ b/packages/two_dimensional_scrollables/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.5.5
+
+* Fixes `TableView` laying out and painting trailing pinned rows and columns twice, which could throw when the table was scrolled to the end.
+
 ## 0.5.4
 
 * Fixes memory leaks.

--- a/packages/two_dimensional_scrollables/lib/src/table_view/table.dart
+++ b/packages/two_dimensional_scrollables/lib/src/table_view/table.dart
@@ -1087,7 +1087,9 @@ class RenderTableViewport extends RenderTwoDimensionalViewport {
       (span) => !span.isPinned && span.trailingOffset >= _targetTrailingColumnPixel,
     );
     if (_firstNonPinnedColumn != null) {
-      _lastNonPinnedColumn ??= _columnMetrics.length - 1;
+      // Trailing pinned columns are laid out and painted separately, so the
+      // range of regular columns must never extend into them.
+      _lastNonPinnedColumn ??= _lastRegularColumnIndex ?? _columnMetrics.length - 1;
     }
 
     if (_rowMetrics.isNotEmpty) {
@@ -1116,7 +1118,9 @@ class RenderTableViewport extends RenderTwoDimensionalViewport {
       (span) => !span.isPinned && span.trailingOffset >= _targetTrailingRowPixel,
     );
     if (_firstNonPinnedRow != null) {
-      _lastNonPinnedRow ??= _rowMetrics.length - 1;
+      // Trailing pinned rows are laid out and painted separately, so the range
+      // of regular rows must never extend into them.
+      _lastNonPinnedRow ??= _lastRegularRowIndex ?? _rowMetrics.length - 1;
     }
   }
 

--- a/packages/two_dimensional_scrollables/pubspec.yaml
+++ b/packages/two_dimensional_scrollables/pubspec.yaml
@@ -1,6 +1,6 @@
 name: two_dimensional_scrollables
 description: Widgets that scroll using the two dimensional scrolling foundation.
-version: 0.5.4
+version: 0.5.5
 repository: https://github.com/flutter/packages/tree/main/packages/two_dimensional_scrollables
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+two_dimensional_scrollables%22+
 

--- a/packages/two_dimensional_scrollables/test/table_view/table_test.dart
+++ b/packages/two_dimensional_scrollables/test/table_view/table_test.dart
@@ -39,6 +39,20 @@ TableSpan getMouseTrackingSpan(
   );
 }
 
+// Counts how many times a span's decoration is painted, keyed by span index.
+class CountingSpanDecoration extends TableSpanDecoration {
+  const CountingSpanDecoration({required this.index, required this.paintCounts});
+
+  final int index;
+  final Map<int, int> paintCounts;
+
+  @override
+  void paint(TableSpanDecorationPaintDetails details) {
+    paintCounts.update(index, (int count) => count + 1, ifAbsent: () => 1);
+    super.paint(details);
+  }
+}
+
 void main() {
   group('TableView.builder', () {
     testWidgets('creates correct delegate', (WidgetTester tester) async {
@@ -4006,6 +4020,103 @@ void main() {
     expect(tester.getRect(find.text('R9 C0')).top, 300);
     expect(tester.getRect(find.text('R9 C9')).left, 300);
     expect(tester.getRect(find.text('R9 C9')).top, 300);
+  });
+
+  // Regression test for https://github.com/flutter/flutter/issues/185842.
+  testWidgets('Trailing pinned columns are excluded from the non-pinned column range', (
+    WidgetTester tester,
+  ) async {
+    final horizontalController = ScrollController();
+    addTearDown(horizontalController.dispose);
+    final paintCounts = <int, int>{};
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: SizedBox(
+            height: 400,
+            width: 400,
+            child: TableView.builder(
+              columnCount: 20,
+              rowCount: 4,
+              trailingPinnedColumnCount: 1,
+              horizontalDetails: ScrollableDetails.horizontal(controller: horizontalController),
+              columnBuilder: (int index) => TableSpan(
+                extent: const FixedTableSpanExtent(100),
+                backgroundDecoration: CountingSpanDecoration(
+                  index: index,
+                  paintCounts: paintCounts,
+                ),
+              ),
+              rowBuilder: (int index) => const TableSpan(extent: FixedTableSpanExtent(100)),
+              cellBuilder: (BuildContext context, TableVicinity vicinity) {
+                return TableViewCell(child: Text('R${vicinity.row} C${vicinity.column}'));
+              },
+            ),
+          ),
+        ),
+      ),
+    );
+
+    // Once scrolled to the end, no regular column reaches the trailing edge of
+    // the layout target. That is where the range of non-pinned columns used to
+    // fall back to the last column of the table, which is a trailing pinned
+    // one, making it part of both the non-pinned and the trailing pinned
+    // region.
+    paintCounts.clear();
+    horizontalController.jumpTo(horizontalController.position.maxScrollExtent);
+    await tester.pump();
+
+    expect(tester.takeException(), isNull);
+    // The trailing pinned column is decorated once, by the trailing pinned
+    // region only.
+    expect(paintCounts[19], 1);
+    expect(find.text('R0 C19'), findsOneWidget);
+  });
+
+  // Regression test for https://github.com/flutter/flutter/issues/185842.
+  testWidgets('Trailing pinned rows are excluded from the non-pinned row range', (
+    WidgetTester tester,
+  ) async {
+    final verticalController = ScrollController();
+    addTearDown(verticalController.dispose);
+    final paintCounts = <int, int>{};
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: SizedBox(
+            height: 400,
+            width: 400,
+            child: TableView.builder(
+              columnCount: 4,
+              rowCount: 20,
+              trailingPinnedRowCount: 1,
+              verticalDetails: ScrollableDetails.vertical(controller: verticalController),
+              columnBuilder: (int index) => const TableSpan(extent: FixedTableSpanExtent(100)),
+              rowBuilder: (int index) => TableSpan(
+                extent: const FixedTableSpanExtent(100),
+                backgroundDecoration: CountingSpanDecoration(
+                  index: index,
+                  paintCounts: paintCounts,
+                ),
+              ),
+              cellBuilder: (BuildContext context, TableVicinity vicinity) {
+                return TableViewCell(child: Text('R${vicinity.row} C${vicinity.column}'));
+              },
+            ),
+          ),
+        ),
+      ),
+    );
+
+    paintCounts.clear();
+    verticalController.jumpTo(verticalController.position.maxScrollExtent);
+    await tester.pump();
+
+    expect(tester.takeException(), isNull);
+    expect(paintCounts[19], 1);
+    expect(find.text('R19 C0'), findsOneWidget);
   });
 
   testWidgets('Intersections of leading and trailing pinned', (WidgetTester tester) async {


### PR DESCRIPTION
`RenderTableViewport` lays out and paints the table as nine regions: leading pinned, regular and
trailing pinned rows, each crossed with the same three column categories.
`_updateFirstAndLastVisibleCell` binary searches for the last regular row and column of the visible
range, and when no regular span reaches the trailing edge of the layout target it fell back to the
last index in the metrics map:

```dart
_lastNonPinnedColumn ??= _columnMetrics.length - 1;
```

Whenever `trailingPinnedRowCount` or `trailingPinnedColumnCount` is greater than zero, that last
index *is* a trailing pinned span. The regular range then overlaps the trailing pinned range, and
the same `TableVicinity` is visited by two regions in a single layout and paint pass.

`_updateColumnMetrics` and `_updateRowMetrics` already cap the same value correctly, with the rule
that `_lastRegularColumnIndex` and `_lastRegularRowIndex` express, so the two code paths disagreed.
This PR makes `_updateFirstAndLastVisibleCell` use those getters. The old fallback is kept for the
case where they are null — infinite spans with no null terminator — where trailing pinned spans
cannot exist, since `_firstTrailingPinnedColumn` and `_firstTrailingPinnedRow` both require a
non-null span count.

Fixes https://github.com/flutter/flutter/issues/185842

## Beyond the duplicated work

The overlap is not only wasted layout. Scrolling a table to the end with a trailing pinned span
throws, because two regions claim the same cell:

```
Expected to re-use an element at (row: 0, column: 19), but none was found.
  package:flutter/src/widgets/two_dimensional_viewport.dart:377  'elementToReuse != null'
```

and, once the spans carry a decoration, the non-pinned region reaches a cell whose `paintOffset` was
never set for it:

```
Null check operator used on a null value
  RenderTableViewport._paintCells.getColumnRect  (table.dart:1888)
```

Dragging through a 60x60 table with pinned and trailing pinned rows and columns throws
`Expected to re-use an element at ...` and `TableViewCell for (row: 1, column: 58) could not be
found` before this change, and nothing after it. That is the same subsystem and trigger as
https://github.com/flutter/flutter/issues/190800, but the specific assertion reported there did not
reproduce in my runs, so I am not claiming this fixes it.

## Tests

Two regression tests are added to `table_test.dart`, one per axis. Each scrolls a table with a
trailing pinned span to the end, asserts that no exception is thrown, and asserts that the trailing
pinned span's decoration is painted exactly once — by the trailing pinned region only. Both fail
before this change.

Counting `cellBuilder` calls does not work as a test here: `buildOrObtainChildFor` caches children
for the frame and `RenderObject.layout` early-returns on unchanged constraints, so the duplicated
visit is invisible from the delegate. The new `CountingSpanDecoration` helper observes it through
the public `TableSpanDecoration.paint` API instead.

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under[^1].
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [x] All existing and new tests are passing.

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[the version and CHANGELOG instructions]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version-and-changelog-updates
[semantic versioning]: https://dart.dev/tools/pub/versioning#semantic-versions
[repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
