### PR TITLE
[material_ui] Fixes SearchAnchor and SearchBar semantics

### DIFF
--- a/packages/material_ui/example/lib/search_anchor/search_anchor.2.dart
+++ b/packages/material_ui/example/lib/search_anchor/search_anchor.2.dart
@@ -27,6 +27,7 @@ class _SearchBarAppState extends State<SearchBarApp> {
         body: Column(
           children: <Widget>[
             SearchAnchor(
+              enableTapHandling: false,
               searchController: controller,
               builder: (BuildContext context, SearchController controller) {
                 return IconButton(

--- a/packages/material_ui/example/lib/search_anchor/search_anchor.3.dart
+++ b/packages/material_ui/example/lib/search_anchor/search_anchor.3.dart
@@ -43,6 +43,7 @@ class _AsyncSearchAnchorState extends State<_AsyncSearchAnchor> {
   @override
   Widget build(BuildContext context) {
     return SearchAnchor(
+      enableTapHandling: false,
       builder: (BuildContext context, SearchController controller) {
         return IconButton(
           icon: const Icon(Icons.search),

--- a/packages/material_ui/example/lib/search_anchor/search_anchor.4.dart
+++ b/packages/material_ui/example/lib/search_anchor/search_anchor.4.dart
@@ -73,6 +73,7 @@ class _AsyncSearchAnchorState extends State<_AsyncSearchAnchor> {
   @override
   Widget build(BuildContext context) {
     return SearchAnchor(
+      enableTapHandling: false,
       builder: (BuildContext context, SearchController controller) {
         return IconButton(
           icon: const Icon(Icons.search),

--- a/packages/material_ui/example/lib/search_anchor/search_anchor.5.dart
+++ b/packages/material_ui/example/lib/search_anchor/search_anchor.5.dart
@@ -1,0 +1,80 @@
+// Copyright 2013 The Flutter Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// #region body
+import 'package:material_ui/material_ui.dart';
+
+/// Flutter code sample for [SearchAnchor] with [SearchAnchor.enableTapHandling].
+
+void main() => runApp(const SearchAnchorCustomSearchBarApp());
+
+class SearchAnchorCustomSearchBarApp extends StatefulWidget {
+  const SearchAnchorCustomSearchBarApp({super.key});
+
+  @override
+  State<SearchAnchorCustomSearchBarApp> createState() =>
+      _SearchAnchorCustomSearchBarAppState();
+}
+
+class _SearchAnchorCustomSearchBarAppState
+    extends State<SearchAnchorCustomSearchBarApp> {
+  String? selectedItem;
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      home: Scaffold(
+        appBar: AppBar(title: const Text('Custom Search Bar Anchor Sample')),
+        body: Align(
+          alignment: Alignment.topCenter,
+          child: Column(
+            children: <Widget>[
+              const SizedBox(height: 16),
+              SearchAnchor(
+                // Set to false because SearchBar handles its own tap events.
+                // This prevents duplicate gesture recognizers and duplicate
+                // tap semantics actions.
+                enableTapHandling: false,
+                builder: (BuildContext context, SearchController controller) {
+                  return SearchBar(
+                    controller: controller,
+                    hintText: 'Search items...',
+                    onTap: () {
+                      controller.openView();
+                    },
+                    onChanged: (String value) {
+                      controller.openView();
+                    },
+                    leading: const Icon(Icons.search),
+                  );
+                },
+                suggestionsBuilder:
+                    (BuildContext context, SearchController controller) {
+                      return List<ListTile>.generate(5, (int index) {
+                        final String item = 'Item $index';
+                        return ListTile(
+                          title: Text(item),
+                          onTap: () {
+                            setState(() {
+                              selectedItem = item;
+                              controller.closeView(item);
+                            });
+                          },
+                        );
+                      });
+                    },
+              ),
+              const SizedBox(height: 16),
+              if (selectedItem == null)
+                const Text('No item selected')
+              else
+                Text('Selected item: $selectedItem'),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+// #endregion body

--- a/packages/material_ui/example/lib/search_anchor/search_bar.0.dart
+++ b/packages/material_ui/example/lib/search_anchor/search_bar.0.dart
@@ -30,6 +30,7 @@ class _SearchBarAppState extends State<SearchBarApp> {
         body: Padding(
           padding: const .all(8.0),
           child: SearchAnchor(
+            enableTapHandling: false,
             builder: (BuildContext context, SearchController controller) {
               return SearchBar(
                 controller: controller,

--- a/packages/material_ui/example/test/search_anchor/search_anchor.5_test.dart
+++ b/packages/material_ui/example/test/search_anchor/search_anchor.5_test.dart
@@ -1,0 +1,35 @@
+// Copyright 2013 The Flutter Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:material_ui/material_ui.dart';
+import 'package:material_ui_examples/search_anchor/search_anchor.5.dart'
+    as example;
+
+void main() {
+  testWidgets(
+    'SearchAnchor with enableTapHandling = false opens view on SearchBar tap',
+    (WidgetTester tester) async {
+      await tester.pumpWidget(const example.SearchAnchorCustomSearchBarApp());
+
+      expect(
+        find.widgetWithText(AppBar, 'Custom Search Bar Anchor Sample'),
+        findsOne,
+      );
+      expect(find.text('No item selected'), findsOne);
+
+      await tester.tap(find.byType(SearchBar));
+      await tester.pumpAndSettle();
+
+      for (int i = 0; i < 5; i++) {
+        expect(find.widgetWithText(ListTile, 'Item $i'), findsOne);
+      }
+
+      await tester.tap(find.text('Item 2'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Selected item: Item 2'), findsOne);
+    },
+  );
+}

--- a/packages/material_ui/lib/src/search_anchor.dart
+++ b/packages/material_ui/lib/src/search_anchor.dart
@@ -606,7 +606,11 @@ class _SearchAnchorState extends State<SearchAnchor> {
       duration: _kAnchorFadeDuration,
       child: IgnorePointer(
         ignoring: !widget.enabled,
-        child: GestureDetector(onTap: _openView, child: widget.builder(context, _searchController)),
+        child: GestureDetector(
+          excludeFromSemantics: true,
+          onTap: _openView,
+          child: widget.builder(context, _searchController),
+        ),
       ),
     );
   }
@@ -1825,6 +1829,10 @@ class _SearchBarState extends State<SearchBar> {
           child: IgnorePointer(
             ignoring: !widget.enabled,
             child: InkWell(
+              canRequestFocus: false,
+              // Avoid providing duplicate semantics actions that the TextField
+              // already provides.
+              excludeFromSemantics: true,
               onTap: () {
                 widget.onTap?.call();
                 if (!_focusNode.hasFocus) {

--- a/packages/material_ui/lib/src/search_anchor.dart
+++ b/packages/material_ui/lib/src/search_anchor.dart
@@ -83,6 +83,35 @@ typedef ViewBuilder = Widget Function(Iterable<Widget> suggestions);
 /// If [builder] returns an Icon, or any un-tappable widgets, we don't have
 /// to explicitly call [SearchController.openView].
 ///
+/// ## Tap handling on the anchor
+///
+/// By default, [SearchAnchor] wraps the widget returned by [builder] in a
+/// [GestureDetector] that calls [SearchController.openView] on tap. This
+/// behavior is controlled by [enableTapHandling], which defaults to true.
+///
+/// ### When to enable tap handling
+///
+/// Keep [enableTapHandling] set to true (the default) when [builder]
+/// returns a passive widget, such as an [Icon] or [Text]. The outer
+/// [GestureDetector] handles taps and provides tap semantics for accessibility
+/// services.
+///
+/// ### When to disable tap handling
+///
+/// Set [enableTapHandling] to false when the widget returned by [builder]
+/// handles its own tap events or provides its own semantics. For example:
+///
+/// * When returning a [SearchBar] that handles taps through its own callbacks.
+/// * When returning buttons like [IconButton] or other interactive widgets that
+///   already call [SearchController.openView].
+///
+/// Setting [enableTapHandling] to false avoids duplicate gesture recognizers
+/// in the gesture arena and prevents duplicate tap semantics (which can cause
+/// accessibility guideline violations, such as unlabeled tap targets).
+///
+/// When using [SearchAnchor.bar], [enableTapHandling] is already set to
+/// false because the factory constructor's [SearchBar] handles its own taps.
+///
 /// The search view route will be popped if the window size is changed and the
 /// search view route is not in full-screen mode. However, if the search view route
 /// is in full-screen mode, changing the window size, such as rotating a mobile
@@ -139,6 +168,19 @@ typedef ViewBuilder = Widget Function(Iterable<Widget> suggestions);
 ///
 /// </callout-box>
 ///
+/// <callout-box>
+///
+/// This example shows how to use a [SearchAnchor] with a custom [SearchBar] as
+/// the anchor and sets [enableTapHandling] to false.
+///
+// TODO(framework): Replace the following block with a @dartpad directive
+// when it's supported. https://github.com/dart-lang/dartdoc/issues/4123
+/// {@macro material_ui.dartpad_guide}
+///
+/// {@example /example/lib/search_anchor/search_anchor.5.dart#body}
+///
+/// </callout-box>
+///
 /// See also:
 ///
 /// * [SearchBar], a widget that defines a search bar.
@@ -181,6 +223,7 @@ class SearchAnchor extends StatefulWidget {
     this.enabled = true,
     this.smartDashesType,
     this.smartQuotesType,
+    this.enableTapHandling = true,
   });
 
   /// Create a [SearchAnchor] that has a [SearchBar] which opens a search view.
@@ -472,6 +515,16 @@ class SearchAnchor extends StatefulWidget {
   ///    configuration option on a standalone [TextField].
   final SmartQuotesType? smartQuotesType;
 
+  /// Whether to wrap the widget returned by [builder] with a [GestureDetector]
+  /// that opens the search view route when tapped.
+  ///
+  /// Defaults to true.
+  ///
+  /// Set this to false if the widget returned by [builder] handles its own
+  /// tap gestures (such as a [SearchBar] or [IconButton]) to avoid duplicate
+  /// gestures and semantics actions.
+  final bool enableTapHandling;
+
   @override
   State<SearchAnchor> createState() => _SearchAnchorState();
 }
@@ -600,19 +653,15 @@ class _SearchAnchorState extends State<SearchAnchor> {
 
   @override
   Widget build(BuildContext context) {
+    Widget child = widget.builder(context, _searchController);
+    if (widget.enableTapHandling) {
+      child = GestureDetector(onTap: _openView, child: child);
+    }
     return AnimatedOpacity(
       key: _anchorKey,
       opacity: _getOpacity(),
       duration: _kAnchorFadeDuration,
-      child: IgnorePointer(
-        ignoring: !widget.enabled,
-        child: GestureDetector(
-          // Avoid providing duplicate semantics actions.
-          excludeFromSemantics: true,
-          onTap: _openView,
-          child: widget.builder(context, _searchController),
-        ),
-      ),
+      child: IgnorePointer(ignoring: !widget.enabled, child: child),
     );
   }
 }
@@ -1319,6 +1368,7 @@ class _SearchAnchorWithSearchBar extends SearchAnchor {
     super.smartDashesType,
     super.smartQuotesType,
   }) : super(
+         enableTapHandling: false,
          viewHintText: viewHintText ?? barHintText,
          headerHeight: viewHeaderHeight,
          headerTextStyle: viewHeaderTextStyle,

--- a/packages/material_ui/lib/src/search_anchor.dart
+++ b/packages/material_ui/lib/src/search_anchor.dart
@@ -607,6 +607,7 @@ class _SearchAnchorState extends State<SearchAnchor> {
       child: IgnorePointer(
         ignoring: !widget.enabled,
         child: GestureDetector(
+          // Avoid providing duplicate semantics actions.
           excludeFromSemantics: true,
           onTap: _openView,
           child: widget.builder(context, _searchController),

--- a/packages/material_ui/pending_changelogs/change_2026_08_27_search_bar_semantics.yaml
+++ b/packages/material_ui/pending_changelogs/change_2026_08_27_search_bar_semantics.yaml
@@ -1,3 +1,4 @@
 changelog: |
   - Fixes unlabeled tap target semantics in `SearchBar`.
-version: patch
+  - Adds `enableTapHandling` to `SearchAnchor`.
+version: minor

--- a/packages/material_ui/pending_changelogs/change_2026_08_27_search_bar_semantics.yaml
+++ b/packages/material_ui/pending_changelogs/change_2026_08_27_search_bar_semantics.yaml
@@ -1,0 +1,3 @@
+changelog: |
+  - Fixes unlabeled tap target semantics in `SearchBar`.
+version: patch

--- a/packages/material_ui/test/search_anchor_test.dart
+++ b/packages/material_ui/test/search_anchor_test.dart
@@ -3450,6 +3450,84 @@ void main() {
     semantics.dispose();
   });
 
+  testWidgets('SearchAnchor with enableTapHandling: false meets labeledTapTargetGuideline', (
+    WidgetTester tester,
+  ) async {
+    final semantics = SemanticsTester(tester);
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: SearchAnchor(
+            enableTapHandling: false,
+            builder: (BuildContext context, SearchController controller) {
+              return SearchBar(
+                controller: controller,
+                hintText: 'Search...',
+                trailing: <Widget>[
+                  IconButton(tooltip: 'Clear', icon: const Icon(Icons.clear), onPressed: () {}),
+                ],
+              );
+            },
+            suggestionsBuilder: (BuildContext context, SearchController controller) {
+              return <Widget>[];
+            },
+          ),
+        ),
+      ),
+    );
+
+    await expectLater(tester, meetsGuideline(labeledTapTargetGuideline));
+    semantics.dispose();
+  });
+
+  testWidgets('SearchAnchor with enableTapHandling provides tap semantics for passive child', (
+    WidgetTester tester,
+  ) async {
+    final semantics = SemanticsTester(tester);
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: SearchAnchor(
+            builder: (BuildContext context, SearchController controller) {
+              return const Icon(Icons.search);
+            },
+            suggestionsBuilder: (BuildContext context, SearchController controller) {
+              return <Widget>[];
+            },
+          ),
+        ),
+      ),
+    );
+
+    expect(semantics, includesNodeWith(actions: <SemanticsAction>[SemanticsAction.tap]));
+    semantics.dispose();
+  });
+
+  testWidgets('SearchAnchor with enableTapHandling: false does not build GestureDetector', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: SearchAnchor(
+            enableTapHandling: false,
+            builder: (BuildContext context, SearchController controller) {
+              return const Icon(Icons.search);
+            },
+            suggestionsBuilder: (BuildContext context, SearchController controller) {
+              return <Widget>[];
+            },
+          ),
+        ),
+      ),
+    );
+
+    expect(
+      find.descendant(of: find.byType(SearchAnchor), matching: find.byType(GestureDetector)),
+      findsNothing,
+    );
+  });
+
   testWidgets('Check SearchBar opacity when disabled', (WidgetTester tester) async {
     await tester.pumpWidget(
       const MaterialApp(

--- a/packages/material_ui/test/search_anchor_test.dart
+++ b/packages/material_ui/test/search_anchor_test.dart
@@ -3450,37 +3450,6 @@ void main() {
     semantics.dispose();
   });
 
-  testWidgets('SearchBar does not produce an intermediate unlabeled semantics node', (
-    WidgetTester tester,
-  ) async {
-    final semantics = SemanticsTester(tester);
-    await tester.pumpWidget(
-      MaterialApp(
-        home: Material(
-          child: Center(
-            child: SearchBar(
-              hintText: 'Search...',
-              trailing: <Widget>[
-                IconButton(tooltip: 'Clear', icon: const Icon(Icons.clear), onPressed: () {}),
-              ],
-            ),
-          ),
-        ),
-      ),
-    );
-
-    for (final SemanticsNode node in semantics.nodesWith(
-      actions: <SemanticsAction>[SemanticsAction.tap],
-    )) {
-      final bool isTextField = node.hasFlag(SemanticsFlag.isTextField);
-      final bool hasLabel = node.label.isNotEmpty;
-      final bool hasTooltip = node.tooltip.isNotEmpty;
-      final bool hasValue = node.value.isNotEmpty;
-      expect(isTextField || hasLabel || hasTooltip || hasValue, isTrue);
-    }
-    semantics.dispose();
-  });
-
   testWidgets('Check SearchBar opacity when disabled', (WidgetTester tester) async {
     await tester.pumpWidget(
       const MaterialApp(

--- a/packages/material_ui/test/search_anchor_test.dart
+++ b/packages/material_ui/test/search_anchor_test.dart
@@ -3407,6 +3407,80 @@ void main() {
     semantics.dispose();
   });
 
+  testWidgets('SearchBar meets labeledTapTargetGuideline', (WidgetTester tester) async {
+    final semantics = SemanticsTester(tester);
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Material(
+          child: Center(
+            child: SearchBar(
+              hintText: 'Search...',
+              trailing: <Widget>[
+                IconButton(tooltip: 'Clear', icon: const Icon(Icons.clear), onPressed: () {}),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await expectLater(tester, meetsGuideline(labeledTapTargetGuideline));
+    semantics.dispose();
+  });
+
+  testWidgets('SearchAnchor.bar meets labeledTapTargetGuideline', (WidgetTester tester) async {
+    final semantics = SemanticsTester(tester);
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: SearchAnchor.bar(
+            barHintText: 'Search...',
+            barTrailing: <Widget>[
+              IconButton(tooltip: 'Clear', icon: const Icon(Icons.clear), onPressed: () {}),
+            ],
+            suggestionsBuilder: (BuildContext context, SearchController controller) {
+              return <Widget>[];
+            },
+          ),
+        ),
+      ),
+    );
+
+    await expectLater(tester, meetsGuideline(labeledTapTargetGuideline));
+    semantics.dispose();
+  });
+
+  testWidgets('SearchBar does not produce an intermediate unlabeled semantics node', (
+    WidgetTester tester,
+  ) async {
+    final semantics = SemanticsTester(tester);
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Material(
+          child: Center(
+            child: SearchBar(
+              hintText: 'Search...',
+              trailing: <Widget>[
+                IconButton(tooltip: 'Clear', icon: const Icon(Icons.clear), onPressed: () {}),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+
+    for (final SemanticsNode node in semantics.nodesWith(
+      actions: <SemanticsAction>[SemanticsAction.tap],
+    )) {
+      final bool isTextField = node.hasFlag(SemanticsFlag.isTextField);
+      final bool hasLabel = node.label.isNotEmpty;
+      final bool hasTooltip = node.tooltip.isNotEmpty;
+      final bool hasValue = node.value.isNotEmpty;
+      expect(isTextField || hasLabel || hasTooltip || hasValue, isTrue);
+    }
+    semantics.dispose();
+  });
+
   testWidgets('Check SearchBar opacity when disabled', (WidgetTester tester) async {
     await tester.pumpWidget(
       const MaterialApp(


### PR DESCRIPTION
fixes https://github.com/flutter/flutter/issues/190884

Too many inkwell and gesture recognizer wrapping the searchAnchor subtree that all tries to provide the same semantics action. This is ok in in renderobject because gesture arena will pick a winer, but not going to work in semantics

## Pre-Review Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [ ] I read the [Tree Hygiene] page, which explains my responsibilities.
- [ ] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [ ] I signed the [CLA].
- [ ] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I [linked to at least one issue that this PR fixes] in the description above.
- [ ] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under[^1].
- [ ] I updated/added any relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[the version and CHANGELOG instructions]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version-and-changelog-updates
[semantic versioning]: https://dart.dev/tools/pub/versioning#semantic-versions
[repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
