### PR TITLE
[google_sign_in_ios] Fix conflicting return type (BOOL vs void) in scene:openURLContexts:

### DIFF
--- a/packages/google_sign_in/google_sign_in_ios/CHANGELOG.md
+++ b/packages/google_sign_in/google_sign_in_ios/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 6.3.4
+
+* Fixes a compile warning by returning `BOOL` from `scene:openURLContexts:` to
+  match the `FlutterSceneLifeCycleDelegate` protocol.
+
 ## 6.3.3
 
 * Creates Swift Package Manager target for Swift implementation.

--- a/packages/google_sign_in/google_sign_in_ios/darwin/google_sign_in_ios/Sources/google_sign_in_ios_objc/FLTGoogleSignInPlugin.m
+++ b/packages/google_sign_in/google_sign_in_ios/darwin/google_sign_in_ios/Sources/google_sign_in_ios_objc/FLTGoogleSignInPlugin.m
@@ -159,7 +159,9 @@ static FSIGoogleSignInErrorCode FSIPigeonErrorCodeForGIDSignInErrorCode(NSIntege
 - (BOOL)handleURLs:(NSArray<NSURL *> *)urls {
   BOOL handled = NO;
   for (NSURL *url in urls) {
-    handled = [self.signIn handleURL:url] || handled;
+    if ([self.signIn handleURL:url]) {
+      handled = YES;
+    }
   }
   return handled;
 }

--- a/packages/google_sign_in/google_sign_in_ios/darwin/google_sign_in_ios/Sources/google_sign_in_ios_objc/FLTGoogleSignInPlugin.m
+++ b/packages/google_sign_in/google_sign_in_ios/darwin/google_sign_in_ios/Sources/google_sign_in_ios_objc/FLTGoogleSignInPlugin.m
@@ -156,18 +156,20 @@ static FSIGoogleSignInErrorCode FSIPigeonErrorCodeForGIDSignInErrorCode(NSIntege
 
 #if TARGET_OS_IOS
 
-- (void)handleURLs:(NSArray<NSURL *> *)urls {
+- (BOOL)handleURLs:(NSArray<NSURL *> *)urls {
+  BOOL handled = NO;
   for (NSURL *url in urls) {
-    [self.signIn handleURL:url];
+    handled = [self.signIn handleURL:url] || handled;
   }
+  return handled;
 }
 
-- (void)scene:(UIScene *)scene openURLContexts:(NSSet<UIOpenURLContext *> *)URLContexts {
+- (BOOL)scene:(UIScene *)scene openURLContexts:(NSSet<UIOpenURLContext *> *)URLContexts {
   NSMutableArray<NSURL *> *urls = [NSMutableArray arrayWithCapacity:URLContexts.count];
   for (UIOpenURLContext *context in URLContexts) {
     [urls addObject:context.URL];
   }
-  [self handleURLs:urls];
+  return [self handleURLs:urls];
 }
 
 - (BOOL)application:(UIApplication *)app openURL:(NSURL *)url options:(NSDictionary *)options {

--- a/packages/google_sign_in/google_sign_in_ios/darwin/google_sign_in_ios/Sources/google_sign_in_ios_objc/include/google_sign_in_ios/FLTGoogleSignInPlugin_Test.h
+++ b/packages/google_sign_in/google_sign_in_ios/darwin/google_sign_in_ios/Sources/google_sign_in_ios_objc/include/google_sign_in_ios/FLTGoogleSignInPlugin_Test.h
@@ -40,7 +40,7 @@ NS_ASSUME_NONNULL_BEGIN
 #if TARGET_OS_IOS
 /// Forwards each URL to GIDSignIn. Extracted so tests can cover scene URL
 /// handling without constructing UIOpenURLContext.
-- (void)handleURLs:(NSArray<NSURL *> *)urls NS_SWIFT_NAME(handleURLs(_:));
+- (BOOL)handleURLs:(NSArray<NSURL *> *)urls NS_SWIFT_NAME(handleURLs(_:));
 #endif
 
 @end


### PR DESCRIPTION
Fixes a compile warning surfaced when building with Flutter 3.44.8 / Xcode 26 (iOS 26 SDK):

```
warning: Conflicting return type in implementation of 'scene:openURLContexts:': 'BOOL' vs 'void'
```

## Cause

`FLTGoogleSignInPlugin` conforms to `<FlutterSceneLifeCycleDelegate>` and implements `- (void)scene:openURLContexts:`. In the Flutter iOS engine shipped with Flutter 3.44.8, `FlutterSceneLifeCycleDelegate.h` declares the method as:

```objc
- (BOOL)scene:(UIScene*)scene openURLContexts:(NSSet<UIOpenURLContext*>*)URLContexts;
```

(documented as "@return `YES` if this handled one or more of the URLs"), so the plugin's `void` implementation conflicts with the protocol's `BOOL` return type.

## Fix

- `handleURLs:` now returns `BOOL` (aggregating the `FSIGIDSignIn handleURL:` results with OR, mirroring the existing macOS `handleOpenURLs:` path).
- `scene:openURLContexts:` now returns `BOOL` and propagates `handleURLs:`, matching the protocol and the existing `application:openURL:options:` pattern.

## Verification

- Checked every `scene:openURLContexts:` / `handleURLs:` occurrence in the package (only the plugin `.m` and the test-only header expose these; the existing Swift test `handleURLs()` still compiles since it ignores the return value).
- Validated the new signature against the real `FlutterSceneLifeCycleDelegate.h` shipped with Flutter 3.44.8 via `clang -fsyntax-only` (exit 0).

Detected with Flutter 3.44.8 / Xcode 26 (iOS 26 SDK). Note: PR #12655 is migrating this plugin class to Swift; this change is complementary and scoped to the current Objective-C code.
