### PR TITLE
[material_ui] Fix `todayBorder` color being overridden by `todayForegroundColor` in `YearPicker`

### DIFF
--- a/packages/material_ui/lib/src/calendar_date_picker.dart
+++ b/packages/material_ui/lib/src/calendar_date_picker.dart
@@ -1523,10 +1523,11 @@ class _YearPickerState extends State<YearPicker> {
 
     BorderSide? borderSide;
     if (isCurrentYear) {
-      borderSide = datePickerTheme.todayBorder ?? defaults.todayBorder;
-      if (borderSide != null) {
-        borderSide = borderSide.copyWith(color: textColor);
-      }
+      final bool hasCustomBorderColor =
+          datePickerTheme.todayBorder != null && datePickerTheme.todayBorder!.color.opacity != 0.0;
+      borderSide = hasCustomBorderColor
+          ? datePickerTheme.todayBorder
+          : (datePickerTheme.todayBorder ?? defaults.todayBorder)?.copyWith(color: textColor);
     }
     final decoration = ShapeDecoration(
       color: background,

--- a/packages/material_ui/lib/src/date_picker_theme.dart
+++ b/packages/material_ui/lib/src/date_picker_theme.dart
@@ -285,8 +285,8 @@ class DatePickerThemeData with Diagnosticable {
   final WidgetStateProperty<Color?>? todayBackgroundColor;
 
   /// Overrides the border used to paint the
-  /// [DatePickerDialog.currentDate] label in the grid of the date
-  /// picker.
+  /// [DatePickerDialog.currentDate] label in both the day grid and the year
+  /// selector of the date picker.
   ///
   /// If the border side's [BorderSide.color] is transparent (has 0 opacity),
   /// [todayForegroundColor] is used instead. Otherwise, the border's color

--- a/packages/material_ui/pending_changelogs/change_2026_08_30_year_picker_today_border.yaml
+++ b/packages/material_ui/pending_changelogs/change_2026_08_30_year_picker_today_border.yaml
@@ -1,0 +1,3 @@
+changelog: |
+  - Fixes `DatePickerThemeData.todayBorder` color being overridden by `todayForegroundColor` in the year selector.
+version: patch

--- a/packages/material_ui/test/calendar_date_picker_test.dart
+++ b/packages/material_ui/test/calendar_date_picker_test.dart
@@ -2113,7 +2113,7 @@ void main() {
   }
 
   // Regression test for https://github.com/flutter/flutter/issues/189298
-  testWidgets('Non-null todayBorder color should be respected over todayBackgroundColor', (
+  testWidgets('Non-null todayBorder color should be respected over todayForegroundColor', (
     WidgetTester tester,
   ) async {
     const Color customBorderColor = Colors.red;

--- a/packages/material_ui/test/calendar_date_picker_test.dart
+++ b/packages/material_ui/test/calendar_date_picker_test.dart
@@ -71,8 +71,10 @@ void main() {
     DateTime? currentDate,
     ValueChanged<DateTime>? onChanged,
     TextDirection textDirection = TextDirection.ltr,
+    ThemeData? theme,
   }) {
     return MaterialApp(
+      theme: theme,
       home: Material(
         child: Directionality(
           textDirection: textDirection,
@@ -2100,6 +2102,84 @@ void main() {
       expect((outerMaterial as dynamic).debugInkFeatures, isNull);
       expect((innerMaterial as dynamic).debugInkFeatures, hasLength(1));
     });
+  });
+
+  ShapeDecoration? findYearDecoration(WidgetTester tester, String year) {
+    final Container container = tester.widget<Container>(
+      find.ancestor(of: find.text(year), matching: find.byType(Container)).first,
+    );
+
+    return container.decoration as ShapeDecoration?;
+  }
+
+  // Regression test for https://github.com/flutter/flutter/issues/189298
+  testWidgets('Non-null todayBorder color should be respected over todayBackgroundColor', (
+    WidgetTester tester,
+  ) async {
+    const Color customBorderColor = Colors.red;
+    await tester.pumpWidget(
+      yearPicker(
+        theme: ThemeData(
+          datePickerTheme: DatePickerThemeData(
+            todayBorder: const BorderSide(color: customBorderColor),
+            todayForegroundColor: WidgetStateProperty.all(Colors.blue),
+          ),
+        ),
+      ),
+    );
+
+    // The current year should be painted with custom border color.
+    final ShapeDecoration? decoration = findYearDecoration(tester, '2016');
+    final shape = decoration!.shape as OutlinedBorder;
+    expect(shape.side.color, customBorderColor);
+  });
+
+  // Regression test for https://github.com/flutter/flutter/issues/189298.
+  testWidgets('Non-null todayBorder color is used even when disabled', (WidgetTester tester) async {
+    const Color customBorderColor = Colors.red;
+    await tester.pumpWidget(
+      yearPicker(
+        firstDate: DateTime(2018, DateTime.june, 9),
+        lastDate: DateTime(2030, DateTime.december, 15),
+        selectedDate: DateTime(2020),
+        currentDate: DateTime(2016), // Not between first and last date.
+        theme: ThemeData(
+          datePickerTheme: DatePickerThemeData(
+            todayBorder: const BorderSide(color: customBorderColor),
+            todayForegroundColor: WidgetStateProperty.all(Colors.blue),
+          ),
+        ),
+      ),
+    );
+
+    // The current year should be painted with the custom border color,
+    // not with foreground color opacity applied, even if it's disabled.
+    final ShapeDecoration? decoration = findYearDecoration(tester, '2016');
+    final shape = decoration!.shape as OutlinedBorder;
+    expect(shape.side.color, customBorderColor);
+  });
+
+  // Regression test for https://github.com/flutter/flutter/issues/189298.
+  testWidgets('Transparent todayBorder should fall back to foreground color', (
+    WidgetTester tester,
+  ) async {
+    const Color customForegroundColor = Colors.green;
+    await tester.pumpWidget(
+      yearPicker(
+        theme: ThemeData(
+          datePickerTheme: DatePickerThemeData(
+            todayBorder: const BorderSide(color: Color(0x00000000)),
+            todayForegroundColor: WidgetStateProperty.all(customForegroundColor),
+          ),
+        ),
+      ),
+    );
+
+    // The current year should use the foreground color since
+    // todayBorder color is transparent.
+    final ShapeDecoration? decoration = findYearDecoration(tester, '2016');
+    final shape = decoration!.shape as OutlinedBorder;
+    expect(shape.side.color, customForegroundColor);
   });
 
   group('Calendar Delegate', () {


### PR DESCRIPTION
This PR ports https://github.com/flutter/flutter/pull/189345 from flutter/flutter to flutter/packages, as part of https://github.com/flutter/flutter/issues/188444.

Fixes https://github.com/flutter/flutter/issues/189298

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under[^1].
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [x] All existing and new tests are passing.
