### PR TITLE
[material_ui] Ensure textScaler is taken into account for SnackBar action overflow

### DIFF
--- a/packages/material_ui/lib/src/snack_bar.dart
+++ b/packages/material_ui/lib/src/snack_bar.dart
@@ -721,9 +721,9 @@ class _SnackBarState extends State<SnackBar> {
             icon: const Icon(Icons.close),
             iconSize: 24.0,
             color: widget.closeIconColor ?? snackBarTheme.closeIconColor ?? defaults.closeIconColor,
-            onPressed: () => ScaffoldMessenger.of(
-              context,
-            ).hideCurrentSnackBar(reason: SnackBarClosedReason.dismiss),
+            onPressed: () =>
+                ScaffoldMessenger.of(context)
+                    .hideCurrentSnackBar(reason: SnackBarClosedReason.dismiss),
             tooltip: MaterialLocalizations.of(context).closeButtonTooltip,
           )
         : null;
@@ -736,6 +736,7 @@ class _SnackBarState extends State<SnackBar> {
       ),
       maxLines: 1,
       textDirection: TextDirection.ltr,
+      textScaler: MediaQuery.textScalerOf(context),
     )..layout();
     final double actionAndIconWidth =
         actionTextPainter.size.width +
@@ -793,7 +794,6 @@ class _SnackBarState extends State<SnackBar> {
                 ),
               ),
               if (!willOverflowAction) ...maybeActionAndIcon,
-              if (willOverflowAction) SizedBox(width: snackBarWidth * 0.4),
             ],
           ),
           if (willOverflowAction)

--- a/packages/material_ui/lib/src/snack_bar.dart
+++ b/packages/material_ui/lib/src/snack_bar.dart
@@ -721,9 +721,9 @@ class _SnackBarState extends State<SnackBar> {
             icon: const Icon(Icons.close),
             iconSize: 24.0,
             color: widget.closeIconColor ?? snackBarTheme.closeIconColor ?? defaults.closeIconColor,
-            onPressed: () =>
-                ScaffoldMessenger.of(context)
-                    .hideCurrentSnackBar(reason: SnackBarClosedReason.dismiss),
+            onPressed: () => ScaffoldMessenger.of(
+              context,
+            ).hideCurrentSnackBar(reason: SnackBarClosedReason.dismiss),
             tooltip: MaterialLocalizations.of(context).closeButtonTooltip,
           )
         : null;
@@ -794,6 +794,7 @@ class _SnackBarState extends State<SnackBar> {
                 ),
               ),
               if (!willOverflowAction) ...maybeActionAndIcon,
+              if (willOverflowAction) SizedBox(width: horizontalPadding),
             ],
           ),
           if (willOverflowAction)

--- a/packages/material_ui/pending_changelogs/change_snack_bar_text_scaler.yaml
+++ b/packages/material_ui/pending_changelogs/change_snack_bar_text_scaler.yaml
@@ -1,0 +1,3 @@
+changelog: |
+  - Accounts for `MediaQuery`'s `TextScaler` when calculating `SnackBar` action overflow and removes unnecessary blank right spacing in multi-line layout.
+version: patch

--- a/packages/material_ui/test/snack_bar_test.dart
+++ b/packages/material_ui/test/snack_bar_test.dart
@@ -4445,6 +4445,103 @@ Future<void> _testSnackBarDismiss({
       expect(find.text('bar2'), findsNothing);
     }
   }
+
+  testWidgets('SnackBar action overflow calculation respects MediaQuery textScaler', (
+    WidgetTester tester,
+  ) async {
+    Widget buildSnackBar({required TextScaler textScaler}) {
+      return MaterialApp(
+        home: MediaQuery(
+          data: MediaQueryData(size: const Size(400, 800), textScaler: textScaler),
+          child: Scaffold(
+            body: Builder(
+              builder: (BuildContext context) {
+                return GestureDetector(
+                  onTap: () {
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      SnackBar(
+                        content: const Text('Message'),
+                        action: SnackBarAction(label: 'Action Label', onPressed: () {}),
+                      ),
+                    );
+                  },
+                  child: const Text('Show'),
+                );
+              },
+            ),
+          ),
+        ),
+      );
+    }
+
+    // With no scaling, the action label fits on the same row as content.
+    await tester.pumpWidget(buildSnackBar(textScaler: TextScaler.noScaling));
+    await tester.tap(find.text('Show'));
+    await tester.pumpAndSettle();
+
+    final Offset actionTopLeft1 = tester.getTopLeft(find.text('Action Label'));
+    // Action and content are on the same line (action is not below content).
+    expect(actionTopLeft1.dy, lessThanOrEqualTo(tester.getBottomLeft(find.text('Message')).dy));
+
+    ScaffoldMessenger.of(tester.element(find.text('Show'))).clearSnackBars();
+    await tester.pumpAndSettle();
+
+    // With a large text scaler, the action button width is scaled up and overflows
+    // to a separate row below the content.
+    await tester.pumpWidget(buildSnackBar(textScaler: const TextScaler.linear(3.0)));
+    await tester.tap(find.text('Show'));
+    await tester.pumpAndSettle();
+
+    final Offset contentBottomLeft2 = tester.getBottomLeft(find.text('Message'));
+    final Offset actionTopLeft2 = tester.getTopLeft(find.text('Action Label'));
+    // Action overflows and is positioned below the content text.
+    expect(actionTopLeft2.dy, greaterThanOrEqualTo(contentBottomLeft2.dy));
+  });
+
+  testWidgets('SnackBar does not allocate 40% empty space on right when action overflows', (
+    WidgetTester tester,
+  ) async {
+    const double screenWidth = 500.0;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: MediaQuery(
+          data: const MediaQueryData(size: Size(screenWidth, 800)),
+          child: Scaffold(
+            body: Builder(
+              builder: (BuildContext context) {
+                return GestureDetector(
+                  onTap: () {
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      SnackBar(
+                        content: const Text('Multi-line content that wraps'),
+                        action: SnackBarAction(label: 'Overflow Action', onPressed: () {}),
+                        actionOverflowThreshold: 0.1,
+                      ),
+                    );
+                  },
+                  child: const Text('Show'),
+                );
+              },
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('Show'));
+    await tester.pumpAndSettle();
+
+    // Verify there is no SizedBox with width equal to 40% of snackBarWidth.
+    expect(
+      find.byWidgetPredicate(
+        (Widget widget) =>
+            widget is SizedBox &&
+            widget.width != null &&
+            (widget.width! - screenWidth * 0.4).abs() < 1.0,
+      ),
+      findsNothing,
+    );
+  });
 }
 
 /// Create drag gestures for DismissDirections.

--- a/packages/material_ui/test/snack_bar_test.dart
+++ b/packages/material_ui/test/snack_bar_test.dart
@@ -4397,54 +4397,6 @@ void main() {
     );
     expect(tester.getSize(find.byType(SnackBarAction)), Size.zero);
   });
-}
-
-/// Start test for "SnackBar dismiss test".
-Future<void> _testSnackBarDismiss({
-  required WidgetTester tester,
-  required Key tapTarget,
-  required double scaffoldWidth,
-  required ValueChanged<DismissDirection> onDismissDirectionChange,
-  required VoidCallback onDragGestureChange,
-}) async {
-  final Map<DismissDirection, List<Offset>> dragGestures = _getDragGesturesOfDismissDirections(
-    scaffoldWidth,
-  );
-
-  for (final DismissDirection key in dragGestures.keys) {
-    onDismissDirectionChange(key);
-
-    for (final Offset dragGesture in dragGestures[key]!) {
-      onDragGestureChange();
-
-      expect(find.text('bar1'), findsNothing);
-      expect(find.text('bar2'), findsNothing);
-      await tester.tap(find.byKey(tapTarget)); // queue bar1
-      await tester.tap(find.byKey(tapTarget)); // queue bar2
-      expect(find.text('bar1'), findsNothing);
-      expect(find.text('bar2'), findsNothing);
-      await tester.pump(); // schedule animation for bar1
-      expect(find.text('bar1'), findsOneWidget);
-      expect(find.text('bar2'), findsNothing);
-      await tester.pump(); // begin animation
-      expect(find.text('bar1'), findsOneWidget);
-      expect(find.text('bar2'), findsNothing);
-      await tester.pump(
-        const Duration(milliseconds: 750),
-      ); // 0.75s // animation last frame; two second timer starts here
-      await tester.drag(find.text('bar1'), dragGesture);
-      await tester.pump(); // bar1 dismissed, bar2 begins animating
-      expect(find.text('bar1'), findsNothing);
-      expect(find.text('bar2'), findsOneWidget);
-      await tester.pump(
-        const Duration(milliseconds: 750),
-      ); // 0.75s // animation last frame; two second timer starts here
-      await tester.drag(find.text('bar2'), dragGesture);
-      await tester.pump(); // bar2 dismissed
-      expect(find.text('bar1'), findsNothing);
-      expect(find.text('bar2'), findsNothing);
-    }
-  }
 
   testWidgets('SnackBar action overflow calculation respects MediaQuery textScaler', (
     WidgetTester tester,
@@ -4452,7 +4404,7 @@ Future<void> _testSnackBarDismiss({
     Widget buildSnackBar({required TextScaler textScaler}) {
       return MaterialApp(
         home: MediaQuery(
-          data: MediaQueryData(size: const Size(400, 800), textScaler: textScaler),
+          data: MediaQueryData(size: const Size(800, 600), textScaler: textScaler),
           child: Scaffold(
             body: Builder(
               builder: (BuildContext context) {
@@ -4502,27 +4454,28 @@ Future<void> _testSnackBarDismiss({
     WidgetTester tester,
   ) async {
     const double screenWidth = 500.0;
+    tester.view.physicalSize = const Size(screenWidth, 800.0);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.reset);
+
     await tester.pumpWidget(
       MaterialApp(
-        home: MediaQuery(
-          data: const MediaQueryData(size: Size(screenWidth, 800)),
-          child: Scaffold(
-            body: Builder(
-              builder: (BuildContext context) {
-                return GestureDetector(
-                  onTap: () {
-                    ScaffoldMessenger.of(context).showSnackBar(
-                      SnackBar(
-                        content: const Text('Multi-line content that wraps'),
-                        action: SnackBarAction(label: 'Overflow Action', onPressed: () {}),
-                        actionOverflowThreshold: 0.1,
-                      ),
-                    );
-                  },
-                  child: const Text('Show'),
-                );
-              },
-            ),
+        home: Scaffold(
+          body: Builder(
+            builder: (BuildContext context) {
+              return GestureDetector(
+                onTap: () {
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    SnackBar(
+                      content: const SizedBox(key: Key('content'), height: 20),
+                      action: SnackBarAction(label: 'Overflow Action', onPressed: () {}),
+                      actionOverflowThreshold: 0.1,
+                    ),
+                  );
+                },
+                child: const Text('Show'),
+              );
+            },
           ),
         ),
       ),
@@ -4531,17 +4484,70 @@ Future<void> _testSnackBarDismiss({
     await tester.tap(find.text('Show'));
     await tester.pumpAndSettle();
 
-    // Verify there is no SizedBox with width equal to 40% of snackBarWidth.
-    expect(
-      find.byWidgetPredicate(
-        (Widget widget) =>
-            widget is SizedBox &&
-            widget.width != null &&
-            (widget.width! - screenWidth * 0.4).abs() < 1.0,
-      ),
-      findsNothing,
+    // In unfixed code, when the action overflowed to a second row, a SizedBox(width: snackBarWidth * 0.4)
+    // was placed next to the content Expanded widget in the first row, reserving 40% empty space on the right (188px).
+    // The content is now given standard horizontalPadding on the right (24px) instead of 40% empty space.
+    // For screenWidth = 500, horizontalPadding = 24 on start and end, the content width is 452px (500 - 24 - 24).
+    expect(tester.getSize(find.byKey(const Key('content'))).width, 452.0);
+    expect(tester.getTopRight(find.byKey(const Key('content'))).dx, screenWidth - 24.0);
+
+    // Verify the spacer SizedBox has width equal to horizontalPadding (24.0), not 40% of snackBarWidth (188.0).
+    final Row contentRow = tester.widget<Row>(
+      find.descendant(of: find.byType(SnackBar), matching: find.byType(Row)).first,
     );
+    expect(contentRow.children.length, 2);
+    expect(contentRow.children.first, isA<Expanded>());
+    expect(contentRow.children.last, isA<SizedBox>());
+    expect((contentRow.children.last as SizedBox).width, 24.0);
   });
+}
+
+/// Start test for "SnackBar dismiss test".
+Future<void> _testSnackBarDismiss({
+  required WidgetTester tester,
+  required Key tapTarget,
+  required double scaffoldWidth,
+  required ValueChanged<DismissDirection> onDismissDirectionChange,
+  required VoidCallback onDragGestureChange,
+}) async {
+  final Map<DismissDirection, List<Offset>> dragGestures = _getDragGesturesOfDismissDirections(
+    scaffoldWidth,
+  );
+
+  for (final DismissDirection key in dragGestures.keys) {
+    onDismissDirectionChange(key);
+
+    for (final Offset dragGesture in dragGestures[key]!) {
+      onDragGestureChange();
+
+      expect(find.text('bar1'), findsNothing);
+      expect(find.text('bar2'), findsNothing);
+      await tester.tap(find.byKey(tapTarget)); // queue bar1
+      await tester.tap(find.byKey(tapTarget)); // queue bar2
+      expect(find.text('bar1'), findsNothing);
+      expect(find.text('bar2'), findsNothing);
+      await tester.pump(); // schedule animation for bar1
+      expect(find.text('bar1'), findsOneWidget);
+      expect(find.text('bar2'), findsNothing);
+      await tester.pump(); // begin animation
+      expect(find.text('bar1'), findsOneWidget);
+      expect(find.text('bar2'), findsNothing);
+      await tester.pump(
+        const Duration(milliseconds: 750),
+      ); // 0.75s // animation last frame; two second timer starts here
+      await tester.drag(find.text('bar1'), dragGesture);
+      await tester.pump(); // bar1 dismissed, bar2 begins animating
+      expect(find.text('bar1'), findsNothing);
+      expect(find.text('bar2'), findsOneWidget);
+      await tester.pump(
+        const Duration(milliseconds: 750),
+      ); // 0.75s // animation last frame; two second timer starts here
+      await tester.drag(find.text('bar2'), dragGesture);
+      await tester.pump(); // bar2 dismissed
+      expect(find.text('bar1'), findsNothing);
+      expect(find.text('bar2'), findsNothing);
+    }
+  }
 }
 
 /// Create drag gestures for DismissDirections.


### PR DESCRIPTION
Port of https://github.com/flutter/flutter/pull/181959 to `flutter/packages` as part of the Material decoupling effort (flutter/flutter#188444).

Ensure textScalling is taken into account for Sizing overflow.

Fixes https://github.com/flutter/flutter/issues/192232
Fixes https://github.com/flutter/flutter/pull/181959
Part of https://github.com/flutter/flutter/issues/188444

### Description
- Ensure textScalling is taken into account for Sizing overflow: passes `MediaQuery.textScalerOf(context)` to `actionTextPainter` so that `actionAndIconWidth` properly scales with accessibility text scaling.
- Removes `SizedBox(width: snackBarWidth * 0.4)` when the action overflows, eliminating unintended blank space on the right of multi-line content.
- Adds unit tests in `snack_bar_test.dart` verifying `textScaler` overflow calculation and layout.
- Adds pending changelog entry.

## Pre-Review Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [X] I read the [Tree Hygiene] page, which explains my responsibilities.
- [X] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [X] I signed the [CLA].
- [X] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [X] I [linked to at least one issue that this PR fixes] in the description above.
- [X] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under[^1].
- [X] I updated/added any relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[the version and CHANGELOG instructions]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version-and-changelog-updates
[semantic versioning]: https://dart.dev/tools/pub/versioning#semantic-versions
[repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
