### PR TITLE
[script/tool] Run cognitive_complexity using flutter pub run for Flutter packages

### DIFF
--- a/script/tool/lib/src/analyze_command.dart
+++ b/script/tool/lib/src/analyze_command.dart
@@ -389,7 +389,10 @@ class AnalyzeCommand extends PackageLoopingCommand {
 
     print('Running cognitive_complexity analysis...');
     final int? threshold = _getLinterThreshold(package);
+    final bool requiresFlutter = package.requiresFlutter();
+    final String binaryPath = requiresFlutter ? flutterCommand : _dartBinaryPath;
     final args = <String>[
+      if (requiresFlutter) 'pub',
       'run',
       'cognitive_complexity',
       if (threshold != null) ...<String>[
@@ -404,7 +407,7 @@ class AnalyzeCommand extends PackageLoopingCommand {
       ...filesToAnalyze,
     ];
     final int linterExitCode = await processRunner.runAndStream(
-      _dartBinaryPath,
+      binaryPath,
       args,
       workingDir: package.directory,
     );

--- a/script/tool/test/analyze_command_test.dart
+++ b/script/tool/test/analyze_command_test.dart
@@ -419,8 +419,8 @@ void main() {
 
         _mockCallsForFlutterAnalyze(
           processRunner,
-          extraDartCalls: [
-            FakeProcessInfo(MockProcess(), <String>['run', 'cognitive_complexity']),
+          extraFlutterCalls: [
+            FakeProcessInfo(MockProcess(), <String>['pub', 'run', 'cognitive_complexity']),
           ],
         );
 
@@ -431,7 +431,8 @@ void main() {
           orderedEquals(<ProcessCall>[
             ProcessCall('flutter', const <String>['pub', 'get'], package.path),
             ProcessCall('dart', const <String>['analyze', '--fatal-infos'], package.path),
-            ProcessCall('dart', const <String>[
+            ProcessCall('flutter', const <String>[
+              'pub',
               'run',
               'cognitive_complexity',
               'lib/lib.dart',
@@ -611,8 +612,8 @@ void main() {
 
         _mockCallsForFlutterAnalyze(
           processRunner,
-          extraDartCalls: [
-            FakeProcessInfo(MockProcess(exitCode: 1), <String>['run', 'cognitive_complexity']),
+          extraFlutterCalls: [
+            FakeProcessInfo(MockProcess(exitCode: 1), <String>['pub', 'run', 'cognitive_complexity']),
           ],
         );
 
@@ -652,8 +653,8 @@ cognitive_complexity:
 
         _mockCallsForFlutterAnalyze(
           processRunner,
-          extraDartCalls: [
-            FakeProcessInfo(MockProcess(exitCode: 1), <String>['run', 'cognitive_complexity']),
+          extraFlutterCalls: [
+            FakeProcessInfo(MockProcess(exitCode: 1), <String>['pub', 'run', 'cognitive_complexity']),
           ],
         );
 
@@ -671,7 +672,8 @@ cognitive_complexity:
           orderedEquals(<ProcessCall>[
             ProcessCall('flutter', const <String>['pub', 'get'], package.path),
             ProcessCall('dart', const <String>['analyze', '--fatal-infos'], package.path),
-            ProcessCall('dart', const <String>[
+            ProcessCall('flutter', const <String>[
+              'pub',
               'run',
               'cognitive_complexity',
               '--threshold',
@@ -824,14 +826,15 @@ cognitive_complexity:
 
           processRunner.mockProcessesForExecutable['flutter'] = <FakeProcessInfo>[
             FakeProcessInfo(MockProcess(), <String>['pub', 'get']),
+            FakeProcessInfo(MockProcess(exitCode: 1), <String>[
+              'pub',
+              'run',
+              'cognitive_complexity',
+            ]), // custom linter
           ];
           processRunner.mockProcessesForExecutable['dart'] = <FakeProcessInfo>[
             FakeProcessInfo(MockProcess(exitCode: 1), <String>['analyze']), // main package
             FakeProcessInfo(MockProcess(exitCode: 1), <String>['analyze']), // skills package
-            FakeProcessInfo(MockProcess(exitCode: 1), <String>[
-              'run',
-              'cognitive_complexity',
-            ]), // custom linter
           ];
 
           Error? commandError;


### PR DESCRIPTION
## Description

In `AnalyzeCommand._runCognitiveComplexityForPackage`, the tool previously always invoked `_dartBinaryPath` (`dart run cognitive_complexity ...`).

For packages that depend on the Flutter SDK (e.g. Flutter plugins), running `dart run` triggers Dart pub dependency resolution, which fails because the package requires the Flutter SDK (`Because <package> requires the Flutter SDK, version solving failed.`).

This change checks `package.requiresFlutter()` and invokes `flutter pub run cognitive_complexity ...` when true, and `dart run cognitive_complexity ...` for pure Dart packages.

## Tests
- Updated `script/tool/test/analyze_command_test.dart` to test both Flutter and pure Dart package flows.
- Validated with `dart test` across `script/tool` (1,227 passing tests) and tested `flutter_plugin_tools analyze --packages=camera_android_camerax --dart`.