### PR TITLE
[material_ui] Update `material_ui` tests to prevent them from failing when framework `TextStyle` changes

### DIFF
--- a/packages/material_ui/test/theme_test.dart
+++ b/packages/material_ui/test/theme_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:ui' as ui;
-
 import 'package:cupertino_ui/cupertino_ui.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -569,9 +567,7 @@ void main() {
     }
 
     for (final textTheme in <TextTheme>[theme.textTheme, theme.primaryTextTheme]) {
-      for (final TextStyle style in extractStyles(
-        textTheme,
-      ).map<TextStyle>((TextStyle style) => _TextStyleProxy(style))) {
+      for (final TextStyle style in extractStyles(textTheme)) {
         expect(style.inherit, false);
         expect(style.color, isNotNull);
         expect(style.fontFamily, isNotNull);
@@ -635,9 +631,7 @@ void main() {
     }
 
     for (final textTheme in <TextTheme>[theme.textTheme, theme.primaryTextTheme]) {
-      for (final TextStyle style in extractStyles(
-        textTheme,
-      ).map<TextStyle>((TextStyle style) => _TextStyleProxy(style))) {
+      for (final TextStyle style in extractStyles(textTheme)) {
         expect(style.inherit, false);
         expect(style.color, isNotNull);
         expect(style.fontFamily, isNotNull);
@@ -1175,188 +1169,6 @@ class Test extends StatelessWidget {
   Widget build(BuildContext context) {
     testBuildCalled += 1;
     return Container(decoration: BoxDecoration(color: Theme.of(context).primaryColor));
-  }
-}
-
-/// This class exists only to make sure that we test all the properties of the
-/// [TextStyle] class. If a property is added/removed/renamed, the analyzer will
-/// complain that this class has incorrect overrides.
-class _TextStyleProxy implements TextStyle {
-  _TextStyleProxy(this._delegate);
-
-  final TextStyle _delegate;
-
-  // Do make sure that all the properties correctly forward to the _delegate.
-  @override
-  Color? get color => _delegate.color;
-  @override
-  Color? get backgroundColor => _delegate.backgroundColor;
-  @override
-  String? get debugLabel => _delegate.debugLabel;
-  @override
-  TextDecoration? get decoration => _delegate.decoration;
-  @override
-  Color? get decorationColor => _delegate.decorationColor;
-  @override
-  TextDecorationStyle? get decorationStyle => _delegate.decorationStyle;
-  @override
-  double? get decorationThickness => _delegate.decorationThickness;
-  @override
-  String? get fontFamily => _delegate.fontFamily;
-  @override
-  List<String>? get fontFamilyFallback => _delegate.fontFamilyFallback;
-  @override
-  double? get fontSize => _delegate.fontSize;
-  @override
-  FontStyle? get fontStyle => _delegate.fontStyle;
-  @override
-  FontWeight? get fontWeight => _delegate.fontWeight;
-  @override
-  double? get height => _delegate.height;
-  @override
-  TextLeadingDistribution? get leadingDistribution => _delegate.leadingDistribution;
-  @override
-  Locale? get locale => _delegate.locale;
-  @override
-  ui.Paint? get foreground => _delegate.foreground;
-  @override
-  ui.Paint? get background => _delegate.background;
-  @override
-  bool get inherit => _delegate.inherit;
-  @override
-  double? get letterSpacing => _delegate.letterSpacing;
-  @override
-  TextBaseline? get textBaseline => _delegate.textBaseline;
-  @override
-  double? get wordSpacing => _delegate.wordSpacing;
-  @override
-  List<Shadow>? get shadows => _delegate.shadows;
-  @override
-  List<ui.FontFeature>? get fontFeatures => _delegate.fontFeatures;
-  @override
-  List<ui.FontVariation>? get fontVariations => _delegate.fontVariations;
-  @override
-  TextOverflow? get overflow => _delegate.overflow;
-
-  @override
-  String toString({DiagnosticLevel minLevel = DiagnosticLevel.info}) => super.toString();
-
-  @override
-  DiagnosticsNode toDiagnosticsNode({String? name, DiagnosticsTreeStyle? style}) {
-    throw UnimplementedError();
-  }
-
-  @override
-  String toStringShort() {
-    throw UnimplementedError();
-  }
-
-  @override
-  TextStyle apply({
-    Color? color,
-    Color? backgroundColor,
-    TextDecoration? decoration,
-    Color? decorationColor,
-    TextDecorationStyle? decorationStyle,
-    double decorationThicknessFactor = 1.0,
-    double decorationThicknessDelta = 0.0,
-    String? fontFamily,
-    List<String>? fontFamilyFallback,
-    double fontSizeFactor = 1.0,
-    double fontSizeDelta = 0.0,
-    int fontWeightDelta = 0,
-    FontStyle? fontStyle,
-    double letterSpacingFactor = 1.0,
-    double letterSpacingDelta = 0.0,
-    double wordSpacingFactor = 1.0,
-    double wordSpacingDelta = 0.0,
-    double heightFactor = 1.0,
-    double heightDelta = 0.0,
-    TextLeadingDistribution? leadingDistribution,
-    TextBaseline? textBaseline,
-    Locale? locale,
-    List<ui.Shadow>? shadows,
-    List<ui.FontFeature>? fontFeatures,
-    List<ui.FontVariation>? fontVariations,
-    TextOverflow? overflow,
-    String? package,
-  }) {
-    throw UnimplementedError();
-  }
-
-  @override
-  RenderComparison compareTo(TextStyle other) {
-    throw UnimplementedError();
-  }
-
-  @override
-  TextStyle copyWith({
-    bool? inherit,
-    Color? color,
-    Color? backgroundColor,
-    String? fontFamily,
-    List<String>? fontFamilyFallback,
-    double? fontSize,
-    FontWeight? fontWeight,
-    FontStyle? fontStyle,
-    double? letterSpacing,
-    double? wordSpacing,
-    TextBaseline? textBaseline,
-    double? height,
-    TextLeadingDistribution? leadingDistribution,
-    Locale? locale,
-    ui.Paint? foreground,
-    ui.Paint? background,
-    List<Shadow>? shadows,
-    List<ui.FontFeature>? fontFeatures,
-    List<ui.FontVariation>? fontVariations,
-    TextDecoration? decoration,
-    Color? decorationColor,
-    TextDecorationStyle? decorationStyle,
-    double? decorationThickness,
-    String? debugLabel,
-    TextOverflow? overflow,
-    String? package,
-  }) {
-    throw UnimplementedError();
-  }
-
-  @override
-  void debugFillProperties(DiagnosticPropertiesBuilder properties, {String prefix = ''}) {
-    throw UnimplementedError();
-  }
-
-  @override
-  ui.ParagraphStyle getParagraphStyle({
-    TextAlign? textAlign,
-    TextDirection? textDirection,
-    double textScaleFactor = 1.0,
-    TextScaler textScaler = TextScaler.noScaling,
-    String? ellipsis,
-    int? maxLines,
-    ui.TextHeightBehavior? textHeightBehavior,
-    Locale? locale,
-    String? fontFamily,
-    double? fontSize,
-    FontWeight? fontWeight,
-    FontStyle? fontStyle,
-    double? height,
-    StrutStyle? strutStyle,
-  }) {
-    throw UnimplementedError();
-  }
-
-  @override
-  ui.TextStyle getTextStyle({
-    double textScaleFactor = 1.0,
-    TextScaler textScaler = TextScaler.noScaling,
-  }) {
-    throw UnimplementedError();
-  }
-
-  @override
-  TextStyle merge(TextStyle? other) {
-    throw UnimplementedError();
   }
 }
 


### PR DESCRIPTION
The mechanism was introduced in https://github.com/flutter/flutter/pull/12552 as a means to notify `TextTheme` maintainers when new fields are added to`TextStyle`. In the past since they both live in the `flutter/flutter` repo, they can and should be updated in the same PR. But now that `TextStyle` lives in an upstream repo, this test would make any new feature from being added to `TextStyle` a breaking change, which is very undesirable.  

Making the change would mean `material_ui` maintainers won't be notified via failing tests when the upstream `TextStyle` gets a new field on master (If I understand correctly, `material_ui` is analyzed/tested against `flutter/flutter`'s  master branch). But that's already the case for any other new features added to the framework.

This is for https://github.com/flutter/flutter/pull/185152.
Previous attempt: https://github.com/flutter/packages/pull/12158.

## Pre-Review Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [ ] I read the [Tree Hygiene] page, which explains my responsibilities.
- [ ] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [ ] I signed the [CLA].
- [ ] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I [linked to at least one issue that this PR fixes] in the description above.
- [ ] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under[^1].
- [ ] I updated/added any relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[the version and CHANGELOG instructions]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version-and-changelog-updates
[semantic versioning]: https://dart.dev/tools/pub/versioning#semantic-versions
[repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
