### PR TITLE
[material_ui] Fix ExpansionTile WidgetSpan semantics assertion

### DIFF
--- a/packages/material_ui/lib/src/expansion_tile.dart
+++ b/packages/material_ui/lib/src/expansion_tile.dart
@@ -693,7 +693,9 @@ class _ExpansionTileState extends State<ExpansionTile> {
       return Semantics(
         // Live region used to announce state changes (e.g., "expanded" or "collapsed")
         // without taking focus.
-        // blockNode prevents this node from being part of the focus traversal.
+        // The container ensures the live region forms the node that blockNode
+        // removes from focus traversal.
+        container: true,
         label: semanticsHint,
         liveRegion: true,
         accessibilityFocusBlockType: AccessibilityFocusBlockType.blockNode,

--- a/packages/material_ui/pending_changelogs/change_2026_08_06_expansion_tile_widget_span.yaml
+++ b/packages/material_ui/pending_changelogs/change_2026_08_06_expansion_tile_widget_span.yaml
@@ -1,0 +1,3 @@
+changelog: |
+  - Fixes an Android semantics assertion when an ExpansionTile title contains a nested WidgetSpan.
+version: patch

--- a/packages/material_ui/pending_changelogs/change_2026_08_06_expansion_tile_widget_span.yaml
+++ b/packages/material_ui/pending_changelogs/change_2026_08_06_expansion_tile_widget_span.yaml
@@ -1,3 +1,3 @@
 changelog: |
-  - Fixes an Android semantics assertion when an ExpansionTile title contains a nested WidgetSpan.
+  - Fixes an Android semantics assertion when an `ExpansionTile` is embedded in a `WidgetSpan`.
 version: patch

--- a/packages/material_ui/test/expansion_tile_test.dart
+++ b/packages/material_ui/test/expansion_tile_test.dart
@@ -2231,7 +2231,9 @@ void main() {
   });
   group('Semantics tests for android platform', () {
     // Regression test for https://github.com/flutter/flutter/issues/188298.
-    testWidgets('ExpansionTile supports a nested WidgetSpan title', (WidgetTester tester) async {
+    testWidgets('ExpansionTile supports being embedded in a WidgetSpan', (
+      WidgetTester tester,
+    ) async {
       final SemanticsHandle handle = tester.ensureSemantics();
 
       await tester.pumpWidget(
@@ -2241,25 +2243,9 @@ void main() {
               TextSpan(
                 children: <InlineSpan>[
                   WidgetSpan(
-                    child: SizedBox(
-                      width: 400,
-                      child: ExpansionTile(
-                        title: Text.rich(
-                          TextSpan(
-                            children: <InlineSpan>[
-                              WidgetSpan(
-                                child: Text.rich(
-                                  TextSpan(
-                                    style: TextStyle(fontSize: 32, fontWeight: FontWeight.bold),
-                                    text: 'Header',
-                                  ),
-                                ),
-                              ),
-                            ],
-                          ),
-                        ),
-                        children: <Widget>[Text('These are the details.')],
-                      ),
+                    child: ExpansionTile(
+                      title: Text('Header'),
+                      children: <Widget>[Text('Details')],
                     ),
                   ),
                 ],
@@ -2268,6 +2254,7 @@ void main() {
           ),
         ),
       );
+      expect(find.text('Header'), findsOneWidget);
       handle.dispose();
     }, variant: const TargetPlatformVariant(<TargetPlatform>{TargetPlatform.android}));
 

--- a/packages/material_ui/test/expansion_tile_test.dart
+++ b/packages/material_ui/test/expansion_tile_test.dart
@@ -2230,6 +2230,47 @@ void main() {
     );
   });
   group('Semantics tests for android platform', () {
+    // Regression test for https://github.com/flutter/flutter/issues/188298.
+    testWidgets('ExpansionTile supports a nested WidgetSpan title', (WidgetTester tester) async {
+      final SemanticsHandle handle = tester.ensureSemantics();
+
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: Text.rich(
+              TextSpan(
+                children: <InlineSpan>[
+                  WidgetSpan(
+                    child: SizedBox(
+                      width: 400,
+                      child: ExpansionTile(
+                        title: Text.rich(
+                          TextSpan(
+                            children: <InlineSpan>[
+                              WidgetSpan(
+                                child: Text.rich(
+                                  TextSpan(
+                                    style: TextStyle(fontSize: 32, fontWeight: FontWeight.bold),
+                                    text: 'Header',
+                                  ),
+                                ),
+                              ),
+                            ],
+                          ),
+                        ),
+                        children: <Widget>[Text('These are the details.')],
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      );
+      handle.dispose();
+    }, variant: const TargetPlatformVariant(<TargetPlatform>{TargetPlatform.android}));
+
     testWidgets('Semantics liveregion updates when expansion state changes', (
       WidgetTester tester,
     ) async {

--- a/packages/material_ui/test/expansion_tile_test.dart
+++ b/packages/material_ui/test/expansion_tile_test.dart
@@ -2234,8 +2234,6 @@ void main() {
     testWidgets('ExpansionTile supports being embedded in a WidgetSpan', (
       WidgetTester tester,
     ) async {
-      final SemanticsHandle handle = tester.ensureSemantics();
-
       await tester.pumpWidget(
         const MaterialApp(
           home: Scaffold(
@@ -2255,7 +2253,6 @@ void main() {
         ),
       );
       expect(find.text('Header'), findsOneWidget);
-      handle.dispose();
     }, variant: const TargetPlatformVariant(<TargetPlatform>{TargetPlatform.android}));
 
     testWidgets('Semantics liveregion updates when expansion state changes', (


### PR DESCRIPTION
On Android, embedding an `ExpansionTile` in a `WidgetSpan` can trigger a sibling-configuration conflict assertion when semantics are enabled. Its live-region `Semantics` uses `AccessibilityFocusBlockType.blockNode` but can merge into the surrounding semantics tree.

This makes the live region a semantics container, so `blockNode` applies to an explicit node. The Android regression test uses the simpler reproduction suggested in flutter/flutter#190639.

Fixes flutter/flutter#188298.

This ports flutter/flutter#190639 to `packages/material_ui`. The earlier package PR, #12383, was closed while contributions were paused. This replacement is rebased onto current main following the request to move the fix here; GitHub would not reopen the old PR after the rebase.

I used AI to help with the fix and regression test.

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under[^1].
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [x] All existing and new tests are passing.

Validation performed locally on macOS:

- Full `material_ui` test suite: `flutter test --no-pub --concurrency=2` (8,147 passed, 11 existing skips).
- Full example suite: the same command in `packages/material_ui/example` (390 passed, 2 existing skips).
- Accessibility app suite: the same command in `packages/material_ui/test_apps/a11y_assessments` (173 passed).
- Defaults generator suite: `dart test` in `packages/material_ui/tool/gen_defaults` (59 passed).
- The new regression test was previously verified to fail with the original `!conflict` assertion when `container: true` is removed, then pass when it is restored.
- Full-package `flutter analyze --no-pub`: no issues.
- Dart formatting and `git diff --check`: passed.
- `dart run script/tool/bin/flutter_plugin_tools.dart validate --packages material_ui --check-for-missing-changes --base-branch upstream/main`: passed. I expanded the sparse checkout with the repository metadata needed for this check.

The existing `flutter_goldens` harness skips golden-image comparisons; I did not change that behavior. These are local test results, not a claim that repository-wide CI has passed. CI is still awaiting the CICD label.

The release metadata uses `material_ui`'s batch-release convention: a pending changelog entry with `version: patch`.

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[the version and CHANGELOG instructions]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version-and-changelog-updates
[semantic versioning]: https://dart.dev/tools/pub/versioning#semantic-versions
[repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
