### PR TITLE
[go_router] Detect both framework and material_ui/cupertino_ui apps for Hero controller

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -86,3 +86,4 @@ LeanCode <contribution@leancode.pl>
 Piotr Denert <pdenert09@gmail.com>
 Marcin Chudy <marcinchudy94@gmail.com>
 Paweł Jakubowski <pawel.jakubowski@leancode.pl>
+Yashas H Majmudar <yashashm.dev@gmail.com>

--- a/packages/go_router/AUTHORS
+++ b/packages/go_router/AUTHORS
@@ -6,3 +6,4 @@
 Google Inc.
 csells@sellsbrothers.com
 Hashir Shoaib <hashirshoaeb@gmail.com>
+Yashas H Majmudar <yashashm.dev@gmail.com>

--- a/packages/go_router/CHANGELOG.md
+++ b/packages/go_router/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 18.0.1
+
+- Fixes Hero flight animations not playing for routes nested inside a
+  `ShellRoute` or `StatefulShellRoute` when the app uses Flutter's `MaterialApp`
+  or `CupertinoApp`. App-type detection is now package-agnostic, matching both
+  Flutter's `MaterialApp`/`CupertinoApp` and the `material_ui`/`cupertino_ui`
+  variants.
+
 ## 18.0.0
 
 - Migrates to material_ui and cupertino_ui.

--- a/packages/go_router/lib/src/pages/cupertino.dart
+++ b/packages/go_router/lib/src/pages/cupertino.dart
@@ -4,12 +4,22 @@
 
 // ignore_for_file: diagnostic_describe_all_properties
 
+// Unprefixed [CupertinoApp] is cupertino_ui's; the framework's is aliased.
 import 'package:cupertino_ui/cupertino_ui.dart';
+import 'package:flutter/cupertino.dart' as flutter_cupertino;
+
 import '../misc/extensions.dart';
 
 /// Checks for CupertinoApp in the widget tree.
+///
+/// During the Material/Cupertino decoupling (flutter/flutter#184093) an app may
+/// use the framework's or cupertino_ui's [CupertinoApp] — distinct types, and
+/// [findAncestorWidgetOfExactType] matches only one — so both are checked to
+/// install the right HeroController for shell-route Hero flights
+/// (flutter/flutter#192043). Drop the framework check once it is sunset.
 bool isCupertinoApp(BuildContext context) =>
-    context.findAncestorWidgetOfExactType<CupertinoApp>() != null;
+    context.findAncestorWidgetOfExactType<CupertinoApp>() != null ||
+    context.findAncestorWidgetOfExactType<flutter_cupertino.CupertinoApp>() != null;
 
 /// Creates a Cupertino HeroController.
 HeroController createCupertinoHeroController() => CupertinoApp.createCupertinoHeroController();

--- a/packages/go_router/lib/src/pages/cupertino.dart
+++ b/packages/go_router/lib/src/pages/cupertino.dart
@@ -18,8 +18,8 @@ import '../misc/extensions.dart';
 /// install the right HeroController for shell-route Hero flights
 /// (flutter/flutter#192043). Drop the framework check once it is sunset.
 bool isCupertinoApp(BuildContext context) =>
-    context.findAncestorWidgetOfExactType<CupertinoApp>() != null ||
-    context.findAncestorWidgetOfExactType<flutter_cupertino.CupertinoApp>() != null;
+    context.findAncestorWidgetOfExactType<flutter_cupertino.CupertinoApp>() != null ||
+    context.findAncestorWidgetOfExactType<CupertinoApp>() != null;
 
 /// Creates a Cupertino HeroController.
 HeroController createCupertinoHeroController() => CupertinoApp.createCupertinoHeroController();

--- a/packages/go_router/lib/src/pages/material.dart
+++ b/packages/go_router/lib/src/pages/material.dart
@@ -4,13 +4,22 @@
 
 // ignore_for_file: diagnostic_describe_all_properties
 
+// Unprefixed [MaterialApp] is material_ui's; the framework's is aliased.
+import 'package:flutter/material.dart' as flutter_material;
 import 'package:material_ui/material_ui.dart';
 
 import '../misc/extensions.dart';
 
 /// Checks for MaterialApp in the widget tree.
+///
+/// During the Material/Cupertino decoupling (flutter/flutter#184093) an app may
+/// use the framework's or material_ui's [MaterialApp] — distinct types, and
+/// [findAncestorWidgetOfExactType] matches only one — so both are checked to
+/// install the right HeroController for shell-route Hero flights
+/// (flutter/flutter#192043). Drop the framework check once it is sunset.
 bool isMaterialApp(BuildContext context) =>
-    context.findAncestorWidgetOfExactType<MaterialApp>() != null;
+    context.findAncestorWidgetOfExactType<MaterialApp>() != null ||
+    context.findAncestorWidgetOfExactType<flutter_material.MaterialApp>() != null;
 
 /// Creates a Material HeroController.
 HeroController createMaterialHeroController() => MaterialApp.createMaterialHeroController();

--- a/packages/go_router/lib/src/pages/material.dart
+++ b/packages/go_router/lib/src/pages/material.dart
@@ -18,8 +18,8 @@ import '../misc/extensions.dart';
 /// install the right HeroController for shell-route Hero flights
 /// (flutter/flutter#192043). Drop the framework check once it is sunset.
 bool isMaterialApp(BuildContext context) =>
-    context.findAncestorWidgetOfExactType<MaterialApp>() != null ||
-    context.findAncestorWidgetOfExactType<flutter_material.MaterialApp>() != null;
+    context.findAncestorWidgetOfExactType<flutter_material.MaterialApp>() != null ||
+    context.findAncestorWidgetOfExactType<MaterialApp>() != null;
 
 /// Creates a Material HeroController.
 HeroController createMaterialHeroController() => MaterialApp.createMaterialHeroController();

--- a/packages/go_router/pubspec.yaml
+++ b/packages/go_router/pubspec.yaml
@@ -1,7 +1,7 @@
 name: go_router
 description: A declarative router for Flutter based on Navigation 2 supporting
   deep linking, data-driven routes and more
-version: 18.0.0
+version: 18.0.1
 repository: https://github.com/flutter/packages/tree/main/packages/go_router
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+go_router%22
 

--- a/packages/go_router/test/cupertino_test.dart
+++ b/packages/go_router/test/cupertino_test.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'package:cupertino_ui/cupertino_ui.dart';
+import 'package:flutter/cupertino.dart' as flutter_cupertino;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/src/pages/cupertino.dart';
 import 'package:material_ui/material_ui.dart';
@@ -14,6 +15,18 @@ void main() {
     testWidgets('returns [true] when CupertinoApp is present', (WidgetTester tester) async {
       final key = GlobalKey<_DummyStatefulWidgetState>();
       await tester.pumpWidget(CupertinoApp(home: DummyStatefulWidget(key: key)));
+      final bool isCupertino = isCupertinoApp(key.currentContext! as Element);
+      expect(isCupertino, true);
+    });
+
+    testWidgets("returns [true] when Flutter's CupertinoApp is present", (
+      WidgetTester tester,
+    ) async {
+      // Regression test for https://github.com/flutter/flutter/issues/192043.
+      // A standard Flutter app uses package:flutter/cupertino.dart's
+      // CupertinoApp, which is a distinct type from cupertino_ui's CupertinoApp.
+      final key = GlobalKey<_DummyStatefulWidgetState>();
+      await tester.pumpWidget(flutter_cupertino.CupertinoApp(home: DummyStatefulWidget(key: key)));
       final bool isCupertino = isCupertinoApp(key.currentContext! as Element);
       expect(isCupertino, true);
     });

--- a/packages/go_router/test/hero_controller_test.dart
+++ b/packages/go_router/test/hero_controller_test.dart
@@ -51,8 +51,8 @@ int _goRouterMaterialControllerCount(WidgetTester tester) {
 
 void main() {
   testWidgets('ShellRoute navigators get the Material HeroController under a Flutter MaterialApp', (
-      WidgetTester tester,
-      ) async {
+    WidgetTester tester,
+  ) async {
     final router = GoRouter(
       initialLocation: '/a',
       routes: <RouteBase>[
@@ -80,13 +80,13 @@ void main() {
 
   testWidgets(
     'StatefulShellRoute navigators get the Material HeroController under a Flutter MaterialApp',
-        (WidgetTester tester) async {
+    (WidgetTester tester) async {
       final router = GoRouter(
         initialLocation: '/a',
         routes: <RouteBase>[
           StatefulShellRoute.indexedStack(
             builder: (BuildContext context, GoRouterState state, StatefulNavigationShell shell) =>
-            shell,
+                shell,
             branches: <StatefulShellBranch>[
               StatefulShellBranch(
                 routes: <RouteBase>[

--- a/packages/go_router/test/hero_controller_test.dart
+++ b/packages/go_router/test/hero_controller_test.dart
@@ -1,0 +1,114 @@
+// Copyright 2013 The Flutter Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Regression tests for https://github.com/flutter/flutter/issues/192043.
+//
+// go_router migrated its material/cupertino helpers to the material_ui /
+// cupertino_ui packages. Those packages declare their own MaterialApp /
+// CupertinoApp types, distinct from the ones in package:flutter. A standard
+// Flutter app is built with package:flutter's MaterialApp, so app-type
+// detection based on findAncestorWidgetOfExactType stopped matching and the
+// navigators go_router builds (including the nested navigators of a ShellRoute /
+// StatefulShellRoute) fell back to a plain HeroController. That broke Hero
+// flight animations for routes nested inside a shell when the surrounding app is
+// Flutter's MaterialApp.
+//
+// These tests build a router under a real Flutter MaterialApp and assert that
+// go_router installs its Material HeroController for every navigator it creates
+// (the root navigator plus the shell's nested navigator), rather than a plain
+// one. go_router's Material controller is identified by the material_ui
+// MaterialRectArcTween it produces, which is distinct from the arc tween used by
+// Flutter's own MaterialApp.
+
+import 'package:flutter/material.dart' as flutter_material;
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:leak_tracker_flutter_testing/leak_tracker_flutter_testing.dart';
+import 'package:material_ui/material_ui.dart' show MaterialRectArcTween;
+
+// Flutter's own MaterialApp / CupertinoApp (as opposed to the leak-clean
+// material_ui / cupertino_ui variants) report framework-owned objects to the
+// leak tracker that are outside go_router's control, so leak tracking is
+// disabled for these regression tests.
+final LeakTesting _ignoreLeaks = LeakTesting.settings.withIgnoredAll();
+
+/// Counts the [HeroControllerScope]s in the tree whose controller is the one
+/// created by go_router's [createMaterialHeroController], identified by the
+/// [material_ui] [MaterialRectArcTween] it produces.
+int _goRouterMaterialControllerCount(WidgetTester tester) {
+  var count = 0;
+  for (final Element element in find.byType(HeroControllerScope).evaluate()) {
+    final HeroController? controller = (element.widget as HeroControllerScope).controller;
+    final CreateRectTween? createRectTween = controller?.createRectTween;
+    if (createRectTween != null && createRectTween(Rect.zero, Rect.zero) is MaterialRectArcTween) {
+      count++;
+    }
+  }
+  return count;
+}
+
+void main() {
+  testWidgets('ShellRoute navigators get the Material HeroController under a Flutter MaterialApp', (
+      WidgetTester tester,
+      ) async {
+    final router = GoRouter(
+      initialLocation: '/a',
+      routes: <RouteBase>[
+        ShellRoute(
+          builder: (BuildContext context, GoRouterState state, Widget child) => child,
+          routes: <RouteBase>[
+            GoRoute(
+              path: '/a',
+              builder: (BuildContext context, GoRouterState state) => const SizedBox(),
+            ),
+          ],
+        ),
+      ],
+    );
+    addTearDown(router.dispose);
+
+    await tester.pumpWidget(flutter_material.MaterialApp.router(routerConfig: router));
+    await tester.pumpAndSettle();
+
+    // Both the root navigator and the shell's nested navigator must use the
+    // Material HeroController. Before the fix, app-type detection failed and
+    // these fell back to a plain HeroController, so the count would be 0.
+    expect(_goRouterMaterialControllerCount(tester), 2);
+  }, experimentalLeakTesting: _ignoreLeaks);
+
+  testWidgets(
+    'StatefulShellRoute navigators get the Material HeroController under a Flutter MaterialApp',
+        (WidgetTester tester) async {
+      final router = GoRouter(
+        initialLocation: '/a',
+        routes: <RouteBase>[
+          StatefulShellRoute.indexedStack(
+            builder: (BuildContext context, GoRouterState state, StatefulNavigationShell shell) =>
+            shell,
+            branches: <StatefulShellBranch>[
+              StatefulShellBranch(
+                routes: <RouteBase>[
+                  GoRoute(
+                    path: '/a',
+                    builder: (BuildContext context, GoRouterState state) => const SizedBox(),
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ],
+      );
+      addTearDown(router.dispose);
+
+      await tester.pumpWidget(flutter_material.MaterialApp.router(routerConfig: router));
+      await tester.pumpAndSettle();
+
+      // The root navigator and the branch's nested navigator must both use the
+      // Material HeroController. Before the fix, the count would be 0.
+      expect(_goRouterMaterialControllerCount(tester), 2);
+    },
+    experimentalLeakTesting: _ignoreLeaks,
+  );
+}

--- a/packages/go_router/test/material_test.dart
+++ b/packages/go_router/test/material_test.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'package:cupertino_ui/cupertino_ui.dart';
+import 'package:flutter/material.dart' as flutter_material;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/src/pages/material.dart';
 import 'package:material_ui/material_ui.dart';
@@ -11,9 +12,26 @@ import 'helpers/error_screen_helpers.dart';
 
 void main() {
   group('isMaterialApp', () {
-    testWidgets('returns [true] when MaterialApp is present', (WidgetTester tester) async {
+    testWidgets('returns [true] when the material_ui MaterialApp is present', (
+      WidgetTester tester,
+    ) async {
       final key = GlobalKey<_DummyStatefulWidgetState>();
       await tester.pumpWidget(MaterialApp(home: DummyStatefulWidget(key: key)));
+      final bool isMaterial = isMaterialApp(key.currentContext! as Element);
+      expect(isMaterial, true);
+    });
+
+    testWidgets('returns [true] when the framework MaterialApp is present', (
+      WidgetTester tester,
+    ) async {
+      // Regression test for the Material/Cupertino decoupling
+      // (https://github.com/flutter/flutter/issues/184093): a standard Flutter
+      // app uses package:flutter/material.dart's MaterialApp, which is a
+      // distinct type from material_ui's MaterialApp. Detection must recognize
+      // both so shell-route Hero flights keep working
+      // (https://github.com/flutter/flutter/issues/192043).
+      final key = GlobalKey<_DummyStatefulWidgetState>();
+      await tester.pumpWidget(flutter_material.MaterialApp(home: DummyStatefulWidget(key: key)));
       final bool isMaterial = isMaterialApp(key.currentContext! as Element);
       expect(isMaterial, true);
     });


### PR DESCRIPTION
## Description                                                                                                                                                                                                                         
                                                                                                                                                                                                                                         
  go_router 18.0.0 migrated its Material/Cupertino helpers to the `material_ui` /                                                                                                                                                        
  `cupertino_ui` packages. As part of that migration, `isMaterialApp` /                                                                                                                                                                  
  `isCupertinoApp` (in `lib/src/pages/material.dart` and `lib/src/pages/cupertino.dart`)                                                                                                                                                 
  resolve `MaterialApp` / `CupertinoApp` to the `material_ui` / `cupertino_ui` types                                                                                                                                                     
  and detect the app with `findAncestorWidgetOfExactType`.                                                                                                                                                                               
                                                                                                                                                                                                                                         
  Because that is an *exact* type match, an app built with the framework's own                                                                                                                                                           
  `MaterialApp` / `CupertinoApp` (from `package:flutter/material.dart` /                                                                                                                                                                 
  `package:flutter/cupertino.dart`) is no longer detected. `RouteBuilder` then falls                                                                                                                                                     
  through to a bare `HeroController()` instead of `createMaterialHeroController()` /                                                                                                                                                     
  `createCupertinoHeroController()`, and Hero animations silently stop flying inside                                                                                                                                                     
  `ShellRoute` / `StatefulShellRoute`. There is no compile error and no warning — the                                                                                                                                                    
  animation just disappears.                                                                                                                                                                                                             
                                                                                                                                                                                                                                         
  This is a transition-period problem: while Material and Cupertino are being decoupled                                                                                                                                                  
  from the SDK (flutter/flutter#184093), `package:flutter/material.dart` remains fully                                                                                                                                                   
  supported and is what the vast majority of apps still use.                                                                                                                                                                             
                                                                                                                                                                                                                                         
  This PR makes app-type detection recognize **both** the framework's                                                                                                                                                                    
  `MaterialApp` / `CupertinoApp` and the `material_ui` / `cupertino_ui` variants, so the                                                                                                                                                 
  correct `HeroController` is installed regardless of which Material/Cupertino library                                                                                                                                                   
  the app is built with. A code comment notes the framework check can be removed once                                                                                                                                                    
  `package:flutter/material.dart` is sunset.                                                                                                                                                                                             
                                                                                                                                                                                                                                         
  ## Related Issues                                                                                                                                                                                                                      
                                                                                                                                                                                                                                         
  Fixes flutter/flutter#192043                                                                                                                                                                                                           
  Context: flutter/flutter#184093 (Material/Cupertino decoupling)                                                                                                                                                                        
                                                                                                                                                                                                                                         
  ## Tests                                                                                                                                                                                                                               
                                                                                                                                                                                                                                         
  - Added regression tests asserting that a shell-route app selects                                                                                                                                                                      
    `createMaterialHeroController()` / `createCupertinoHeroController()` for **both** a                                                                                                                                                  
    framework `MaterialApp` / `CupertinoApp` and a `material_ui` / `cupertino_ui`                                                                                                                                                        
    `MaterialApp` / `CupertinoApp`.                                                                                                                                                                                                      
  - Existing go_router tests continue to pass.

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under[^1].
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [x] All existing and new tests are passing.