### PR TITLE
[file_selector] Handle a null stream from openInputStream on Android

### DIFF
--- a/packages/file_selector/file_selector_android/CHANGELOG.md
+++ b/packages/file_selector/file_selector_android/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.5.2+11
+
+* Fixes a crash when the content provider returns no stream for a selected
+  file; the pick now completes with an error instead.
+
 ## 0.5.2+10
 
 * Updates pigeon dev_dependency to ^27.3.2 for analyzer 14 compatibility.

--- a/packages/file_selector/file_selector_android/android/src/main/java/dev/flutter/packages/file_selector_android/FileSelectorApiImpl.java
+++ b/packages/file_selector/file_selector_android/android/src/main/java/dev/flutter/packages/file_selector_android/FileSelectorApiImpl.java
@@ -351,6 +351,13 @@ public class FileSelectorApiImpl implements FileSelectorApi {
 
     final byte[] bytes = new byte[size];
     try (InputStream inputStream = contentResolver.openInputStream(uri)) {
+      if (inputStream == null) {
+        // `ContentResolver#openInputStream()` returns null when the provider cannot serve the
+        // file (for example after the provider crashed). Reading it would throw a
+        // NullPointerException on the activity-result callback, i.e. the main thread.
+        Log.w(TAG, "The content provider returned no stream for the selected file.");
+        return null;
+      }
       final DataInputStream dataInputStream = objectFactory.newDataInputStream(inputStream);
       dataInputStream.readFully(bytes);
     } catch (IOException exception) {

--- a/packages/file_selector/file_selector_android/android/src/main/java/dev/flutter/packages/file_selector_android/FileUtils.java
+++ b/packages/file_selector/file_selector_android/android/src/main/java/dev/flutter/packages/file_selector_android/FileUtils.java
@@ -124,6 +124,11 @@ public class FileUtils {
   public static String getPathFromCopyOfFileFromUri(@NonNull Context context, @NonNull Uri uri)
       throws IOException, SecurityException, IllegalArgumentException {
     try (InputStream inputStream = context.getContentResolver().openInputStream(uri)) {
+      if (inputStream == null) {
+        // The provider cannot serve the file (see `FileSelectorApiImpl#toFileResponse`); surface
+        // it as the IO failure it is instead of dereferencing the null stream in `copy()`.
+        throw new IOException("The content provider returned no stream for the file.");
+      }
       String uuid = UUID.nameUUIDFromBytes(uri.toString().getBytes()).toString();
       File targetDirectory = new File(context.getCacheDir(), uuid);
       targetDirectory.mkdir();

--- a/packages/file_selector/file_selector_android/android/src/test/java/dev/flutter/packages/file_selector_android/FileSelectorAndroidPluginTest.java
+++ b/packages/file_selector/file_selector_android/android/src/test/java/dev/flutter/packages/file_selector_android/FileSelectorAndroidPluginTest.java
@@ -12,6 +12,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -288,6 +289,60 @@ public class FileSelectorAndroidPluginTest {
   // Regression test for https://github.com/flutter/flutter/issues/159568: the
   // single-file `openFile` path must likewise surface a copy failure to Dart
   // instead of crashing.
+  @SuppressWarnings({"rawtypes", "unchecked"})
+  @Test
+  public void openFileCompletesWithError_whenProviderReturnsNullStream()
+      throws FileNotFoundException {
+    final ContentResolver mockContentResolver = mock(ContentResolver.class);
+    final Uri mockUri = mock(Uri.class);
+
+    final Cursor mockCursor = mock(Cursor.class);
+    when(mockCursor.moveToFirst()).thenReturn(true);
+    when(mockCursor.getColumnIndex(OpenableColumns.DISPLAY_NAME)).thenReturn(0);
+    when(mockCursor.getString(0)).thenReturn("filename");
+    when(mockCursor.getColumnIndex(OpenableColumns.SIZE)).thenReturn(1);
+    when(mockCursor.isNull(1)).thenReturn(false);
+    when(mockCursor.getInt(1)).thenReturn(30);
+    when(mockContentResolver.query(mockUri, null, null, null, null, null)).thenReturn(mockCursor);
+    // A provider that cannot serve the file answers the open with null; previously this reached
+    // `DataInputStream#readFully` and threw a NullPointerException on the main thread.
+    when(mockContentResolver.openInputStream(mockUri)).thenReturn(null);
+
+    when(mockObjectFactory.newIntent(Intent.ACTION_OPEN_DOCUMENT)).thenReturn(mockIntent);
+    when(mockActivity.getContentResolver()).thenReturn(mockContentResolver);
+    when(mockActivityBinding.getActivity()).thenReturn(mockActivity);
+    final FileSelectorApiImpl fileSelectorApi =
+        new FileSelectorApiImpl(
+            mockActivityBinding, mockObjectFactory, (version) -> Build.VERSION.SDK_INT >= version);
+
+    final boolean[] callbackCalled = new boolean[1];
+    final Throwable[] failure = new Throwable[1];
+    fileSelectorApi.openFile(
+        null,
+        new FileTypes(Collections.emptyList(), Collections.emptyList()),
+        ResultCompat.asCompatCallback(
+            (reply) -> {
+              callbackCalled[0] = true;
+              failure[0] = reply.exceptionOrNull();
+              return null;
+            }));
+
+    verify(mockActivity).startActivityForResult(mockIntent, 221);
+
+    final ArgumentCaptor<PluginRegistry.ActivityResultListener> listenerArgumentCaptor =
+        ArgumentCaptor.forClass(PluginRegistry.ActivityResultListener.class);
+    verify(mockActivityBinding).addActivityResultListener(listenerArgumentCaptor.capture());
+
+    final Intent resultMockIntent = mock(Intent.class);
+    when(resultMockIntent.getData()).thenReturn(mockUri);
+    listenerArgumentCaptor.getValue().onActivityResult(221, Activity.RESULT_OK, resultMockIntent);
+
+    assertTrue(callbackCalled[0]);
+    assertNotNull(failure[0]);
+    assertTrue(failure[0].getMessage().contains("Failed to read file"));
+    verify(mockObjectFactory, never()).newDataInputStream(any());
+  }
+
   @SuppressWarnings({"rawtypes", "unchecked"})
   @Test
   public void openFileCompletesWithError_whenSecurityExceptionInGetPathFromCopyOfFileFromUri()

--- a/packages/file_selector/file_selector_android/android/src/test/java/dev/flutter/packages/file_selector_android/FileUtilsTest.java
+++ b/packages/file_selector/file_selector_android/android/src/test/java/dev/flutter/packages/file_selector_android/FileUtilsTest.java
@@ -10,8 +10,10 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
 import static org.robolectric.Shadows.shadowOf;
 
 import android.content.ContentProvider;
@@ -66,6 +68,18 @@ public class FileUtilsTest {
       mimeTypeMap.addExtensionMimeTypeMapping("png", "image/png");
       mimeTypeMap.addExtensionMimeTypeMapping("webp", "image/webp");
     }
+  }
+
+  @Test
+  public void getPathFromCopyOfFileFromUri_throwsIOExceptionForNullStream() throws IOException {
+    Uri uri = Uri.parse("content://dummy/dummy.txt");
+
+    ContentResolver mockContentResolver = mock(ContentResolver.class);
+    when(mockContentResolver.openInputStream(uri)).thenReturn(null);
+    Context mockContext = mock(Context.class);
+    when(mockContext.getContentResolver()).thenReturn(mockContentResolver);
+
+    assertThrows(IOException.class, () -> FileUtils.getPathFromCopyOfFileFromUri(mockContext, uri));
   }
 
   @Test

--- a/packages/file_selector/file_selector_android/pubspec.yaml
+++ b/packages/file_selector/file_selector_android/pubspec.yaml
@@ -2,7 +2,7 @@ name: file_selector_android
 description: Android implementation of the file_selector package.
 repository: https://github.com/flutter/packages/tree/main/packages/file_selector/file_selector_android
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+file_selector%22
-version: 0.5.2+10
+version: 0.5.2+11
 
 environment:
   sdk: ^3.12.0


### PR DESCRIPTION
`ContentResolver#openInputStream()` returns null when the provider cannot serve the selected file (for example after the provider process crashed). `FileSelectorApiImpl#toFileResponse` opens the stream in a try-with-resources (where a null resource is legal) and hands it to `DataInputStream#readFully`, which dereferences it; because `toFileResponse` runs inside the `onActivityResult` listener, the `NullPointerException` surfaces on the main thread and kills the app. `FileUtils.getPathFromCopyOfFileFromUri` has the same unguarded `copy(inputStream, …)` one step later. This is the `file_selector_android` sibling of the `image_picker_android` null-stream crash (flutter/flutter#191988); #159568 covered a copy failure in the same callback, but not a null stream.

`toFileResponse` now returns `null` for a null stream, so the caller completes the callback with the existing `"Failed to read file"` error instead of crashing, and `getPathFromCopyOfFileFromUri` reports the condition as the `IOException` its contract already declares. Two unit tests in the shape of the existing #159568 regression tests, one of them also asserting the read is never attempted.

Fixes https://github.com/flutter/flutter/issues/191989


## Pre-Review Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [ ] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [ ] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under[^1].
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [ ] All existing and new tests are passing.

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[the version and CHANGELOG instructions]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version-and-changelog-updates
[semantic versioning]: https://dart.dev/tools/pub/versioning#semantic-versions
[repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
