### PR TITLE
Update Chrome for stable tests

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -183,7 +183,7 @@ targets:
 
   - name: Linux_web web_dart_unit_test_shard_1 master
     recipe: packages/packages
-    timeout: 60
+    timeout: 90
     properties:
       add_recipes_cq: "true"
       target_file: web_dart_unit_tests.yaml
@@ -193,7 +193,7 @@ targets:
 
   - name: Linux_web web_dart_unit_test_shard_2 master
     recipe: packages/packages
-    timeout: 60
+    timeout: 90
     properties:
       target_file: web_dart_unit_tests.yaml
       channel: master
@@ -202,7 +202,7 @@ targets:
 
   - name: Linux_web web_dart_unit_test_shard_3 master
     recipe: packages/packages
-    timeout: 60
+    timeout: 90
     properties:
       target_file: web_dart_unit_tests.yaml
       channel: master
@@ -211,7 +211,7 @@ targets:
 
   - name: Linux_web web_dart_unit_test_shard_1 stable
     recipe: packages/packages
-    timeout: 60
+    timeout: 90
     properties:
       target_file: web_dart_unit_tests.yaml
       channel: stable
@@ -228,7 +228,7 @@ targets:
 
   - name: Linux_web web_dart_unit_test_shard_2 stable
     recipe: packages/packages
-    timeout: 60
+    timeout: 90
     properties:
       target_file: web_dart_unit_tests.yaml
       channel: stable
@@ -245,7 +245,7 @@ targets:
 
   - name: Linux_web web_dart_unit_test_shard_3 stable
     recipe: packages/packages
-    timeout: 60
+    timeout: 90
     properties:
       target_file: web_dart_unit_tests.yaml
       channel: stable

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -223,7 +223,7 @@ targets:
       # and --disable-background-timer-throttling; see https://github.com/flutter/flutter/issues/191299
       dependencies: >-
         [
-          {"dependency": "chrome_and_driver", "version": "version:125.0.6422.141"}
+          {"dependency": "chrome_and_driver", "version": "version:128.0.6613.137"}
         ]
 
   - name: Linux_web web_dart_unit_test_shard_2 stable
@@ -240,7 +240,7 @@ targets:
       # and --disable-background-timer-throttling; see https://github.com/flutter/flutter/issues/191299
       dependencies: >-
         [
-          {"dependency": "chrome_and_driver", "version": "version:125.0.6422.141"}
+          {"dependency": "chrome_and_driver", "version": "version:128.0.6613.137"}
         ]
 
   - name: Linux_web web_dart_unit_test_shard_3 stable
@@ -257,7 +257,7 @@ targets:
       # and --disable-background-timer-throttling; see https://github.com/flutter/flutter/issues/191299
       dependencies: >-
         [
-          {"dependency": "chrome_and_driver", "version": "version:125.0.6422.141"}
+          {"dependency": "chrome_and_driver", "version": "version:128.0.6613.137"}
         ]
 
   # Wasm unit tests in master
@@ -368,7 +368,7 @@ targets:
           {"dependency": "clang", "version": "git_revision:5d5aba78dbbee75508f01bcaa69aedb2ab79065a"},
           {"dependency": "cmake", "version": "build_id:8787856497187628321"},
           {"dependency": "ninja", "version": "version:1.9.0"},
-          {"dependency": "chrome_and_driver", "version": "version:125.0.6422.141"}
+          {"dependency": "chrome_and_driver", "version": "version:128.0.6613.137"}
         ]
       channel: stable
 
@@ -756,7 +756,7 @@ targets:
       # and --disable-background-timer-throttling; see https://github.com/flutter/flutter/issues/191299
       dependencies: >-
         [
-          {"dependency": "chrome_and_driver", "version": "version:125.0.6422.141"}
+          {"dependency": "chrome_and_driver", "version": "version:128.0.6613.137"}
         ]
 
   - name: Linux_web web_platform_tests_shard_2 stable
@@ -773,7 +773,7 @@ targets:
       # and --disable-background-timer-throttling; see https://github.com/flutter/flutter/issues/191299
       dependencies: >-
         [
-          {"dependency": "chrome_and_driver", "version": "version:125.0.6422.141"}
+          {"dependency": "chrome_and_driver", "version": "version:128.0.6613.137"}
         ]
 
   - name: Linux_web web_platform_tests_shard_3 stable
@@ -790,7 +790,7 @@ targets:
       # and --disable-background-timer-throttling; see https://github.com/flutter/flutter/issues/191299
       dependencies: >-
         [
-          {"dependency": "chrome_and_driver", "version": "version:125.0.6422.141"}
+          {"dependency": "chrome_and_driver", "version": "version:128.0.6613.137"}
         ]
 
   ### Linux desktop tasks
@@ -839,7 +839,7 @@ targets:
       # and --disable-background-timer-throttling; see https://github.com/flutter/flutter/issues/191299
       dependencies: >-
         [
-          {"dependency": "chrome_and_driver", "version": "version:125.0.6422.141"}
+          {"dependency": "chrome_and_driver", "version": "version:128.0.6613.137"}
         ]
 
   ### iOS+macOS tasks ###

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -223,7 +223,7 @@ targets:
       # and --disable-background-timer-throttling; see https://github.com/flutter/flutter/issues/191299
       dependencies: >-
         [
-          {"dependency": "chrome_and_driver", "version": "version:134.0.6998.165"}
+          {"dependency": "chrome_and_driver", "version": "version:137.0.7151.119"}
         ]
 
   - name: Linux_web web_dart_unit_test_shard_2 stable
@@ -240,7 +240,7 @@ targets:
       # and --disable-background-timer-throttling; see https://github.com/flutter/flutter/issues/191299
       dependencies: >-
         [
-          {"dependency": "chrome_and_driver", "version": "version:134.0.6998.165"}
+          {"dependency": "chrome_and_driver", "version": "version:137.0.7151.119"}
         ]
 
   - name: Linux_web web_dart_unit_test_shard_3 stable
@@ -257,7 +257,7 @@ targets:
       # and --disable-background-timer-throttling; see https://github.com/flutter/flutter/issues/191299
       dependencies: >-
         [
-          {"dependency": "chrome_and_driver", "version": "version:134.0.6998.165"}
+          {"dependency": "chrome_and_driver", "version": "version:137.0.7151.119"}
         ]
 
   # Wasm unit tests in master
@@ -368,7 +368,7 @@ targets:
           {"dependency": "clang", "version": "git_revision:5d5aba78dbbee75508f01bcaa69aedb2ab79065a"},
           {"dependency": "cmake", "version": "build_id:8787856497187628321"},
           {"dependency": "ninja", "version": "version:1.9.0"},
-          {"dependency": "chrome_and_driver", "version": "version:134.0.6998.165"}
+          {"dependency": "chrome_and_driver", "version": "version:137.0.7151.119"}
         ]
       channel: stable
 
@@ -756,7 +756,7 @@ targets:
       # and --disable-background-timer-throttling; see https://github.com/flutter/flutter/issues/191299
       dependencies: >-
         [
-          {"dependency": "chrome_and_driver", "version": "version:134.0.6998.165"}
+          {"dependency": "chrome_and_driver", "version": "version:137.0.7151.119"}
         ]
 
   - name: Linux_web web_platform_tests_shard_2 stable
@@ -773,7 +773,7 @@ targets:
       # and --disable-background-timer-throttling; see https://github.com/flutter/flutter/issues/191299
       dependencies: >-
         [
-          {"dependency": "chrome_and_driver", "version": "version:134.0.6998.165"}
+          {"dependency": "chrome_and_driver", "version": "version:137.0.7151.119"}
         ]
 
   - name: Linux_web web_platform_tests_shard_3 stable
@@ -790,7 +790,7 @@ targets:
       # and --disable-background-timer-throttling; see https://github.com/flutter/flutter/issues/191299
       dependencies: >-
         [
-          {"dependency": "chrome_and_driver", "version": "version:134.0.6998.165"}
+          {"dependency": "chrome_and_driver", "version": "version:137.0.7151.119"}
         ]
 
   ### Linux desktop tasks
@@ -839,7 +839,7 @@ targets:
       # and --disable-background-timer-throttling; see https://github.com/flutter/flutter/issues/191299
       dependencies: >-
         [
-          {"dependency": "chrome_and_driver", "version": "version:134.0.6998.165"}
+          {"dependency": "chrome_and_driver", "version": "version:137.0.7151.119"}
         ]
 
   ### iOS+macOS tasks ###

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -223,7 +223,7 @@ targets:
       # and --disable-background-timer-throttling; see https://github.com/flutter/flutter/issues/191299
       dependencies: >-
         [
-          {"dependency": "chrome_and_driver", "version": "version:128.0.6613.137"}
+          {"dependency": "chrome_and_driver", "version": "version:134.0.6998.165"}
         ]
 
   - name: Linux_web web_dart_unit_test_shard_2 stable
@@ -240,7 +240,7 @@ targets:
       # and --disable-background-timer-throttling; see https://github.com/flutter/flutter/issues/191299
       dependencies: >-
         [
-          {"dependency": "chrome_and_driver", "version": "version:128.0.6613.137"}
+          {"dependency": "chrome_and_driver", "version": "version:134.0.6998.165"}
         ]
 
   - name: Linux_web web_dart_unit_test_shard_3 stable
@@ -257,7 +257,7 @@ targets:
       # and --disable-background-timer-throttling; see https://github.com/flutter/flutter/issues/191299
       dependencies: >-
         [
-          {"dependency": "chrome_and_driver", "version": "version:128.0.6613.137"}
+          {"dependency": "chrome_and_driver", "version": "version:134.0.6998.165"}
         ]
 
   # Wasm unit tests in master
@@ -368,7 +368,7 @@ targets:
           {"dependency": "clang", "version": "git_revision:5d5aba78dbbee75508f01bcaa69aedb2ab79065a"},
           {"dependency": "cmake", "version": "build_id:8787856497187628321"},
           {"dependency": "ninja", "version": "version:1.9.0"},
-          {"dependency": "chrome_and_driver", "version": "version:128.0.6613.137"}
+          {"dependency": "chrome_and_driver", "version": "version:134.0.6998.165"}
         ]
       channel: stable
 
@@ -756,7 +756,7 @@ targets:
       # and --disable-background-timer-throttling; see https://github.com/flutter/flutter/issues/191299
       dependencies: >-
         [
-          {"dependency": "chrome_and_driver", "version": "version:128.0.6613.137"}
+          {"dependency": "chrome_and_driver", "version": "version:134.0.6998.165"}
         ]
 
   - name: Linux_web web_platform_tests_shard_2 stable
@@ -773,7 +773,7 @@ targets:
       # and --disable-background-timer-throttling; see https://github.com/flutter/flutter/issues/191299
       dependencies: >-
         [
-          {"dependency": "chrome_and_driver", "version": "version:128.0.6613.137"}
+          {"dependency": "chrome_and_driver", "version": "version:134.0.6998.165"}
         ]
 
   - name: Linux_web web_platform_tests_shard_3 stable
@@ -790,7 +790,7 @@ targets:
       # and --disable-background-timer-throttling; see https://github.com/flutter/flutter/issues/191299
       dependencies: >-
         [
-          {"dependency": "chrome_and_driver", "version": "version:128.0.6613.137"}
+          {"dependency": "chrome_and_driver", "version": "version:134.0.6998.165"}
         ]
 
   ### Linux desktop tasks
@@ -839,7 +839,7 @@ targets:
       # and --disable-background-timer-throttling; see https://github.com/flutter/flutter/issues/191299
       dependencies: >-
         [
-          {"dependency": "chrome_and_driver", "version": "version:128.0.6613.137"}
+          {"dependency": "chrome_and_driver", "version": "version:134.0.6998.165"}
         ]
 
   ### iOS+macOS tasks ###


### PR DESCRIPTION
`test` 1.32.0 [requires at least Chrome 128], which caused OOB tree breakage. Our `stable` tests can't use the latest version of Chrome yet, so update from 125 to 137 so that the version of Chrome is compatible. (134, the oldest available in CIPD that's newer than 125, seemed to crash flakily.)

Fixes https://github.com/flutter/flutter/issues/192248