### PR TITLE
[material_ui] Fix `DropdownMenuFormField` missing leading icon

### DIFF
--- a/packages/material_ui/lib/src/dropdown_menu.dart
+++ b/packages/material_ui/lib/src/dropdown_menu.dart
@@ -1269,7 +1269,7 @@ class _DropdownMenuState<T> extends State<DropdownMenu<T>> {
         final DropdownMenuDecorationBuilder decorationBuilder =
             widget.decorationBuilder ?? _buildDefaultDecoration;
         InputDecoration decoration = decorationBuilder(context, controller);
-        if (decoration.prefixIcon == null) {
+        if (widget.leadingIcon != null && decoration.prefixIcon == null) {
           decoration = decoration.copyWith(prefixIcon: widget.leadingIcon);
         }
         // If no suffixIcon is provided, the default IconButton is used for convenience.

--- a/packages/material_ui/lib/src/dropdown_menu.dart
+++ b/packages/material_ui/lib/src/dropdown_menu.dart
@@ -421,6 +421,9 @@ class DropdownMenu<T> extends StatefulWidget {
 
   /// The builder function used to create the [InputDecoration] passed to the text field.
   ///
+  /// If the resulting [InputDecoration.prefixIcon] is null, [leadingIcon] is
+  /// assigned as the prefix icon.
+  ///
   /// If a value is provided for this property and the resulting [InputDecoration.suffixIcon]
   /// is null, a default [IconButton] is assigned as the suffix icon. This button's icon will
   /// use [trailingIcon] and [selectedTrailingIcon] if those are explicitly defined; otherwise,
@@ -1266,6 +1269,9 @@ class _DropdownMenuState<T> extends State<DropdownMenu<T>> {
         final DropdownMenuDecorationBuilder decorationBuilder =
             widget.decorationBuilder ?? _buildDefaultDecoration;
         InputDecoration decoration = decorationBuilder(context, controller);
+        if (decoration.prefixIcon == null) {
+          decoration = decoration.copyWith(prefixIcon: widget.leadingIcon);
+        }
         // If no suffixIcon is provided, the default IconButton is used for convenience.
         if (decoration.suffixIcon == null) {
           decoration = decoration.copyWith(

--- a/packages/material_ui/pending_changelogs/change_2026_09_04_dropdown_menu_leading_icon.yaml
+++ b/packages/material_ui/pending_changelogs/change_2026_09_04_dropdown_menu_leading_icon.yaml
@@ -1,0 +1,3 @@
+changelog: |
+  - Fixes `DropdownMenuFormField.leadingIcon` not being shown in the text field.
+version: patch

--- a/packages/material_ui/test/dropdown_menu_form_field_test.dart
+++ b/packages/material_ui/test/dropdown_menu_form_field_test.dart
@@ -175,6 +175,32 @@ void main() {
     expect(dropdownMenu.leadingIcon, leadingIcon);
   });
 
+  testWidgets('leadingIcon is shown in the text field prefix decoration', (
+    WidgetTester tester,
+  ) async {
+    const Widget leadingIcon = Icon(Icons.check);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: DropdownMenuFormField<MenuItem>(
+            leadingIcon: leadingIcon,
+            dropdownMenuEntries: menuEntries,
+          ),
+        ),
+      ),
+    );
+
+    final TextField textField = tester.widget(find.byType(TextField));
+    final Widget? prefixIcon = textField.decoration?.prefixIcon;
+    expect(prefixIcon, isNotNull);
+    final Finder prefixCheckIcon = find.descendant(
+      of: find.byWidget(prefixIcon!),
+      matching: find.byIcon(Icons.check),
+    );
+    expect(prefixCheckIcon, findsOneWidget);
+  });
+
   testWidgets('Passes trailingIcon to underlying DropdownMenu', (WidgetTester tester) async {
     await tester.pumpWidget(
       MaterialApp(


### PR DESCRIPTION
Fixes a regression where DropdownMenuFormField.leadingIcon was not shown in the field.

DropdownMenuFormField took a leadingIcon, but didn’t actually show it in the field. This change makes it behave like trailingIcon, so the leading icon now shows up as the default prefix icon.

Fixes https://github.com/flutter/flutter/issues/185416

**With only leadingIcon**
<img width="2310" height="914" alt="image" src="https://github.com/user-attachments/assets/04d8f8ef-aa42-49b7-8709-d0f78e5278b8" />

**decorationBuilder has higher priority than leading icon.**
<img width="2576" height="1120" alt="image" src="https://github.com/user-attachments/assets/a88723d4-b70d-4ca2-8170-db8954856745" />


## Pre-Review Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [X] I read the [Tree Hygiene] page, which explains my responsibilities.
- [X] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [X] I signed the [CLA].
- [X] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [X] I [linked to at least one issue that this PR fixes] in the description above.
- [X] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under[^1].
- [X] I updated/added any relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [X] All existing and new tests are passing.

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[the version and CHANGELOG instructions]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version-and-changelog-updates
[semantic versioning]: https://dart.dev/tools/pub/versioning#semantic-versions
[repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
