### PR TITLE
[material_ui] Add ReorderableListView.separated constructor

### DIFF
--- a/packages/material_ui/example/lib/reorderable_list/reorderable_list_view.separated.0.dart
+++ b/packages/material_ui/example/lib/reorderable_list/reorderable_list_view.separated.0.dart
@@ -1,0 +1,86 @@
+// Copyright 2013 The Flutter Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// #region body
+import 'package:material_ui/material_ui.dart';
+
+/// Flutter code sample for [ReorderableListView.separated].
+
+void main() => runApp(const ReorderableApp());
+
+class ReorderableApp extends StatelessWidget {
+  const ReorderableApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      home: Scaffold(
+        appBar: AppBar(
+          title: const Text('ReorderableListView.separated Sample'),
+        ),
+        body: const ReorderableExample(),
+      ),
+    );
+  }
+}
+
+class ReorderableExample extends StatefulWidget {
+  const ReorderableExample({super.key});
+
+  @override
+  State<ReorderableExample> createState() => _ReorderableExampleState();
+}
+
+class _ReorderableExampleState extends State<ReorderableExample> {
+  final List<int> _items = List<int>.generate(20, (int index) => index);
+
+  @override
+  Widget build(BuildContext context) {
+    final ColorScheme colorScheme = Theme.of(context).colorScheme;
+    final Color oddItemColor = colorScheme.primary.withValues(alpha: 0.05);
+    final Color evenItemColor = colorScheme.primary.withValues(alpha: 0.15);
+
+    return ReorderableListView.separated(
+      padding: const .symmetric(horizontal: 40.0),
+      itemCount: _items.length,
+      itemBuilder: (BuildContext context, int index) {
+        // ListTile.tileColor is painted by the nearest Material ancestor, so
+        // each tile brings its own Material: without it the color would be
+        // painted by the Scaffold's Material and would not move with the tile
+        // during a reorder drag (per the ListTile documentation).
+        return Material(
+          // Key each tile by its item rather than by its position, so a tile's
+          // identity follows the item it shows when the order changes.
+          key: ValueKey<int>(_items[index]),
+          child: ListTile(
+            tileColor: _items[index].isOdd ? oddItemColor : evenItemColor,
+            title: Text('Item ${_items[index]}'),
+          ),
+        );
+      },
+      // The separator index is a boundary index: separator `index` sits between
+      // the items built for `index` and `index + 1`, so it describes a position
+      // in the list rather than a particular item. The thick dividers therefore
+      // stay on the even boundaries no matter how the items are reordered, and
+      // every divider stays visible while an item is being dragged.
+      separatorBuilder: (BuildContext context, int index) {
+        return Divider(
+          height: 8.0,
+          thickness: index.isEven ? 4.0 : 1.0,
+          color: index.isEven
+              ? colorScheme.primary
+              : colorScheme.outlineVariant,
+        );
+      },
+      onReorderItem: (int oldIndex, int newIndex) {
+        setState(() {
+          final int item = _items.removeAt(oldIndex);
+          _items.insert(newIndex, item);
+        });
+      },
+    );
+  }
+}
+
+// #endregion body

--- a/packages/material_ui/example/test/reorderable_list/reorderable_list_view.separated.0_test.dart
+++ b/packages/material_ui/example/test/reorderable_list/reorderable_list_view.separated.0_test.dart
@@ -1,0 +1,86 @@
+// Copyright 2013 The Flutter Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:material_ui/material_ui.dart';
+import 'package:material_ui_examples/reorderable_list/reorderable_list_view.separated.0.dart'
+    as example;
+
+void main() {
+  testWidgets('Example separates each pair of items with a divider', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(const example.ReorderableApp());
+
+    expect(find.text('Item 0'), findsOneWidget);
+    expect(find.text('Item 1'), findsOneWidget);
+    expect(find.byType(Divider), findsAtLeast(2));
+
+    // Separator 0 is the boundary between items 0 and 1, so it occupies the gap
+    // between the two tiles rather than any space inside either of them.
+    final Finder firstItem = find.ancestor(
+      of: find.text('Item 0'),
+      matching: find.byType(ListTile),
+    );
+    final Finder secondItem = find.ancestor(
+      of: find.text('Item 1'),
+      matching: find.byType(ListTile),
+    );
+    final double firstSeparatorCenter = tester
+        .getCenter(find.byType(Divider).first)
+        .dy;
+    expect(
+      firstSeparatorCenter,
+      greaterThan(tester.getBottomLeft(firstItem).dy),
+    );
+    expect(firstSeparatorCenter, lessThan(tester.getTopLeft(secondItem).dy));
+  });
+
+  testWidgets(
+    'Example gives each tile its own Material, so its background moves with it during a drag',
+    (WidgetTester tester) async {
+      await tester.pumpWidget(const example.ReorderableApp());
+
+      // ListTile.tileColor is painted by the tile's nearest ancestor Material.
+      // Each tile must bring its own (the wrapper carrying the item's key):
+      // with a bare ListTile the nearest Material is the Scaffold's, and the
+      // background would stay put while the tile moves during a reorder drag.
+      final List<Element> tiles = find.byType(ListTile).evaluate().toList();
+      expect(tiles, isNotEmpty);
+      for (final Element tile in tiles) {
+        final Text title = (tile.widget as ListTile).title! as Text;
+        final int item = int.parse(title.data!.split(' ').last);
+        final Material? material = tile
+            .findAncestorWidgetOfExactType<Material>();
+        expect(
+          material?.key,
+          ValueKey<int>(item),
+          reason:
+              'the Material painting "${title.data}" must be its own wrapper',
+        );
+      }
+    },
+  );
+
+  testWidgets('Example thickens the separators on even boundaries', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(const example.ReorderableApp());
+
+    final List<Divider> separators = tester
+        .widgetList<Divider>(find.byType(Divider))
+        .toList();
+    expect(separators.length, greaterThan(1));
+
+    // The list starts unscrolled, so the separators onstage are boundaries 0, 1,
+    // 2, ... in order, and each one is built from its own boundary index.
+    for (int i = 0; i < separators.length; i += 1) {
+      expect(
+        separators[i].thickness,
+        i.isEven ? 4.0 : 1.0,
+        reason: 'separator at boundary $i',
+      );
+    }
+  });
+}

--- a/packages/material_ui/lib/src/reorderable_list.dart
+++ b/packages/material_ui/lib/src/reorderable_list.dart
@@ -149,7 +149,9 @@ class ReorderableListView extends StatefulWidget {
          'Remove the onReorder callback when both callbacks are provided.',
        ),
        itemBuilder = ((BuildContext context, int index) => children[index]),
-       itemCount = children.length;
+       itemCount = children.length,
+       _separatorBuilder = null,
+       _findItemIndexCallback = null;
 
   /// Creates a reorderable list from widget items that are created on demand.
   ///
@@ -227,7 +229,9 @@ class ReorderableListView extends StatefulWidget {
     this.autoScrollerVelocityScalar,
     this.dragBoundaryProvider,
     this.mouseCursor,
-  }) : assert(itemCount >= 0),
+  }) : _separatorBuilder = null,
+       _findItemIndexCallback = null,
+       assert(itemCount >= 0),
        assert(
          (itemExtent == null && prototypeItem == null) ||
              (itemExtent == null && itemExtentBuilder == null) ||
@@ -240,6 +244,107 @@ class ReorderableListView extends StatefulWidget {
          'The onReorder callback is obsolete and is replaced by onReorderItem. '
          'Remove the onReorder callback when both callbacks are provided.',
        );
+
+  /// Creates a reorderable list where the items and the separators between
+  /// them are created on demand.
+  ///
+  /// This constructor is appropriate for separated list views with a large
+  /// number of items, and mirrors [ListView.separated]: [itemCount] counts
+  /// data items only, and the separator built for boundary index `j` appears
+  /// between the items built for indices `j` and `j + 1`.
+  ///
+  /// The [itemBuilder] is called with item indices in the range `0` to
+  /// `itemCount - 1`, and every item it returns must have a unique key, just
+  /// like the other [ReorderableListView] constructors.
+  ///
+  /// The `separatorBuilder` is called with boundary indices in the range `0`
+  /// to `itemCount - 2`. Separators do not need a key, never receive a default
+  /// drag handle, and cannot start a reorder. They appear only between items:
+  /// no separator is created before the first item or after the last item, so
+  /// none appears next to [header] or [footer].
+  /// {@macro flutter.widgets.reorderable_list.separated.positionBasedSeparators}
+  ///
+  /// Only the dragged item appears in the drag proxy, so [proxyDecorator]
+  /// receives an item-only child and size; no separator is measured or
+  /// decorated by it.
+  /// {@macro flutter.widgets.reorderable_list.separated.dragBehavior}
+  /// See [SliverReorderableList.separated], which implements this behavior,
+  /// for details.
+  ///
+  /// [onReorderItem] reports the reorder using item indices: `newIndex` is
+  /// already adjusted for the removal of the item at `oldIndex`, so it is
+  /// always in the range `0` to `itemCount - 1` and is the final index of the
+  /// moved item.
+  ///
+  /// The `findItemIndexCallback` matches the parameter of the same name on
+  /// [ListView.separated]: it receives the original item keys (the keys of the
+  /// widgets returned by [itemBuilder]) and must return the item's logical
+  /// index in the range `0` to `itemCount - 1`, or null for an unknown key.
+  /// It operates purely in item-index space, unlike
+  /// [SliverChildBuilderDelegate.findChildIndexCallback], whose delegate child
+  /// indices also count separators.
+  /// {@macro flutter.widgets.reorderable_list.separated.statePreservation}
+  ///
+  /// The `onReorder` and `cacheExtent` parameters are intentionally
+  /// unavailable on this constructor; it accepts [onReorderItem] and
+  /// [scrollCacheExtent] only. The `itemExtent`, `itemExtentBuilder`, and
+  /// `prototypeItem` options are also unavailable, because a single
+  /// item-extent policy cannot describe alternating, heterogeneous items and
+  /// separators.
+  ///
+  /// See also:
+  ///
+  ///   * [ReorderableListView.builder], which builds a reorderable list
+  ///     without separators.
+  ///   * [ListView.separated], which is the non-reorderable equivalent of this
+  ///     constructor.
+  const ReorderableListView.separated({
+    super.key,
+    required this.itemBuilder,
+    required IndexedWidgetBuilder this._separatorBuilder,
+    required this.itemCount,
+    // The explicit type keeps the parameter non-nullable, unlike the shared
+    // field: there is no `onReorder` alternative here, so an explicit null
+    // would silently swallow every reorder.
+    required ReorderCallback this.onReorderItem,
+    this._findItemIndexCallback,
+    this.onReorderStart,
+    this.onReorderEnd,
+    this.proxyDecorator,
+    this.buildDefaultDragHandles = true,
+    this.padding,
+    this.header,
+    this.footer,
+    this.scrollDirection = Axis.vertical,
+    this.reverse = false,
+    this.scrollController,
+    this.primary,
+    this.physics,
+    this.shrinkWrap = false,
+    this.anchor = 0.0,
+    this.scrollCacheExtent,
+    this.dragStartBehavior = DragStartBehavior.start,
+    this.keyboardDismissBehavior,
+    this.restorationId,
+    this.clipBehavior = Clip.hardEdge,
+    this.autoScrollerVelocityScalar,
+    this.dragBoundaryProvider,
+    this.mouseCursor,
+  }) : onReorder = null,
+       cacheExtent = null,
+       itemExtent = null,
+       itemExtentBuilder = null,
+       prototypeItem = null,
+       assert(itemCount >= 0);
+
+  /// The builder used to build separators between items. Non-null only for the
+  /// [ReorderableListView.separated] constructor; the other constructors leave
+  /// it null so their widget trees and timing are unchanged.
+  final IndexedWidgetBuilder? _separatorBuilder;
+
+  /// The finder used to map an original item key to its logical item index for
+  /// the separated constructor. See [ReorderableListView.separated].
+  final ChildIndexGetter? _findItemIndexCallback;
 
   /// {@macro flutter.widgets.reorderable_list.itemBuilder}
   final IndexedWidgetBuilder itemBuilder;
@@ -481,6 +586,20 @@ class _ReorderableListViewState extends State<ReorderableListView> {
     return KeyedSubtree(key: itemGlobalKey, child: item);
   }
 
+  /// Unwraps the private key that [_itemBuilder] adds around every item before
+  /// invoking the user's `findItemIndexCallback`, so user code only ever sees
+  /// original item keys. Unknown keys map to null.
+  int? _findItemIndex(Key key) {
+    assert(
+      widget._findItemIndexCallback != null,
+      'Only forwarded to the sliver when the user supplied a callback.',
+    );
+    if (key is! _ReorderableListViewChildGlobalKey) {
+      return null;
+    }
+    return widget._findItemIndexCallback!(key.subKey);
+  }
+
   Widget _proxyDecorator(Widget child, int index, Animation<double> animation) {
     return AnimatedBuilder(
       animation: animation,
@@ -536,6 +655,18 @@ class _ReorderableListViewState extends State<ReorderableListView> {
         widget.scrollCacheExtent ??
         (widget.cacheExtent == null ? null : ScrollCacheExtent.pixels(widget.cacheExtent!));
 
+    void handleReorderStart(int index) {
+      _dragging.value = true;
+      widget.onReorderStart?.call(index);
+    }
+
+    void handleReorderEnd(int index) {
+      _dragging.value = false;
+      widget.onReorderEnd?.call(index);
+    }
+
+    final IndexedWidgetBuilder? separatorBuilder = widget._separatorBuilder;
+
     return CustomScrollView(
       scrollDirection: widget.scrollDirection,
       reverse: widget.reverse,
@@ -549,6 +680,11 @@ class _ReorderableListViewState extends State<ReorderableListView> {
       keyboardDismissBehavior: widget.keyboardDismissBehavior,
       restorationId: widget.restorationId,
       clipBehavior: widget.clipBehavior,
+      // Only the separated path reports a semantic child count: its sliver's
+      // children include separators, which are not semantic list items, so
+      // accessibility scrolling needs the dense item-only count. The other
+      // constructors deliberately leave it unset.
+      semanticChildCount: separatorBuilder == null ? null : widget.itemCount,
       slivers: <Widget>[
         if (widget.header != null)
           SliverPadding(
@@ -557,26 +693,38 @@ class _ReorderableListViewState extends State<ReorderableListView> {
           ),
         SliverPadding(
           padding: listPadding,
-          sliver: SliverReorderableList(
-            itemBuilder: _itemBuilder,
-            itemExtent: widget.itemExtent,
-            itemExtentBuilder: widget.itemExtentBuilder,
-            prototypeItem: widget.prototypeItem,
-            itemCount: widget.itemCount,
-            onReorder: widget.onReorder,
-            onReorderItem: widget.onReorderItem,
-            onReorderStart: (int index) {
-              _dragging.value = true;
-              widget.onReorderStart?.call(index);
-            },
-            onReorderEnd: (int index) {
-              _dragging.value = false;
-              widget.onReorderEnd?.call(index);
-            },
-            proxyDecorator: widget.proxyDecorator ?? _proxyDecorator,
-            autoScrollerVelocityScalar: widget.autoScrollerVelocityScalar,
-            dragBoundaryProvider: widget.dragBoundaryProvider,
-          ),
+          sliver: separatorBuilder == null
+              ? SliverReorderableList(
+                  itemBuilder: _itemBuilder,
+                  itemExtent: widget.itemExtent,
+                  itemExtentBuilder: widget.itemExtentBuilder,
+                  prototypeItem: widget.prototypeItem,
+                  itemCount: widget.itemCount,
+                  onReorder: widget.onReorder,
+                  onReorderItem: widget.onReorderItem,
+                  onReorderStart: handleReorderStart,
+                  onReorderEnd: handleReorderEnd,
+                  proxyDecorator: widget.proxyDecorator ?? _proxyDecorator,
+                  autoScrollerVelocityScalar: widget.autoScrollerVelocityScalar,
+                  dragBoundaryProvider: widget.dragBoundaryProvider,
+                )
+              : SliverReorderableList.separated(
+                  itemBuilder: _itemBuilder,
+                  separatorBuilder: separatorBuilder,
+                  itemCount: widget.itemCount,
+                  onReorderItem: widget.onReorderItem!,
+                  // Forward the unwrapping wrapper only when the user supplied
+                  // a callback: a null here keeps the sliver's relocation
+                  // lookup disabled exactly as if no callback existed.
+                  findItemIndexCallback: widget._findItemIndexCallback == null
+                      ? null
+                      : _findItemIndex,
+                  onReorderStart: handleReorderStart,
+                  onReorderEnd: handleReorderEnd,
+                  proxyDecorator: widget.proxyDecorator ?? _proxyDecorator,
+                  autoScrollerVelocityScalar: widget.autoScrollerVelocityScalar,
+                  dragBoundaryProvider: widget.dragBoundaryProvider,
+                ),
         ),
         if (widget.footer != null)
           SliverPadding(

--- a/packages/material_ui/pending_changelogs/change_2026_09_08_reorderable_list_view_separated.yaml
+++ b/packages/material_ui/pending_changelogs/change_2026_09_08_reorderable_list_view_separated.yaml
@@ -1,0 +1,3 @@
+changelog: |
+  - Adds `ReorderableListView.separated`, a reorderable list with separators between items, mirroring `ListView.separated`.
+version: minor

--- a/packages/material_ui/test/reorderable_list_test.dart
+++ b/packages/material_ui/test/reorderable_list_test.dart
@@ -2766,6 +2766,605 @@ void main() {
     );
     expect(tester.getSize(find.byType(ReorderableListView)), Size.zero);
   });
+
+  group('ReorderableListView.separated', () {
+    const itemHeight = 48.0;
+    const separatorHeight = 16.0;
+    late List<String> items;
+
+    setUp(() {
+      items = <String>['Item 1', 'Item 2', 'Item 3', 'Item 4'];
+    });
+
+    Widget itemBuilder(BuildContext context, int index) {
+      final String item = items[index];
+      return SizedBox(key: Key(item), height: itemHeight, child: Text(item));
+    }
+
+    // Separators are deliberately keyless: only items must have a key.
+    Widget separatorBuilder(BuildContext context, int boundary) {
+      return SizedBox(height: separatorHeight, child: Text('Separator $boundary'));
+    }
+
+    // The pointer travel that drops a dragged item [count] slots away, where
+    // one slot is an item plus a separator. Dropping into a slot requires the
+    // proxy's edge to enter the target item's nearer half: traveling a full
+    // multiple of one slot would land the edge exactly on the far end of that
+    // trigger window (the target's trailing edge going down, its leading edge
+    // going up), so stopping a quarter item short parks it safely inside.
+    double dragDistance(int count) => count * (itemHeight + separatorHeight) - itemHeight / 4;
+
+    Widget buildList({
+      Widget? header,
+      Widget? footer,
+      EdgeInsets? padding,
+      IndexedWidgetBuilder? itemBuilderOverride,
+      IndexedWidgetBuilder? separatorBuilderOverride,
+      ReorderCallback? onReorderItem,
+      ChildIndexGetter? findItemIndexCallback,
+      ReorderItemProxyDecorator? proxyDecorator,
+    }) {
+      return MaterialApp(
+        home: Scaffold(
+          body: StatefulBuilder(
+            builder: (BuildContext context, StateSetter setState) {
+              return ReorderableListView.separated(
+                header: header,
+                footer: footer,
+                padding: padding,
+                itemBuilder: itemBuilderOverride ?? itemBuilder,
+                separatorBuilder: separatorBuilderOverride ?? separatorBuilder,
+                itemCount: items.length,
+                proxyDecorator: proxyDecorator,
+                findItemIndexCallback: findItemIndexCallback,
+                onReorderItem: (int oldIndex, int newIndex) {
+                  onReorderItem?.call(oldIndex, newIndex);
+                  setState(() {
+                    items.insert(newIndex, items.removeAt(oldIndex));
+                  });
+                },
+              );
+            },
+          ),
+        ),
+      );
+    }
+
+    // All separators remain visible for the whole drag: there is no hiding
+    // mechanism, so every one of the itemCount - 1 separators must be present.
+    void expectAllSeparatorsVisible(WidgetTester tester) {
+      for (var boundary = 0; boundary < items.length - 1; boundary += 1) {
+        expect(
+          find.text('Separator $boundary'),
+          findsOneWidget,
+          reason: 'separator $boundary should exist',
+        );
+      }
+      expect(find.text('Separator ${items.length - 1}'), findsNothing);
+    }
+
+    testWidgets('asserts on a negative itemCount', (WidgetTester tester) async {
+      expect(
+        () => ReorderableListView.separated(
+          itemBuilder: (_, _) => const SizedBox(),
+          separatorBuilder: (_, _) => const SizedBox(),
+          itemCount: -1,
+          onReorderItem: (_, _) {},
+        ),
+        throwsAssertionError,
+      );
+    });
+
+    testWidgets('creates only the items and separators it needs', (WidgetTester tester) async {
+      final itemsCreated = <int>{};
+      final separatorsCreated = <int>{};
+      await tester.pumpWidget(
+        MaterialApp(
+          home: ReorderableListView.separated(
+            itemBuilder: (BuildContext context, int index) {
+              itemsCreated.add(index);
+              return SizedBox(key: ValueKey<int>(index), height: itemHeight, child: Text('$index'));
+            },
+            separatorBuilder: (BuildContext context, int boundary) {
+              separatorsCreated.add(boundary);
+              return const SizedBox(height: separatorHeight);
+            },
+            itemCount: 1000,
+            onReorderItem: (_, _) {},
+          ),
+        ),
+      );
+
+      // With the default 800x600 test surface and the default 250 pixel cache
+      // extent, the build budget is 600 + 250 = 850 pixels: around 14 of the
+      // 64 pixel item-plus-separator slots. The looser bound of 20 leaves
+      // slack for those defaults changing while still proving lazy building
+      // nowhere near the full 1000.
+      expect(itemsCreated, isNotEmpty);
+      expect(separatorsCreated, isNotEmpty);
+      expect(itemsCreated.every((int index) => index < 20), isTrue);
+      expect(separatorsCreated.every((int boundary) => boundary < 20), isTrue);
+    });
+
+    testWidgets('throws an error when an item has no key', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        buildList(itemBuilderOverride: (BuildContext context, int index) => Text(items[index])),
+      );
+      final dynamic exception = tester.takeException();
+      expect(exception, isFlutterError);
+      expect(exception.toString(), contains('Every item of ReorderableListView must have a key.'));
+    });
+
+    testWidgets('accepts keyless separators', (WidgetTester tester) async {
+      await tester.pumpWidget(buildList());
+      expect(tester.takeException(), isNull);
+      expectAllSeparatorsVisible(tester);
+      // Separators appear at their boundary geometry: separator j sits
+      // directly below item j.
+      for (var boundary = 0; boundary < items.length - 1; boundary += 1) {
+        expect(
+          tester.getTopLeft(find.text('Separator $boundary')).dy,
+          (boundary + 1) * itemHeight + boundary * separatorHeight,
+        );
+      }
+    });
+
+    testWidgets('shows default drag handles on items only', (WidgetTester tester) async {
+      await tester.pumpWidget(buildList());
+
+      // One handle per item, none for the three separators: no separator sits
+      // inside a drag listener, and no handle icon sits inside a separator.
+      expect(find.byIcon(Icons.drag_handle), findsNWidgets(items.length));
+      for (var boundary = 0; boundary < items.length - 1; boundary += 1) {
+        final Finder separatorText = find.text('Separator $boundary');
+        expect(
+          find.ancestor(of: separatorText, matching: find.byType(ReorderableDragStartListener)),
+          findsNothing,
+        );
+        // The nearest SizedBox ancestor is the separator subtree built by
+        // separatorBuilder.
+        final Finder separator = find
+            .ancestor(of: separatorText, matching: find.byType(SizedBox))
+            .first;
+        expect(
+          find.descendant(of: separator, matching: find.byIcon(Icons.drag_handle)),
+          findsNothing,
+        );
+      }
+    }, variant: TargetPlatformVariant.desktop());
+
+    testWidgets(
+      'wraps items but not separators in delayed drag listeners',
+      (WidgetTester tester) async {
+        await tester.pumpWidget(buildList());
+
+        // On mobile platforms the default handles are not icons; instead each
+        // whole item is wrapped in a ReorderableDelayedDragStartListener.
+        // Separators get neither.
+        expect(find.byIcon(Icons.drag_handle), findsNothing);
+        expect(find.byType(ReorderableDelayedDragStartListener), findsNWidgets(items.length));
+        for (final item in items) {
+          expect(
+            find.ancestor(
+              of: find.byKey(Key(item)),
+              matching: find.byType(ReorderableDelayedDragStartListener),
+            ),
+            findsOneWidget,
+          );
+        }
+        for (var boundary = 0; boundary < items.length - 1; boundary += 1) {
+          expect(
+            find.ancestor(
+              of: find.text('Separator $boundary'),
+              matching: find.byType(ReorderableDelayedDragStartListener),
+            ),
+            findsNothing,
+          );
+        }
+      },
+      variant: TargetPlatformVariant.mobile(),
+    );
+
+    testWidgets('forwards onReorderStart and onReorderEnd on the separated path', (
+      WidgetTester tester,
+    ) async {
+      final startIndices = <int>[];
+      final endIndices = <int>[];
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: ReorderableListView.separated(
+              itemBuilder: itemBuilder,
+              separatorBuilder: separatorBuilder,
+              itemCount: items.length,
+              onReorderStart: startIndices.add,
+              onReorderEnd: endIndices.add,
+              onReorderItem: (int oldIndex, int newIndex) {
+                items.insert(newIndex, items.removeAt(oldIndex));
+              },
+            ),
+          ),
+        ),
+      );
+
+      final Offset start = tester.getCenter(find.text('Item 1'));
+      final TestGesture drag = await tester.startGesture(start);
+      await tester.pump(kLongPressTimeout + kPressTimeout);
+      expect(startIndices, <int>[0]);
+      expect(endIndices, isEmpty);
+
+      await drag.moveTo(start + Offset(0, dragDistance(1)));
+      await tester.pump(kPressTimeout);
+      await drag.up();
+      await tester.pumpAndSettle();
+
+      // onReorderStart reports the dragged item's index and onReorderEnd the
+      // raw insertion index, exactly as for the other constructors, while
+      // onReorderItem receives the adjusted final item index.
+      expect(startIndices, <int>[0]);
+      expect(endIndices, <int>[2]);
+      expect(items, orderedEquals(<String>['Item 2', 'Item 1', 'Item 3', 'Item 4']));
+    });
+
+    testWidgets('renders zero and one item lists without separators', (WidgetTester tester) async {
+      items = <String>[];
+      await tester.pumpWidget(buildList());
+      expect(tester.takeException(), isNull);
+      expect(find.textContaining('Item'), findsNothing);
+      expect(find.textContaining('Separator'), findsNothing);
+      expect(tester.widget<CustomScrollView>(find.byType(CustomScrollView)).semanticChildCount, 0);
+
+      items = <String>['Item 1'];
+      await tester.pumpWidget(buildList());
+      expect(find.text('Item 1'), findsOneWidget);
+      expect(find.textContaining('Separator'), findsNothing);
+      expect(tester.widget<CustomScrollView>(find.byType(CustomScrollView)).semanticChildCount, 1);
+    });
+
+    testWidgets('long pressing a separator cannot start a reorder', (WidgetTester tester) async {
+      var reorderCalls = 0;
+      await tester.pumpWidget(buildList(onReorderItem: (_, _) => reorderCalls += 1));
+
+      // On mobile platforms the default handles make the whole item a delayed
+      // drag listener; separators receive no such listener.
+      await longPressDrag(
+        tester,
+        tester.getCenter(find.text('Separator 0')),
+        tester.getCenter(find.text('Item 4')),
+      );
+      await tester.pumpAndSettle();
+      expect(reorderCalls, 0);
+      expect(items, orderedEquals(<String>['Item 1', 'Item 2', 'Item 3', 'Item 4']));
+    });
+
+    testWidgets('default proxy decoration elevates only the dragged item', (
+      WidgetTester tester,
+    ) async {
+      await tester.pumpWidget(buildList());
+
+      final TestGesture drag = await tester.startGesture(tester.getCenter(find.text('Item 2')));
+      await tester.pump(kLongPressTimeout + kPressTimeout);
+      await drag.moveBy(const Offset(0, itemHeight));
+      // Drive the 250 ms elevation animation to its end while holding.
+      await tester.pump(const Duration(milliseconds: 300));
+
+      // The dragged item is rendered by the item-only proxy: it keeps the bare
+      // item size with no separator accreted.
+      expect(tester.getSize(find.byKey(const Key('Item 2'))), const Size(800.0, itemHeight));
+      final Material material = tester.widget<Material>(
+        find.ancestor(of: find.byKey(const Key('Item 2')), matching: find.byType(Material)).first,
+      );
+      expect(material.elevation, 6.0);
+      // No separator is duplicated into the overlay proxy.
+      for (var boundary = 0; boundary < items.length - 1; boundary += 1) {
+        expect(find.text('Separator $boundary'), findsOneWidget);
+      }
+
+      await drag.up();
+      await tester.pumpAndSettle();
+    });
+
+    testWidgets('a custom proxy decorator receives an item-only child and size', (
+      WidgetTester tester,
+    ) async {
+      final decoratedIndices = <int>[];
+      await tester.pumpWidget(
+        buildList(
+          proxyDecorator: (Widget child, int index, Animation<double> animation) {
+            decoratedIndices.add(index);
+            return ColoredBox(
+              key: const Key('proxy'),
+              color: const Color(0xFF00FF00),
+              child: child,
+            );
+          },
+        ),
+      );
+
+      final TestGesture drag = await tester.startGesture(tester.getCenter(find.text('Item 2')));
+      await tester.pump(kLongPressTimeout + kPressTimeout);
+      await drag.moveBy(const Offset(0, itemHeight));
+      await tester.pump(const Duration(milliseconds: 300));
+
+      // The decorator was handed the dragged item's index, and the widget it
+      // decorates measures exactly one item: no separator extent is included.
+      expect(decoratedIndices, isNotEmpty);
+      expect(decoratedIndices.toSet(), <int>{1});
+      expect(tester.getSize(find.byKey(const Key('proxy'))), const Size(800.0, itemHeight));
+      expect(
+        find.descendant(
+          of: find.byKey(const Key('proxy')),
+          matching: find.textContaining('Separator'),
+        ),
+        findsNothing,
+      );
+
+      await drag.up();
+      await tester.pumpAndSettle();
+    });
+
+    testWidgets('reports final item indices for first, middle, and last reorders', (
+      WidgetTester tester,
+    ) async {
+      final reorders = <(int, int)>[];
+      await tester.pumpWidget(
+        buildList(
+          onReorderItem: (int oldIndex, int newIndex) => reorders.add((oldIndex, newIndex)),
+        ),
+      );
+
+      // A one-slot downward move: the reported index must be the final item
+      // index, one less than the raw insertion index (and in particular not
+      // double-decremented, which would swallow a one-slot move entirely).
+      Offset start = tester.getCenter(find.text('Item 1'));
+      await longPressDrag(tester, start, start + Offset(0, dragDistance(1)));
+      await tester.pumpAndSettle();
+      expect(reorders, orderedEquals(<(int, int)>[(0, 1)]));
+      expect(items, orderedEquals(<String>['Item 2', 'Item 1', 'Item 3', 'Item 4']));
+
+      // A multi-slot downward move of the first item to the last slot.
+      start = tester.getCenter(find.text('Item 2'));
+      await longPressDrag(tester, start, start + Offset(0, dragDistance(3)));
+      await tester.pumpAndSettle();
+      expect(reorders.last, (0, 3));
+      expect(items, orderedEquals(<String>['Item 1', 'Item 3', 'Item 4', 'Item 2']));
+
+      // An upward move of the last item to the very top.
+      start = tester.getCenter(find.text('Item 2'));
+      await longPressDrag(tester, start, start - Offset(0, dragDistance(3)));
+      await tester.pumpAndSettle();
+      expect(reorders.last, (3, 0));
+      expect(items, orderedEquals(<String>['Item 2', 'Item 1', 'Item 3', 'Item 4']));
+
+      // A one-slot upward move from the middle.
+      start = tester.getCenter(find.text('Item 3'));
+      await longPressDrag(tester, start, start - Offset(0, dragDistance(1)));
+      await tester.pumpAndSettle();
+      expect(reorders.last, (2, 1));
+      expect(items, orderedEquals(<String>['Item 2', 'Item 3', 'Item 1', 'Item 4']));
+
+      // Every reported newIndex is a final item index in 0 .. itemCount - 1.
+      for (final (int oldIndex, int newIndex) in reorders) {
+        expect(oldIndex, inInclusiveRange(0, items.length - 1));
+        expect(newIndex, inInclusiveRange(0, items.length - 1));
+      }
+    });
+
+    testWidgets('repeated successive reorders preserve every separator', (
+      WidgetTester tester,
+    ) async {
+      await tester.pumpWidget(buildList());
+      expectAllSeparatorsVisible(tester);
+
+      // Alternate downward and upward drags several times; after every drop
+      // and pumpAndSettle all itemCount - 1 separators must be visible again
+      // at their boundary geometry, guarding against stale drag state leaving
+      // a separator permanently missing or displaced after a drop.
+      for (var round = 0; round < 3; round += 1) {
+        final String first = items.first;
+        Offset start = tester.getCenter(find.text(first));
+        await longPressDrag(tester, start, start + Offset(0, dragDistance(2)));
+        await tester.pumpAndSettle();
+        expect(items.first, isNot(first));
+        expectAllSeparatorsVisible(tester);
+
+        final String last = items.last;
+        start = tester.getCenter(find.text(last));
+        await longPressDrag(tester, start, start - Offset(0, dragDistance(3)));
+        await tester.pumpAndSettle();
+        expect(items.last, isNot(last));
+        expectAllSeparatorsVisible(tester);
+
+        for (var boundary = 0; boundary < items.length - 1; boundary += 1) {
+          expect(
+            tester.getTopLeft(find.text('Separator $boundary')).dy,
+            (boundary + 1) * itemHeight + boundary * separatorHeight,
+            reason: 'separator $boundary should be back at its boundary after round $round',
+          );
+        }
+      }
+    });
+
+    testWidgets('separators appear only between items, never next to the header or footer', (
+      WidgetTester tester,
+    ) async {
+      const padding = EdgeInsets.fromLTRB(10, 20, 30, 40);
+      await tester.pumpWidget(
+        buildList(
+          padding: padding,
+          header: const SizedBox(key: Key('Header'), height: 30),
+          footer: const SizedBox(key: Key('Footer'), height: 30),
+        ),
+      );
+
+      // Header and footer carry their split padding; the separated body sits
+      // between them with no separator synthesized at either boundary.
+      expect(tester.getRect(find.byKey(const Key('Header'))), const Rect.fromLTRB(10, 20, 770, 50));
+      expect(tester.getRect(find.byKey(const Key('Item 1'))), const Rect.fromLTRB(10, 50, 770, 98));
+      expect(
+        tester.getRect(find.byKey(const Key('Item 4'))),
+        const Rect.fromLTRB(10, 242, 770, 290),
+      );
+      expect(
+        tester.getRect(find.byKey(const Key('Footer'))),
+        const Rect.fromLTRB(10, 290, 770, 320),
+      );
+      expect(find.textContaining('Separator'), findsNWidgets(items.length - 1));
+      expect(tester.getTopLeft(find.text('Separator 0')).dy, 98);
+      expect(tester.getBottomLeft(find.text('Separator 2')).dy, 242);
+    });
+
+    testWidgets('reports a semantic child count of itemCount', (WidgetTester tester) async {
+      await tester.pumpWidget(buildList());
+      // Separators are not semantic list items, so the scroll view reports
+      // the dense item-only count for accessibility scrolling.
+      expect(
+        tester.widget<CustomScrollView>(find.byType(CustomScrollView)).semanticChildCount,
+        items.length,
+      );
+
+      // The non-separated constructors are unchanged and set no count.
+      await tester.pumpWidget(
+        MaterialApp(
+          home: ReorderableListView.builder(
+            itemBuilder: itemBuilder,
+            itemCount: items.length,
+            onReorderItem: (_, _) {},
+          ),
+        ),
+      );
+      expect(
+        tester.widget<CustomScrollView>(find.byType(CustomScrollView)).semanticChildCount,
+        isNull,
+      );
+    });
+
+    testWidgets('findItemIndexCallback receives original item keys and preserves item state', (
+      WidgetTester tester,
+    ) async {
+      final receivedKeys = <Key>[];
+      await tester.pumpWidget(
+        buildList(
+          itemBuilderOverride: (BuildContext context, int index) {
+            final String item = items[index];
+            return SizedBox(
+              key: Key(item),
+              height: itemHeight,
+              child: _StatefulLabel(label: item),
+            );
+          },
+          findItemIndexCallback: (Key key) {
+            receivedKeys.add(key);
+            if (key is ValueKey<String>) {
+              final int index = items.indexOf(key.value);
+              return index == -1 ? null : index;
+            }
+            return null;
+          },
+        ),
+      );
+
+      // Capture the State of an item the reorder relocates and give it local
+      // state that only survives if the State instance itself survives.
+      final _StatefulLabelState stateBefore = tester.state<_StatefulLabelState>(
+        find.byWidgetPredicate(
+          (Widget widget) => widget is _StatefulLabel && widget.label == 'Item 2',
+        ),
+      );
+      stateBefore.localState = 42;
+
+      // A non-adjacent reorder forces the delegate to relocate keyed children,
+      // which invokes findItemIndexCallback.
+      final Offset start = tester.getCenter(find.text('Item 1'));
+      await longPressDrag(tester, start, start + Offset(0, dragDistance(2)));
+      await tester.pumpAndSettle();
+      expect(items, orderedEquals(<String>['Item 2', 'Item 3', 'Item 1', 'Item 4']));
+
+      // Every forwarded key is an original item key (the Material-private
+      // wrapper key is unwrapped before user code sees it).
+      expect(receivedKeys, isNotEmpty);
+      expect(
+        receivedKeys.every((Key key) => key.runtimeType == ValueKey<String>),
+        isTrue,
+        reason: 'findItemIndexCallback must only receive original item keys, got $receivedKeys',
+      );
+
+      // Relocating the keyed item preserved its State.
+      final _StatefulLabelState stateAfter = tester.state<_StatefulLabelState>(
+        find.byWidgetPredicate(
+          (Widget widget) => widget is _StatefulLabel && widget.label == 'Item 2',
+        ),
+      );
+      expect(identical(stateAfter, stateBefore), isTrue);
+      expect(stateAfter.localState, 42);
+    });
+
+    testWidgets('ListTile items with alternating separators keep boundary-based styling', (
+      WidgetTester tester,
+    ) async {
+      const evenColor = Color(0xFFFF0000);
+      const oddColor = Color(0xFF0000FF);
+      await tester.pumpWidget(
+        buildList(
+          itemBuilderOverride: (BuildContext context, int index) {
+            final String item = items[index];
+            return ListTile(key: Key(item), title: Text(item));
+          },
+          separatorBuilderOverride: (BuildContext context, int boundary) {
+            // Position-dependent style: even boundaries are tall and red, odd
+            // boundaries short and blue.
+            return Container(
+              height: boundary.isEven ? 24.0 : 8.0,
+              color: boundary.isEven ? evenColor : oddColor,
+              child: Text('Separator $boundary'),
+            );
+          },
+        ),
+      );
+
+      void expectBoundaryStyles() {
+        for (var boundary = 0; boundary < items.length - 1; boundary += 1) {
+          final Finder separator = find.ancestor(
+            of: find.text('Separator $boundary'),
+            matching: find.byType(Container),
+          );
+          expect(tester.getSize(separator).height, boundary.isEven ? 24.0 : 8.0);
+          final Container container = tester.widget<Container>(separator);
+          expect(container.color, boundary.isEven ? evenColor : oddColor);
+        }
+        // Separators tile the gaps exactly: each one starts where the item
+        // above it ends, with no overlap and no paint-order artifacts.
+        double top = tester.getBottomLeft(find.byKey(Key(items[0]))).dy;
+        for (var boundary = 0; boundary < items.length - 1; boundary += 1) {
+          final Finder separator = find.ancestor(
+            of: find.text('Separator $boundary'),
+            matching: find.byType(Container),
+          );
+          expect(tester.getTopLeft(separator).dy, top);
+          top = tester.getBottomLeft(separator).dy;
+          expect(tester.getTopLeft(find.byKey(Key(items[boundary + 1]))).dy, top);
+          top = tester.getBottomLeft(find.byKey(Key(items[boundary + 1]))).dy;
+        }
+      }
+
+      expectBoundaryStyles();
+
+      // A two-slot downward move: the pointer must end between the top and
+      // the center of the third tile so that the proxy's trailing edge lands
+      // in the tile's trailing half.
+      final double tileHeight = tester.getSize(find.byKey(const Key('Item 1'))).height;
+      await longPressDrag(
+        tester,
+        tester.getCenter(find.text('Item 1')),
+        tester.getCenter(find.byKey(const Key('Item 3'))) - Offset(0, tileHeight / 4),
+      );
+      await tester.pumpAndSettle();
+
+      // The styles stay tied to the visual boundary index after the reorder.
+      expect(items, orderedEquals(<String>['Item 2', 'Item 3', 'Item 1', 'Item 4']));
+      expectBoundaryStyles();
+    });
+  });
 }
 
 Future<void> longPressDrag(WidgetTester tester, Offset start, Offset end) async {
@@ -2796,5 +3395,26 @@ class _StatefulState extends State<_Stateful> {
         child: Checkbox(value: checked, onChanged: (bool? newValue) => checked = newValue),
       ),
     );
+  }
+}
+
+// A stateful leaf for the separated-list tests. Its [State] retains
+// [localState] only if the framework relocates (rather than recreates) its
+// element when a keyed item moves to a new index.
+class _StatefulLabel extends StatefulWidget {
+  const _StatefulLabel({required this.label});
+
+  final String label;
+
+  @override
+  State<_StatefulLabel> createState() => _StatefulLabelState();
+}
+
+class _StatefulLabelState extends State<_StatefulLabel> {
+  int localState = 0;
+
+  @override
+  Widget build(BuildContext context) {
+    return Text(widget.label);
   }
 }


### PR DESCRIPTION
Ports the Material half of flutter/flutter#190131 per flutter/flutter#188444: a reorderable list with separators between items, mirroring ListView.separated.

This ports the Material half of flutter/flutter#190131 to `material_ui`,
following flutter/flutter#188444 (Material is frozen in
flutter/flutter). The widgets half (`SliverReorderableList.separated`,
which this constructor wraps) remains in flutter/flutter#190131. The API
example wraps each `ListTile` in its own keyed `Material` so tile
backgrounds move with their tiles during a drag, addressing
[review feedback](https://github.com/flutter/flutter/pull/190131#pullrequestreview-5011901684)
from @Piinks on the original PR (`tileColor` is painted by the nearest
ancestor `Material`, per the `ListTile` documentation).

This PR depends on `SliverReorderableList.separated` landing in
flutter/flutter (flutter/flutter#190131). Once that API is in a Flutter
release CI can use, I'll bump `flutter:` in pubspec.yaml and mark
this ready for review.

Fixes https://github.com/flutter/flutter/issues/76706

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under[^1].
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[the version and CHANGELOG instructions]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version-and-changelog-updates
[semantic versioning]: https://dart.dev/tools/pub/versioning#semantic-versions
[repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
