### PR TITLE
[camera_android_camerax] Update skills_lint to published version ^0.5.1

### DIFF
--- a/packages/camera/camera_android_camerax/pubspec.yaml
+++ b/packages/camera/camera_android_camerax/pubspec.yaml
@@ -36,11 +36,7 @@ dev_dependencies:
   mockito: ^5.4.4
   path: ^1.8.0
   pigeon: ^27.3.2
-  skills_lint:
-    git:
-      url: https://github.com/google/skills_lint.dart.git
-      path: packages/skills_lint
-      ref: e6e695e1550f81342fe5acd4dbe65040b5aa44c3
+  skills_lint: ^0.5.1
 
 topics:
   - camera


### PR DESCRIPTION
TBH the agent authored description is pretty spot on.

- @reidbaker 

Agent authored description
---
Migrates the \`camera_android_camerax\` package skill validation dependency from Git to the published [\`skills_lint: ^0.5.1\`](https://pub.dev/packages/skills_lint) package on pub.dev.

- Updates \`packages/camera/camera_android_camerax/pubspec.yaml\` to depend on \`skills_lint: ^0.5.1\`.
- Verified with \`flutter pub get\` and \`flutter test\`.