### PR TITLE
[google_maps_flutter_platform_interface] Add onPointOfInterestTap support

### DIFF
--- a/packages/google_maps_flutter/google_maps_flutter_platform_interface/CHANGELOG.md
+++ b/packages/google_maps_flutter/google_maps_flutter_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.17.0
+
+* Adds support for tapping points of interest on the map.
+
 ## 2.16.1
 
 * Fixes the `PinConfig` code sample in the `BitmapDescriptor` documentation.

--- a/packages/google_maps_flutter/google_maps_flutter_platform_interface/lib/src/events/map_event.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_platform_interface/lib/src/events/map_event.dart
@@ -160,6 +160,15 @@ class GroundOverlayTapEvent extends MapEvent<GroundOverlayId> {
   GroundOverlayTapEvent(super.mapId, super.croundOverlayId);
 }
 
+/// An event fired when a point of interest is tapped.
+class PointOfInterestTapEvent extends MapEvent<PointOfInterestId> {
+  /// Build a PointOfInterestTap Event triggered from the map represented by `mapId`.
+  ///
+  /// The `value` of this event is a [PointOfInterestId] object that represents the
+  /// tapped point of interest.
+  PointOfInterestTapEvent(super.mapId, super.pointOfInterestId);
+}
+
 /// An event fired when a Map is tapped.
 class MapTapEvent extends _PositionedMapEvent<void> {
   /// Build an MapTap Event triggered from the map represented by `mapId`.

--- a/packages/google_maps_flutter/google_maps_flutter_platform_interface/lib/src/platform_interface/google_maps_flutter_platform.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_platform_interface/lib/src/platform_interface/google_maps_flutter_platform.dart
@@ -337,6 +337,11 @@ abstract class GoogleMapsFlutterPlatform extends PlatformInterface {
     throw UnimplementedError('onCircleTap() has not been implemented.');
   }
 
+  /// A point of interest has been tapped.
+  Stream<PointOfInterestTapEvent> onPointOfInterestTap({required int mapId}) {
+    return const Stream<PointOfInterestTapEvent>.empty();
+  }
+
   /// A Map has been tapped at a certain [LatLng].
   Stream<MapTapEvent> onTap({required int mapId}) {
     throw UnimplementedError('onTap() has not been implemented.');

--- a/packages/google_maps_flutter/google_maps_flutter_platform_interface/lib/src/types/point_of_interest_id.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_platform_interface/lib/src/types/point_of_interest_id.dart
@@ -1,0 +1,16 @@
+// Copyright 2013 The Flutter Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/foundation.dart' show immutable;
+
+import 'types.dart';
+
+/// Uniquely identifies a point of interest on a [GoogleMap].
+///
+/// The [value] is the Google Maps place ID for the tapped point of interest.
+@immutable
+class PointOfInterestId extends MapsObjectId<PointOfInterestId> {
+  /// Creates an immutable identifier for a point of interest.
+  const PointOfInterestId(super.value);
+}

--- a/packages/google_maps_flutter/google_maps_flutter_platform_interface/lib/src/types/types.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_platform_interface/lib/src/types/types.dart
@@ -28,6 +28,7 @@ export 'maps_object_updates.dart';
 export 'marker.dart';
 export 'marker_updates.dart';
 export 'pattern_item.dart';
+export 'point_of_interest_id.dart';
 export 'polygon.dart';
 export 'polygon_updates.dart';
 export 'polyline.dart';

--- a/packages/google_maps_flutter/google_maps_flutter_platform_interface/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter_platform_interface/pubspec.yaml
@@ -4,7 +4,7 @@ repository: https://github.com/flutter/packages/tree/main/packages/google_maps_f
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+maps%22
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 2.16.1
+version: 2.17.0
 
 environment:
   sdk: ^3.10.0

--- a/packages/google_maps_flutter/google_maps_flutter_platform_interface/test/platform_interface/google_maps_flutter_platform_test.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_platform_interface/test/platform_interface/google_maps_flutter_platform_test.dart
@@ -95,6 +95,12 @@ void main() {
       );
     });
 
+    test('onPointOfInterestTap() returns empty stream', () async {
+      final Stream<PointOfInterestTapEvent> stream = BuildViewGoogleMapsFlutterPlatform()
+          .onPointOfInterestTap(mapId: 0);
+      expect(await stream.isEmpty, isTrue);
+    });
+
     test('default implementation of `getStyleError` returns null', () async {
       final GoogleMapsFlutterPlatform platform = BuildViewGoogleMapsFlutterPlatform();
       expect(await platform.getStyleError(mapId: 0), null);

--- a/packages/google_maps_flutter/google_maps_flutter_platform_interface/test/types/point_of_interest_id_test.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_platform_interface/test/types/point_of_interest_id_test.dart
@@ -1,0 +1,23 @@
+// Copyright 2013 The Flutter Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:google_maps_flutter_platform_interface/google_maps_flutter_platform_interface.dart';
+
+void main() {
+  test('PointOfInterestId equality', () {
+    const id1 = PointOfInterestId('place-123');
+    const id2 = PointOfInterestId('place-123');
+    const id3 = PointOfInterestId('place-456');
+
+    expect(id1, equals(id2));
+    expect(id1, isNot(equals(id3)));
+    expect(id1.hashCode, equals(id2.hashCode));
+  });
+
+  test('PointOfInterestId toString', () {
+    const id = PointOfInterestId('place-123');
+    expect(id.toString(), contains('place-123'));
+  });
+}


### PR DESCRIPTION
This is the platform interface portion of https://github.com/flutter/packages/pull/11872

Adds `PointOfInterestId`, `PointOfInterestTapEvent`, and `GoogleMapsFlutterPlatform.onPointOfInterestTap`. The default implementation returns an empty stream so existing platform implementations are not broken.

Fixes https://github.com/flutter/flutter/issues/60695 (platform interface only; app-facing and implementation packages land in follow-up PRs per the federated plugin contribution process).

## Pre-Review Checklist

- [x] I read the [Contributor Guide](https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md) and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines](https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#handling-useful-p-rs-produced-by-ai-agents--llm-based-tools) and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene](https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md) page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides](https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md) and ran the auto-formatter.
- [x] I signed the [CLA](https://cla.developers.google.com/).
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I linked to at least one issue that this PR fixes in the description above.
- [x] I followed the [version and CHANGELOG](https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version-and-changelog-updates) instructions, using semantic versioning and the repository CHANGELOG style.
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.

@stuartmorgan-g — this is the first sub-PR from #11872 as requested.
