### PR TITLE
[two_dimensional_scrollables] Fix crash when trailing pinned spans fall within the cache extent

### DIFF
--- a/packages/two_dimensional_scrollables/CHANGELOG.md
+++ b/packages/two_dimensional_scrollables/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.5.5
+
+* Fixes a crash when trailing pinned rows or columns fall within the viewport's cache extent.
+
 ## 0.5.4
 
 * Fixes memory leaks.

--- a/packages/two_dimensional_scrollables/lib/src/table_view/table.dart
+++ b/packages/two_dimensional_scrollables/lib/src/table_view/table.dart
@@ -1087,7 +1087,10 @@ class RenderTableViewport extends RenderTwoDimensionalViewport {
       (span) => !span.isPinned && span.trailingOffset >= _targetTrailingColumnPixel,
     );
     if (_firstNonPinnedColumn != null) {
-      _lastNonPinnedColumn ??= _columnMetrics.length - 1;
+      // The last column of the metrics may be a trailing pinned column, which
+      // is laid out separately. Exclude them so the same column is not laid out
+      // in both the non-pinned and the trailing pinned quadrants.
+      _lastNonPinnedColumn ??= _columnMetrics.length - 1 - delegate.trailingPinnedColumnCount;
     }
 
     if (_rowMetrics.isNotEmpty) {
@@ -1116,7 +1119,10 @@ class RenderTableViewport extends RenderTwoDimensionalViewport {
       (span) => !span.isPinned && span.trailingOffset >= _targetTrailingRowPixel,
     );
     if (_firstNonPinnedRow != null) {
-      _lastNonPinnedRow ??= _rowMetrics.length - 1;
+      // The last row of the metrics may be a trailing pinned row, which is laid
+      // out separately. Exclude them so the same row is not laid out in both
+      // the non-pinned and the trailing pinned quadrants.
+      _lastNonPinnedRow ??= _rowMetrics.length - 1 - delegate.trailingPinnedRowCount;
     }
   }
 

--- a/packages/two_dimensional_scrollables/pubspec.yaml
+++ b/packages/two_dimensional_scrollables/pubspec.yaml
@@ -1,6 +1,6 @@
 name: two_dimensional_scrollables
 description: Widgets that scroll using the two dimensional scrolling foundation.
-version: 0.5.4
+version: 0.5.5
 repository: https://github.com/flutter/packages/tree/main/packages/two_dimensional_scrollables
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+two_dimensional_scrollables%22+
 

--- a/packages/two_dimensional_scrollables/test/table_view/table_test.dart
+++ b/packages/two_dimensional_scrollables/test/table_view/table_test.dart
@@ -4085,6 +4085,92 @@ void main() {
     expect(mergedRect.top, 200);
     expect(mergedRect.bottom, 400);
   });
+
+  testWidgets('Trailing pinned columns are not laid out twice when the table fits the viewport', (
+    WidgetTester tester,
+  ) async {
+    // Regression test for https://github.com/flutter/flutter/issues/192152
+    final verticalController = ScrollController();
+    addTearDown(verticalController.dispose);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: SizedBox(
+            height: 300,
+            width: 400,
+            // All of the columns fit within the viewport, so the search for the
+            // last visible non-pinned column comes up empty and falls back to
+            // the last column of the metrics - which is a trailing pinned one.
+            child: TableView.builder(
+              verticalDetails: ScrollableDetails.vertical(controller: verticalController),
+              columnCount: 3,
+              rowCount: 100,
+              pinnedRowCount: 1,
+              trailingPinnedColumnCount: 1,
+              columnBuilder: (int index) => const TableSpan(extent: FixedTableSpanExtent(100)),
+              rowBuilder: (int index) => const TableSpan(extent: FixedTableSpanExtent(36)),
+              cellBuilder: (BuildContext context, TableVicinity vicinity) {
+                return TableViewCell(child: Text('R${vicinity.row} C${vicinity.column}'));
+              },
+            ),
+          ),
+        ),
+      ),
+    );
+    expect(find.text('R0 C2'), findsOneWidget);
+
+    // Lay out again without rebuilding the delegate, which exercises the child
+    // reuse path. The trailing pinned column must not be requested twice.
+    verticalController.jumpTo(1);
+    await tester.pump();
+
+    expect(tester.takeException(), isNull);
+    expect(find.text('R0 C2'), findsOneWidget);
+  });
+
+  testWidgets('Trailing pinned rows are not laid out twice when the table fits the viewport', (
+    WidgetTester tester,
+  ) async {
+    // Regression test for https://github.com/flutter/flutter/issues/192152
+    final horizontalController = ScrollController();
+    addTearDown(horizontalController.dispose);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: SizedBox(
+            height: 400,
+            width: 300,
+            // All of the rows fit within the viewport, so the search for the
+            // last visible non-pinned row comes up empty and falls back to the
+            // last row of the metrics - which is a trailing pinned one.
+            child: TableView.builder(
+              horizontalDetails: ScrollableDetails.horizontal(controller: horizontalController),
+              columnCount: 100,
+              rowCount: 3,
+              pinnedColumnCount: 1,
+              trailingPinnedRowCount: 1,
+              columnBuilder: (int index) => const TableSpan(extent: FixedTableSpanExtent(36)),
+              rowBuilder: (int index) => const TableSpan(extent: FixedTableSpanExtent(100)),
+              cellBuilder: (BuildContext context, TableVicinity vicinity) {
+                return TableViewCell(child: Text('R${vicinity.row} C${vicinity.column}'));
+              },
+            ),
+          ),
+        ),
+      ),
+    );
+    expect(find.text('R2 C0'), findsOneWidget);
+
+    // Lay out again without rebuilding the delegate, which exercises the child
+    // reuse path. The trailing pinned row must not be requested twice.
+    horizontalController.jumpTo(1);
+    await tester.pump();
+
+    expect(tester.takeException(), isNull);
+    expect(find.text('R2 C0'), findsOneWidget);
+  });
 }
 
 class _NullBuildContext implements BuildContext, TwoDimensionalChildManager {


### PR DESCRIPTION
`RenderTableViewport._updateFirstAndLastVisibleCell` binary searches for the last non-pinned span whose trailing offset reaches the target trailing pixel. When the whole table fits inside the viewport plus the cache extent that search finds nothing, and the code falls back to the last index of the metrics map:

```dart
if (_firstNonPinnedColumn != null) {
  _lastNonPinnedColumn ??= _columnMetrics.length - 1;
}
```

With `trailingPinnedColumnCount` (or `trailingPinnedRowCount`) greater than zero, that index is a *pinned* span. `layoutChildSequence` then asks for the same vicinity twice: once for the non-pinned quadrant and once for the trailing pinned quadrant.

The first layout hides the problem, because `_needsDelegateRebuild` routes both calls through `_buildChild`. Any later layout without a delegate rebuild — a scroll, for instance — takes the `_reuseChild` path, and the second request trips the assert in `two_dimensional_viewport.dart`:

```
'elementToReuse != null': Expected to re-use an element at (row: 0, column: 2), but none was found.
```

This is easy to hit in practice: a table with a pinned trailing "actions" or "total" column whose columns happen to fit the viewport crashes on the first scroll.

The fix excludes the trailing pinned spans from the fallback, matching what `_updateColumnMetrics` / `_updateRowMetrics` already do when they compute the same value (`delegate.columnCount! - delegate.trailingPinnedColumnCount - 1`). `trailingPinned*Count` is required to be 0 when the corresponding count is null, so the subtraction is a no-op for infinite tables.

Two regression tests are added, one for columns and one for rows. Both fail on `main` with the assert above and pass with the fix.

Fixes flutter/flutter#192152

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under[^1].
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [x] All existing and new tests are passing.

### AI disclosure

Per the AI contribution guidelines: this change was written with the assistance of an AI coding agent (Claude Code). I have reviewed the diff, reproduced the crash against `main`, and verified the tests fail without the fix and pass with it. I take responsibility for the contents of this PR.

`flutter test` in `packages/two_dimensional_scrollables`:

- with the fix: `+167: All tests passed!`
- with `lib/` reverted to `main`: the two new tests fail with `'elementToReuse != null': Expected to re-use an element at (row: 0, column: 2), but none was found.`

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[the version and CHANGELOG instructions]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version-and-changelog-updates
[semantic versioning]: https://dart.dev/tools/pub/versioning#semantic-versions
[repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MRZHkuG9nCwvNdMgxU8gQm
