### PR TITLE
[go_router] Rematch an inactive StatefulShellBranch against the current routing table when it becomes active again

### DIFF
--- a/packages/go_router/lib/src/route.dart
+++ b/packages/go_router/lib/src/route.dart
@@ -1473,7 +1473,7 @@ class StatefulNavigationShellState extends State<StatefulNavigationShell> with R
     assert(index >= 0 && index < route.branches.length);
     final RouteMatchList? matchList = initialLocation ? null : _matchListForBranch(index);
     if (matchList != null && matchList.isNotEmpty) {
-      _router.restore(matchList);
+      _router.restore(_router.configuration.reparse(matchList));
     } else {
       _router.go(widget._effectiveInitialBranchLocation(index));
     }

--- a/packages/go_router/pending_changelogs/reparse_inactive_shell_branch.yaml
+++ b/packages/go_router/pending_changelogs/reparse_inactive_shell_branch.yaml
@@ -1,0 +1,2 @@
+changelog: Reparses the match list a stateful shell branch saved when it becomes active again, so a branch left behind by a `GoRouter.routingConfig` update no longer restores routes the current table does not contain — which made an imperative push on top of it mount a second copy of the shell.
+version: patch

--- a/packages/go_router/test/routing_config_test.dart
+++ b/packages/go_router/test/routing_config_test.dart
@@ -184,6 +184,82 @@ void main() {
     },
   );
 
+  testWidgets('routing config rematches an inactive stateful shell branch', (
+    WidgetTester tester,
+  ) async {
+    final shellNavigatorKey = GlobalKey<NavigatorState>(debugLabel: 'shell');
+    final shellKey = GlobalKey<StatefulNavigationShellState>(debugLabel: 'statefulShell');
+    final firstBranchKey = GlobalKey<NavigatorState>(debugLabel: 'first');
+    final secondBranchKey = GlobalKey<NavigatorState>(debugLabel: 'second');
+
+    final branches = <StatefulShellBranch>[
+      StatefulShellBranch(
+        navigatorKey: firstBranchKey,
+        routes: <RouteBase>[
+          GoRoute(
+            path: '/first',
+            builder: (_, _) => const Text('first'),
+            routes: <RouteBase>[
+              GoRoute(
+                path: 'details',
+                parentNavigatorKey: shellNavigatorKey,
+                builder: (_, _) => const Text('details'),
+              ),
+            ],
+          ),
+        ],
+      ),
+      StatefulShellBranch(
+        navigatorKey: secondBranchKey,
+        routes: <RouteBase>[GoRoute(path: '/second', builder: (_, _) => const Text('second'))],
+      ),
+    ];
+
+    RoutingConfig buildConfig() => RoutingConfig(
+      routes: <RouteBase>[
+        ShellRoute(
+          navigatorKey: shellNavigatorKey,
+          pageBuilder: (_, _, Widget child) => NoTransitionPage<void>(child: child),
+          routes: <RouteBase>[
+            StatefulShellRoute.indexedStack(
+              key: shellKey,
+              branches: branches,
+              pageBuilder: (_, _, StatefulNavigationShell navigationShell) =>
+                  NoTransitionPage<void>(child: navigationShell),
+            ),
+          ],
+        ),
+      ],
+    );
+
+    final config = ValueNotifier<RoutingConfig>(buildConfig());
+    addTearDown(config.dispose);
+    final GoRouter router = await createRouterWithRoutingConfig(
+      config,
+      tester,
+      initialLocation: '/first',
+    );
+
+    shellKey.currentState!.goBranch(1);
+    await tester.pumpAndSettle();
+    expect(find.text('second'), findsOneWidget);
+
+    config.value = buildConfig();
+    await tester.pumpAndSettle();
+
+    shellKey.currentState!.goBranch(0);
+    await tester.pumpAndSettle();
+    expect(find.text('first'), findsOneWidget);
+
+    router.push<void>('/first/details');
+    await tester.pumpAndSettle();
+
+    expect(tester.takeException(), isNull);
+    expect(find.text('details'), findsOneWidget);
+    expect(router.routerDelegate.currentConfiguration.matches, hasLength(1));
+    expect(shellNavigatorKey.currentState!.canPop(), isTrue);
+  });
+
   testWidgets('routing config works with named route', (WidgetTester tester) async {
     final config = ValueNotifier<RoutingConfig>(
       RoutingConfig(


### PR DESCRIPTION
* Fixes https://github.com/flutter/flutter/issues/192413

## Pre-Review Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [X] I read the [Tree Hygiene] page, which explains my responsibilities.
- [X] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [X] I signed the [CLA].
- [X] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [X] I [linked to at least one issue that this PR fixes] in the description above.
- [X] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under[^1].
- [X] I updated/added any relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [X] All existing and new tests are passing.