### PR TITLE
[image_picker] Handle a null stream from openInputStream on Android

### DIFF
--- a/packages/image_picker/image_picker_android/CHANGELOG.md
+++ b/packages/image_picker/image_picker_android/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.8.13+22
+
+* Fixes a crash when the content provider returns no stream for a picked
+  image; the pick now fails with `missing_valid_image_uri` instead.
+
 ## 0.8.13+21
 
 * Updates pigeon dev_dependency to ^27.3.2 for analyzer 14 compatibility.

--- a/packages/image_picker/image_picker_android/android/src/main/java/io/flutter/plugins/imagepicker/FileUtils.java
+++ b/packages/image_picker/image_picker_android/android/src/main/java/io/flutter/plugins/imagepicker/FileUtils.java
@@ -61,6 +61,13 @@ class FileUtils {
    */
   String getPathFromUri(final Context context, final Uri uri) {
     try (InputStream inputStream = context.getContentResolver().openInputStream(uri)) {
+      if (inputStream == null) {
+        // `ContentResolver#openInputStream()` returns null when the provider cannot serve the
+        // item (for example after the provider crashed, or for a cloud-only photo it could not
+        // fetch). Treat it like any other unreadable item: no path, so the caller reports
+        // `missing_valid_image_uri` instead of crashing on the null stream.
+        return null;
+      }
       String uuid = UUID.randomUUID().toString();
       File targetDirectory = new File(context.getCacheDir(), uuid);
       targetDirectory.mkdir();

--- a/packages/image_picker/image_picker_android/android/src/test/java/io/flutter/plugins/imagepicker/FileUtilTest.java
+++ b/packages/image_picker/image_picker_android/android/src/test/java/io/flutter/plugins/imagepicker/FileUtilTest.java
@@ -85,6 +85,23 @@ public class FileUtilTest {
   }
 
   @Test
+  public void FileUtil_GetPathFromUri_nullStream() throws IOException {
+    Uri uri = Uri.parse("content://dummy/dummy.png");
+
+    // `openInputStream` returns null when the provider cannot serve the item; this used to
+    // reach `copy()` and crash the plugin's executor thread with a NullPointerException.
+    ContentResolver mockContentResolver = mock(ContentResolver.class);
+    when(mockContentResolver.openInputStream(any(Uri.class))).thenReturn(null);
+
+    Context mockContext = mock(Context.class);
+    when(mockContext.getContentResolver()).thenReturn(mockContentResolver);
+
+    String path = fileUtils.getPathFromUri(mockContext, uri);
+
+    assertNull(path);
+  }
+
+  @Test
   public void FileUtil_GetPathFromUri_securityException() throws IOException {
     Uri uri = Uri.parse("content://dummy/dummy.png");
 

--- a/packages/image_picker/image_picker_android/pubspec.yaml
+++ b/packages/image_picker/image_picker_android/pubspec.yaml
@@ -2,7 +2,7 @@ name: image_picker_android
 description: Android implementation of the image_picker plugin.
 repository: https://github.com/flutter/packages/tree/main/packages/image_picker/image_picker_android
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+image_picker%22
-version: 0.8.13+21
+version: 0.8.13+22
 
 environment:
   sdk: ^3.12.0


### PR DESCRIPTION
`ContentResolver#openInputStream()` returns null when the provider cannot serve the picked item (a provider that crashed, a cloud-only photo it could not fetch). `FileUtils.getPathFromUri` opens the stream in a try-with-resources (where a null resource is legal) and hands it straight to `copy()`; the resulting `NullPointerException` on the delegate's executor thread is uncaught and kills the process. The null-*URI* sibling was guarded in #5009; the null-*stream* step right after it was not.

This returns `null` from `getPathFromUri` for a null stream, so the delegate reports the existing `missing_valid_image_uri` error exactly as it does for the other unreadable cases, and adds a unit test in the shape of the existing `SecurityException` one.

Fixes https://github.com/flutter/flutter/issues/191988

## Pre-Review Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [ ] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [ ] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under[^1].
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [ ] All existing and new tests are passing.

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[the version and CHANGELOG instructions]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version-and-changelog-updates
[semantic versioning]: https://dart.dev/tools/pub/versioning#semantic-versions
[repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
