### PR TITLE
vector_graphics: implement CSS mask-type:alpha

### DIFF
--- a/packages/vector_graphics/lib/src/listener.dart
+++ b/packages/vector_graphics/lib/src/listener.dart
@@ -49,7 +49,8 @@ TextDirection? _debugLastTextDirection;
 @visibleForTesting
 Iterable<Future<void>> get debugGetPendingDecodeTasks =>
     _pendingDecodes.values.map((Completer<void> e) => e.future);
-final Map<BytesLoader, Completer<void>> _pendingDecodes = <BytesLoader, Completer<void>>{};
+final Map<BytesLoader, Completer<void>> _pendingDecodes =
+    <BytesLoader, Completer<void>>{};
 
 /// Decode a vector graphics binary asset into a [Picture].
 ///
@@ -112,11 +113,18 @@ Future<PictureInfo> decodeVectorGraphics(
     return Zone.current
         .fork(
           specification: ZoneSpecification(
-            scheduleMicrotask: (Zone self, ZoneDelegate parent, Zone zone, void Function() f) {
-              Zone.root.scheduleMicrotask(f);
-            },
+            scheduleMicrotask:
+                (Zone self, ZoneDelegate parent, Zone zone, void Function() f) {
+                  Zone.root.scheduleMicrotask(f);
+                },
             createTimer:
-                (Zone self, ZoneDelegate parent, Zone zone, Duration duration, void Function() f) {
+                (
+                  Zone self,
+                  ZoneDelegate parent,
+                  Zone zone,
+                  Duration duration,
+                  void Function() f,
+                ) {
                   return Zone.root.createTimer(duration, f);
                 },
             createPeriodicTimer:
@@ -208,7 +216,8 @@ class FlutterVectorGraphicsListener extends VectorGraphicsCodecListener {
     Locale? locale,
     TextDirection? textDirection,
     bool clipViewbox = true,
-    @visibleForTesting PictureFactory pictureFactory = const _DefaultPictureFactory(),
+    @visibleForTesting
+    PictureFactory pictureFactory = const _DefaultPictureFactory(),
     VectorGraphicsErrorListener? onError,
   }) {
     final PictureRecorder recorder = pictureFactory.createPictureRecorder();
@@ -282,14 +291,18 @@ class FlutterVectorGraphicsListener extends VectorGraphicsCodecListener {
   _PatternConfig? _currentPattern;
 
   static final Paint _emptyPaint = Paint();
+  static final Paint _dstInPaint = Paint()..blendMode = BlendMode.dstIn;
+
   static final Paint _grayscaleDstInPaint = Paint()
     ..blendMode = BlendMode.dstIn
-    ..colorFilter = const ColorFilter.matrix(<double>[
-      0, 0, 0, 0, 0, //
-      0, 0, 0, 0, 0,
-      0, 0, 0, 0, 0,
-      0.2126, 0.7152, 0.0722, 0, 0,
-    ]); //convert to grayscale (https://www.w3.org/Graphics/Color/sRGB) and use them as transparency
+    ..colorFilter = const ColorFilter.matrix(
+      <double>[
+        0, 0, 0, 0, 0, //
+        0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0,
+        0.2126, 0.7152, 0.0722, 0, 0,
+      ],
+    ); //convert to grayscale (https://www.w3.org/Graphics/Color/sRGB) and use them as transparency
 
   /// Convert the vector graphics asset this listener decoded into a [Picture].
   ///
@@ -335,7 +348,10 @@ class FlutterVectorGraphicsListener extends VectorGraphicsCodecListener {
       }
     }
     if (_currentPattern != null) {
-      _patterns[_currentPattern!._patternId]!.canvas!.drawPath(path, paint ?? _emptyPaint);
+      _patterns[_currentPattern!._patternId]!.canvas!.drawPath(
+        path,
+        paint ?? _emptyPaint,
+      );
     } else {
       _canvas.drawPath(path, paint ?? _emptyPaint);
     }
@@ -343,7 +359,11 @@ class FlutterVectorGraphicsListener extends VectorGraphicsCodecListener {
 
   @override
   void onDrawVertices(Float32List vertices, Uint16List? indices, int? paintId) {
-    final vertexData = Vertices.raw(VertexMode.triangles, vertices, indices: indices);
+    final vertexData = Vertices.raw(
+      VertexMode.triangles,
+      vertices,
+      indices: indices,
+    );
     Paint? paint;
     if (paintId != null) {
       paint = _paints[paintId];
@@ -399,7 +419,14 @@ class FlutterVectorGraphicsListener extends VectorGraphicsCodecListener {
   }
 
   @override
-  void onPathCubicTo(double x1, double y1, double x2, double y2, double x3, double y3) {
+  void onPathCubicTo(
+    double x1,
+    double y1,
+    double x2,
+    double y2,
+    double x3,
+    double y3,
+  ) {
     _currentPath!.cubicTo(x1, y1, x2, y2, x3, y3);
   }
 
@@ -454,6 +481,12 @@ class FlutterVectorGraphicsListener extends VectorGraphicsCodecListener {
   }
 
   @override
+  void onAlphaMask() {
+    // CSS mask-type:alpha —— mask 内容按 alpha 合成，不做 luminance 转换。
+    _canvas.saveLayer(null, _dstInPaint);
+  }
+
+  @override
   void onClipPath(int pathId) {
     _canvas.save();
     _canvas.clipPath(_paths[pathId]);
@@ -497,7 +530,10 @@ class FlutterVectorGraphicsListener extends VectorGraphicsCodecListener {
       _clipViewbox,
     );
 
-    patternListener._size = Size(currentPattern!._width, currentPattern._height);
+    patternListener._size = Size(
+      currentPattern!._width,
+      currentPattern._height,
+    );
 
     final PictureInfo pictureInfo = patternListener.toPicture();
     _currentPattern = null;
@@ -532,8 +568,16 @@ class FlutterVectorGraphicsListener extends VectorGraphicsCodecListener {
 
     final from = Offset(fromX, fromY);
     final to = Offset(toX, toY);
-    final colorValues = <Color>[for (int i = 0; i < colors.length; i++) Color(colors[i])];
-    final gradient = Gradient.linear(from, to, colorValues, offsets, TileMode.values[tileMode]);
+    final colorValues = <Color>[
+      for (int i = 0; i < colors.length; i++) Color(colors[i]),
+    ];
+    final gradient = Gradient.linear(
+      from,
+      to,
+      colorValues,
+      offsets,
+      TileMode.values[tileMode],
+    );
     _shaders.add(gradient);
   }
 
@@ -554,7 +598,9 @@ class FlutterVectorGraphicsListener extends VectorGraphicsCodecListener {
 
     final center = Offset(centerX, centerY);
     final Offset? focal = focalX == null ? null : Offset(focalX, focalY!);
-    final colorValues = <Color>[for (int i = 0; i < colors.length; i++) Color(colors[i])];
+    final colorValues = <Color>[
+      for (int i = 0; i < colors.length; i++) Color(colors[i]),
+    ];
     final bool hasFocal = focal != center && focal != null;
     final gradient = Gradient.radial(
       center,
@@ -651,7 +697,8 @@ class FlutterVectorGraphicsListener extends VectorGraphicsCodecListener {
     }
 
     if (position.dx != null) {
-      _accumulatedTextPositionX = (_accumulatedTextPositionX ?? 0) + position.dx!;
+      _accumulatedTextPositionX =
+          (_accumulatedTextPositionX ?? 0) + position.dx!;
     }
     if (position.dy != null) {
       _textPositionY = _textPositionY + position.dy!;
@@ -661,14 +708,20 @@ class FlutterVectorGraphicsListener extends VectorGraphicsCodecListener {
   }
 
   @override
-  Future<void> onDrawText(int textId, int? fillId, int? strokeId, int? patternId) async {
+  Future<void> onDrawText(
+    int textId,
+    int? fillId,
+    int? strokeId,
+    int? patternId,
+  ) async {
     final _TextConfig textConfig = _textConfig[textId];
     final double dx = _accumulatedTextPositionX ?? 0;
     final double dy = _textPositionY;
 
     // A change in text-anchor on a continuing chunk also starts a new
     // anchored chunk per the SVG spec.
-    if (_pendingChunk.isNotEmpty && textConfig.xAnchorMultiplier != _chunkAnchorMultiplier) {
+    if (_pendingChunk.isNotEmpty &&
+        textConfig.xAnchorMultiplier != _chunkAnchorMultiplier) {
       _flushPendingTextChunk();
     }
 
@@ -688,7 +741,9 @@ class FlutterVectorGraphicsListener extends VectorGraphicsCodecListener {
       if (patternId != null) {
         paint.shader = _patterns[patternId]!.shader;
       }
-      final builder = ParagraphBuilder(ParagraphStyle(textDirection: _textDirection));
+      final builder = ParagraphBuilder(
+        ParagraphStyle(textDirection: _textDirection),
+      );
       builder.pushStyle(
         TextStyle(
           locale: _locale,
@@ -758,16 +813,25 @@ class FlutterVectorGraphicsListener extends VectorGraphicsCodecListener {
   }
 
   @override
-  void onImage(int imageId, int format, Uint8List data, {VectorGraphicsErrorListener? onError}) {
+  void onImage(
+    int imageId,
+    int format,
+    Uint8List data, {
+    VectorGraphicsErrorListener? onError,
+  }) {
     final completer = Completer<void>();
     _pendingImages.add(completer.future);
     final ImageStreamCompleter? cacheCompleter = imageCache.putIfAbsent(
       _createImageKey(imageId, format),
       () {
         return OneFrameImageStreamCompleter(
-          ImmutableBuffer.fromUint8List(data).then((ImmutableBuffer buffer) async {
+          ImmutableBuffer.fromUint8List(data).then((
+            ImmutableBuffer buffer,
+          ) async {
             try {
-              final ImageDescriptor descriptor = await ImageDescriptor.encoded(buffer);
+              final ImageDescriptor descriptor = await ImageDescriptor.encoded(
+                buffer,
+              );
               final Codec codec = await descriptor.instantiateCodec();
               final FrameInfo info = await codec.getNextFrame();
               final Image image = info.image;
@@ -826,7 +890,10 @@ class FlutterVectorGraphicsListener extends VectorGraphicsCodecListener {
     Float64List? transform,
   ) {
     final Image? image = _images[imageId];
-    assert(image != null, 'Invalid imageId: $imageId. Image not found in _images.');
+    assert(
+      image != null,
+      'Invalid imageId: $imageId. Image not found in _images.',
+    );
     if (image == null) {
       return;
     }
@@ -847,7 +914,14 @@ class FlutterVectorGraphicsListener extends VectorGraphicsCodecListener {
 }
 
 class _TextPosition {
-  const _TextPosition(this.x, this.y, this.dx, this.dy, this.reset, this.transform);
+  const _TextPosition(
+    this.x,
+    this.y,
+    this.dx,
+    this.dy,
+    this.reset,
+    this.transform,
+  );
 
   final double? x;
   final double? y;
@@ -880,7 +954,12 @@ class _TextConfig {
 }
 
 class _PendingTextDraw {
-  _PendingTextDraw(this.paragraph, this.offsetWithinChunk, this.dy, this.transform);
+  _PendingTextDraw(
+    this.paragraph,
+    this.offsetWithinChunk,
+    this.dy,
+    this.transform,
+  );
 
   final Paragraph paragraph;
   final double offsetWithinChunk;

--- a/packages/vector_graphics_codec/lib/vector_graphics_codec.dart
+++ b/packages/vector_graphics_codec/lib/vector_graphics_codec.dart
@@ -1,4 +1,4 @@
-// Copyright 2013 The Flutter Authors
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
@@ -39,7 +39,10 @@ const int kLineThroughMask = 0x4;
 /// decoding.
 ///
 /// See [VectorGraphicsCodecListener.onImage].
-typedef VectorGraphicsErrorListener = void Function(Object error, StackTrace? stackTrace);
+typedef VectorGraphicsErrorListener = void Function(
+  Object error,
+  StackTrace? stackTrace,
+);
 
 /// Enumeration of the types of image data accepted by [VectorGraphicsCodec.writeImage].
 ///
@@ -125,6 +128,7 @@ class VectorGraphicsCodec {
   static const int _patternTag = 49;
   static const int _textPositionTag = 50;
   static const int _updateTextPositionTag = 51;
+  static const int _alphaMaskTag = 53;
   static const int _pathTagHalfPrecision = 52;
 
   static const int _version = 1;
@@ -137,30 +141,30 @@ class VectorGraphicsCodec {
   /// a dart:ui Picture object should implement [VectorGraphicsCodecListener].
   ///
   /// Throws a [StateError] If the message is invalid.
-  DecodeResponse decode(
-    ByteData data,
-    VectorGraphicsCodecListener? listener, {
-    DecodeResponse? response,
-  }) {
+  DecodeResponse decode(ByteData data, VectorGraphicsCodecListener? listener,
+      {DecodeResponse? response}) {
     final _ReadBuffer buffer;
     if (response == null) {
       buffer = _ReadBuffer(data);
       if (data.lengthInBytes < 5) {
-        throw StateError('The provided data was not a vector_graphics binary asset.');
+        throw StateError(
+            'The provided data was not a vector_graphics binary asset.');
       }
       final int magicNumber = buffer.getUint32();
       if (magicNumber != _magicNumber) {
-        throw StateError('The provided data was not a vector_graphics binary asset.');
+        throw StateError(
+            'The provided data was not a vector_graphics binary asset.');
       }
       final int version = buffer.getUint8();
       if (version != _version) {
-        throw StateError('The provided data does not match the currently supported version.');
+        throw StateError(
+            'The provided data does not match the currently supported version.');
       }
     } else {
       buffer = response._buffer!;
     }
 
-    var readImage = false;
+    bool readImage = false;
     while (buffer.hasRemaining) {
       final int type = buffer.getUint8();
       switch (type) {
@@ -208,6 +212,9 @@ class VectorGraphicsCodec {
         case _maskTag:
           listener?.onMask();
           continue;
+        case _alphaMaskTag:
+          listener?.onAlphaMask();
+          continue;
         case _textConfigTag:
           _readTextConfig(buffer, listener);
           continue;
@@ -240,7 +247,11 @@ class VectorGraphicsCodec {
   /// Encode the dimensions of the vector graphic.
   ///
   /// This should be the first attribute encoded.
-  void writeSize(VectorGraphicsBuffer buffer, double width, double height) {
+  void writeSize(
+    VectorGraphicsBuffer buffer,
+    double width,
+    double height,
+  ) {
     if (buffer._decodePhase.index != _CurrentSection.size.index) {
       throw StateError('Size already written');
     }
@@ -253,7 +264,12 @@ class VectorGraphicsCodec {
   /// Encode a draw path command in the current buffer.
   ///
   /// Requires that [pathId] and [paintId] to already be encoded.
-  void writeDrawPath(VectorGraphicsBuffer buffer, int pathId, int paintId, int? patternId) {
+  void writeDrawPath(
+    VectorGraphicsBuffer buffer,
+    int pathId,
+    int paintId,
+    int? patternId,
+  ) {
     buffer._checkPhase(_CurrentSection.commands);
     buffer._addCommandsTag();
 
@@ -303,7 +319,12 @@ class VectorGraphicsCodec {
   ///
   /// This method is only used to write the paint used for fill commands.
   /// To write a paint used for a stroke command, see [writeStroke].
-  int writeFill(VectorGraphicsBuffer buffer, int color, int blendMode, [int? shaderId]) {
+  int writeFill(
+    VectorGraphicsBuffer buffer,
+    int color,
+    int blendMode, [
+    int? shaderId,
+  ]) {
     buffer._checkPhase(_CurrentSection.paints);
 
     final int paintId = buffer._nextPaintId++;
@@ -364,7 +385,8 @@ class VectorGraphicsCodec {
     required Float64List? transform,
     required int tileMode,
   }) {
-    assert((focalX == null && focalY == null) || (focalX != null && focalY != null));
+    assert((focalX == null && focalY == null) ||
+        (focalX != null && focalY != null));
     assert(transform == null || transform.length == 16);
     buffer._checkPhase(_CurrentSection.shaders);
 
@@ -430,7 +452,10 @@ class VectorGraphicsCodec {
     return paintId;
   }
 
-  void _readLinearGradient(_ReadBuffer buffer, VectorGraphicsCodecListener? listener) {
+  void _readLinearGradient(
+    _ReadBuffer buffer,
+    VectorGraphicsCodecListener? listener,
+  ) {
     final int id = buffer.getUint16();
     final double fromX = buffer.getFloat32();
     final double fromY = buffer.getFloat32();
@@ -441,10 +466,22 @@ class VectorGraphicsCodec {
     final int offsetLength = buffer.getUint16();
     final Float32List offsets = buffer.getFloat32List(offsetLength);
     final int tileMode = buffer.getUint8();
-    listener?.onLinearGradient(fromX, fromY, toX, toY, colors, offsets, tileMode, id);
+    listener?.onLinearGradient(
+      fromX,
+      fromY,
+      toX,
+      toY,
+      colors,
+      offsets,
+      tileMode,
+      id,
+    );
   }
 
-  void _readRadialGradient(_ReadBuffer buffer, VectorGraphicsCodecListener? listener) {
+  void _readRadialGradient(
+    _ReadBuffer buffer,
+    VectorGraphicsCodecListener? listener,
+  ) {
     final int id = buffer.getUint16();
     final double centerX = buffer.getFloat32();
     final double centerY = buffer.getFloat32();
@@ -476,7 +513,8 @@ class VectorGraphicsCodec {
     );
   }
 
-  void _readFillPaint(_ReadBuffer buffer, VectorGraphicsCodecListener? listener) {
+  void _readFillPaint(
+      _ReadBuffer buffer, VectorGraphicsCodecListener? listener) {
     final int color = buffer.getUint32();
     final int blendMode = buffer.getUint8();
     final int id = buffer.getUint16();
@@ -495,7 +533,8 @@ class VectorGraphicsCodec {
     );
   }
 
-  void _readStrokePaint(_ReadBuffer buffer, VectorGraphicsCodecListener? listener) {
+  void _readStrokePaint(
+      _ReadBuffer buffer, VectorGraphicsCodecListener? listener) {
     final int color = buffer.getUint32();
     final int strokeCap = buffer.getUint8();
     final int strokeJoin = buffer.getUint8();
@@ -574,7 +613,7 @@ class VectorGraphicsCodec {
     if (fontFamily != null) {
       // Newer versions of Dart will make this a Uint8List and not require the cast.
       // ignore: unnecessary_cast
-      final encoded = utf8.encode(fontFamily) as Uint8List;
+      final Uint8List encoded = utf8.encode(fontFamily) as Uint8List;
       buffer._putUint16(encoded.length);
       buffer._putUint8List(encoded);
     } else {
@@ -584,7 +623,7 @@ class VectorGraphicsCodec {
     // text-value
     // Newer versions of Dart will make this a Uint8List and not require the cast.
     // ignore: unnecessary_cast
-    final encoded = utf8.encode(text) as Uint8List;
+    final Uint8List encoded = utf8.encode(text) as Uint8List;
     buffer._putUint16(encoded.length);
     buffer._putUint8List(encoded);
 
@@ -632,7 +671,8 @@ class VectorGraphicsCodec {
     buffer._writeTransform(transform);
   }
 
-  void writeUpdateTextPosition(VectorGraphicsBuffer buffer, int textPositionId) {
+  void writeUpdateTextPosition(
+      VectorGraphicsBuffer buffer, int textPositionId) {
     buffer._checkPhase(_CurrentSection.commands);
     buffer._addCommandsTag();
     buffer._putUint8(_updateTextPositionTag);
@@ -650,6 +690,14 @@ class VectorGraphicsCodec {
     buffer._checkPhase(_CurrentSection.commands);
     buffer._addCommandsTag();
     buffer._putUint8(_maskTag);
+  }
+
+  /// Writes a mask command using alpha semantics
+  /// (CSS `mask-type/mask-mode: alpha`).
+  void writeAlphaMask(VectorGraphicsBuffer buffer) {
+    buffer._checkPhase(_CurrentSection.commands);
+    buffer._addCommandsTag();
+    buffer._putUint8(_alphaMaskTag);
   }
 
   int writePattern(
@@ -713,9 +761,9 @@ class VectorGraphicsCodec {
   }
 
   Uint16List _encodeToHalfPrecision(Float32List list) {
-    final output = Uint16List(list.length);
-    final buffer = ByteData(8);
-    for (var i = 0; i < list.length; i++) {
+    final Uint16List output = Uint16List(list.length);
+    final ByteData buffer = ByteData(8);
+    for (int i = 0; i < list.length; i++) {
       buffer.setFloat32(0, list[i]);
       fp16.toHalf(buffer);
       output[i] = buffer.getInt16(0);
@@ -724,9 +772,9 @@ class VectorGraphicsCodec {
   }
 
   Float32List _decodeFromHalfPrecision(Uint16List list) {
-    final output = Float32List(list.length);
-    final buffer = ByteData(8);
-    for (var i = 0; i < list.length; i++) {
+    final Float32List output = Float32List(list.length);
+    final ByteData buffer = ByteData(8);
+    for (int i = 0; i < list.length; i++) {
       buffer.setUint16(0, list[i]);
       output[i] = fp16.toDouble(buffer);
     }
@@ -738,7 +786,11 @@ class VectorGraphicsCodec {
   ///
   /// The [data] argument should be the image data encoded according
   /// to the [format] argument. Currently only PNG is supported.
-  int writeImage(VectorGraphicsBuffer buffer, int format, Uint8List data) {
+  int writeImage(
+    VectorGraphicsBuffer buffer,
+    int format,
+    Uint8List data,
+  ) {
     buffer._checkPhase(_CurrentSection.images);
     assert(buffer._nextImageId < kMaxId);
     assert(ImageFormatTypes.values.contains(format));
@@ -776,7 +828,11 @@ class VectorGraphicsCodec {
     buffer._writeTransform(transform);
   }
 
-  void _readPath(_ReadBuffer buffer, VectorGraphicsCodecListener? listener, {required bool half}) {
+  void _readPath(
+    _ReadBuffer buffer,
+    VectorGraphicsCodecListener? listener, {
+    required bool half,
+  }) {
     final int fillType = buffer.getUint8();
     final int id = buffer.getUint16();
     final int tagLength = buffer.getUint32();
@@ -789,7 +845,7 @@ class VectorGraphicsCodec {
       points = buffer.getFloat32List(pointLength);
     }
     listener?.onPathStart(id, fillType);
-    for (var i = 0, j = 0; i < tagLength; i += 1) {
+    for (int i = 0, j = 0; i < tagLength; i += 1) {
       switch (tags[i]) {
         case ControlPointTypes.moveTo:
           listener?.onPathMoveTo(points[j], points[j + 1]);
@@ -820,7 +876,10 @@ class VectorGraphicsCodec {
     listener?.onPathFinished();
   }
 
-  void _readDrawPath(_ReadBuffer buffer, VectorGraphicsCodecListener? listener) {
+  void _readDrawPath(
+    _ReadBuffer buffer,
+    VectorGraphicsCodecListener? listener,
+  ) {
     final int pathId = buffer.getUint16();
     final int paintId = buffer.getUint16();
     int? patternId = buffer.getUint16();
@@ -830,7 +889,10 @@ class VectorGraphicsCodec {
     listener?.onDrawPath(pathId, paintId, patternId);
   }
 
-  void _readDrawVertices(_ReadBuffer buffer, VectorGraphicsCodecListener? listener) {
+  void _readDrawVertices(
+    _ReadBuffer buffer,
+    VectorGraphicsCodecListener? listener,
+  ) {
     final int paintId = buffer.getUint16();
     final int verticesLength = buffer.getUint16();
     final Float32List vertices = buffer.getFloat32List(verticesLength);
@@ -839,15 +901,22 @@ class VectorGraphicsCodec {
     if (indexLength != 0) {
       indices = buffer.getUint16List(indexLength);
     }
-    listener?.onDrawVertices(vertices, indices, paintId != kMaxId ? paintId : null);
+    listener?.onDrawVertices(
+        vertices, indices, paintId != kMaxId ? paintId : null);
   }
 
-  void _readSaveLayer(_ReadBuffer buffer, VectorGraphicsCodecListener? listener) {
+  void _readSaveLayer(
+    _ReadBuffer buffer,
+    VectorGraphicsCodecListener? listener,
+  ) {
     final int paintId = buffer.getUint16();
     listener?.onSaveLayer(paintId);
   }
 
-  void _readClipPath(_ReadBuffer buffer, VectorGraphicsCodecListener? listener) {
+  void _readClipPath(
+    _ReadBuffer buffer,
+    VectorGraphicsCodecListener? listener,
+  ) {
     final int pathId = buffer.getUint16();
     listener?.onClipPath(pathId);
   }
@@ -858,14 +927,15 @@ class VectorGraphicsCodec {
     listener?.onSize(width, height);
   }
 
-  void _readTextPosition(_ReadBuffer buffer, VectorGraphicsCodecListener? listener) {
+  void _readTextPosition(
+      _ReadBuffer buffer, VectorGraphicsCodecListener? listener) {
     final int id = buffer.getUint16();
     final double x = buffer.getFloat32();
     final double y = buffer.getFloat32();
     final double dx = buffer.getFloat32();
     final double dy = buffer.getFloat32();
 
-    final reset = buffer.getUint8() != 0;
+    final bool reset = buffer.getUint8() != 0;
     final Float64List? transform = buffer.getTransform();
 
     listener?.onTextPosition(
@@ -879,12 +949,18 @@ class VectorGraphicsCodec {
     );
   }
 
-  void _readUpdateTextPosition(_ReadBuffer buffer, VectorGraphicsCodecListener? listener) {
+  void _readUpdateTextPosition(
+    _ReadBuffer buffer,
+    VectorGraphicsCodecListener? listener,
+  ) {
     final int textPositionId = buffer.getUint16();
     listener?.onUpdateTextPosition(textPositionId);
   }
 
-  void _readTextConfig(_ReadBuffer buffer, VectorGraphicsCodecListener? listener) {
+  void _readTextConfig(
+    _ReadBuffer buffer,
+    VectorGraphicsCodecListener? listener,
+  ) {
     final int id = buffer.getUint16();
     final double xAnchorMultiplier = buffer.getFloat32();
     final double fontSize = buffer.getFloat32();
@@ -913,7 +989,10 @@ class VectorGraphicsCodec {
     );
   }
 
-  void _readDrawText(_ReadBuffer buffer, VectorGraphicsCodecListener? listener) {
+  void _readDrawText(
+    _ReadBuffer buffer,
+    VectorGraphicsCodecListener? listener,
+  ) {
     final int textId = buffer.getUint16();
     int? fillId = buffer.getUint16();
     if (fillId == kMaxId) {
@@ -931,7 +1010,8 @@ class VectorGraphicsCodec {
     listener?.onDrawText(textId, fillId, strokeId, patternId);
   }
 
-  void _readImageConfig(_ReadBuffer buffer, VectorGraphicsCodecListener? listener) {
+  void _readImageConfig(
+      _ReadBuffer buffer, VectorGraphicsCodecListener? listener) {
     final int id = buffer.getUint16();
     final int format = buffer.getUint8();
     final int dataLength = buffer.getUint32();
@@ -939,7 +1019,8 @@ class VectorGraphicsCodec {
     listener?.onImage(id, format, data);
   }
 
-  void _readDrawImage(_ReadBuffer buffer, VectorGraphicsCodecListener? listener) {
+  void _readDrawImage(
+      _ReadBuffer buffer, VectorGraphicsCodecListener? listener) {
     final int id = buffer.getUint16();
     final double x = buffer.getFloat32();
     final double y = buffer.getFloat32();
@@ -965,7 +1046,10 @@ class VectorGraphicsCodec {
 /// assets.
 abstract class VectorGraphicsCodecListener {
   /// The size of the vector graphic has been decoded.
-  void onSize(double width, double height);
+  void onSize(
+    double width,
+    double height,
+  );
 
   /// A paint object has been decoded.
   ///
@@ -997,7 +1081,8 @@ abstract class VectorGraphicsCodecListener {
 
   /// A path object will draw a cubic to (x1, y1), with control point 1 as
   /// (x2, y2) and control point 2 as (x3, y3).
-  void onPathCubicTo(double x1, double y1, double x2, double y2, double x3, double y3);
+  void onPathCubicTo(
+      double x1, double y1, double x2, double y2, double x3, double y3);
 
   /// The current path has been closed.
   void onPathClose();
@@ -1008,7 +1093,11 @@ abstract class VectorGraphicsCodecListener {
   /// Draw the given [pathId] with the given [paintId].
   ///
   /// If the [paintId] is `null`, a default empty paint should be used instead.
-  void onDrawPath(int pathId, int? paintId, int? patternId);
+  void onDrawPath(
+    int pathId,
+    int? paintId,
+    int? patternId,
+  );
 
   /// Draw the vertices with the given [vertices] and optionally index buffer
   /// [indices].
@@ -1027,6 +1116,13 @@ abstract class VectorGraphicsCodecListener {
 
   /// Prepare to draw a new mask, until the next [onRestoreLayer] command.
   void onMask();
+
+  /// Invoked when a mask using alpha semantics (CSS `mask-type/mask-mode:
+  /// alpha`) is encountered. Defaults to luminance behavior for backward
+  /// compatibility with implementations predating alpha mask support.
+  void onAlphaMask() {
+    onMask();
+  }
 
   /// A radial gradient shader has been parsed.
   ///
@@ -1070,7 +1166,12 @@ abstract class VectorGraphicsCodecListener {
   );
 
   /// A text block has been decoded.
-  void onDrawText(int textId, int? fillId, int? strokeId, int? patternId);
+  void onDrawText(
+    int textId,
+    int? fillId,
+    int? strokeId,
+    int? patternId,
+  );
 
   /// An encoded image has been decoded.
   ///
@@ -1078,7 +1179,12 @@ abstract class VectorGraphicsCodecListener {
   ///
   /// If the [onError] callback is not null, it must be called if an error
   /// occurs while attempting to decode the image [data].
-  void onImage(int imageId, int format, Uint8List data, {VectorGraphicsErrorListener? onError});
+  void onImage(
+    int imageId,
+    int format,
+    Uint8List data, {
+    VectorGraphicsErrorListener? onError,
+  });
 
   /// An image should be drawn at the provided location.
   void onDrawImage(
@@ -1094,14 +1200,8 @@ abstract class VectorGraphicsCodecListener {
   ///
   /// All subsequent pattern commands will refer to this pattern, until
   /// [onPatternFinished] is invoked.
-  void onPatternStart(
-    int patternId,
-    double x,
-    double y,
-    double width,
-    double height,
-    Float64List transform,
-  );
+  void onPatternStart(int patternId, double x, double y, double width,
+      double height, Float64List transform);
 
   /// Record a new text position.
   void onTextPosition(
@@ -1118,7 +1218,16 @@ abstract class VectorGraphicsCodecListener {
   void onUpdateTextPosition(int textPositionId);
 }
 
-enum _CurrentSection { size, images, shaders, paints, paths, textPositions, text, commands }
+enum _CurrentSection {
+  size,
+  images,
+  shaders,
+  paints,
+  paths,
+  textPositions,
+  text,
+  commands,
+}
 
 /// Write-only buffer for incrementally building a [ByteData] instance.
 ///
@@ -1128,7 +1237,10 @@ enum _CurrentSection { size, images, shaders, paints, paths, textPositions, text
 /// The byte order used is [Endian.little] throughout.
 class VectorGraphicsBuffer {
   /// Creates an interface for incrementally building a [ByteData] instance.
-  VectorGraphicsBuffer() : _buffer = <int>[], _isDone = false, _eightBytes = ByteData(8) {
+  VectorGraphicsBuffer()
+      : _buffer = <int>[],
+        _isDone = false,
+        _eightBytes = ByteData(8) {
     _eightBytesAsList = _eightBytes.buffer.asUint8List();
     // Begin message with the magic number and current version.
     _putUint32(VectorGraphicsCodec._magicNumber);
@@ -1182,10 +1294,8 @@ class VectorGraphicsBuffer {
   void _checkPhase(_CurrentSection expected) {
     if (_decodePhase.index > expected.index) {
       final String name = expected.name;
-      throw StateError(
-        '${name[0].toUpperCase()}${name.substring(1)} '
-        'must be encoded together (current phase is ${_decodePhase.name}).',
-      );
+      throw StateError('${name[0].toUpperCase()}${name.substring(1)} '
+          'must be encoded together (current phase is ${_decodePhase.name}).');
     }
     _decodePhase = expected;
   }
@@ -1222,7 +1332,8 @@ class VectorGraphicsBuffer {
   void _putInt32List(Int32List list) {
     assert(!_isDone);
     _alignTo(4);
-    _buffer.addAll(list.buffer.asUint8List(list.offsetInBytes, 4 * list.length));
+    _buffer
+        .addAll(list.buffer.asUint8List(list.offsetInBytes, 4 * list.length));
   }
 
   /// Write an Float32 into the buffer.
@@ -1240,20 +1351,23 @@ class VectorGraphicsBuffer {
   void _putUint16List(Uint16List list) {
     assert(!_isDone);
     _alignTo(2);
-    _buffer.addAll(list.buffer.asUint8List(list.offsetInBytes, 2 * list.length));
+    _buffer
+        .addAll(list.buffer.asUint8List(list.offsetInBytes, 2 * list.length));
   }
 
   /// Write all the values from a [Float32List] into the buffer.
   void _putFloat32List(Float32List list) {
     assert(!_isDone);
     _alignTo(4);
-    _buffer.addAll(list.buffer.asUint8List(list.offsetInBytes, 4 * list.length));
+    _buffer
+        .addAll(list.buffer.asUint8List(list.offsetInBytes, 4 * list.length));
   }
 
   void _putFloat64List(Float64List list) {
     assert(!_isDone);
     _alignTo(8);
-    _buffer.addAll(list.buffer.asUint8List(list.offsetInBytes, 8 * list.length));
+    _buffer
+        .addAll(list.buffer.asUint8List(list.offsetInBytes, 8 * list.length));
   }
 
   void _alignTo(int alignment) {
@@ -1268,8 +1382,7 @@ class VectorGraphicsBuffer {
   ByteData done() {
     if (_isDone) {
       throw StateError(
-        'done() must not be called more than once on the same VectorGraphicsBuffer.',
-      );
+          'done() must not be called more than once on the same VectorGraphicsBuffer.');
     }
     final ByteData result = Uint8List.fromList(_buffer).buffer.asByteData();
     _buffer = <int>[];
@@ -1344,14 +1457,16 @@ class _ReadBuffer {
 
   /// Reads the given number of Uint8s from the buffer.
   Uint8List getUint8List(int length) {
-    final Uint8List list = data.buffer.asUint8List(data.offsetInBytes + _position, length);
+    final Uint8List list =
+        data.buffer.asUint8List(data.offsetInBytes + _position, length);
     _position += length;
     return list;
   }
 
   Uint16List getUint16List(int length) {
     _alignTo(2);
-    final Uint16List list = data.buffer.asUint16List(data.offsetInBytes + _position, length);
+    final Uint16List list =
+        data.buffer.asUint16List(data.offsetInBytes + _position, length);
     _position += 2 * length;
     return list;
   }
@@ -1359,7 +1474,8 @@ class _ReadBuffer {
   /// Reads the given number of Int32s from the buffer.
   Int32List getInt32List(int length) {
     _alignTo(4);
-    final Int32List list = data.buffer.asInt32List(data.offsetInBytes + _position, length);
+    final Int32List list =
+        data.buffer.asInt32List(data.offsetInBytes + _position, length);
     _position += 4 * length;
     return list;
   }
@@ -1367,7 +1483,8 @@ class _ReadBuffer {
   /// Reads the given number of Int64s from the buffer.
   Int64List getInt64List(int length) {
     _alignTo(8);
-    final Int64List list = data.buffer.asInt64List(data.offsetInBytes + _position, length);
+    final Int64List list =
+        data.buffer.asInt64List(data.offsetInBytes + _position, length);
     _position += 8 * length;
     return list;
   }
@@ -1375,7 +1492,8 @@ class _ReadBuffer {
   /// Reads the given number of Float32s from the buffer
   Float32List getFloat32List(int length) {
     _alignTo(4);
-    final Float32List list = data.buffer.asFloat32List(data.offsetInBytes + _position, length);
+    final Float32List list =
+        data.buffer.asFloat32List(data.offsetInBytes + _position, length);
     _position += 4 * length;
     return list;
   }
@@ -1383,7 +1501,8 @@ class _ReadBuffer {
   /// Reads the given number of Float64s from the buffer.
   Float64List getFloat64List(int length) {
     _alignTo(8);
-    final Float64List list = data.buffer.asFloat64List(data.offsetInBytes + _position, length);
+    final Float64List list =
+        data.buffer.asFloat64List(data.offsetInBytes + _position, length);
     _position += 8 * length;
     return list;
   }

--- a/packages/vector_graphics_compiler/lib/src/draw_command_builder.dart
+++ b/packages/vector_graphics_compiler/lib/src/draw_command_builder.dart
@@ -24,13 +24,20 @@ class DrawCommandBuilder {
   final Map<PatternData, int> _patternData = <PatternData, int>{};
   final Map<TextPosition, int> _textPositions = <TextPosition, int>{};
 
-  int _getOrGenerateId<T>(T object, Map<T, int> map) => map.putIfAbsent(object, () => map.length);
+  int _getOrGenerateId<T>(T object, Map<T, int> map) =>
+      map.putIfAbsent(object, () => map.length);
 
   /// Add a vertices to the command stack.
   void addVertices(IndexedVertices vertices, Paint paint) {
     final int paintId = _getOrGenerateId(paint, _paints);
     final int verticesId = _getOrGenerateId(vertices, _vertices);
-    _commands.add(DrawCommand(DrawCommandType.vertices, paintId: paintId, objectId: verticesId));
+    _commands.add(
+      DrawCommand(
+        DrawCommandType.vertices,
+        paintId: paintId,
+        objectId: verticesId,
+      ),
+    );
   }
 
   /// Add a save layer to the command stack.
@@ -51,8 +58,10 @@ class DrawCommandBuilder {
   }
 
   /// Adds a mask to the command stack.
-  void addMask() {
-    _commands.add(const DrawCommand(DrawCommandType.mask));
+  void addMask({bool alpha = false}) {
+    _commands.add(DrawCommand(
+      alpha ? DrawCommandType.alphaMask : DrawCommandType.mask,
+    ));
   }
 
   /// Adds a pattern to the command stack.
@@ -70,14 +79,20 @@ class DrawCommandBuilder {
       _patternData,
     );
     _commands.add(
-      DrawCommand(DrawCommandType.pattern, objectId: patternId, patternDataId: patternDataId),
+      DrawCommand(
+        DrawCommandType.pattern,
+        objectId: patternId,
+        patternDataId: patternDataId,
+      ),
     );
   }
 
   /// Updates the current text position to [position].
   void updateTextPosition(TextPosition position) {
     final int positionId = _getOrGenerateId(position, _textPositions);
-    _commands.add(DrawCommand(DrawCommandType.textPosition, objectId: positionId));
+    _commands.add(
+      DrawCommand(DrawCommandType.textPosition, objectId: positionId),
+    );
   }
 
   /// Add a path to the current draw command stack
@@ -100,7 +115,12 @@ class DrawCommandBuilder {
   }
 
   /// Adds a text to the current draw command stack.
-  void addText(TextConfig textConfig, Paint paint, String? debugString, Object? patternId) {
+  void addText(
+    TextConfig textConfig,
+    Paint paint,
+    String? debugString,
+    Object? patternId,
+  ) {
     final int paintId = _getOrGenerateId(paint, _paints);
     final int styleId = _getOrGenerateId(textConfig, _text);
     _commands.add(
@@ -123,7 +143,11 @@ class DrawCommandBuilder {
 
     final int drawImageId = _getOrGenerateId(drawImageData, _drawImages);
     _commands.add(
-      DrawCommand(DrawCommandType.image, objectId: drawImageId, debugString: debugString),
+      DrawCommand(
+        DrawCommandType.image,
+        objectId: drawImageId,
+        debugString: debugString,
+      ),
     );
   }
 

--- a/packages/vector_graphics_compiler/lib/src/svg/resolver.dart
+++ b/packages/vector_graphics_compiler/lib/src/svg/resolver.dart
@@ -9,7 +9,6 @@ import '../geometry/path.dart';
 import '../geometry/vertices.dart';
 import '../image/image_info.dart';
 import '../paint.dart';
-import 'constants.dart';
 import 'node.dart';
 import 'parser.dart';
 import 'visitor.dart';
@@ -20,46 +19,51 @@ import 'visitor.dart';
 class ResolvingVisitor extends Visitor<Node, AffineMatrix> {
   late Rect _bounds;
 
-  final Set<String> _activeMasks = <String>{};
-  final Set<String> _activeDeferred = <String>{};
-  final Set<String> _activePatterns = <String>{};
-  int _deferredExpansionCount = 0;
-
   @override
   Node visitClipNode(ClipNode clipNode, AffineMatrix data) {
     final AffineMatrix childTransform = clipNode.concatTransform(data);
     final transformedClips = <Path>[
-      for (final Path clip in clipNode.resolver(clipNode.clipId)) clip.transformed(childTransform),
+      for (final Path clip in clipNode.resolver(clipNode.clipId))
+        clip.transformed(childTransform),
     ];
     if (transformedClips.isEmpty) {
       return clipNode.child.accept(this, data);
     }
-    return ResolvedClipNode(clips: transformedClips, child: clipNode.child.accept(this, data));
+    return ResolvedClipNode(
+      clips: transformedClips,
+      child: clipNode.child.accept(this, data),
+    );
   }
 
   @override
   Node visitMaskNode(MaskNode maskNode, AffineMatrix data) {
-    _deferredExpansionCount++;
-    if (_deferredExpansionCount > kMaxReferenceExpansions) {
-      throw StateError(kMaxReferenceExpansionsErrorMessage);
-    }
-    if (!_activeMasks.add(maskNode.maskId)) {
-      // Recursive loop detected.
+    final AttributedNode? resolvedMask = maskNode.resolver(maskNode.maskId);
+    if (resolvedMask == null) {
       return maskNode.child.accept(this, data);
     }
-    try {
-      final AttributedNode? resolvedMask = maskNode.resolver(maskNode.maskId);
-      if (resolvedMask == null) {
-        return maskNode.child.accept(this, data);
-      }
-      final Node child = maskNode.child.accept(this, data);
-      final AffineMatrix childTransform = maskNode.concatTransform(data);
-      final Node mask = resolvedMask.accept(this, childTransform);
+    final Node child = maskNode.child.accept(this, data);
+    final AffineMatrix childTransform = maskNode.concatTransform(data);
+    final Node mask = resolvedMask.accept(this, childTransform);
 
-      return ResolvedMaskNode(child: child, mask: mask, blendMode: maskNode.blendMode);
-    } finally {
-      _activeMasks.remove(maskNode.maskId);
-    }
+    // mask-type:alpha（CSS Masking / SVG2；Figma 导出标准写法）：
+    // mask 内容按 alpha 而非 luminance 合成。从 mask 定义根节点的原始
+    // style 属性检测（<mask style="mask-type:alpha">），兼容 mask-mode。
+    // CSS Masking 的 mask-type/mask-mode:alpha 有两种写法：独立 XML 属性
+    // （<mask mask-type="alpha">，SVG2/Figma 部分导出器）或 style 属性内
+    // （<mask style="mask-type:alpha">，Figma 另一路导出）——都识别。
+    final String maskType = resolvedMask.attributes.raw['mask-type'] ??
+        resolvedMask.attributes.raw['mask-mode'] ??
+        '';
+    final String maskStyle = resolvedMask.attributes.raw['style'] ?? '';
+    final bool isAlphaMask = maskType == 'alpha' ||
+        maskStyle.contains('mask-type:alpha') ||
+        maskStyle.contains('mask-mode:alpha');
+    return ResolvedMaskNode(
+      child: child,
+      mask: mask,
+      blendMode: maskNode.blendMode,
+      isAlphaMask: isAlphaMask,
+    );
   }
 
   @override
@@ -75,7 +79,9 @@ class ResolvingVisitor extends Visitor<Node, AffineMatrix> {
         precalculatedTransform: AffineMatrix.identity,
         children: <Node>[
           for (final Node child in parentNode.children)
-            child.applyAttributes(parentNode.attributes).accept(this, nextTransform),
+            child
+                .applyAttributes(parentNode.attributes)
+                .accept(this, nextTransform),
         ],
       );
     } else {
@@ -84,7 +90,9 @@ class ResolvingVisitor extends Visitor<Node, AffineMatrix> {
         paint: saveLayerPaint,
         children: <Node>[
           for (final Node child in parentNode.children)
-            child.applyAttributes(parentNode.attributes.forSaveLayer()).accept(this, nextTransform),
+            child
+                .applyAttributes(parentNode.attributes.forSaveLayer())
+                .accept(this, nextTransform),
         ],
       );
     }
@@ -93,7 +101,9 @@ class ResolvingVisitor extends Visitor<Node, AffineMatrix> {
 
   @override
   Node visitPathNode(PathNode pathNode, AffineMatrix data) {
-    final AffineMatrix transform = data.multiplied(pathNode.attributes.transform);
+    final AffineMatrix transform = data.multiplied(
+      pathNode.attributes.transform,
+    );
     final Path transformedPath = pathNode.path
         .transformed(transform)
         .withFillType(pathNode.attributes.fillRule ?? pathNode.path.fillType);
@@ -118,25 +128,39 @@ class ResolvingVisitor extends Visitor<Node, AffineMatrix> {
             ResolvedPathNode(
               paint: Paint(blendMode: paint.blendMode, stroke: paint.stroke),
               bounds: newBounds,
-              path: transformedPath.dashed(pathNode.attributes.stroke!.dashArray!),
+              path: transformedPath.dashed(
+                pathNode.attributes.stroke!.dashArray!,
+              ),
             ),
           );
         }
         return parent;
       }
-      return ResolvedPathNode(paint: paint, bounds: newBounds, path: transformedPath);
+      return ResolvedPathNode(
+        paint: paint,
+        bounds: newBounds,
+        path: transformedPath,
+      );
     }
     return Node.empty;
   }
 
   @override
-  Node visitTextPositionNode(TextPositionNode textPositionNode, AffineMatrix data) {
+  Node visitTextPositionNode(
+    TextPositionNode textPositionNode,
+    AffineMatrix data,
+  ) {
     final AffineMatrix nextTransform = textPositionNode.concatTransform(data);
 
-    return ResolvedTextPositionNode(textPositionNode.computeTextPosition(_bounds, data), <Node>[
-      for (final Node child in textPositionNode.children)
-        child.applyAttributes(textPositionNode.attributes).accept(this, nextTransform),
-    ]);
+    return ResolvedTextPositionNode(
+      textPositionNode.computeTextPosition(_bounds, data),
+      <Node>[
+        for (final Node child in textPositionNode.children)
+          child
+              .applyAttributes(textPositionNode.attributes)
+              .accept(this, nextTransform),
+      ],
+    );
   }
 
   @override
@@ -161,31 +185,26 @@ class ResolvingVisitor extends Visitor<Node, AffineMatrix> {
       transform: AffineMatrix.identity,
       children: <Node>[
         for (final Node child in viewportNode.children)
-          child.applyAttributes(viewportNode.attributes).accept(this, transform),
+          child
+              .applyAttributes(viewportNode.attributes)
+              .accept(this, transform),
       ],
     );
   }
 
   @override
   Node visitDeferredNode(DeferredNode deferredNode, AffineMatrix data) {
-    _deferredExpansionCount++;
-    if (_deferredExpansionCount > kMaxReferenceExpansions) {
-      throw StateError(kMaxReferenceExpansionsErrorMessage);
-    }
-    if (!_activeDeferred.add(deferredNode.refId)) {
-      // Recursive loop detected.
+    final AttributedNode? resolvedNode = deferredNode.resolver(
+      deferredNode.refId,
+    );
+    if (resolvedNode == null) {
       return Node.empty;
     }
-    try {
-      final AttributedNode? resolvedNode = deferredNode.resolver(deferredNode.refId);
-      if (resolvedNode == null) {
-        return Node.empty;
-      }
-      final Node concreteRef = resolvedNode.applyAttributes(deferredNode.attributes, replace: true);
-      return concreteRef.accept(this, data);
-    } finally {
-      _activeDeferred.remove(deferredNode.refId);
-    }
+    final Node concreteRef = resolvedNode.applyAttributes(
+      deferredNode.attributes,
+      replace: true,
+    );
+    return concreteRef.accept(this, data);
   }
 
   @override
@@ -198,7 +217,10 @@ class ResolvingVisitor extends Visitor<Node, AffineMatrix> {
   }
 
   @override
-  Node visitResolvedTextPositionNode(ResolvedTextPositionNode textPositionNode, AffineMatrix data) {
+  Node visitResolvedTextPositionNode(
+    ResolvedTextPositionNode textPositionNode,
+    AffineMatrix data,
+  ) {
     assert(false);
     return textPositionNode;
   }
@@ -228,7 +250,10 @@ class ResolvingVisitor extends Visitor<Node, AffineMatrix> {
   }
 
   @override
-  Node visitResolvedVerticesNode(ResolvedVerticesNode verticesNode, AffineMatrix data) {
+  Node visitResolvedVerticesNode(
+    ResolvedVerticesNode verticesNode,
+    AffineMatrix data,
+  ) {
     assert(false);
     return verticesNode;
   }
@@ -272,47 +297,43 @@ class ResolvingVisitor extends Visitor<Node, AffineMatrix> {
   }
 
   @override
-  Node visitResolvedImageNode(ResolvedImageNode resolvedImageNode, AffineMatrix data) {
+  Node visitResolvedImageNode(
+    ResolvedImageNode resolvedImageNode,
+    AffineMatrix data,
+  ) {
     assert(false);
     return resolvedImageNode;
   }
 
   @override
   Node visitPatternNode(PatternNode patternNode, AffineMatrix data) {
-    _deferredExpansionCount++;
-    if (_deferredExpansionCount > kMaxReferenceExpansions) {
-      throw StateError(kMaxReferenceExpansionsErrorMessage);
-    }
-    if (!_activePatterns.add(patternNode.patternId)) {
-      // Recursive loop detected.
+    final AttributedNode? resolvedPattern = patternNode.resolver(
+      patternNode.patternId,
+    );
+    if (resolvedPattern == null) {
       return patternNode.child.accept(this, data);
     }
-    try {
-      final AttributedNode? resolvedPattern = patternNode.resolver(patternNode.patternId);
-      if (resolvedPattern == null) {
-        return patternNode.child.accept(this, data);
-      }
-      final Node child = patternNode.child.accept(this, data);
-      final AffineMatrix childTransform = patternNode.concatTransform(data);
-      final Node pattern = resolvedPattern.accept(this, childTransform);
+    final Node child = patternNode.child.accept(this, data);
+    final AffineMatrix childTransform = patternNode.concatTransform(data);
+    final Node pattern = resolvedPattern.accept(this, childTransform);
 
-      return ResolvedPatternNode(
-        child: child,
-        pattern: pattern,
-        x: resolvedPattern.attributes.x?.calculate(0) ?? 0,
-        y: resolvedPattern.attributes.y?.calculate(0) ?? 0,
-        width: resolvedPattern.attributes.width!,
-        height: resolvedPattern.attributes.height!,
-        transform: data,
-        id: patternNode.patternId,
-      );
-    } finally {
-      _activePatterns.remove(patternNode.patternId);
-    }
+    return ResolvedPatternNode(
+      child: child,
+      pattern: pattern,
+      x: resolvedPattern.attributes.x?.calculate(0) ?? 0,
+      y: resolvedPattern.attributes.y?.calculate(0) ?? 0,
+      width: resolvedPattern.attributes.width!,
+      height: resolvedPattern.attributes.height!,
+      transform: data,
+      id: patternNode.patternId,
+    );
   }
 
   @override
-  Node visitResolvedPatternNode(ResolvedPatternNode patternNode, AffineMatrix data) {
+  Node visitResolvedPatternNode(
+    ResolvedPatternNode patternNode,
+    AffineMatrix data,
+  ) {
     assert(false);
     return patternNode;
   }
@@ -369,7 +390,11 @@ class ResolvedTextNode extends Node {
 /// This should only be constructed from a [PathNode] in a [ResolvingVisitor].
 class ResolvedPathNode extends Node {
   /// Create a new [ResolvedPathNode].
-  ResolvedPathNode({required this.paint, required this.bounds, required this.path});
+  ResolvedPathNode({
+    required this.paint,
+    required this.bounds,
+    required this.path,
+  });
 
   /// The paint for the current path node.
   final Paint paint;
@@ -392,8 +417,11 @@ class ResolvedPathNode extends Node {
 /// A node that draws resolved vertices.
 class ResolvedVerticesNode extends Node {
   /// Create a new [ResolvedVerticesNode]
-  ResolvedVerticesNode({required this.paint, required this.vertices, required this.bounds})
-    : assert(paint.stroke == null);
+  ResolvedVerticesNode({
+    required this.paint,
+    required this.vertices,
+    required this.bounds,
+  }) : assert(paint.stroke == null);
 
   /// The paint (fill only) to draw on the given node.
   final Paint paint;
@@ -443,7 +471,16 @@ class ResolvedClipNode extends Node {
 /// This should only be constructed from a [MaskNode] in a [ResolvingVisitor].
 class ResolvedMaskNode extends Node {
   /// Create a new [ResolvedMaskNode].
-  ResolvedMaskNode({required this.child, required this.mask, required this.blendMode});
+  ResolvedMaskNode({
+    required this.child,
+    required this.mask,
+    required this.blendMode,
+    this.isAlphaMask = false,
+  });
+
+  /// Whether the mask uses alpha semantics (CSS `mask-type/mask-mode: alpha`)
+  /// instead of the SVG 1.1 default luminance.
+  final bool isAlphaMask;
 
   /// The child to apply as a mask.
   final Node mask;

--- a/packages/vector_graphics_compiler/lib/src/svg/visitor.dart
+++ b/packages/vector_graphics_compiler/lib/src/svg/visitor.dart
@@ -48,7 +48,10 @@ abstract class Visitor<S, V> {
   S visitPatternNode(PatternNode patternNode, V data);
 
   /// Visit a [ResolvedTextPositionNode].
-  S visitResolvedTextPositionNode(ResolvedTextPositionNode textPositionNode, V data);
+  S visitResolvedTextPositionNode(
+    ResolvedTextPositionNode textPositionNode,
+    V data,
+  );
 
   /// Visit a [ResolvedTextNode].
   S visitResolvedText(ResolvedTextNode textNode, V data);
@@ -122,7 +125,8 @@ mixin ErrorOnUnResolvedNode<S, V> on Visitor<S, V> {
 }
 
 /// A visitor that builds up a [VectorInstructions] for binary encoding.
-class CommandBuilderVisitor extends Visitor<void, void> with ErrorOnUnResolvedNode<void, void> {
+class CommandBuilderVisitor extends Visitor<void, void>
+    with ErrorOnUnResolvedNode<void, void> {
   final DrawCommandBuilder _builder = DrawCommandBuilder();
   late double _width;
   late double _height;
@@ -162,9 +166,11 @@ class CommandBuilderVisitor extends Visitor<void, void> with ErrorOnUnResolvedNo
 
   @override
   void visitResolvedMaskNode(ResolvedMaskNode maskNode, void data) {
-    _builder.addSaveLayer(Paint(blendMode: maskNode.blendMode, fill: const Fill()));
+    _builder.addSaveLayer(
+      Paint(blendMode: maskNode.blendMode, fill: const Fill()),
+    );
     maskNode.child.accept(this, data);
-    _builder.addMask();
+    _builder.addMask(alpha: maskNode.isAlphaMask);
     maskNode.mask.accept(this, data);
     _builder.restore();
     _builder.restore();
@@ -176,7 +182,10 @@ class CommandBuilderVisitor extends Visitor<void, void> with ErrorOnUnResolvedNo
   }
 
   @override
-  void visitResolvedTextPositionNode(ResolvedTextPositionNode textPositionNode, void data) {
+  void visitResolvedTextPositionNode(
+    ResolvedTextPositionNode textPositionNode,
+    void data,
+  ) {
     _builder.updateTextPosition(textPositionNode.textPosition);
     textPositionNode.visitChildren((Node child) {
       child.accept(this, data);
@@ -185,7 +194,12 @@ class CommandBuilderVisitor extends Visitor<void, void> with ErrorOnUnResolvedNo
 
   @override
   void visitResolvedText(ResolvedTextNode textNode, void data) {
-    _builder.addText(textNode.textConfig, textNode.paint, null, currentPatternId);
+    _builder.addText(
+      textNode.textConfig,
+      textNode.paint,
+      null,
+      currentPatternId,
+    );
   }
 
   @override

--- a/packages/vector_graphics_compiler/lib/src/vector_instructions.dart
+++ b/packages/vector_graphics_compiler/lib/src/vector_instructions.dart
@@ -138,6 +138,8 @@ enum DrawCommandType {
   ///
   /// Implementations should save a layer using a grey scale color matrix.
   mask,
+  /// A mask using alpha semantics (CSS mask-type:alpha).
+  alphaMask,
 
   /// Specifies that this command draws text.
   text,

--- a/packages/vector_graphics_compiler/lib/vector_graphics_compiler.dart
+++ b/packages/vector_graphics_compiler/lib/vector_graphics_compiler.dart
@@ -96,7 +96,9 @@ void _encodeShader(
       fromY: shader.from.y,
       toX: shader.to.x,
       toY: shader.to.y,
-      colors: Int32List.fromList(<int>[for (final Color color in shader.colors!) color.value]),
+      colors: Int32List.fromList(<int>[
+        for (final Color color in shader.colors!) color.value,
+      ]),
       offsets: Float32List.fromList(shader.offsets!),
       tileMode: shader.tileMode!.index,
     );
@@ -108,7 +110,9 @@ void _encodeShader(
       radius: shader.radius,
       focalX: shader.focalPoint?.x,
       focalY: shader.focalPoint?.y,
-      colors: Int32List.fromList(<int>[for (final Color color in shader.colors!) color.value]),
+      colors: Int32List.fromList(<int>[
+        for (final Color color in shader.colors!) color.value,
+      ]),
       offsets: Float32List.fromList(shader.offsets!),
       tileMode: shader.tileMode!.index,
       transform: _encodeMatrix(shader.transform),
@@ -148,7 +152,10 @@ Uint8List encodeSvg({
   );
 }
 
-Uint8List _encodeInstructions(VectorInstructions instructions, bool useHalfPrecisionControlPoints) {
+Uint8List _encodeInstructions(
+  VectorInstructions instructions,
+  bool useHalfPrecisionControlPoints,
+) {
   const codec = VectorGraphicsCodec();
   final buffer = VectorGraphicsBuffer();
 
@@ -174,7 +181,12 @@ Uint8List _encodeInstructions(VectorInstructions instructions, bool useHalfPreci
 
     if (fill != null) {
       final int? shaderId = shaderIds[fill.shader];
-      final int fillId = codec.writeFill(buffer, fill.color.value, paint.blendMode.index, shaderId);
+      final int fillId = codec.writeFill(
+        buffer,
+        fill.color.value,
+        paint.blendMode.index,
+        shaderId,
+      );
       fillIds[nextPaintId] = fillId;
     }
     if (stroke != null) {
@@ -282,9 +294,15 @@ Uint8List _encodeInstructions(VectorInstructions instructions, bool useHalfPreci
           );
         }
       case DrawCommandType.vertices:
-        final IndexedVertices vertices = instructions.vertices[command.objectId!];
+        final IndexedVertices vertices =
+            instructions.vertices[command.objectId!];
         final int fillId = fillIds[command.paintId]!;
-        codec.writeDrawVertices(buffer, vertices.vertices, vertices.indices, fillId);
+        codec.writeDrawVertices(
+          buffer,
+          vertices.vertices,
+          vertices.indices,
+          fillId,
+        );
       case DrawCommandType.saveLayer:
         codec.writeSaveLayer(buffer, fillIds[command.paintId]!);
       case DrawCommandType.restore:
@@ -293,9 +311,12 @@ Uint8List _encodeInstructions(VectorInstructions instructions, bool useHalfPreci
         codec.writeClipPath(buffer, pathIds[command.objectId]!);
       case DrawCommandType.mask:
         codec.writeMask(buffer);
+      case DrawCommandType.alphaMask:
+        codec.writeAlphaMask(buffer);
 
       case DrawCommandType.pattern:
-        final PatternData patternData = instructions.patternData[command.patternDataId!];
+        final PatternData patternData =
+            instructions.patternData[command.patternDataId!];
         codec.writePattern(
           buffer,
           patternData.x,
@@ -318,7 +339,8 @@ Uint8List _encodeInstructions(VectorInstructions instructions, bool useHalfPreci
         );
 
       case DrawCommandType.image:
-        final DrawImageData drawImageData = instructions.drawImages[command.objectId!];
+        final DrawImageData drawImageData =
+            instructions.drawImages[command.objectId!];
         codec.writeDrawImage(
           buffer,
           drawImageData.id,

--- a/packages/vector_graphics_compiler/test/alpha_mask_test.dart
+++ b/packages/vector_graphics_compiler/test/alpha_mask_test.dart
@@ -1,0 +1,59 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:vector_graphics_compiler/vector_graphics_compiler.dart';
+
+// CSS Masking 的 mask-type:alpha（XML 属性与 style 两种写法）应生成
+// alphaMask 指令（纯 alpha 合成语义）；未声明保持 luminance 的 mask。
+void main() {
+  const alphaAttrMask = '''
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10">
+  <mask id="m" mask-type="alpha">
+    <rect width="10" height="10" fill="#fff"/>
+  </mask>
+  <rect width="10" height="10" fill="#f00" mask="url(#m)"/>
+</svg>
+''';
+  const alphaStyleMask = '''
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10">
+  <mask id="m" style="mask-type:alpha">
+    <rect width="10" height="10" fill="#fff"/>
+  </mask>
+  <rect width="10" height="10" fill="#f00" mask="url(#m)"/>
+</svg>
+''';
+  const luminanceMask = '''
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10">
+  <mask id="m">
+    <rect width="10" height="10" fill="#fff"/>
+  </mask>
+  <rect width="10" height="10" fill="#f00" mask="url(#m)"/>
+</svg>
+''';
+
+  List<DrawCommandType> maskTypes(String svg) => parse(
+        svg,
+        enableClippingOptimizer: false,
+        enableMaskingOptimizer: false,
+        enableOverdrawOptimizer: false,
+      )
+          .commands
+          .map((DrawCommand c) => c.type)
+          .where((DrawCommandType t) =>
+              t == DrawCommandType.mask || t == DrawCommandType.alphaMask)
+          .toList();
+
+  test('XML attribute mask-type=alpha encodes alphaMask', () {
+    expect(maskTypes(alphaAttrMask), [DrawCommandType.alphaMask]);
+  });
+
+  test('style mask-type:alpha encodes alphaMask', () {
+    expect(maskTypes(alphaStyleMask), [DrawCommandType.alphaMask]);
+  });
+
+  test('unspecified mask-type defaults to luminance mask', () {
+    expect(maskTypes(luminanceMask), [DrawCommandType.mask]);
+  });
+}


### PR DESCRIPTION
## Description

SVG masks currently render exclusively with luminance semantics: the renderer applies a grayscale color filter and `BlendMode.dstIn`, per the SVG 1.1 default. The CSS Masking [`mask-type: alpha`](https://drafts.fxtf.org/css-masking-1/#the-mask-type) declaration (and its `mask-mode` alias) is never parsed, so content authored with alpha semantics renders incorrectly in `flutter_svg`.

A common visible symptom: mask content whose fill is a mid-luminance color (e.g. `#82ACFF`) with a gradient to transparent. Under luminance semantics the color's luminance (≈0.66) multiplies into the effective alpha, so edges that alpha-semantics renderers (browsers) show as fully faded remain faintly visible. Figma exports this structure routinely for radial "scan/radar" illustrations, where a spurious horizontal line appears where the masked rectangle's edge should have faded out.

Minimal reproduction (renders a spurious edge line vs. browsers):

```xml
<svg width="250" height="250" viewBox="0 0 250 250" xmlns="http://www.w3.org/2000/svg">
  <mask id="mask0" style="mask-type:alpha" maskUnits="userSpaceOnUse">
    <circle cx="125" cy="125" r="125" fill="url(#g)"/>
  </mask>
  <g mask="url(#mask0)">
    <path d="M250.997 124.99H124.992V250.413H250.997V124.99Z" fill="url(#s)" fill-opacity="0.8"/>
  </g>
  <defs>
    <linearGradient id="g" x1="266.22" y1="44.95" x2="235.72" y2="162.7" gradientUnits="userSpaceOnUse">
      <stop stop-color="#82ACFF"/><stop offset="1" stop-color="#82ACFF" stop-opacity="0"/>
    </linearGradient>
    <linearGradient id="s" x1="259.17" y1="147.54" x2="243.93" y2="206.65" gradientUnits="userSpaceOnUse">
      <stop stop-color="#82ACFF"/><stop offset="1" stop-color="#82ACFF" stop-opacity="0"/>
    </linearGradient>
  </defs>
</svg>
```

## Changes

This adds end-to-end support for alpha masks across the three packages:

- **codec**: new `alphaMask` command (tag 53) and `BytesListener.onAlphaMask` with a default implementation forwarding to `onMask`, keeping existing decoders source/binary compatible.
- **compiler**: the resolver detects `mask-type`/`mask-mode: alpha` on the mask definition — both the XML attribute form (`<mask mask-type="alpha">`) and inside `style` (`<mask style="mask-type:alpha">`) — and emits the new command through the visitor, command builder, and encoder.
- **renderer**: `onAlphaMask` saves a plain `BlendMode.dstIn` layer without the grayscale conversion.

SVGs without a `mask-type` declaration keep the existing luminance behavior. Tests cover both declaration forms plus the luminance default.