### PR TITLE
[material_ui] Add a README and placeholders for migrating gen_defaults templates

### DIFF
--- a/packages/material_ui/tool/gen_defaults/bin/gen_defaults.dart
+++ b/packages/material_ui/tool/gen_defaults/bin/gen_defaults.dart
@@ -12,7 +12,48 @@
 
 import 'package:args/args.dart';
 
+// import '../templates/action_chip_template.dart';
 import '../templates/app_bar_template.dart';
+// import '../templates/badge_template.dart';
+// import '../templates/banner_template.dart';
+// import '../templates/bottom_app_bar_template.dart';
+// import '../templates/bottom_sheet_template.dart';
+// import '../templates/button_template.dart';
+// import '../templates/card_template.dart';
+// import '../templates/checkbox_template.dart';
+// import '../templates/chip_template.dart';
+// import '../templates/color_scheme_template.dart';
+// import '../templates/date_picker_template.dart';
+// import '../templates/dialog_template.dart';
+// import '../templates/divider_template.dart';
+// import '../templates/drawer_template.dart';
+// import '../templates/expansion_tile_template.dart';
+// import '../templates/fab_template.dart';
+// import '../templates/filter_chip_template.dart';
+// import '../templates/icon_button_template.dart';
+// import '../templates/input_chip_template.dart';
+// import '../templates/input_decorator_template.dart';
+// import '../templates/list_tile_template.dart';
+// import '../templates/menu_template.dart';
+// import '../templates/motion_template.dart';
+// import '../templates/navigation_bar_template.dart';
+// import '../templates/navigation_drawer_template.dart';
+// import '../templates/navigation_rail_template.dart';
+// import '../templates/popup_menu_template.dart';
+// import '../templates/progress_indicator_template.dart';
+// import '../templates/radio_template.dart';
+// import '../templates/range_slider_template.dart';
+// import '../templates/search_bar_template.dart';
+// import '../templates/search_view_template.dart';
+// import '../templates/segmented_button_template.dart';
+// import '../templates/slider_template.dart';
+// import '../templates/snackbar_template.dart';
+// import '../templates/surface_tint_template.dart';
+// import '../templates/switch_template.dart';
+// import '../templates/tabs_template.dart';
+// import '../templates/text_field_template.dart';
+// import '../templates/time_picker_template.dart';
+// import '../templates/typography_template.dart';
 
 Future<void> main(List<String> args) async {
   // Parse arguments
@@ -21,5 +62,47 @@ Future<void> main(List<String> args) async {
   final ArgResults argResults = parser.parse(args);
   // TODO(elliette): Add token logger when verbose flag is used.
   final verbose = argResults['verbose'] as bool;
+
+  // const ActionChipTemplateM3().generateFile(verbose: verbose);
   const AppBarTemplateM3().generateFile(verbose: verbose);
+  // const BadgeTemplateM3().generateFile(verbose: verbose);
+  // const BannerTemplateM3().generateFile(verbose: verbose);
+  // const BottomAppBarTemplateM3().generateFile(verbose: verbose);
+  // const BottomSheetTemplateM3().generateFile(verbose: verbose);
+  // const ButtonTemplateM3().generateFile(verbose: verbose);
+  // const CardTemplateM3().generateFile(verbose: verbose);
+  // const CheckboxTemplateM3().generateFile(verbose: verbose);
+  // const ChipTemplateM3().generateFile(verbose: verbose);
+  // const ColorSchemeTemplateM3().generateFile(verbose: verbose);
+  // const DatePickerTemplateM3().generateFile(verbose: verbose);
+  // const DialogTemplateM3().generateFile(verbose: verbose);
+  // const DividerTemplateM3().generateFile(verbose: verbose);
+  // const DrawerTemplateM3().generateFile(verbose: verbose);
+  // const ExpansionTileTemplateM3().generateFile(verbose: verbose);
+  // const FabTemplateM3().generateFile(verbose: verbose);
+  // const FilterChipTemplateM3().generateFile(verbose: verbose);
+  // const IconButtonTemplateM3().generateFile(verbose: verbose);
+  // const InputChipTemplateM3().generateFile(verbose: verbose);
+  // const InputDecoratorTemplateM3().generateFile(verbose: verbose);
+  // const ListTileTemplateM3().generateFile(verbose: verbose);
+  // const MenuTemplateM3().generateFile(verbose: verbose);
+  // const MotionTemplateM3().generateFile(verbose: verbose);
+  // const NavigationBarTemplateM3().generateFile(verbose: verbose);
+  // const NavigationDrawerTemplateM3().generateFile(verbose: verbose);
+  // const NavigationRailTemplateM3().generateFile(verbose: verbose);
+  // const PopupMenuTemplateM3().generateFile(verbose: verbose);
+  // const ProgressIndicatorTemplateM3().generateFile(verbose: verbose);
+  // const RadioTemplateM3().generateFile(verbose: verbose);
+  // const RangeSliderTemplateM3().generateFile(verbose: verbose);
+  // const SearchBarTemplateM3().generateFile(verbose: verbose);
+  // const SearchViewTemplateM3().generateFile(verbose: verbose);
+  // const SegmentedButtonTemplateM3().generateFile(verbose: verbose);
+  // const SliderTemplateM3().generateFile(verbose: verbose);
+  // const SnackbarTemplateM3().generateFile(verbose: verbose);
+  // const SurfaceTintTemplateM3().generateFile(verbose: verbose);
+  // const SwitchTemplateM3().generateFile(verbose: verbose);
+  // const TabsTemplateM3().generateFile(verbose: verbose);
+  // const TextFieldTemplateM3().generateFile(verbose: verbose);
+  // const TimePickerTemplateM3().generateFile(verbose: verbose);
+  // const TypographyTemplateM3().generateFile(verbose: verbose);
 }

--- a/packages/material_ui/tool/gen_defaults/bin/gen_defaults.dart
+++ b/packages/material_ui/tool/gen_defaults/bin/gen_defaults.dart
@@ -14,6 +14,7 @@ import 'package:args/args.dart';
 
 // import '../templates/action_chip_template.dart';
 import '../templates/app_bar_template.dart';
+
 // import '../templates/badge_template.dart';
 // import '../templates/banner_template.dart';
 // import '../templates/bottom_app_bar_template.dart';

--- a/packages/material_ui/tool/gen_defaults/temporarily_excluded/README.md
+++ b/packages/material_ui/tool/gen_defaults/temporarily_excluded/README.md
@@ -1,0 +1,103 @@
+# Temporarily Excluded `gen_defaults` Templates and Code
+
+This directory contains the templates and generated code used by the old
+`gen_defaults` script in `flutter/flutter`. They are in the process of being
+migrated to the new `gen_defaults` script. Please see
+https://github.com/flutter/flutter/issues/187899.
+
+## Instructions for migrating
+
+In these instructions, placeholders are used for the component name. Please substitute them as follows, using "Icon Button" as an example:
+- `{{COMPONENT_NAME}}`: the snake_case name (e.g., `icon_button`).
+- `ComponentName`: the PascalCase name (e.g., `IconButton`).
+- `Component Name`: the title case name (e.g., `Icon Button`).
+
+> Currently all `gen_defaults` migration PRs should be branched off of and rebased against the `m3e_migration` branch, not `main`. 
+
+> Please only format the files you edit.
+
+1. Select an unmigrated component listed in https://github.com/flutter/flutter/issues/187899.
+
+2. Move the respective template and generated code for that template out of `temporarily_excluded/`:
+
+   From the `packages/material_ui` directory, run:
+
+   ```bash
+   mv tool/gen_defaults/temporarily_excluded/templates/{{COMPONENT_NAME}}_template.dart tool/gen_defaults/templates/{{COMPONENT_NAME}}_template.dart
+   mv tool/gen_defaults/temporarily_excluded/generated/{{COMPONENT_NAME}}_defaults.g.dart lib/src/generated/{{COMPONENT_NAME}}_defaults_m3.g.dart
+   ```
+
+3. Commit the file moves. This will allow us to review the changes on the PR.
+   **Do not skip this step!**
+
+   ```bash
+   git add -A
+   git commit -m "Move template/generated code out of temporarily_excluded directory"
+   ```
+
+4. Locate the respective component file that contains the generated code in `packages/material_ui/lib/src`.
+   Mark it as the parent file, and delete the generated code.
+
+   Add this line after all import statements:
+
+   ```dart
+   part 'generated/{{COMPONENT_NAME}}_defaults_m3.g.dart';
+   ```
+
+   Delete the generated code, including the headers:
+
+   ```dart
+   // BEGIN GENERATED TOKEN PROPERTIES - ComponentName
+
+   // Do not edit by hand. The code between the "BEGIN GENERATED" and
+   // "END GENERATED" comments are generated from data in the Material
+   // Design token database by the script:
+   //   dev/tools/gen_defaults/bin/gen_defaults.dart.
+
+   // dart format off
+   class _ComponentNameDefaultsM3 {
+     ...
+   }
+   // dart format on
+
+   // END GENERATED TOKEN PROPERTIES - ComponentName
+   ```
+
+5. Make the necessary changes to `tool/gen_defaults/templates/{{COMPONENT_NAME}}_template.dart`.
+
+   These include:
+   - Template class extends `TokenTemplateM3` instead of `TokenTemplate`
+   - `String generate` becomes `String generateContents(String className)`
+   - Use the provided `className` in `generateContents`.
+   - Delete the `blockName`, `fileName`, and `tokens` super parameters.
+   - Add the `name` and `parentFilePath` getters:
+
+   ```dart
+   @override
+   String get name => 'Component Name';
+
+   @override
+   String get parentFilePath => 'component_name.dart';
+   ```
+
+   > **[Important]** If the original template used a token instead of a
+   > hard-coded value, then try to locate the equivalent token in
+   > `tool/gen_defaults/data`. If no appropriate token can be found, please add
+   > TODO a comment like: `// TODO(username): Using hard-coded value due to
+   > missing token`. Hard-coded values should only be used as a last resort.
+
+6. Once the template compiles, uncomment it and its respective import in `packages/material_ui/tool/gen_defaults/bin/gen_defaults.dart`:
+
+   ```dart
+   import '../templates/component_name_template.dart';
+
+   const ComponentNameTemplateM3().generateFile(verbose: verbose);
+   ```
+
+7. From `packages/material_ui`, run `gen_defaults` and compare the generated code.
+
+   ```bash
+   dart run tool/gen_defaults/bin/gen_defaults.dart
+   ```
+
+8. Fill in the appropriate test case in `packages/material_ui/tool/gen_defaults/test/gen_defaults_test.dart`.

--- a/packages/material_ui/tool/gen_defaults/temporarily_excluded/README.md
+++ b/packages/material_ui/tool/gen_defaults/temporarily_excluded/README.md
@@ -12,7 +12,7 @@ In these instructions, placeholders are used for the component name. Please subs
 - `ComponentName`: the PascalCase name (e.g., `IconButton`).
 - `Component Name`: the title case name (e.g., `Icon Button`).
 
-> Currently all `gen_defaults` migration PRs should be branched off of and rebased against the `m3e_migration` branch, not `main`. 
+> Currently all `gen_defaults` migration PRs should be branched off of and rebased against the `m3e_migration` branch, not `main`.
 
 > Please only format the files you edit.
 
@@ -83,13 +83,13 @@ In these instructions, placeholders are used for the component name. Please subs
    > **[Important]** If the original template used a token instead of a
    > hard-coded value, then try to locate the equivalent token in
    > `tool/gen_defaults/data`. If no appropriate token can be found, please add
-   > TODO a comment like: `// TODO(username): Using hard-coded value due to
+   > a TODO comment like: `// TODO(username): Using hard-coded value due to
    > missing token`. Hard-coded values should only be used as a last resort.
 
 6. Once the template compiles, uncomment it and its respective import in `packages/material_ui/tool/gen_defaults/bin/gen_defaults.dart`:
 
    ```dart
-   import '../templates/component_name_template.dart';
+   import '../templates/{{COMPONENT_NAME}}_template.dart';
 
    const ComponentNameTemplateM3().generateFile(verbose: verbose);
    ```

--- a/packages/material_ui/tool/gen_defaults/test/gen_defaults_test.dart
+++ b/packages/material_ui/tool/gen_defaults/test/gen_defaults_test.dart
@@ -148,7 +148,12 @@ void main() {
       );
     });
 
-    test('AppBarTemplateM3 emits M3 AppBar defaults from app bar tokens', () {
+    test('ActionChipTemplateM3 emits M3 ActionChip defaults from tokens', () {
+      // Intentionally empty, will be implemented during migration. See:
+      // https://github.com/flutter/flutter/issues/187899
+    });
+
+    test('AppBarTemplateM3 emits M3 AppBar defaults from tokens', () {
       final String contents = const AppBarTemplateM3().generateContents('_AppBarDefaultsM3');
       expect(contents, contains('class _AppBarDefaultsM3 extends AppBarThemeData'));
       expect(contents, contains('scrolledUnderElevation: 3.0'));
@@ -159,6 +164,207 @@ void main() {
       expect(contents, contains('static const double expandedHeight = 112.0'));
       expect(contents, contains('static const double expandedHeight = 152.0'));
     });
+
+    test('BadgeTemplateM3 emits M3 Badge defaults from tokens', () {
+      // Intentionally empty, will be implemented during migration. See:
+      // https://github.com/flutter/flutter/issues/187899
+    });
+
+    test('BannerTemplateM3 emits M3 Banner defaults from tokens', () {
+      // Intentionally empty, will be implemented during migration. See:
+      // https://github.com/flutter/flutter/issues/187899
+    });
+
+    test('BottomAppBarTemplateM3 emits M3 BottomAppBar defaults from tokens', () {
+      // Intentionally empty, will be implemented during migration. See:
+      // https://github.com/flutter/flutter/issues/187899
+    });
+
+    test('BottomSheetTemplateM3 emits M3 BottomSheet defaults from tokens', () {
+      // Intentionally empty, will be implemented during migration. See:
+      // https://github.com/flutter/flutter/issues/187899
+    });
+
+    test('ButtonTemplateM3 emits M3 Button defaults from tokens', () {
+      // Intentionally empty, will be implemented during migration. See:
+      // https://github.com/flutter/flutter/issues/187899
+    });
+
+    test('CardTemplateM3 emits M3 Card defaults from tokens', () {
+      // Intentionally empty, will be implemented during migration. See:
+      // https://github.com/flutter/flutter/issues/187899
+    });
+
+    test('CheckboxTemplateM3 emits M3 Checkbox defaults from tokens', () {
+      // Intentionally empty, will be implemented during migration. See:
+      // https://github.com/flutter/flutter/issues/187899
+    });
+
+    test('ChipTemplateM3 emits M3 Chip defaults from tokens', () {
+      // Intentionally empty, will be implemented during migration. See:
+      // https://github.com/flutter/flutter/issues/187899
+    });
+
+    test('ColorSchemeTemplateM3 emits M3 ColorScheme defaults from tokens', () {
+      // Intentionally empty, will be implemented during migration. See:
+      // https://github.com/flutter/flutter/issues/187899
+    });
+
+    test('DatePickerTemplateM3 emits M3 DatePicker defaults from tokens', () {
+      // Intentionally empty, will be implemented during migration. See:
+      // https://github.com/flutter/flutter/issues/187899
+    });
+
+    test('DialogTemplateM3 emits M3 Dialog defaults from tokens', () {
+      // Intentionally empty, will be implemented during migration. See:
+      // https://github.com/flutter/flutter/issues/187899
+    });
+
+    test('DividerTemplateM3 emits M3 Divider defaults from tokens', () {
+      // Intentionally empty, will be implemented during migration. See:
+      // https://github.com/flutter/flutter/issues/187899
+    });
+
+    test('DrawerTemplateM3 emits M3 Drawer defaults from tokens', () {
+      // Intentionally empty, will be implemented during migration. See:
+      // https://github.com/flutter/flutter/issues/187899
+    });
+
+    test('ExpansionTileTemplateM3 emits M3 ExpansionTile defaults from tokens', () {
+      // Intentionally empty, will be implemented during migration. See:
+      // https://github.com/flutter/flutter/issues/187899
+    });
+
+    test('FabTemplateM3 emits M3 Fab defaults from tokens', () {
+      // Intentionally empty, will be implemented during migration. See:
+      // https://github.com/flutter/flutter/issues/187899
+    });
+
+    test('FilterChipTemplateM3 emits M3 FilterChip defaults from tokens', () {
+      // Intentionally empty, will be implemented during migration. See:
+      // https://github.com/flutter/flutter/issues/187899
+    });
+
+    test('IconButtonTemplateM3 emits M3 IconButton defaults from tokens', () {
+      // Intentionally empty, will be implemented during migration. See:
+      // https://github.com/flutter/flutter/issues/187899
+    });
+
+    test('InputChipTemplateM3 emits M3 InputChip defaults from tokens', () {
+      // Intentionally empty, will be implemented during migration. See:
+      // https://github.com/flutter/flutter/issues/187899
+    });
+
+    test('InputDecoratorTemplateM3 emits M3 InputDecorator defaults from tokens', () {
+      // Intentionally empty, will be implemented during migration. See:
+      // https://github.com/flutter/flutter/issues/187899
+    });
+
+    test('ListTileTemplateM3 emits M3 ListTile defaults from tokens', () {
+      // Intentionally empty, will be implemented during migration. See:
+      // https://github.com/flutter/flutter/issues/187899
+    });
+
+    test('MenuTemplateM3 emits M3 Menu defaults from tokens', () {
+      // Intentionally empty, will be implemented during migration. See:
+      // https://github.com/flutter/flutter/issues/187899
+    });
+
+    test('MotionTemplateM3 emits M3 Motion defaults from tokens', () {
+      // Intentionally empty, will be implemented during migration. See:
+      // https://github.com/flutter/flutter/issues/187899
+    });
+
+    test('NavigationBarTemplateM3 emits M3 NavigationBar defaults from tokens', () {
+      // Intentionally empty, will be implemented during migration. See:
+      // https://github.com/flutter/flutter/issues/187899
+    });
+
+    test('NavigationDrawerTemplateM3 emits M3 NavigationDrawer defaults from tokens', () {
+      // Intentionally empty, will be implemented during migration. See:
+      // https://github.com/flutter/flutter/issues/187899
+    });
+
+    test('NavigationRailTemplateM3 emits M3 NavigationRail defaults from tokens', () {
+      // Intentionally empty, will be implemented during migration. See:
+      // https://github.com/flutter/flutter/issues/187899
+    });
+
+    test('PopupMenuTemplateM3 emits M3 PopupMenu defaults from tokens', () {
+      // Intentionally empty, will be implemented during migration. See:
+      // https://github.com/flutter/flutter/issues/187899
+    });
+
+    test('ProgressIndicatorTemplateM3 emits M3 ProgressIndicator defaults from tokens', () {
+      // Intentionally empty, will be implemented during migration. See:
+      // https://github.com/flutter/flutter/issues/187899
+    });
+
+    test('RadioTemplateM3 emits M3 Radio defaults from tokens', () {
+      // Intentionally empty, will be implemented during migration. See:
+      // https://github.com/flutter/flutter/issues/187899
+    });
+
+    test('RangeSliderTemplateM3 emits M3 RangeSlider defaults from tokens', () {
+      // Intentionally empty, will be implemented during migration. See:
+      // https://github.com/flutter/flutter/issues/187899
+    });
+
+    test('SearchBarTemplateM3 emits M3 SearchBar defaults from tokens', () {
+      // Intentionally empty, will be implemented during migration. See:
+      // https://github.com/flutter/flutter/issues/187899
+    });
+
+    test('SearchViewTemplateM3 emits M3 SearchView defaults from tokens', () {
+      // Intentionally empty, will be implemented during migration. See:
+      // https://github.com/flutter/flutter/issues/187899
+    });
+
+    test('SegmentedButtonTemplateM3 emits M3 SegmentedButton defaults from tokens', () {
+      // Intentionally empty, will be implemented during migration. See:
+      // https://github.com/flutter/flutter/issues/187899
+    });
+
+    test('SliderTemplateM3 emits M3 Slider defaults from tokens', () {
+      // Intentionally empty, will be implemented during migration. See:
+      // https://github.com/flutter/flutter/issues/187899
+    });
+
+    test('SnackbarTemplateM3 emits M3 Snackbar defaults from tokens', () {
+      // Intentionally empty, will be implemented during migration. See:
+      // https://github.com/flutter/flutter/issues/187899
+    });
+
+    test('SurfaceTintTemplateM3 emits M3 SurfaceTint defaults from tokens', () {
+      // Intentionally empty, will be implemented during migration. See:
+      // https://github.com/flutter/flutter/issues/187899
+    });
+
+    test('SwitchTemplateM3 emits M3 Switch defaults from tokens', () {
+      // Intentionally empty, will be implemented during migration. See:
+      // https://github.com/flutter/flutter/issues/187899
+    });
+
+    test('TabsTemplateM3 emits M3 Tabs defaults from tokens', () {
+      // Intentionally empty, will be implemented during migration. See:
+      // https://github.com/flutter/flutter/issues/187899
+    });
+
+    test('TextFieldTemplateM3 emits M3 TextField defaults from tokens', () {
+      // Intentionally empty, will be implemented during migration. See:
+      // https://github.com/flutter/flutter/issues/187899
+    });
+
+    test('TimePickerTemplateM3 emits M3 TimePicker defaults from tokens', () {
+      // Intentionally empty, will be implemented during migration. See:
+      // https://github.com/flutter/flutter/issues/187899
+    });
+
+    test('TypographyTemplateM3 emits M3 Typography defaults from tokens', () {
+      // Intentionally empty, will be implemented during migration. See:
+      // https://github.com/flutter/flutter/issues/187899
+    });
+
     test('will run dart format over the generated file', () {
       final template = UnformattedTemplate(testPath());
       template.generateFile();


### PR DESCRIPTION
Work towards https://github.com/flutter/flutter/issues/191088

**Ports over https://github.com/flutter/packages/pull/12220 which landed on the `m3e_migration` feature branch.**

### Original PR description

Work towards https://github.com/flutter/flutter/issues/187899

* Adds a README on how to migrate the gen_defaults templates, to be used by contributors or agents.
* Adds placeholders (referenced in README) for templates to prevent merge conflicts while migrating.

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under[^1].
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[the version and CHANGELOG instructions]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version-and-changelog-updates
[semantic versioning]: https://dart.dev/tools/pub/versioning#semantic-versions
[repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
