### PR TITLE
[material_ui] Migrate M3 ActionChip template to use new gen_defaults

### DIFF
--- a/packages/material_ui/lib/src/action_chip.dart
+++ b/packages/material_ui/lib/src/action_chip.dart
@@ -23,6 +23,8 @@ import 'text_theme.dart';
 import 'theme.dart';
 import 'theme_data.dart';
 
+part 'generated/action_chip_defaults_m3.g.dart';
+
 enum _ChipVariant { flat, elevated }
 
 /// A Material Design action chip.
@@ -261,107 +263,3 @@ class ActionChip extends StatelessWidget
     );
   }
 }
-
-// BEGIN GENERATED TOKEN PROPERTIES - ActionChip
-
-// Do not edit by hand. The code between the "BEGIN GENERATED" and
-// "END GENERATED" comments are generated from data in the Material
-// Design token database by the script:
-//   dev/tools/gen_defaults/bin/gen_defaults.dart.
-
-// dart format off
-class _ActionChipDefaultsM3 extends ChipThemeData {
-  _ActionChipDefaultsM3(this.context, this.isEnabled, this._chipVariant)
-    : super(
-        shape: const RoundedRectangleBorder(borderRadius: BorderRadius.all(Radius.circular(8.0))),
-        showCheckmark: true,
-      );
-
-  final BuildContext context;
-  final bool isEnabled;
-  final _ChipVariant _chipVariant;
-  late final ColorScheme _colors = Theme.of(context).colorScheme;
-  late final TextTheme _textTheme = Theme.of(context).textTheme;
-
-  @override
-  double? get elevation => _chipVariant == _ChipVariant.flat
-    ? 0.0
-    : isEnabled ? 1.0 : 0.0;
-
-  @override
-  double? get pressElevation => 1.0;
-
-  @override
-  TextStyle? get labelStyle => _textTheme.labelLarge?.copyWith(
-    color: isEnabled
-      ? _colors.onSurface
-      : _colors.onSurface,
-  );
-
-  @override
-  WidgetStateProperty<Color?>? get color =>
-    WidgetStateProperty.resolveWith((Set<WidgetState> states) {
-      if (states.contains(WidgetState.disabled)) {
-        return _chipVariant == _ChipVariant.flat
-          ? null
-          : _colors.onSurface.withOpacity(0.12);
-      }
-      return _chipVariant == _ChipVariant.flat
-        ? null
-        : _colors.surfaceContainerLow;
-    });
-
-  @override
-  Color? get shadowColor => _chipVariant == _ChipVariant.flat
-    ? Colors.transparent
-    : _colors.shadow;
-
-  @override
-  Color? get surfaceTintColor => Colors.transparent;
-
-  @override
-  Color? get checkmarkColor => null;
-
-  @override
-  Color? get deleteIconColor => null;
-
-  @override
-  BorderSide? get side => _chipVariant == _ChipVariant.flat
-    ? isEnabled
-        ? BorderSide(color: _colors.outlineVariant)
-        : BorderSide(color: _colors.onSurface.withOpacity(0.12))
-    : const BorderSide(color: Colors.transparent);
-
-  @override
-  IconThemeData? get iconTheme => IconThemeData(
-    color: isEnabled
-      ? _colors.primary
-      : _colors.onSurface,
-    size: 18.0,
-  );
-
-  @override
-  EdgeInsetsGeometry? get padding => const EdgeInsets.all(8.0);
-
-  /// The label padding of the chip scales with the font size specified in the
-  /// [labelStyle], and the system font size settings that scale font sizes
-  /// globally.
-  ///
-  /// The chip at effective font size 14.0 starts with 8px on each side and as
-  /// the font size scales up to closer to 28.0, the label padding is linearly
-  /// interpolated from 8px to 4px. Once the label has a font size of 2 or
-  /// higher, label padding remains 4px.
-  @override
-  EdgeInsetsGeometry? get labelPadding {
-    final double fontSize = labelStyle?.fontSize ?? 14.0;
-    final double fontSizeRatio = MediaQuery.textScalerOf(context).scale(fontSize) / 14.0;
-    return EdgeInsets.lerp(
-      const EdgeInsets.symmetric(horizontal: 8.0),
-      const EdgeInsets.symmetric(horizontal: 4.0),
-      clampDouble(fontSizeRatio - 1.0, 0.0, 1.0),
-    )!;
-  }
-}
-// dart format on
-
-// END GENERATED TOKEN PROPERTIES - ActionChip

--- a/packages/material_ui/lib/src/generated/action_chip_defaults_m3.g.dart
+++ b/packages/material_ui/lib/src/generated/action_chip_defaults_m3.g.dart
@@ -2,6 +2,11 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// Do not edit by hand. The code is generated from data in the Material
+// Design token database by the script:
+//   packages/material_ui/tool/gen_defaults/bin/gen_defaults.dart.
+part of '../action_chip.dart';
+
 class _ActionChipDefaultsM3 extends ChipThemeData {
   _ActionChipDefaultsM3(this.context, this.isEnabled, this._chipVariant)
     : super(

--- a/packages/material_ui/tool/gen_defaults/bin/gen_defaults.dart
+++ b/packages/material_ui/tool/gen_defaults/bin/gen_defaults.dart
@@ -12,7 +12,7 @@
 
 import 'package:args/args.dart';
 
-// import '../templates/action_chip_template.dart';
+import '../templates/action_chip_template.dart';
 import '../templates/app_bar_template.dart';
 
 // import '../templates/badge_template.dart';
@@ -64,7 +64,7 @@ Future<void> main(List<String> args) async {
   // TODO(elliette): Add token logger when verbose flag is used.
   final verbose = argResults['verbose'] as bool;
 
-  // const ActionChipTemplateM3().generateFile(verbose: verbose);
+  const ActionChipTemplateM3().generateFile(verbose: verbose);
   const AppBarTemplateM3().generateFile(verbose: verbose);
   // const BadgeTemplateM3().generateFile(verbose: verbose);
   // const BannerTemplateM3().generateFile(verbose: verbose);

--- a/packages/material_ui/tool/gen_defaults/templates/action_chip_template.dart
+++ b/packages/material_ui/tool/gen_defaults/templates/action_chip_template.dart
@@ -12,7 +12,7 @@ class ActionChipTemplateM3 extends TokenTemplateM3 {
 
   @override
   String get parentFilePath => 'action_chip.dart';
-  
+
   String get _colorSchemePrefix => '_colors';
 
   String get _textThemePrefix => '_textTheme';

--- a/packages/material_ui/tool/gen_defaults/templates/action_chip_template.dart
+++ b/packages/material_ui/tool/gen_defaults/templates/action_chip_template.dart
@@ -2,50 +2,50 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import '../data/assist_chip.dart';
 import 'template.dart';
 
-class ActionChipTemplate extends TokenTemplate {
-  const ActionChipTemplate(
-    super.blockName,
-    super.fileName,
-    super.tokens, {
-    super.colorSchemePrefix = '_colors.',
-    super.textThemePrefix = '_textTheme.',
-  });
-
-  static const String tokenGroup = 'md.comp.assist-chip';
-  static const String flatVariant = '.flat';
-  static const String elevatedVariant = '.elevated';
+class ActionChipTemplateM3 extends TokenTemplateM3 {
+  const ActionChipTemplateM3();
+  @override
+  String get name => 'Action Chip';
 
   @override
-  String generate() =>
+  String get parentFilePath => 'action_chip.dart';
+  
+  String get _colorSchemePrefix => '_colors';
+
+  String get _textThemePrefix => '_textTheme';
+
+  @override
+  String generateContents(String className) =>
       '''
-class _${blockName}DefaultsM3 extends ChipThemeData {
-  _${blockName}DefaultsM3(this.context, this.isEnabled, this._chipVariant)
+class $className extends ChipThemeData {
+  $className(this.context, this.isEnabled, this._chipVariant)
     : super(
-        shape: ${shape("$tokenGroup.container")},
+        shape: ${shape(TokenAssistChip.containerShape)},
         showCheckmark: true,
       );
 
   final BuildContext context;
   final bool isEnabled;
   final _ChipVariant _chipVariant;
-  late final ColorScheme _colors = Theme.of(context).colorScheme;
-  late final TextTheme _textTheme = Theme.of(context).textTheme;
+  late final ColorScheme $_colorSchemePrefix = Theme.of(context).colorScheme;
+  late final TextTheme $_textThemePrefix = Theme.of(context).textTheme;
 
   @override
   double? get elevation => _chipVariant == _ChipVariant.flat
-    ? ${elevation("$tokenGroup$flatVariant.container")}
-    : isEnabled ? ${elevation("$tokenGroup$elevatedVariant.container")} : ${elevation("$tokenGroup$elevatedVariant.disabled.container")};
+    ? ${TokenAssistChip.flatContainerElevation}
+    : isEnabled ? ${TokenAssistChip.elevatedContainerElevation} : ${TokenAssistChip.elevatedDisabledContainerElevation};
 
   @override
-  double? get pressElevation => ${elevation("$tokenGroup$elevatedVariant.pressed.container")};
+  double? get pressElevation => ${TokenAssistChip.elevatedPressedContainerElevation};
 
   @override
-  TextStyle? get labelStyle => ${textStyle("$tokenGroup.label-text")}?.copyWith(
+  TextStyle? get labelStyle => ${textStyle(TokenAssistChip.labelTextType, _textThemePrefix)}?.copyWith(
     color: isEnabled
-      ? ${color("$tokenGroup.label-text.color")}
-      : ${color("$tokenGroup.disabled.label-text.color")},
+      ? ${color(TokenAssistChip.labelTextColor, _colorSchemePrefix)}
+      : ${color(TokenAssistChip.disabledLabelTextColor, _colorSchemePrefix)},
   );
 
   @override
@@ -53,21 +53,21 @@ class _${blockName}DefaultsM3 extends ChipThemeData {
     WidgetStateProperty.resolveWith((Set<WidgetState> states) {
       if (states.contains(WidgetState.disabled)) {
         return _chipVariant == _ChipVariant.flat
-          ? ${componentColor("$tokenGroup$flatVariant.disabled.container")}
-          : ${componentColor("$tokenGroup$elevatedVariant.disabled.container")};
+          ? null
+          : ${colorWithOpacity(TokenAssistChip.elevatedDisabledContainerColor, TokenAssistChip.elevatedDisabledContainerOpacity, _colorSchemePrefix)};
       }
       return _chipVariant == _ChipVariant.flat
-        ? ${componentColor("$tokenGroup$flatVariant.container")}
-        : ${componentColor("$tokenGroup$elevatedVariant.container")};
+        ? null
+        : ${color(TokenAssistChip.elevatedContainerColor, _colorSchemePrefix)};
     });
 
   @override
   Color? get shadowColor => _chipVariant == _ChipVariant.flat
-    ? ${colorOrTransparent("$tokenGroup$flatVariant.container.shadow-color")}
-    : ${colorOrTransparent("$tokenGroup$elevatedVariant.container.shadow-color")};
+    ? Colors.transparent
+    : ${color(TokenAssistChip.elevatedContainerShadowColor, _colorSchemePrefix)};
 
   @override
-  Color? get surfaceTintColor => ${colorOrTransparent("$tokenGroup.container.surface-tint-layer.color")};
+  Color? get surfaceTintColor => Colors.transparent;
 
   @override
   Color? get checkmarkColor => null;
@@ -78,16 +78,16 @@ class _${blockName}DefaultsM3 extends ChipThemeData {
   @override
   BorderSide? get side => _chipVariant == _ChipVariant.flat
     ? isEnabled
-        ? ${border('$tokenGroup$flatVariant.outline')}
-        : ${border('$tokenGroup$flatVariant.disabled.outline')}
+        ? ${border(color(TokenAssistChip.flatOutlineColor, _colorSchemePrefix), width: TokenAssistChip.flatOutlineWidth)}
+        : ${border(colorWithOpacity(TokenAssistChip.flatDisabledOutlineColor, TokenAssistChip.flatDisabledOutlineOpacity, _colorSchemePrefix))}
     : const BorderSide(color: Colors.transparent);
 
   @override
   IconThemeData? get iconTheme => IconThemeData(
     color: isEnabled
-      ? ${color("$tokenGroup.with-icon.icon.color")}
-      : ${color("$tokenGroup.with-icon.disabled.icon.color")},
-    size: ${getToken("$tokenGroup.with-icon.icon.size")},
+      ? ${color(TokenAssistChip.withIconIconColor, _colorSchemePrefix)}
+      : ${color(TokenAssistChip.withIconDisabledIconColor, _colorSchemePrefix)},
+    size: ${TokenAssistChip.withIconIconSize},
   );
 
   @override

--- a/packages/material_ui/tool/gen_defaults/templates/template.dart
+++ b/packages/material_ui/tool/gen_defaults/templates/template.dart
@@ -8,6 +8,7 @@ import 'package:meta/meta.dart';
 
 import '../data/color_role.dart';
 import '../data/shape_struct.dart';
+import '../data/typescale_struct.dart';
 
 enum _MaterialVersion { material3, material3Expressive }
 
@@ -75,12 +76,13 @@ abstract class TokenTemplate {
 
   /// The name of the class that will be generated (e.g. `_IconButtonDefaultsM3`
   /// or `_IconButtonDefaultsM3E`).
-  String get _className {
+  @visibleForTesting
+  String get className {
     assert(
       _nameRegExp.hasMatch(name),
       'The template name "$name" must use spaces and capitalized words (e.g., "Typography" or "Icon Button").',
     );
-    final String camelName = name.replaceAll(' ', '');
+    final String camelName = _joinAsCamelCase(name.split(' '), lowerCamelCase: false);
     return switch (_version) {
       _MaterialVersion.material3 => '_${camelName}DefaultsM3',
       _MaterialVersion.material3Expressive => '_${camelName}DefaultsM3E',
@@ -89,7 +91,7 @@ abstract class TokenTemplate {
 
   /// The regular expression used to verify that the generated contents declare
   /// the class.
-  RegExp get _classRegExp => RegExp('class\\s+$_className\\b');
+  RegExp get _classRegExp => RegExp('class\\s+$className\\b');
 
   /// Returns the body of the generated file as a string.
   ///
@@ -108,6 +110,12 @@ abstract class TokenTemplate {
       return color(role, prefix);
     }
     return '${color(role, prefix)}.withOpacity(${number(opacity)})';
+  }
+
+  /// Generate a [BorderSide] for the given component.
+  String border(String color, {double? width}) {
+    final widthString = (width != null && width != 1.0) ? ', width: $width' : '';
+    return 'BorderSide(color: $color$widthString)';
   }
 
   /// Generates an [OutlinedBorder] expression for a shape token.
@@ -150,6 +158,32 @@ abstract class TokenTemplate {
     throw UnsupportedError('Unsupported shape family type: ${shape.family}');
   }
 
+  /// Generate a [TextTheme] text style name for the given component token.
+  String textStyle(TypescaleStruct token, String prefix) {
+    final List<String> nameAttributes = token.name.split('.');
+    final String baseName = _joinAsCamelCase(nameAttributes.last.split('-'));
+    final bool isEmphasized = nameAttributes.contains('emphasized');
+    return '$prefix.$baseName${isEmphasized ? 'Emphasized' : ''}';
+  }
+
+  /// Converts a list of sub-strings into a single camelcased string.
+  String _joinAsCamelCase(List<String> subStrings, {bool lowerCamelCase = true}) {
+    if (subStrings.isEmpty) {
+      return '';
+    }
+    var camelCased = '';
+    for (var i = 0; i < subStrings.length; i++) {
+      final String subString = subStrings[i];
+      if (subString.isEmpty) {
+        continue;
+      }
+      camelCased += (lowerCamelCase && i == 0)
+          ? subString.toLowerCase()
+          : subString[0].toUpperCase() + subString.substring(1).toLowerCase();
+    }
+    return camelCased;
+  }
+
   /// Generates the file under the target path [materialLib] and formats it.
   void generateFile({bool verbose = false}) {
     final String snakeName = name.toLowerCase().replaceAll(' ', '_');
@@ -177,10 +211,10 @@ abstract class TokenTemplate {
     if (verbose) {
       stdout.writeln('Generating contents...');
     }
-    final String contents = generateContents(_className);
+    final String contents = generateContents(className);
     assert(
       contents.contains(_classRegExp),
-      'The generated contents for "$name" must define the class "$_className". '
+      'The generated contents for "$name" must define the class "$className". '
       'Make sure you are utilizing the passed `className` parameter.',
     );
 

--- a/packages/material_ui/tool/gen_defaults/test/gen_defaults_test.dart
+++ b/packages/material_ui/tool/gen_defaults/test/gen_defaults_test.dart
@@ -7,6 +7,9 @@ import 'dart:io';
 import 'package:test/test.dart';
 import '../data/color_role.dart';
 import '../data/shape_struct.dart';
+import '../data/typescale.dart';
+import '../data/typescale_emphasized.dart';
+import '../templates/action_chip_template.dart';
 import '../templates/app_bar_template.dart';
 import '../templates/template.dart';
 import 'test_fixtures/test_templates.dart';
@@ -74,6 +77,18 @@ void main() {
       expect(template.color(TokenColorRole.onSurface, '_colors'), '_colors.onSurface');
     });
 
+    test('textStyle generates text name', () {
+      final template = IconButtonTemplateM3(testPath());
+      expect(
+        template.textStyle(TokenTypescale.titleMedium, '_textTheme'),
+        '_textTheme.titleMedium',
+      );
+      expect(
+        template.textStyle(TokenTypescaleEmphasized.titleMedium, '_textTheme'),
+        '_textTheme.titleMediumEmphasized',
+      );
+    });
+
     test('colorWithOpacity generates color expression with opacity', () {
       final template = IconButtonTemplateM3(testPath());
       expect(
@@ -84,6 +99,16 @@ void main() {
         template.colorWithOpacity(TokenColorRole.onSurface, 1.0, '_colors'),
         '_colors.onSurface',
       );
+    });
+    
+    test('border generates border expression', () {
+      final template = IconButtonTemplateM3(testPath());
+      expect(template.border('_colors.outline'), 'BorderSide(color: _colors.outline)');
+      expect(
+        template.border('_colors.outline', width: 2.0),
+        'BorderSide(color: _colors.outline, width: 2.0)',
+      );
+      expect(template.border('_colors.outline', width: 1.0), 'BorderSide(color: _colors.outline)');
     });
 
     test('shape generates shape expressions', () {
@@ -149,12 +174,25 @@ void main() {
     });
 
     test('ActionChipTemplateM3 emits M3 ActionChip defaults from tokens', () {
-      // Intentionally empty, will be implemented during migration. See:
-      // https://github.com/flutter/flutter/issues/187899
+      final String contents = _generateContents(const ActionChipTemplateM3());
+      expect(contents, contains('class _ActionChipDefaultsM3 extends ChipThemeData'));
+      expect(
+        contents,
+        contains(
+          'shape: const RoundedRectangleBorder(borderRadius: BorderRadius.all(Radius.circular(8.0)))',
+        ),
+      );
+      expect(contents, contains('showCheckmark: true'));
+      expect(contents, contains('double? get elevation => _chipVariant == _ChipVariant.flat'));
+      expect(contents, contains('? 0.0'));
+      expect(contents, contains(': isEnabled ? 1.0 : 0.0;'));
+      expect(contents, contains('double? get pressElevation => 1.0;'));
+      expect(contents, contains('_colors.onSurface.withOpacity(0.12)'));
+      expect(contents, contains('size: 18.0'));
     });
 
     test('AppBarTemplateM3 emits M3 AppBar defaults from tokens', () {
-      final String contents = const AppBarTemplateM3().generateContents('_AppBarDefaultsM3');
+      final String contents = _generateContents(const AppBarTemplateM3());
       expect(contents, contains('class _AppBarDefaultsM3 extends AppBarThemeData'));
       expect(contents, contains('scrolledUnderElevation: 3.0'));
       expect(contents, contains('toolbarHeight: 64.0'));
@@ -402,6 +440,8 @@ void main() {
     });
   });
 }
+
+String _generateContents(TokenTemplate template) => template.generateContents(template.className);
 
 const _fileHeader = '''
 // Copyright 2013 The Flutter Authors

--- a/packages/material_ui/tool/gen_defaults/test/gen_defaults_test.dart
+++ b/packages/material_ui/tool/gen_defaults/test/gen_defaults_test.dart
@@ -100,7 +100,7 @@ void main() {
         '_colors.onSurface',
       );
     });
-    
+
     test('border generates border expression', () {
       final template = IconButtonTemplateM3(testPath());
       expect(template.border('_colors.outline'), 'BorderSide(color: _colors.outline)');


### PR DESCRIPTION
Work towards https://github.com/flutter/flutter/issues/191088

**Ports over https://github.com/flutter/packages/pull/12219 which landed on the `m3e_migration` feature branch.**

### Original PR description

Work towards https://github.com/flutter/flutter/issues/187899
Fixes https://github.com/flutter/flutter/issues/188396

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under[^1].
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[the version and CHANGELOG instructions]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version-and-changelog-updates
[semantic versioning]: https://dart.dev/tools/pub/versioning#semantic-versions
[repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
