### PR TITLE
[go_router_builder] Support nested parentheses, groups, and lookaround assertions in path parameters

### DIFF
--- a/packages/go_router_builder/CHANGELOG.md
+++ b/packages/go_router_builder/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.4.1
+
+- Fixes path parameter regex parsing to support nested parentheses, grouping constructs, and lookahead assertions in `TypedGoRoute` paths.
+
 ## 4.4.0
 
 - Adds `hasOverriddenOnExit` parameter to `GoRouteData.$route` and `RelativeGoRouteData.$route` helper methods for type-safe routes. When set to `true`, enables custom `onExit` callback invocation from route data classes extending `GoRouteData` or `RelativeGoRouteData` when the route is removed from the navigation stack.

--- a/packages/go_router_builder/lib/src/path_utils.dart
+++ b/packages/go_router_builder/lib/src/path_utils.dart
@@ -1,6 +1,7 @@
 // Copyright 2013 The Flutter Authors
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+import 'package:collection/collection.dart';
 
 final RegExp _parameterNameRegExp = RegExp(r':(\w+)');
 

--- a/packages/go_router_builder/lib/src/path_utils.dart
+++ b/packages/go_router_builder/lib/src/path_utils.dart
@@ -2,7 +2,79 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-final RegExp _parameterRegExp = RegExp(r':(\w+)(\((?:\\.|[^\\()])+\))?');
+final RegExp _parameterNameRegExp = RegExp(r':(\w+)');
+
+/// A `:name` occurrence in a path pattern, with its optional constraint.
+class _PathParameter {
+  const _PathParameter({required this.start, required this.end, required this.name});
+
+  /// Index of the leading `:`.
+  final int start;
+
+  /// Exclusive end of the whole occurrence, constraint included.
+  final int end;
+
+  final String name;
+}
+
+/// Scans [pattern] for `:name` occurrences, each optionally followed by a
+/// `(...)` constraint.
+List<_PathParameter> _pathParametersOf(String pattern) {
+  final parameters = <_PathParameter>[];
+  RegExpMatch? match = _parameterNameRegExp.firstMatch(pattern);
+  while (match != null) {
+    final int closingParen = _closingParenIndex(pattern, match.end);
+    final int end = closingParen != -1 ? closingParen + 1 : match.end;
+    final String? name = match[1];
+
+    if (name != null) {
+      parameters.add(_PathParameter(start: match.start, end: end, name: name));
+    }
+    match = _parameterNameRegExp.allMatches(pattern, end).firstOrNull;
+  }
+  return parameters;
+}
+
+/// The index of the `)` that closes the `(` at [start], or -1 when [start] is
+/// not a `(` or the group is never closed.
+///
+/// Escaped characters and character classes never open or close a group, so
+/// `(\()` and `([()])` are both single groups.
+int _closingParenIndex(String pattern, int start) {
+  if (start >= pattern.length || pattern[start] != '(') {
+    return -1;
+  }
+
+  var depth = 0;
+  var inCharacterClass = false;
+  for (var currentIndex = start; currentIndex < pattern.length; currentIndex++) {
+    final String character = pattern[currentIndex];
+    if (character == r'\') {
+      // The next character is a literal: skip it together with the backslash.
+      currentIndex++;
+      continue;
+    }
+    if (inCharacterClass) {
+      if (character == ']') {
+        inCharacterClass = false;
+      }
+      continue;
+    }
+    switch (character) {
+      case '[':
+        inCharacterClass = true;
+      case '(':
+        depth++;
+      case ')':
+        depth--;
+        if (depth == 0) {
+          return currentIndex;
+        }
+    }
+  }
+
+  return -1;
+}
 
 /// Extracts the path parameters from a [pattern] such as `/user/:id`.
 ///
@@ -15,7 +87,7 @@ final RegExp _parameterRegExp = RegExp(r':(\w+)(\((?:\\.|[^\\()])+\))?');
 /// final pathParameters = pathParametersFromPattern(pattern); // {'id', 'bookId'}
 /// ```
 Set<String> pathParametersFromPattern(String pattern) => <String>{
-  for (final RegExpMatch match in _parameterRegExp.allMatches(pattern)) match[1]!,
+  for (final _PathParameter parameter in _pathParametersOf(pattern)) parameter.name,
 };
 
 /// Reconstructs the full path from a [pattern] and path parameters.
@@ -29,13 +101,12 @@ Set<String> pathParametersFromPattern(String pattern) => <String>{
 String patternToPath(String pattern, Map<String, String> pathParameters) {
   final buffer = StringBuffer();
   var start = 0;
-  for (final RegExpMatch match in _parameterRegExp.allMatches(pattern)) {
-    if (match.start > start) {
-      buffer.write(pattern.substring(start, match.start));
+  for (final _PathParameter parameter in _pathParametersOf(pattern)) {
+    if (parameter.start > start) {
+      buffer.write(pattern.substring(start, parameter.start));
     }
-    final String name = match[1]!;
-    buffer.write(pathParameters[name]);
-    start = match.end;
+    buffer.write(pathParameters[parameter.name]);
+    start = parameter.end;
   }
 
   if (start < pattern.length) {

--- a/packages/go_router_builder/pubspec.yaml
+++ b/packages/go_router_builder/pubspec.yaml
@@ -2,7 +2,7 @@ name: go_router_builder
 description: >-
   A builder that supports generated strongly-typed route helpers for
   package:go_router
-version: 4.4.0
+version: 4.4.1
 repository: https://github.com/flutter/packages/tree/main/packages/go_router_builder
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+go_router_builder%22
 

--- a/packages/go_router_builder/test/path_utils_test.dart
+++ b/packages/go_router_builder/test/path_utils_test.dart
@@ -14,6 +14,27 @@ void main() {
       expect(pathParametersFromPattern('/user/:id/book'), const <String>{'id'});
       expect(pathParametersFromPattern('/user/:id/book/:bookId'), const <String>{'id', 'bookId'});
     });
+
+    test('It should support a nested group in the parameter pattern', () {
+      expect(
+        pathParametersFromPattern(r'/user/:id((?!(?:0|1)(?:/|$))[^/]+)/book/:bookId'),
+        const <String>{'id', 'bookId'},
+      );
+    });
+
+    test('It should support group constructs in the parameter pattern', () {
+      expect(pathParametersFromPattern(r'/user/:id((?:0x)?\d+)'), const <String>{'id'});
+    });
+
+    test('It should support parentheses in a character class', () {
+      expect(pathParametersFromPattern(r'/a/:x([()])/:y'), const <String>{'x', 'y'});
+    });
+
+    test('It should support a nested group containing an alternation', () {
+      expect(pathParametersFromPattern(r'/details/:id((FOO|BAR)[0-9a-zA-Z]{10})'), const <String>{
+        'id',
+      });
+    });
   });
 
   group('patternToPath', () {
@@ -31,6 +52,35 @@ void main() {
           'bookId': 'book-id',
         }),
         '/user/user-id/book/book-id',
+      );
+    });
+
+    test('It should support a nested group in the parameter pattern', () {
+      expect(
+        patternToPath(r'/tags/:slug((?!(?:admin|new)(?:/|$))[^/]+)', const <String, String>{
+          'slug': 'flutter',
+        }),
+        '/tags/flutter',
+      );
+    });
+
+    test('It should support group constructs in the parameter pattern', () {
+      expect(
+        patternToPath(r'/user/:id((?:0x)?\d+)/book', const <String, String>{'id': '0x42'}),
+        '/user/0x42/book',
+      );
+    });
+
+    test('It should support parentheses in a character class', () {
+      expect(patternToPath(r'/a/:x([()])', const <String, String>{'x': '('}), '/a/(');
+    });
+
+    test('It should support a nested group containing an alternation', () {
+      expect(
+        patternToPath(r'/details/:id((FOO|BAR)[0-9a-zA-Z]{10})', const <String, String>{
+          'id': 'FOO0123456789',
+        }),
+        '/details/FOO0123456789',
       );
     });
   });


### PR DESCRIPTION
* Fixes https://github.com/flutter/flutter/issues/192300

See https://github.com/flutter/packages/pull/12571 for details about the changes

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under[^1].
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [x] All existing and new tests are passing.