### PR TITLE
[cupertino_ui] Deprecate `CupertinoSegmentedControl`

### DIFF
--- a/packages/cupertino_ui/lib/src/segmented_control.dart
+++ b/packages/cupertino_ui/lib/src/segmented_control.dart
@@ -94,6 +94,7 @@ const Duration _kFadeDuration = Duration(milliseconds: 165);
 ///  * [CupertinoSegmentedControl], a segmented control widget in the style used
 ///    up until iOS 13.
 ///  * <https://developer.apple.com/design/human-interface-guidelines/ios/controls/segmented-controls/>
+@Deprecated('Use CupertinoSlidingSegmentedControl instead.')
 class CupertinoSegmentedControl<T extends Object> extends StatefulWidget {
   /// Creates an iOS-style segmented control bar.
   ///
@@ -110,6 +111,7 @@ class CupertinoSegmentedControl<T extends Object> extends StatefulWidget {
   /// If no [groupValue] is provided, or the [groupValue] is null, no widget will
   /// appear as selected. The [groupValue] must be either null or one of the keys
   /// in the [children] map.
+@Deprecated('Use CupertinoSlidingSegmentedControl instead.')
   CupertinoSegmentedControl({
     super.key,
     required this.children,

--- a/packages/cupertino_ui/lib/src/segmented_control.dart
+++ b/packages/cupertino_ui/lib/src/segmented_control.dart
@@ -111,7 +111,7 @@ class CupertinoSegmentedControl<T extends Object> extends StatefulWidget {
   /// If no [groupValue] is provided, or the [groupValue] is null, no widget will
   /// appear as selected. The [groupValue] must be either null or one of the keys
   /// in the [children] map.
-@Deprecated('Use CupertinoSlidingSegmentedControl instead.')
+  @Deprecated('Use CupertinoSlidingSegmentedControl instead.')
   CupertinoSegmentedControl({
     super.key,
     required this.children,

--- a/packages/cupertino_ui/pending_changelogs/change_2026_09_05_deprecate_cupertino_segmented_control.yaml
+++ b/packages/cupertino_ui/pending_changelogs/change_2026_09_05_deprecate_cupertino_segmented_control.yaml
@@ -1,0 +1,3 @@
+changelog: |
+  - Deprecates CupertinoSegmentedControl in favor of CupertinoSlidingSegmentedControl.
+version: patch


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/152910

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under[^1].
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[the version and CHANGELOG instructions]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version-and-changelog-updates
[semantic versioning]: https://dart.dev/tools/pub/versioning#semantic-versions
[repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
