### PR TITLE
[material_ui] Add tertiary tap callbacks to InkResponse and InkWell

### DIFF
--- a/packages/material_ui/lib/src/ink_well.dart
+++ b/packages/material_ui/lib/src/ink_well.dart
@@ -315,6 +315,9 @@ class InkResponse extends StatelessWidget {
     this.onSecondaryTapUp,
     this.onSecondaryTapDown,
     this.onSecondaryTapCancel,
+    this.onTertiaryTapUp,
+    this.onTertiaryTapDown,
+    this.onTertiaryTapCancel,
     this.onHighlightChanged,
     this.onHover,
     this.mouseCursor,
@@ -409,6 +412,35 @@ class InkResponse extends StatelessWidget {
   ///
   ///  * [kSecondaryButton], the button this callback responds to.
   final GestureTapCallback? onSecondaryTapCancel;
+
+  /// Called when the user taps down on this part of the material with a
+  /// tertiary button.
+  ///
+  /// A common use case for the tertiary button is opening a link in a new tab
+  /// or window with a middle click of a mouse.
+  ///
+  /// See also:
+  ///
+  ///  * [kTertiaryButton], the button this callback responds to.
+  final GestureTapDownCallback? onTertiaryTapDown;
+
+  /// Called when the user releases a tertiary button tap that was started on
+  /// this part of the material.
+  ///
+  /// See also:
+  ///
+  ///  * [onTertiaryTapDown], which is called when the tertiary button tap
+  ///    starts.
+  ///  * [kTertiaryButton], the button this callback responds to.
+  final GestureTapUpCallback? onTertiaryTapUp;
+
+  /// Called when the user cancels a tertiary button tap that was started on
+  /// this part of the material.
+  ///
+  /// See also:
+  ///
+  ///  * [kTertiaryButton], the button this callback responds to.
+  final GestureTapCancelCallback? onTertiaryTapCancel;
 
   /// Called when this part of the material either becomes highlighted or stops
   /// being highlighted.
@@ -674,6 +706,9 @@ class InkResponse extends StatelessWidget {
       onSecondaryTapUp: onSecondaryTapUp,
       onSecondaryTapDown: onSecondaryTapDown,
       onSecondaryTapCancel: onSecondaryTapCancel,
+      onTertiaryTapUp: onTertiaryTapUp,
+      onTertiaryTapDown: onTertiaryTapDown,
+      onTertiaryTapCancel: onTertiaryTapCancel,
       onHighlightChanged: onHighlightChanged,
       onHover: onHover,
       mouseCursor: mouseCursor,
@@ -732,6 +767,9 @@ class _InkResponseStateWidget extends StatefulWidget {
     this.onSecondaryTapUp,
     this.onSecondaryTapDown,
     this.onSecondaryTapCancel,
+    this.onTertiaryTapUp,
+    this.onTertiaryTapDown,
+    this.onTertiaryTapCancel,
     this.onHighlightChanged,
     this.onHover,
     this.mouseCursor,
@@ -771,6 +809,9 @@ class _InkResponseStateWidget extends StatefulWidget {
   final GestureTapUpCallback? onSecondaryTapUp;
   final GestureTapDownCallback? onSecondaryTapDown;
   final GestureTapCallback? onSecondaryTapCancel;
+  final GestureTapUpCallback? onTertiaryTapUp;
+  final GestureTapDownCallback? onTertiaryTapDown;
+  final GestureTapCancelCallback? onTertiaryTapCancel;
   final ValueChanged<bool>? onHighlightChanged;
   final ValueChanged<bool>? onHover;
   final MouseCursor? mouseCursor;
@@ -815,6 +856,9 @@ class _InkResponseStateWidget extends StatefulWidget {
       if (onSecondaryTapUp != null) 'secondary tap up',
       if (onSecondaryTapDown != null) 'secondary tap down',
       if (onSecondaryTapCancel != null) 'secondary tap cancel',
+      if (onTertiaryTapUp != null) 'tertiary tap up',
+      if (onTertiaryTapDown != null) 'tertiary tap down',
+      if (onTertiaryTapCancel != null) 'tertiary tap cancel',
     ];
     properties.add(IterableProperty<String>('gestures', gestures, ifEmpty: '<none>'));
     properties.add(DiagnosticsProperty<MouseCursor>('mouseCursor', mouseCursor));
@@ -1183,6 +1227,25 @@ class _InkResponseState extends State<_InkResponseStateWidget>
     widget.onSecondaryTapUp?.call(details);
   }
 
+  void handleTertiaryTapDown(TapDownDetails details) {
+    handleAnyTapDown(details);
+    widget.onTertiaryTapDown?.call(details);
+  }
+
+  void handleTertiaryTapUp(TapUpDetails details) {
+    _currentSplash?.confirm();
+    _currentSplash = null;
+    updateHighlight(_HighlightType.pressed, value: false);
+    widget.onTertiaryTapUp?.call(details);
+  }
+
+  void handleTertiaryTapCancel() {
+    _currentSplash?.cancel();
+    _currentSplash = null;
+    widget.onTertiaryTapCancel?.call();
+    updateHighlight(_HighlightType.pressed, value: false);
+  }
+
   void _startNewSplash({TapDownDetails? details, BuildContext? context}) {
     assert(details != null || context != null);
 
@@ -1284,7 +1347,9 @@ class _InkResponseState extends State<_InkResponseStateWidget>
   }
 
   bool isWidgetEnabled(_InkResponseStateWidget widget) {
-    return _primaryButtonEnabled(widget) || _secondaryButtonEnabled(widget);
+    return _primaryButtonEnabled(widget) ||
+        _secondaryButtonEnabled(widget) ||
+        _tertiaryButtonEnabled(widget);
   }
 
   bool _primaryButtonEnabled(_InkResponseStateWidget widget) {
@@ -1302,9 +1367,14 @@ class _InkResponseState extends State<_InkResponseStateWidget>
         widget.onSecondaryTapDown != null;
   }
 
+  bool _tertiaryButtonEnabled(_InkResponseStateWidget widget) {
+    return widget.onTertiaryTapUp != null || widget.onTertiaryTapDown != null;
+  }
+
   bool get enabled => isWidgetEnabled(widget);
   bool get _primaryEnabled => _primaryButtonEnabled(widget);
   bool get _secondaryEnabled => _secondaryButtonEnabled(widget);
+  bool get _tertiaryEnabled => _tertiaryButtonEnabled(widget);
 
   void handleMouseEnter(PointerEnterEvent event) {
     _hovering = true;
@@ -1409,6 +1479,9 @@ class _InkResponseState extends State<_InkResponseStateWidget>
                   onSecondaryTapUp: _secondaryEnabled ? handleSecondaryTapUp : null,
                   onSecondaryTap: _secondaryEnabled ? handleSecondaryTap : null,
                   onSecondaryTapCancel: _secondaryEnabled ? handleSecondaryTapCancel : null,
+                  onTertiaryTapDown: _tertiaryEnabled ? handleTertiaryTapDown : null,
+                  onTertiaryTapUp: _tertiaryEnabled ? handleTertiaryTapUp : null,
+                  onTertiaryTapCancel: _tertiaryEnabled ? handleTertiaryTapCancel : null,
                   behavior: HitTestBehavior.opaque,
                   excludeFromSemantics: true,
                   child: widget.child,
@@ -1524,6 +1597,9 @@ class InkWell extends InkResponse {
     super.onSecondaryTapUp,
     super.onSecondaryTapDown,
     super.onSecondaryTapCancel,
+    super.onTertiaryTapUp,
+    super.onTertiaryTapDown,
+    super.onTertiaryTapCancel,
     super.onHighlightChanged,
     super.onHover,
     super.mouseCursor,

--- a/packages/material_ui/pending_changelogs/change_2026_08_28_inkwell_tertiary_tap.yaml
+++ b/packages/material_ui/pending_changelogs/change_2026_08_28_inkwell_tertiary_tap.yaml
@@ -1,0 +1,3 @@
+changelog: |
+  - Adds `onTertiaryTapDown`, `onTertiaryTapUp` and `onTertiaryTapCancel` to `InkResponse` and `InkWell`, so a tertiary (middle) button click can be handled directly.
+version: minor

--- a/packages/material_ui/test/ink_well_test.dart
+++ b/packages/material_ui/test/ink_well_test.dart
@@ -2500,6 +2500,102 @@ void main() {
     },
   );
 
+  // Regression test for https://github.com/flutter/flutter/issues/129058.
+  testWidgets('InkWell tertiary tap test', (WidgetTester tester) async {
+    final log = <String>[];
+
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: Material(
+          child: Center(
+            child: InkWell(
+              onTertiaryTapDown: (TapDownDetails details) {
+                log.add('tertiary-tap-down');
+              },
+              onTertiaryTapUp: (TapUpDetails details) {
+                log.add('tertiary-tap-up');
+              },
+              onTertiaryTapCancel: () {
+                log.add('tertiary-tap-cancel');
+              },
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.byType(InkWell), pointer: 1, buttons: kTertiaryButton);
+
+    expect(log, equals(<String>['tertiary-tap-down', 'tertiary-tap-up']));
+    log.clear();
+
+    final TestGesture gesture = await tester.startGesture(
+      tester.getCenter(find.byType(InkWell)),
+      pointer: 2,
+      buttons: kTertiaryButton,
+    );
+    await gesture.moveTo(const Offset(100, 100));
+    await gesture.up();
+
+    expect(log, equals(<String>['tertiary-tap-down', 'tertiary-tap-cancel']));
+  });
+
+  testWidgets('InkWell tertiary tap highlights only when a tertiary callback is defined', (
+    WidgetTester tester,
+  ) async {
+    final log = <bool>[];
+
+    Widget buildFrame({required bool withTertiaryCallback}) {
+      return Directionality(
+        textDirection: TextDirection.ltr,
+        child: Material(
+          child: Center(
+            child: SizedBox(
+              width: 100.0,
+              height: 100.0,
+              child: InkWell(
+                onTap: () {},
+                onHighlightChanged: log.add,
+                onTertiaryTapUp: withTertiaryCallback ? (TapUpDetails details) {} : null,
+              ),
+            ),
+          ),
+        ),
+      );
+    }
+
+    await tester.pumpWidget(buildFrame(withTertiaryCallback: true));
+
+    TestGesture gesture = await tester.startGesture(
+      tester.getRect(find.byType(InkWell)).center,
+      buttons: kTertiaryButton,
+    );
+    await tester.pump(const Duration(milliseconds: 200));
+
+    expect(log, equals(<bool>[true]));
+    log.clear();
+
+    await gesture.up();
+    await tester.pump(const Duration(milliseconds: 200));
+
+    expect(log, equals(<bool>[false]));
+    log.clear();
+
+    // Without a tertiary callback, a tertiary button press is ignored.
+    await tester.pumpWidget(buildFrame(withTertiaryCallback: false));
+
+    gesture = await tester.startGesture(
+      tester.getRect(find.byType(InkWell)).center,
+      buttons: kTertiaryButton,
+    );
+    await tester.pump(const Duration(milliseconds: 200));
+
+    expect(log, isEmpty);
+
+    await gesture.up();
+  });
+
   testWidgets('try out hoverDuration property', (WidgetTester tester) async {
     final log = <String>[];
 


### PR DESCRIPTION
Ported from https://github.com/flutter/flutter/pull/191971, which was opened against `flutter/flutter` before I noticed the Material code freeze (https://github.com/flutter/flutter/issues/188444). That PR has been closed in favour of this one.

`GestureDetector` exposes `onTertiaryTapDown`, `onTertiaryTapUp` and `onTertiaryTapCancel`, but `InkResponse`/`InkWell` only forward the primary and secondary button callbacks. That means a middle click on an `InkWell` — the usual way to open a link in a new tab or window on desktop and web — can't be handled without wrapping the widget in a second gesture detector, which then has to be reconciled with the ink splash.

This PR adds the three tertiary callbacks to `InkResponse` and `InkWell`, mirroring the existing secondary button plumbing:

- The pressed highlight and ink splash start on tertiary tap down and are resolved on tap up or cancel, exactly as they are for the secondary button.
- The tertiary button is only listened for when `onTertiaryTapDown` or `onTertiaryTapUp` is non-null, so widgets that don't opt in behave exactly as before (no splash on middle click, same as today).
- `onTertiaryTapCancel` alone does not enable the button, which matches how `onSecondaryTapCancel` already behaves.

There is no `onTertiaryTap` because `TapGestureRecognizer`/`GestureDetector` don't have one; `onTertiaryTapUp` is the completion signal for that button.

This follows the approach suggested in the issue: a specific widget with a concrete use case, rather than a general reworking of the button callback pattern.

**Tests added** to `packages/material_ui/test/ink_well_test.dart`:

- `InkWell tertiary tap test` — verifies the down/up ordering on a completed middle click, and down/cancel when the pointer is dragged away.
- `InkWell tertiary tap highlights only when a tertiary callback is defined` — verifies the pressed highlight is raised and lowered on a tertiary press when a tertiary callback is supplied, and that a tertiary press is ignored when one is not.

A pending changelog entry is included with a `minor` version bump, since this is additive API.

Fixes https://github.com/flutter/flutter/issues/129058

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under.
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[the version and CHANGELOG instructions]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version-and-changelog-updates
[semantic versioning]: https://dart.dev/tools/pub/versioning#semantic-versions
[repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests

