### PR TITLE
[material_ui] Fix predictive back transition during CupertinoSheet drag

### DIFF
--- a/packages/material_ui/lib/src/predictive_back_page_transitions_builder.dart
+++ b/packages/material_ui/lib/src/predictive_back_page_transitions_builder.dart
@@ -76,11 +76,8 @@ class PredictiveBackPageTransitionsBuilder extends PageTransitionsBuilder {
             PredictiveBackEvent? startBackEvent,
             PredictiveBackEvent? currentBackEvent,
           ) {
-            // Only do a predictive back transition when the user is performing a
-            // pop gesture. Otherwise, for things like button presses or other
-            // programmatic navigation, fall back to
-            // FadeForwardsPageTransitionsBuilder.
-            if (route.popGestureInProgress) {
+            // Only use the predictive back transition during an active back gesture.
+            if (phase != _PredictiveBackPhase.idle) {
               return _PredictiveBackSharedElementPageTransition(
                 isDelegatedTransition: true,
                 animation: animation,
@@ -156,10 +153,8 @@ class PredictiveBackFullscreenPageTransitionsBuilder extends PageTransitionsBuil
             PredictiveBackEvent? startBackEvent,
             PredictiveBackEvent? currentBackEvent,
           ) {
-            // Only do a predictive back transition when the user is performing a
-            // pop gesture. Otherwise, for things like button presses or other
-            // programmatic navigation, fall back to ZoomPageTransitionsBuilder.
-            if (route.popGestureInProgress) {
+            // Only use the predictive back transition during an active back gesture.
+            if (phase != _PredictiveBackPhase.idle) {
               return _PredictiveBackFullscreenPageTransition(
                 animation: animation,
                 secondaryAnimation: secondaryAnimation,

--- a/packages/material_ui/pending_changelogs/change_2026_08_28_predictive_back_sheet_drag.yaml
+++ b/packages/material_ui/pending_changelogs/change_2026_08_28_predictive_back_sheet_drag.yaml
@@ -1,0 +1,3 @@
+changelog: |
+  - Prevents a covered route from entering a predictive back transition while dragging a `CupertinoSheet`.
+version: patch

--- a/packages/material_ui/test/predictive_back_page_transitions_builder_test.dart
+++ b/packages/material_ui/test/predictive_back_page_transitions_builder_test.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:cupertino_ui/cupertino_ui.dart' show CupertinoPageScaffold, showCupertinoSheet;
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -673,6 +674,70 @@ void main() {
         findsOneWidget,
       );
     });
+
+    testWidgets(
+      'route covered by a CupertinoSheet does not switch to the predictive back '
+      'transition while the sheet is dragged (${pageTransitionsBuilder.runtimeType})',
+      (WidgetTester tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            theme: ThemeData(
+              pageTransitionsTheme: PageTransitionsTheme(
+                builders: <TargetPlatform, PageTransitionsBuilder>{
+                  for (final TargetPlatform platform in TargetPlatform.values)
+                    platform: pageTransitionsBuilder,
+                },
+              ),
+            ),
+            home: Builder(
+              builder: (BuildContext context) {
+                return Scaffold(
+                  body: Center(
+                    child: TextButton(
+                      onPressed: () {
+                        showCupertinoSheet<void>(
+                          context: context,
+                          scrollableBuilder: (BuildContext context, ScrollController controller) {
+                            return CupertinoPageScaffold(
+                              child: ListView.builder(
+                                controller: controller,
+                                itemCount: 30,
+                                itemBuilder: (BuildContext context, int index) {
+                                  return SizedBox(height: 56.0, child: Text('item $index'));
+                                },
+                              ),
+                            );
+                          },
+                        );
+                      },
+                      child: const Text('open sheet'),
+                    ),
+                  ),
+                );
+              },
+            ),
+          ),
+        );
+
+        await tester.tap(find.text('open sheet'));
+        await tester.pumpAndSettle();
+
+        expect(_findPredictiveBackPageTransition(pageTransitionsBuilder), findsNothing);
+        expect(_findFallbackPageTransition(pageTransitionsBuilder), findsOneWidget);
+
+        final TestGesture gesture = await tester.startGesture(const Offset(100, 300));
+        // A small drag first wins the gesture arena before the larger drag.
+        await gesture.moveBy(const Offset(0, 30));
+        await gesture.moveBy(const Offset(0, 100));
+        await tester.pump();
+
+        expect(_findPredictiveBackPageTransition(pageTransitionsBuilder), findsNothing);
+        expect(_findFallbackPageTransition(pageTransitionsBuilder), findsOneWidget);
+
+        await gesture.up();
+        await tester.pumpAndSettle();
+      },
+    );
   }
 
   testWidgets('PredictiveBackPageTransitionsBuilder uses fallbackColor', (


### PR DESCRIPTION
Ports flutter/flutter#187494 to `material_ui` following flutter/flutter#188444.

Fixes flutter/flutter#187492.

This PR fixes an issue where a route covered by a `CupertinoSheet` could incorrectly enter the predictive back transition during an unrelated navigator gesture, causing its corners to snap to the display corner radius while the sheet was being dragged.

`PredictiveBackPageTransitionsBuilder` and `PredictiveBackFullscreenPageTransitionsBuilder` previously used `route.popGestureInProgress` to determine whether to show the predictive back transition. However, this value is derived from `navigator.userGestureInProgress`, which becomes true for any navigator user gesture, including dragging a `CupertinoSheet` above the route.

The resulting corner jump is visible on physical Android devices that report display corner radii. When no display corner radius is reported, the fallback value of `BorderRadius.zero` masks the visual symptom. The issue does not occur on iOS because it uses `CupertinoPageTransitionsBuilder`.

This change uses the predictive back phase instead, so a covered route only enters the predictive back transition during an actual system back gesture. It also adds regression coverage for both predictive back transition builders.

## Tests

- `flutter test test/predictive_back_page_transitions_builder_test.dart --no-pub`
- `dart run script/tool/bin/flutter_plugin_tools.dart analyze --packages material_ui`
- `dart run script/tool/bin/flutter_plugin_tools.dart validate --packages material_ui --base-sha=9854cd5607da4001f2dd3cbdcd6903202d28958c --check-for-missing-changes`
- `dart run script/tool/bin/flutter_plugin_tools.dart publish-check --packages material_ui`

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under[^1].
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [x] All existing and new tests are passing.

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[the version and CHANGELOG instructions]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version-and-changelog-updates
[semantic versioning]: https://dart.dev/tools/pub/versioning#semantic-versions
[repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests