### PR TITLE
add cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
     groups:
       all-github-actions:
         patterns: [ "*" ]
@@ -71,6 +73,8 @@ updates:
       prefix: "[dependabot]"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
     labels:
       - "autosubmit"
       - "triage-android"
@@ -105,6 +109,8 @@ updates:
       prefix: "[dependabot]"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
     open-pull-requests-limit: 10
     labels:
       - "autosubmit"


### PR DESCRIPTION
adds a cooldown to the dependabot yml. This should fix the zizmor failures on https://github.com/flutter/packages/pull/11352