### PR TITLE
[tool] Exempt AGENTS.md from version and changelog checks

### DIFF
--- a/packages/camera/camera_android_camerax/.pubignore
+++ b/packages/camera/camera_android_camerax/.pubignore
@@ -1,2 +1,3 @@
 .agents/
+AGENTS.md
 evals/

--- a/script/tool/CHANGELOG.md
+++ b/script/tool/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## NEXT
 
 * Adds support for batch release of pre-1.0 packages.
+* Exempts `AGENTS.md` from requiring version and changelog changes.
 
 ## 0.14.4
 

--- a/script/tool/lib/src/common/file_filters.dart
+++ b/script/tool/lib/src/common/file_filters.dart
@@ -55,5 +55,6 @@ bool isPackageSupportFile(String path) {
   return path.endsWith('/AUTHORS') ||
       path.endsWith('/CHANGELOG.md') ||
       path.endsWith('/CONTRIBUTING.md') ||
-      path.endsWith('/README.md');
+      path.endsWith('/README.md') ||
+      path.endsWith('/AGENTS.md');
 }

--- a/script/tool/lib/src/common/package_state_utils.dart
+++ b/script/tool/lib/src/common/package_state_utils.dart
@@ -206,6 +206,8 @@ Future<bool> _isDevChange(
       pathComponents.first == 'run_tests.sh' ||
       // CONTRIBUTING.md is dev-facing.
       pathComponents.last == 'CONTRIBUTING.md' ||
+      // AGENTS.md is dev/agent-facing.
+      pathComponents.last == 'AGENTS.md' ||
       // The top-level "pending_changelogs" directory is the repo convention for storing
       // pending changelog files.
       pathComponents.first == 'pending_changelogs' ||

--- a/script/tool/test/common/file_filters_test.dart
+++ b/script/tool/test/common/file_filters_test.dart
@@ -36,4 +36,19 @@ void main() {
       expect(isRepoLevelNonCodeImpactingFile('lib/main.dart'), isFalse);
     });
   });
+
+  group('isPackageSupportFile', () {
+    test('returns true for known package support files', () {
+      expect(isPackageSupportFile('packages/foo/AUTHORS'), isTrue);
+      expect(isPackageSupportFile('packages/foo/CHANGELOG.md'), isTrue);
+      expect(isPackageSupportFile('packages/foo/CONTRIBUTING.md'), isTrue);
+      expect(isPackageSupportFile('packages/foo/README.md'), isTrue);
+      expect(isPackageSupportFile('packages/foo/AGENTS.md'), isTrue);
+    });
+
+    test('returns false for other files', () {
+      expect(isPackageSupportFile('packages/foo/pubspec.yaml'), isFalse);
+      expect(isPackageSupportFile('packages/foo/lib/main.dart'), isFalse);
+    });
+  });
 }

--- a/script/tool/test/common/package_state_utils_test.dart
+++ b/script/tool/test/common/package_state_utils_test.dart
@@ -57,6 +57,7 @@ void main() {
         'packages/a_plugin/CHANGELOG.md',
         // Dev-facing docs.
         'packages/a_plugin/CONTRIBUTING.md',
+        'packages/a_plugin/AGENTS.md',
         // Analysis.
         'packages/a_plugin/example/android/lint-baseline.xml',
         // Tests.
@@ -121,6 +122,22 @@ void main() {
       final RepositoryPackage package = createFakePlugin('a_plugin', packagesDir);
 
       const changedFiles = <String>['packages/a_plugin/evals/foo.dart'];
+
+      final PackageChangeState state = await checkPackageChangeState(
+        package,
+        changedPaths: changedFiles,
+        relativePackagePath: 'packages/a_plugin/',
+      );
+
+      expect(state.hasChanges, true);
+      expect(state.needsVersionChange, false);
+      expect(state.needsChangelogChange, false);
+    });
+
+    test('does not require version or changelog change for AGENTS.md changes', () async {
+      final RepositoryPackage package = createFakePlugin('a_plugin', packagesDir);
+
+      const changedFiles = <String>['packages/a_plugin/AGENTS.md'];
 
       final PackageChangeState state = await checkPackageChangeState(
         package,

--- a/script/tool/test/validate_command_version_test.dart
+++ b/script/tool/test/validate_command_version_test.dart
@@ -982,6 +982,7 @@ packages/plugin/example/ios/RunnerTests/Foo.m
 packages/plugin/example/ios/RunnerUITests/info.plist
 packages/plugin/darwin/Tests/Foo.swift
 packages/plugin/analysis_options.yaml
+packages/plugin/AGENTS.md
 packages/plugin/CHANGELOG.md
 ''',
             ),


### PR DESCRIPTION
This came up as part of https://github.com/flutter/packages/pull/12668/ which needed the labels. This pr excludes AGENTS.md from both pub publishing and from needing changelog/version requirements. 

- @reidbaker 

Agent authored description 
---
Exempts `AGENTS.md` from requiring CHANGELOG updates and version bumps in package validation, adds `AGENTS.md` as a package support file in repo tooling, and adds `AGENTS.md` to `.pubignore` in `camera_android_camerax`.

## Summary
- **Repository Tooling**:
  - `script/tool/lib/src/common/package_state_utils.dart`: Added `pathComponents.last == 'AGENTS.md'` to `_isDevChange` so developer/agent guidelines in `AGENTS.md` do not trigger missing CHANGELOG or version bump errors.
  - `script/tool/lib/src/common/file_filters.dart`: Added `path.endsWith('/AGENTS.md')` to `isPackageSupportFile`.
  - `script/tool/CHANGELOG.md`: Added changelog entry under `## NEXT`.
- **Package `.pubignore`**:
  - `packages/camera/camera_android_camerax/.pubignore`: Added `AGENTS.md` to prevent publishing agent guidelines to pub.dev.
- **Tests**:
  - Added unit tests in `script/tool/test/common/package_state_utils_test.dart`, `script/tool/test/common/file_filters_test.dart`, and `script/tool/test/validate_command_version_test.dart`.

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed features or bug fixes.
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation.
- [x] The title of the PR starts with the name of the package and conforms to the [style guide].

[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[style guide]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#title