### PR TITLE
[image_picker_ios] Replace deprecated kUTTypeImage/kUTTypeMovie with UTType API

### DIFF
--- a/packages/image_picker/image_picker_ios/CHANGELOG.md
+++ b/packages/image_picker/image_picker_ios/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.8.13+8
+
+* Replaces deprecated `kUTTypeImage` and `kUTTypeMovie` with `UTTypeImage` and `UTTypeMovie` to fix iOS 15+ deprecation warnings.
+
 ## 0.8.13+7
 
 * Updates pigeon dev_dependency to ^27.3.2 for analyzer 14 compatibility.

--- a/packages/image_picker/image_picker_ios/ios/image_picker_ios/Sources/image_picker_ios/FLTImagePickerPlugin.m
+++ b/packages/image_picker/image_picker_ios/ios/image_picker_ios/Sources/image_picker_ios/FLTImagePickerPlugin.m
@@ -11,6 +11,7 @@
 #import <PhotosUI/PHPhotoLibrary+PhotosUISupport.h>
 #import <PhotosUI/PhotosUI.h>
 #import <UIKit/UIKit.h>
+#import <UniformTypeIdentifiers/UniformTypeIdentifiers.h>
 
 #import "./include/image_picker_ios/messages.g.h"
 #import "FLTImagePickerImageUtil.h"
@@ -127,10 +128,22 @@ typedef NS_ENUM(NSInteger, ImagePickerClassType) { UIImagePickerClassType, PHPic
   imagePickerController.delegate = self;
   NSMutableArray<NSString *> *mediaTypes = [[NSMutableArray alloc] init];
   if (context.includeImages) {
-    [mediaTypes addObject:(NSString *)kUTTypeImage];
+    NSString *imageType;
+    if (@available(iOS 14.0, *)) {
+      imageType = UTTypeImage.identifier;
+    } else {
+      imageType = (NSString *)kUTTypeImage;
+    }
+    [mediaTypes addObject:imageType];
   }
   if (context.includeVideo) {
-    [mediaTypes addObject:(NSString *)kUTTypeMovie];
+    NSString *movieType;
+    if (@available(iOS 14.0, *)) {
+      movieType = UTTypeMovie.identifier;
+    } else {
+      movieType = (NSString *)kUTTypeMovie;
+    }
+    [mediaTypes addObject:movieType];
     imagePickerController.videoQuality = UIImagePickerControllerQualityTypeHigh;
   }
   imagePickerController.mediaTypes = mediaTypes;

--- a/packages/image_picker/image_picker_ios/ios/image_picker_ios/Sources/image_picker_ios/FLTImagePickerPlugin.m
+++ b/packages/image_picker/image_picker_ios/ios/image_picker_ios/Sources/image_picker_ios/FLTImagePickerPlugin.m
@@ -128,20 +128,16 @@ typedef NS_ENUM(NSInteger, ImagePickerClassType) { UIImagePickerClassType, PHPic
   imagePickerController.delegate = self;
   NSMutableArray<NSString *> *mediaTypes = [[NSMutableArray alloc] init];
   if (context.includeImages) {
-    NSString *imageType;
+    NSString *imageType = (NSString *)kUTTypeImage;
     if (@available(iOS 14.0, *)) {
       imageType = UTTypeImage.identifier;
-    } else {
-      imageType = (NSString *)kUTTypeImage;
     }
     [mediaTypes addObject:imageType];
   }
   if (context.includeVideo) {
-    NSString *movieType;
+    NSString *movieType = (NSString *)kUTTypeMovie;
     if (@available(iOS 14.0, *)) {
       movieType = UTTypeMovie.identifier;
-    } else {
-      movieType = (NSString *)kUTTypeMovie;
     }
     [mediaTypes addObject:movieType];
     imagePickerController.videoQuality = UIImagePickerControllerQualityTypeHigh;

--- a/packages/image_picker/image_picker_ios/pubspec.yaml
+++ b/packages/image_picker/image_picker_ios/pubspec.yaml
@@ -2,7 +2,7 @@ name: image_picker_ios
 description: iOS implementation of the image_picker plugin.
 repository: https://github.com/flutter/packages/tree/main/packages/image_picker/image_picker_ios
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+image_picker%22
-version: 0.8.13+7
+version: 0.8.13+8
 
 environment:
   sdk: ^3.10.0


### PR DESCRIPTION
Fixes iOS deprecation warnings surfaced when building with Flutter 3.44.8 / Xcode 26 (iOS 26 SDK):

```
warning: 'kUTTypeImage' is deprecated: first deprecated in iOS 15.0 - Use UTTypeImage instead [-Wdeprecated-declarations]
warning: 'kUTTypeMovie' is deprecated: first deprecated in iOS 15.0 - Use UTTypeMovie instead [-Wdeprecated-declarations]
```

(`FLTImagePickerPlugin.m:130,133`)

## Cause

`launchUIImagePickerWithSource:` still adds `kUTTypeImage` / `kUTTypeMovie` directly to `UIImagePickerController.mediaTypes`. The legacy `kUTType*` constants were deprecated in iOS 15 in favor of the modern `UTType` API.

## Fix

Replaces the deprecated constants with `UTTypeImage.identifier` / `UTTypeMovie.identifier` guarded by `@available(iOS 14.0, *)`, keeping the legacy constants as the fallback for iOS 13 (the pod deployment target is 13.0). This mirrors the pattern already merged upstream in #10848 for the same plugin's `kUTTypeGIF` usages in `FLTImagePickerImageUtil.m` and `FLTImagePickerPhotoAssetUtil.m`, which appear to have missed these two call sites in `FLTImagePickerPlugin.m`.

## Verification

- `clang -fsyntax-only -fobjc-arc` against the iOS 26 simulator SDK (deployment target 13.0) passes.
- Version bumped to 0.8.13+8 with CHANGELOG entry, following the convention of #10848.

Detected with Flutter 3.44.8 / Xcode 26 (iOS 26 SDK).
