### PR TITLE
[material_ui] Split dropdown_test.dart into specific test files

### DIFF
--- a/packages/material_ui/test/dropdown_button_form_field_test.dart
+++ b/packages/material_ui/test/dropdown_button_form_field_test.dart
@@ -1593,4 +1593,191 @@ void main() {
       'Currently, selectedItemBuilder returns a list of length 1, but items has length 2.',
     );
   });
+
+  testWidgets('DropdownButtonFormField uses form field state', (WidgetTester tester) async {
+    final Key buttonKey = UniqueKey();
+    final formKey = GlobalKey<FormState>();
+    String? value;
+    await tester.pumpWidget(
+      StatefulBuilder(
+        builder: (BuildContext context, StateSetter setState) {
+          return MaterialApp(
+            home: Material(
+              child: Form(
+                key: formKey,
+                child: DropdownButtonFormField<String>(
+                  key: buttonKey,
+                  initialValue: value,
+                  hint: const Text('Select Value'),
+                  decoration: const InputDecoration(prefixIcon: Icon(Icons.fastfood)),
+                  items: menuItems.map((String val) {
+                    return DropdownMenuItem<String>(value: val, child: Text(val));
+                  }).toList(),
+                  validator: (String? v) => v == null ? 'Must select value' : null,
+                  onChanged: (String? newValue) {},
+                  onSaved: (String? v) {
+                    setState(() {
+                      value = v;
+                    });
+                  },
+                ),
+              ),
+            ),
+          );
+        },
+      ),
+    );
+    int getIndex() {
+      final stack = tester.element(find.byType(IndexedStack)).widget as IndexedStack;
+      return stack.index!;
+    }
+
+    // Initial value of null displays hint
+    expect(value, equals(null));
+    expect(getIndex(), 4);
+    await tester.tap(find.text('Select Value', skipOffstage: false), warnIfMissed: false);
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('three').last);
+    await tester.pumpAndSettle();
+    expect(getIndex(), 2);
+    // Changes only made to FormField state until form saved
+    expect(value, equals(null));
+    final FormState form = formKey.currentState!;
+    form.save();
+    expect(value, equals('three'));
+  });
+
+  testWidgets('DropdownButtonFormField does not crash at zero area', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Center(
+            child: SizedBox.shrink(
+              child: DropdownButtonFormField<String>(
+                onChanged: (_) {},
+                items: const <DropdownMenuItem<String>>[
+                  DropdownMenuItem<String>(value: 'a', child: Text('a')),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    expect(tester.getSize(find.byType(DropdownButtonFormField<String>)), Size.zero);
+  });
+
+  testWidgets('BorderRadius property works properly for DropdownButtonFormField', (
+    WidgetTester tester,
+  ) async {
+    const radius = 20.0;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Center(
+            child: DropdownButtonFormField<String>(
+              borderRadius: const BorderRadius.all(Radius.circular(radius)),
+              initialValue: 'One',
+              items: <String>['One', 'Two', 'Three', 'Four'].map<DropdownMenuItem<String>>((
+                String value,
+              ) {
+                return DropdownMenuItem<String>(value: value, child: Text(value));
+              }).toList(),
+              onChanged: (_) {},
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('One'));
+    await tester.pumpAndSettle();
+
+    expect(
+      find.ancestor(of: find.text('One').last, matching: find.byType(CustomPaint)).at(2),
+      paints
+        ..save()
+        ..rrect()
+        ..rrect()
+        ..rrect()
+        ..rrect(rrect: const RRect.fromLTRBXY(0.0, 0.0, 800.0, 208.0, radius, radius)),
+    );
+  });
+
+  testWidgets(
+    'DropdownButtonFormField deprecated "value" parameter can still be used to set the initial value',
+    (WidgetTester tester) async {
+      final fieldKey = GlobalKey<FormFieldState<String>>();
+      await tester.pumpWidget(
+        StatefulBuilder(
+          builder: (BuildContext context, StateSetter setState) {
+            return MaterialApp(
+              home: Material(
+                child: DropdownButtonFormField<String>(
+                  key: fieldKey,
+                  value: 'one',
+                  hint: const Text('Select Value'),
+                  items: menuItems.map((String val) {
+                    return DropdownMenuItem<String>(value: val, child: Text(val));
+                  }).toList(),
+                  onChanged: (_) {},
+                ),
+              ),
+            );
+          },
+        ),
+      );
+      expect(fieldKey.currentState!.value, 'one');
+    },
+  );
+
+  testWidgets(
+    'DropdownButtonFormField only uses initialValue parameter when first built and when reset',
+    (WidgetTester tester) async {
+      final fieldKey = GlobalKey<FormFieldState<String>>();
+      await tester.pumpWidget(
+        StatefulBuilder(
+          builder: (BuildContext context, StateSetter setState) {
+            return MaterialApp(
+              home: Material(
+                child: DropdownButtonFormField<String>(
+                  key: fieldKey,
+                  initialValue: 'one',
+                  hint: const Text('Select Value'),
+                  items: menuItems.map((String val) {
+                    return DropdownMenuItem<String>(value: val, child: Text(val));
+                  }).toList(),
+                  onChanged: (String? newValue) {
+                    setState(() {
+                      // Do nothing, just to trigger a rebuild.
+                    });
+                  },
+                ),
+              ),
+            );
+          },
+        ),
+      );
+      expect(fieldKey.currentState!.value, 'one');
+
+      // Open the dropdown menu.
+      await tester.tap(find.text('one'));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('three').last);
+      await tester.pumpAndSettle();
+
+      // The value should update to selected, not the initial value.
+      expect(find.text('three'), findsOneWidget);
+      expect(fieldKey.currentState!.value, 'three');
+
+      fieldKey.currentState!.reset();
+      await tester.pump();
+
+      // Reset to the initial value.
+      expect(find.text('one'), findsOneWidget);
+      expect(fieldKey.currentState!.value, 'one');
+    },
+  );
 }

--- a/packages/material_ui/test/dropdown_button_form_field_test.dart
+++ b/packages/material_ui/test/dropdown_button_form_field_test.dart
@@ -829,7 +829,6 @@ void main() {
   testWidgets('DropdownButtonFormField - default elevation', (WidgetTester tester) async {
     final Key buttonKey = UniqueKey();
     debugDisableShadows = false;
-    addTearDown(() => debugDisableShadows = true);
     await tester.pumpWidget(buildFormFrame(buttonKey: buttonKey, onChanged: onChanged));
     await tester.tap(find.byKey(buttonKey));
     await tester.pumpAndSettle();
@@ -840,11 +839,11 @@ void main() {
 
     // Verifying whether or not default elevation(i.e. 8) paints desired shadow
     verifyPaintedShadow(customPaint, 8);
+    debugDisableShadows = true;
   });
 
   testWidgets('DropdownButtonFormField - custom elevation', (WidgetTester tester) async {
     debugDisableShadows = false;
-    addTearDown(() => debugDisableShadows = true);
     final Key buttonKeyOne = UniqueKey();
     final Key buttonKeyTwo = UniqueKey();
 
@@ -871,6 +870,7 @@ void main() {
         .last;
 
     verifyPaintedShadow(customPaintTwo, 24);
+    debugDisableShadows = true;
   });
 
   testWidgets('DropdownButtonFormField does not allow duplicate item values', (

--- a/packages/material_ui/test/dropdown_button_form_field_test.dart
+++ b/packages/material_ui/test/dropdown_button_form_field_test.dart
@@ -16,6 +16,30 @@ Finder _iconRichText(Key iconKey) {
   return find.descendant(of: find.byKey(iconKey), matching: find.byType(RichText));
 }
 
+void verifyPaintedShadow(Finder customPaint, int elevation) {
+  const originalRectangle = Rect.fromLTRB(0.0, 0.0, 800, 208.0);
+
+  final boxShadows = List<BoxShadow>.generate(
+    3,
+    (int index) => kElevationToShadow[elevation]![index],
+  );
+  final rrects = List<RRect>.generate(3, (int index) {
+    return RRect.fromRectAndRadius(
+      originalRectangle.shift(boxShadows[index].offset).inflate(boxShadows[index].spreadRadius),
+      const Radius.circular(2.0),
+    );
+  });
+
+  expect(
+    customPaint,
+    paints
+      ..save()
+      ..rrect(rrect: rrects[0], color: boxShadows[0].color, hasMaskFilter: true)
+      ..rrect(rrect: rrects[1], color: boxShadows[1].color, hasMaskFilter: true)
+      ..rrect(rrect: rrects[2], color: boxShadows[2].color, hasMaskFilter: true),
+  );
+}
+
 Widget buildFormFrame({
   Key? buttonKey,
   AutovalidateMode autovalidateMode = AutovalidateMode.disabled,
@@ -73,6 +97,17 @@ Widget buildFormFrame({
   );
 }
 
+class TestApp extends StatefulWidget {
+  const TestApp({super.key, required this.textDirection, required this.child, this.mediaSize});
+
+  final TextDirection textDirection;
+  final Widget child;
+  final Size? mediaSize;
+
+  @override
+  State<TestApp> createState() => _TestAppState();
+}
+
 class _TestAppState extends State<TestApp> {
   @override
   Widget build(BuildContext context) {
@@ -99,41 +134,6 @@ class _TestAppState extends State<TestApp> {
       ),
     );
   }
-}
-
-class TestApp extends StatefulWidget {
-  const TestApp({super.key, required this.textDirection, required this.child, this.mediaSize});
-
-  final TextDirection textDirection;
-  final Widget child;
-  final Size? mediaSize;
-
-  @override
-  State<TestApp> createState() => _TestAppState();
-}
-
-void verifyPaintedShadow(Finder customPaint, int elevation) {
-  const originalRectangle = Rect.fromLTRB(0.0, 0.0, 800, 208.0);
-
-  final boxShadows = List<BoxShadow>.generate(
-    3,
-    (int index) => kElevationToShadow[elevation]![index],
-  );
-  final rrects = List<RRect>.generate(3, (int index) {
-    return RRect.fromRectAndRadius(
-      originalRectangle.shift(boxShadows[index].offset).inflate(boxShadows[index].spreadRadius),
-      const Radius.circular(2.0),
-    );
-  });
-
-  expect(
-    customPaint,
-    paints
-      ..save()
-      ..rrect(rrect: rrects[0], color: boxShadows[0].color, hasMaskFilter: true)
-      ..rrect(rrect: rrects[1], color: boxShadows[1].color, hasMaskFilter: true)
-      ..rrect(rrect: rrects[2], color: boxShadows[2].color, hasMaskFilter: true),
-  );
 }
 
 void main() {
@@ -499,15 +499,14 @@ void main() {
     const value = 'two';
     const scaleFactor = 3.0;
 
-    final List<DropdownMenuItem<String>> dropdownItems = menuItems.map<DropdownMenuItem<String>>((
-      String item,
-    ) {
-      return DropdownMenuItem<String>(
-        key: ValueKey<String>(item),
-        value: item,
-        child: Text(item, key: ValueKey<String>('${item}Text')),
-      );
-    }).toList();
+    final List<DropdownMenuItem<String>> dropdownItems = [
+      for (final item in menuItems)
+        DropdownMenuItem<String>(
+          key: ValueKey<String>(item),
+          value: item,
+          child: Text(item, key: ValueKey<String>('${item}Text')),
+        ),
+    ];
 
     await tester.pumpWidget(
       TestApp(
@@ -830,6 +829,7 @@ void main() {
   testWidgets('DropdownButtonFormField - default elevation', (WidgetTester tester) async {
     final Key buttonKey = UniqueKey();
     debugDisableShadows = false;
+    addTearDown(() => debugDisableShadows = true);
     await tester.pumpWidget(buildFormFrame(buttonKey: buttonKey, onChanged: onChanged));
     await tester.tap(find.byKey(buttonKey));
     await tester.pumpAndSettle();
@@ -840,11 +840,11 @@ void main() {
 
     // Verifying whether or not default elevation(i.e. 8) paints desired shadow
     verifyPaintedShadow(customPaint, 8);
-    debugDisableShadows = true;
   });
 
   testWidgets('DropdownButtonFormField - custom elevation', (WidgetTester tester) async {
     debugDisableShadows = false;
+    addTearDown(() => debugDisableShadows = true);
     final Key buttonKeyOne = UniqueKey();
     final Key buttonKeyTwo = UniqueKey();
 
@@ -871,7 +871,6 @@ void main() {
         .last;
 
     verifyPaintedShadow(customPaintTwo, 24);
-    debugDisableShadows = true;
   });
 
   testWidgets('DropdownButtonFormField does not allow duplicate item values', (
@@ -918,7 +917,7 @@ void main() {
       () => tester.pumpWidget(
         MaterialApp(
           home: Scaffold(
-            body: DropdownButton<String>(
+            body: DropdownButtonFormField<String>(
               value: 'e',
               onChanged: (String? newValue) {},
               items: itemsWithDuplicateValues,
@@ -975,7 +974,9 @@ void main() {
     expect(find.text('Two as an Arabic numeral: 2'), findsOneWidget);
   });
 
-  testWidgets('DropdownButton onTap callback is called when defined', (WidgetTester tester) async {
+  testWidgets('DropdownButtonFormField onTap callback is called when defined', (
+    WidgetTester tester,
+  ) async {
     var dropdownButtonTapCounter = 0;
     String? value = 'one';
     void onChanged(String? newValue) {
@@ -1068,7 +1069,9 @@ void main() {
     expect(find.text(currentValue), findsOneWidget);
   });
 
-  testWidgets('autovalidateMode is passed to super', (WidgetTester tester) async {
+  testWidgets('DropdownButtonFormField autovalidateMode is passed to super', (
+    WidgetTester tester,
+  ) async {
     var validateCalled = 0;
 
     await tester.pumpWidget(
@@ -1197,7 +1200,9 @@ void main() {
   });
 
   // Regression test for https://github.com/flutter/flutter/issues/106659.
-  testWidgets('Error visual logic is delegated to InputDecorator', (WidgetTester tester) async {
+  testWidgets('DropdownButtonFormField - Error visual logic is delegated to InputDecorator', (
+    WidgetTester tester,
+  ) async {
     final formKey = GlobalKey<FormState>();
 
     await tester.pumpWidget(
@@ -1231,7 +1236,9 @@ void main() {
   });
 
   // Regression test for https://github.com/flutter/flutter/issues/135292.
-  testWidgets('Widget returned by errorBuilder is shown', (WidgetTester tester) async {
+  testWidgets('DropdownButtonFormField - Widget returned by errorBuilder is shown', (
+    WidgetTester tester,
+  ) async {
     await tester.pumpWidget(
       MaterialApp(
         home: Material(
@@ -1253,132 +1260,137 @@ void main() {
     expect(find.text('**Required**'), findsOneWidget);
   });
 
-  testWidgets('ButtonTheme.alignedDropdown does not affect the field content position', (
-    WidgetTester tester,
-  ) async {
-    Widget buildFrame({required bool alignedDropdown, required TextDirection textDirection}) {
-      return MaterialApp(
-        home: Directionality(
-          textDirection: textDirection,
-          child: ButtonTheme(
-            alignedDropdown: alignedDropdown,
-            child: Material(
-              child: DropdownButtonFormField<String>(
-                initialValue: menuItems.first,
-                items: menuItems.map((String value) {
-                  return DropdownMenuItem<String>(value: value, child: Text(value));
-                }).toList(),
-                onChanged: onChanged,
+  testWidgets(
+    'DropdownButtonFormField - ButtonTheme.alignedDropdown does not affect the field content position',
+    (WidgetTester tester) async {
+      Widget buildFrame({required bool alignedDropdown, required TextDirection textDirection}) {
+        return MaterialApp(
+          home: Directionality(
+            textDirection: textDirection,
+            child: ButtonTheme(
+              alignedDropdown: alignedDropdown,
+              child: Material(
+                child: DropdownButtonFormField<String>(
+                  initialValue: menuItems.first,
+                  items: menuItems.map((String value) {
+                    return DropdownMenuItem<String>(value: value, child: Text(value));
+                  }).toList(),
+                  onChanged: onChanged,
+                ),
+              ),
+            ),
+          ),
+        );
+      }
+
+      final Finder findSelectedValue = find.text(menuItems.first).first;
+
+      await tester.pumpWidget(buildFrame(alignedDropdown: false, textDirection: TextDirection.ltr));
+      Rect contentRectForUnalignedDropdown = tester.getRect(findSelectedValue);
+
+      // When alignedDropdown is true, the content should be at the same position.
+      await tester.pumpWidget(buildFrame(alignedDropdown: true, textDirection: TextDirection.ltr));
+      expect(tester.getRect(findSelectedValue), contentRectForUnalignedDropdown);
+
+      await tester.pumpWidget(buildFrame(alignedDropdown: false, textDirection: TextDirection.rtl));
+      contentRectForUnalignedDropdown = tester.getRect(findSelectedValue);
+
+      // When alignedDropdown is true, the content should be at the same position.
+      await tester.pumpWidget(buildFrame(alignedDropdown: true, textDirection: TextDirection.rtl));
+      expect(tester.getRect(findSelectedValue), contentRectForUnalignedDropdown);
+    },
+  );
+
+  testWidgets(
+    'DropdownButtonFormField - isValid returns false when forceErrorText is set and changes error display',
+    (WidgetTester tester) async {
+      final fieldKey1 = GlobalKey<FormFieldState<String>>();
+      final fieldKey2 = GlobalKey<FormFieldState<String>>();
+      const forceErrorText = 'Forcing error.';
+      await tester.pumpWidget(
+        MaterialApp(
+          home: MediaQuery(
+            data: const MediaQueryData(),
+            child: Directionality(
+              textDirection: TextDirection.ltr,
+              child: Center(
+                child: Material(
+                  child: Form(
+                    child: ListView(
+                      children: <Widget>[
+                        DropdownButtonFormField<String>(
+                          key: fieldKey1,
+                          items: menuItems.map((String value) {
+                            return DropdownMenuItem<String>(value: value, child: Text(value));
+                          }).toList(),
+                          onChanged: null,
+                          autovalidateMode: AutovalidateMode.disabled,
+                        ),
+                        DropdownButtonFormField<String>(
+                          key: fieldKey2,
+                          items: menuItems.map((String value) {
+                            return DropdownMenuItem<String>(value: value, child: Text(value));
+                          }).toList(),
+                          forceErrorText: forceErrorText,
+                          onChanged: onChanged,
+                          autovalidateMode: AutovalidateMode.disabled,
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
               ),
             ),
           ),
         ),
       );
-    }
 
-    final Finder findSelectedValue = find.text(menuItems.first).first;
+      expect(fieldKey1.currentState!.isValid, isTrue);
+      expect(fieldKey1.currentState!.hasError, isFalse);
+      expect(fieldKey2.currentState!.isValid, isFalse);
+      expect(fieldKey2.currentState!.hasError, isTrue);
+    },
+  );
 
-    await tester.pumpWidget(buildFrame(alignedDropdown: false, textDirection: TextDirection.ltr));
-    Rect contentRectForUnalignedDropdown = tester.getRect(findSelectedValue);
+  testWidgets(
+    'DropdownButtonFormField - forceErrorText overrides InputDecoration.error when both are provided',
+    (WidgetTester tester) async {
+      const forceErrorText = 'Forcing error';
+      const decorationErrorText = 'Decoration';
 
-    // When alignedDropdown is true, the content should be at the same position.
-    await tester.pumpWidget(buildFrame(alignedDropdown: true, textDirection: TextDirection.ltr));
-    expect(tester.getRect(findSelectedValue), contentRectForUnalignedDropdown);
-
-    await tester.pumpWidget(buildFrame(alignedDropdown: false, textDirection: TextDirection.rtl));
-    contentRectForUnalignedDropdown = tester.getRect(findSelectedValue);
-
-    // When alignedDropdown is true, the content should be at the same position.
-    await tester.pumpWidget(buildFrame(alignedDropdown: true, textDirection: TextDirection.rtl));
-    expect(tester.getRect(findSelectedValue), contentRectForUnalignedDropdown);
-  });
-
-  testWidgets('isValid returns false when forceErrorText is set and changes error display', (
-    WidgetTester tester,
-  ) async {
-    final fieldKey1 = GlobalKey<FormFieldState<String>>();
-    final fieldKey2 = GlobalKey<FormFieldState<String>>();
-    const forceErrorText = 'Forcing error.';
-    await tester.pumpWidget(
-      MaterialApp(
-        home: MediaQuery(
-          data: const MediaQueryData(),
-          child: Directionality(
-            textDirection: TextDirection.ltr,
-            child: Center(
-              child: Material(
-                child: Form(
-                  child: ListView(
-                    children: <Widget>[
-                      DropdownButtonFormField<String>(
-                        key: fieldKey1,
-                        items: menuItems.map((String value) {
-                          return DropdownMenuItem<String>(value: value, child: Text(value));
-                        }).toList(),
-                        onChanged: null,
-                        autovalidateMode: AutovalidateMode.disabled,
-                      ),
-                      DropdownButtonFormField<String>(
-                        key: fieldKey2,
-                        items: menuItems.map((String value) {
-                          return DropdownMenuItem<String>(value: value, child: Text(value));
-                        }).toList(),
-                        forceErrorText: forceErrorText,
-                        onChanged: onChanged,
-                        autovalidateMode: AutovalidateMode.disabled,
-                      ),
-                    ],
+      await tester.pumpWidget(
+        MaterialApp(
+          home: MediaQuery(
+            data: const MediaQueryData(),
+            child: Directionality(
+              textDirection: TextDirection.ltr,
+              child: Center(
+                child: Material(
+                  child: Form(
+                    child: DropdownButtonFormField<String>(
+                      items: menuItems.map<DropdownMenuItem<String>>((String value) {
+                        return DropdownMenuItem<String>(value: value, child: Text(value));
+                      }).toList(),
+                      decoration: const InputDecoration(errorText: decorationErrorText),
+                      forceErrorText: forceErrorText,
+                      onChanged: null,
+                    ),
                   ),
                 ),
               ),
             ),
           ),
         ),
-      ),
-    );
+      );
 
-    expect(fieldKey1.currentState!.isValid, isTrue);
-    expect(fieldKey1.currentState!.hasError, isFalse);
-    expect(fieldKey2.currentState!.isValid, isFalse);
-    expect(fieldKey2.currentState!.hasError, isTrue);
-  });
+      expect(find.text(forceErrorText), findsOne);
+      expect(find.text(decorationErrorText), findsNothing);
+    },
+  );
 
-  testWidgets('forceErrorText overrides InputDecoration.error when both are provided', (
+  testWidgets('DropdownButtonFormField closes when barrier is tapped by default', (
     WidgetTester tester,
   ) async {
-    const forceErrorText = 'Forcing error';
-    const decorationErrorText = 'Decoration';
-
-    await tester.pumpWidget(
-      MaterialApp(
-        home: MediaQuery(
-          data: const MediaQueryData(),
-          child: Directionality(
-            textDirection: TextDirection.ltr,
-            child: Center(
-              child: Material(
-                child: Form(
-                  child: DropdownButtonFormField<String>(
-                    items: menuItems.map<DropdownMenuItem<String>>((String value) {
-                      return DropdownMenuItem<String>(value: value, child: Text(value));
-                    }).toList(),
-                    decoration: const InputDecoration(errorText: decorationErrorText),
-                    forceErrorText: forceErrorText,
-                    onChanged: null,
-                  ),
-                ),
-              ),
-            ),
-          ),
-        ),
-      ),
-    );
-
-    expect(find.text(forceErrorText), findsOne);
-    expect(find.text(decorationErrorText), findsNothing);
-  });
-
-  testWidgets('dropdown closes when barrier is tapped by default', (WidgetTester tester) async {
     await tester.pumpWidget(
       MaterialApp(
         home: Scaffold(
@@ -1407,7 +1419,7 @@ void main() {
     expect(find.text('second'), findsNothing);
   });
 
-  testWidgets('dropdown does not close when barrier dismissible set to false', (
+  testWidgets('DropdownButtonFormField does not close when barrier dismissible set to false', (
     WidgetTester tester,
   ) async {
     await tester.pumpWidget(
@@ -1463,7 +1475,7 @@ void main() {
     expect(tester.getCenter(find.text(labelText)).dy, tester.getCenter(find.byType(Icon).last).dy);
   });
 
-  testWidgets('DropdownFormField has expected default mouse cursor on hover', (
+  testWidgets('DropdownButtonFormField has expected default mouse cursor on hover', (
     WidgetTester tester,
   ) async {
     await tester.pumpWidget(
@@ -1527,6 +1539,58 @@ void main() {
     expect(
       RendererBinding.instance.mouseTracker.debugDeviceActiveCursor(1),
       SystemMouseCursors.cell,
+    );
+  });
+
+  testWidgets(
+    'DropdownButtonFormField asserts when both errorBuilder and decoration.errorText are provided',
+    (WidgetTester tester) async {
+      expect(
+        () => DropdownButtonFormField<String>(
+          items: const <DropdownMenuItem<String>>[],
+          onChanged: (String? value) {},
+          decoration: const InputDecoration(errorText: 'Decoration error'),
+          errorBuilder: (BuildContext context, String errorText) {
+            return Text(errorText);
+          },
+        ),
+        throwsAssertionError,
+      );
+    },
+  );
+
+  testWidgets('DropdownButtonFormField selectedItemBuilder length must match items length', (
+    WidgetTester tester,
+  ) async {
+    // Regression test for https://github.com/flutter/flutter/issues/92773
+    final List<DropdownMenuItem<String>> items = <String>['a', 'b']
+        .map<DropdownMenuItem<String>>(
+          (String value) => DropdownMenuItem<String>(value: value, child: Text(value)),
+        )
+        .toList();
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Center(
+            child: SizedBox.shrink(
+              child: DropdownButtonFormField<String>(
+                onChanged: (_) {},
+                items: items,
+                selectedItemBuilder: (BuildContext context) {
+                  return <Widget>[const Text('a')];
+                },
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(
+      (tester.takeException() as AssertionError).message,
+      'The selectedItemBuilder must return a list of widgets with the same length as the items list.\n'
+      'Currently, selectedItemBuilder returns a list of length 1, but items has length 2.',
     );
   });
 }

--- a/packages/material_ui/test/dropdown_button_test.dart
+++ b/packages/material_ui/test/dropdown_button_test.dart
@@ -1,0 +1,215 @@
+// Copyright 2013 The Flutter Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:material_ui/material_ui.dart';
+
+// TODO(navaronbracke): port tests from dropdown_button_form_field_test.dart to plain DropdownButton tests as well
+
+void main() {
+  testWidgets('DropdownButton value should only appear in one menu item', (
+    WidgetTester tester,
+  ) async {
+    final List<DropdownMenuItem<String>> itemsWithDuplicateValues = <String>['a', 'b', 'c', 'd']
+        .map<DropdownMenuItem<String>>((String value) {
+          return DropdownMenuItem<String>(value: value, child: Text(value));
+        })
+        .toList();
+
+    await expectLater(
+      () => tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: DropdownButton<String>(
+              value: 'e',
+              onChanged: (String? newValue) {},
+              items: itemsWithDuplicateValues,
+            ),
+          ),
+        ),
+      ),
+      throwsA(
+        isAssertionError.having(
+          (AssertionError error) => error.toString(),
+          '.toString()',
+          contains("There should be exactly one item with [DropdownButton]'s value"),
+        ),
+      ),
+    );
+  });
+
+  testWidgets('DropdownButton - selectedItemBuilder builds custom buttons', (
+    WidgetTester tester,
+  ) async {
+    const items = <String>['One', 'Two', 'Three'];
+    String? selectedItem = items[0];
+
+    await tester.pumpWidget(
+      StatefulBuilder(
+        builder: (BuildContext context, StateSetter setState) {
+          return MaterialApp(
+            home: Scaffold(
+              body: DropdownButton<String>(
+                value: selectedItem,
+                onChanged: (String? string) => setState(() => selectedItem = string),
+                selectedItemBuilder: (BuildContext context) {
+                  var index = 0;
+                  return items.map((String string) {
+                    index += 1;
+                    return Text('$string as an Arabic numeral: $index');
+                  }).toList();
+                },
+                items: items.map((String string) {
+                  return DropdownMenuItem<String>(value: string, child: Text(string));
+                }).toList(),
+              ),
+            ),
+          );
+        },
+      ),
+    );
+
+    expect(find.text('One as an Arabic numeral: 1'), findsOneWidget);
+    await tester.tap(find.text('One as an Arabic numeral: 1'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Two'));
+    await tester.pumpAndSettle();
+    expect(find.text('Two as an Arabic numeral: 2'), findsOneWidget);
+  });
+
+  testWidgets('DropdownButton selectedItemBuilder length must match items length', (
+    WidgetTester tester,
+  ) async {
+    // Regression test for https://github.com/flutter/flutter/issues/92773
+    final List<DropdownMenuItem<String>> items = <String>['a', 'b']
+        .map<DropdownMenuItem<String>>(
+          (String value) => DropdownMenuItem<String>(value: value, child: Text(value)),
+        )
+        .toList();
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Center(
+            child: SizedBox.shrink(
+              child: DropdownButton<String>(
+                onChanged: (_) {},
+                items: items,
+                selectedItemBuilder: (BuildContext context) {
+                  return <Widget>[const Text('a')];
+                },
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(
+      (tester.takeException() as AssertionError).message,
+      'The selectedItemBuilder must return a list of widgets with the same length as the items list.\n'
+      'Currently, selectedItemBuilder returns a list of length 1, but items has length 2.',
+    );
+  });
+
+  testWidgets('BorderRadius property works properly for DropdownButton', (
+    WidgetTester tester,
+  ) async {
+    const radius = 20.0;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Center(
+            child: DropdownButton(
+              borderRadius: const BorderRadius.all(Radius.circular(radius)),
+              value: 'One',
+              items: <String>['One', 'Two', 'Three', 'Four'].map<DropdownMenuItem<String>>((
+                String value,
+              ) {
+                return DropdownMenuItem<String>(value: value, child: Text(value));
+              }).toList(),
+              onChanged: (_) {},
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('One'));
+    await tester.pumpAndSettle();
+
+    expect(
+      find.ancestor(of: find.text('One').last, matching: find.byType(CustomPaint)).at(2),
+      paints
+        ..save()
+        ..rrect()
+        ..rrect()
+        ..rrect()
+        ..rrect(rrect: const RRect.fromLTRBXY(0.0, 0.0, 800.0, 208.0, radius, radius)),
+    );
+  });
+
+  testWidgets('DropdownButton in ListView', (WidgetTester tester) async {
+    // Regression test for https://github.com/flutter/flutter/issues/12053
+    // Positions a DropdownButton at the left and right edges of the screen,
+    // forcing it to be sized down to the viewport width
+    const value = 'foo';
+    final itemKey = UniqueKey();
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Material(
+          child: ListView(
+            children: <Widget>[
+              DropdownButton<String>(
+                value: value,
+                items: <DropdownMenuItem<String>>[
+                  DropdownMenuItem<String>(key: itemKey, value: value, child: const Text(value)),
+                ],
+                onChanged: (_) {},
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+    await tester.tap(find.text(value));
+    await tester.pump();
+    final List<RenderBox> itemBoxes = tester
+        .renderObjectList<RenderBox>(find.byKey(itemKey))
+        .toList();
+    expect(itemBoxes[0].localToGlobal(Offset.zero).dx, equals(0.0));
+    expect(itemBoxes[1].localToGlobal(Offset.zero).dx, equals(16.0));
+    expect(itemBoxes[1].size.width, equals(800.0 - 16.0 * 2));
+  });
+
+  testWidgets('DropdownButton does not allow duplicate item values', (WidgetTester tester) async {
+    final List<DropdownMenuItem<String>> itemsWithDuplicateValues = <String>['a', 'b', 'c', 'c']
+        .map<DropdownMenuItem<String>>((String value) {
+          return DropdownMenuItem<String>(value: value, child: Text(value));
+        })
+        .toList();
+
+    await expectLater(
+      () => tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: DropdownButton<String>(
+              value: 'c',
+              onChanged: (String? newValue) {},
+              items: itemsWithDuplicateValues,
+            ),
+          ),
+        ),
+      ),
+      throwsA(
+        isAssertionError.having(
+          (AssertionError error) => error.toString(),
+          '.toString()',
+          contains("There should be exactly one item with [DropdownButton]'s value"),
+        ),
+      ),
+    );
+  });
+}

--- a/packages/material_ui/test/dropdown_button_test.dart
+++ b/packages/material_ui/test/dropdown_button_test.dart
@@ -123,6 +123,7 @@ void main() {
         home: Scaffold(
           body: Center(
             child: DropdownButton(
+              isExpanded: true,
               borderRadius: const BorderRadius.all(Radius.circular(radius)),
               value: 'One',
               items: <String>['One', 'Two', 'Three', 'Four'].map<DropdownMenuItem<String>>((

--- a/packages/material_ui/test/dropdown_test.dart
+++ b/packages/material_ui/test/dropdown_test.dart
@@ -537,141 +537,6 @@ void main() {
     );
   });
 
-  testWidgets('Dropdown form field uses form field state', (WidgetTester tester) async {
-    final Key buttonKey = UniqueKey();
-    final formKey = GlobalKey<FormState>();
-    String? value;
-    await tester.pumpWidget(
-      StatefulBuilder(
-        builder: (BuildContext context, StateSetter setState) {
-          return MaterialApp(
-            home: Material(
-              child: Form(
-                key: formKey,
-                child: DropdownButtonFormField<String>(
-                  key: buttonKey,
-                  initialValue: value,
-                  hint: const Text('Select Value'),
-                  decoration: const InputDecoration(prefixIcon: Icon(Icons.fastfood)),
-                  items: menuItems.map((String val) {
-                    return DropdownMenuItem<String>(value: val, child: Text(val));
-                  }).toList(),
-                  validator: (String? v) => v == null ? 'Must select value' : null,
-                  onChanged: (String? newValue) {},
-                  onSaved: (String? v) {
-                    setState(() {
-                      value = v;
-                    });
-                  },
-                ),
-              ),
-            ),
-          );
-        },
-      ),
-    );
-    int getIndex() {
-      final stack = tester.element(find.byType(IndexedStack)).widget as IndexedStack;
-      return stack.index!;
-    }
-
-    // Initial value of null displays hint
-    expect(value, equals(null));
-    expect(getIndex(), 4);
-    await tester.tap(find.text('Select Value', skipOffstage: false), warnIfMissed: false);
-    await tester.pumpAndSettle();
-    await tester.tap(find.text('three').last);
-    await tester.pumpAndSettle();
-    expect(getIndex(), 2);
-    // Changes only made to FormField state until form saved
-    expect(value, equals(null));
-    final FormState form = formKey.currentState!;
-    form.save();
-    expect(value, equals('three'));
-  });
-
-  testWidgets(
-    'Dropdown form field only uses initialValue parameter when first built and when reset',
-    (WidgetTester tester) async {
-      final fieldKey = GlobalKey<FormFieldState<String>>();
-      await tester.pumpWidget(
-        StatefulBuilder(
-          builder: (BuildContext context, StateSetter setState) {
-            return MaterialApp(
-              home: Material(
-                child: DropdownButtonFormField<String>(
-                  key: fieldKey,
-                  initialValue: 'one',
-                  hint: const Text('Select Value'),
-                  items: menuItems.map((String val) {
-                    return DropdownMenuItem<String>(value: val, child: Text(val));
-                  }).toList(),
-                  onChanged: (String? newValue) {
-                    setState(() {
-                      // Do nothing, just to trigger a rebuild.
-                    });
-                  },
-                ),
-              ),
-            );
-          },
-        ),
-      );
-      expect(fieldKey.currentState!.value, 'one');
-
-      // Open the dropdown menu.
-      await tester.tap(find.text('one'));
-      await tester.pumpAndSettle();
-
-      await tester.tap(find.text('three').last);
-      await tester.pumpAndSettle();
-
-      // The value should update to selected, not the initial value.
-      expect(find.text('three'), findsOneWidget);
-      expect(fieldKey.currentState!.value, 'three');
-
-      fieldKey.currentState!.reset();
-      await tester.pump();
-
-      // Reset to the initial value.
-      expect(find.text('one'), findsOneWidget);
-      expect(fieldKey.currentState!.value, 'one');
-    },
-  );
-
-  testWidgets('Dropdown in ListView', (WidgetTester tester) async {
-    // Regression test for https://github.com/flutter/flutter/issues/12053
-    // Positions a DropdownButton at the left and right edges of the screen,
-    // forcing it to be sized down to the viewport width
-    const value = 'foo';
-    final itemKey = UniqueKey();
-    await tester.pumpWidget(
-      MaterialApp(
-        home: Material(
-          child: ListView(
-            children: <Widget>[
-              DropdownButton<String>(
-                value: value,
-                items: <DropdownMenuItem<String>>[
-                  DropdownMenuItem<String>(key: itemKey, value: value, child: const Text(value)),
-                ],
-                onChanged: (_) {},
-              ),
-            ],
-          ),
-        ),
-      ),
-    );
-    await tester.tap(find.text(value));
-    await tester.pump();
-    final List<RenderBox> itemBoxes = tester
-        .renderObjectList<RenderBox>(find.byKey(itemKey))
-        .toList();
-    expect(itemBoxes[0].localToGlobal(Offset.zero).dx, equals(0.0));
-    expect(itemBoxes[1].localToGlobal(Offset.zero).dx, equals(16.0));
-    expect(itemBoxes[1].size.width, equals(800.0 - 16.0 * 2));
-  });
-
   testWidgets('Dropdown menu can position correctly inside a nested navigator', (
     WidgetTester tester,
   ) async {
@@ -4294,44 +4159,6 @@ void main() {
     expect(tester.takeException(), null);
   });
 
-  testWidgets('BorderRadius property works properly for DropdownButtonFormField', (
-    WidgetTester tester,
-  ) async {
-    const radius = 20.0;
-
-    await tester.pumpWidget(
-      MaterialApp(
-        home: Scaffold(
-          body: Center(
-            child: DropdownButtonFormField<String>(
-              borderRadius: const BorderRadius.all(Radius.circular(radius)),
-              initialValue: 'One',
-              items: <String>['One', 'Two', 'Three', 'Four'].map<DropdownMenuItem<String>>((
-                String value,
-              ) {
-                return DropdownMenuItem<String>(value: value, child: Text(value));
-              }).toList(),
-              onChanged: (_) {},
-            ),
-          ),
-        ),
-      ),
-    );
-
-    await tester.tap(find.text('One'));
-    await tester.pumpAndSettle();
-
-    expect(
-      find.ancestor(of: find.text('One').last, matching: find.byType(CustomPaint)).at(2),
-      paints
-        ..save()
-        ..rrect()
-        ..rrect()
-        ..rrect()
-        ..rrect(rrect: const RRect.fromLTRBXY(0.0, 0.0, 800.0, 208.0, radius, radius)),
-    );
-  });
-
   testWidgets('DropdownButton hint alignment', (WidgetTester tester) async {
     const hintText = 'hint';
 
@@ -4827,33 +4654,6 @@ void main() {
     variant: TargetPlatformVariant.mobile(),
   );
 
-  testWidgets(
-    'DropdownButtonFormField deprecated "value" parameter can still be used to set the initial value',
-    (WidgetTester tester) async {
-      final fieldKey = GlobalKey<FormFieldState<String>>();
-      await tester.pumpWidget(
-        StatefulBuilder(
-          builder: (BuildContext context, StateSetter setState) {
-            return MaterialApp(
-              home: Material(
-                child: DropdownButtonFormField<String>(
-                  key: fieldKey,
-                  value: 'one',
-                  hint: const Text('Select Value'),
-                  items: menuItems.map((String val) {
-                    return DropdownMenuItem<String>(value: val, child: Text(val));
-                  }).toList(),
-                  onChanged: (_) {},
-                ),
-              ),
-            );
-          },
-        ),
-      );
-      expect(fieldKey.currentState!.value, 'one');
-    },
-  );
-
   testWidgets('DropdownButton does not crash at zero area', (WidgetTester tester) async {
     await tester.pumpWidget(
       MaterialApp(
@@ -4873,26 +4673,6 @@ void main() {
       ),
     );
     expect(tester.getSize(find.byType(DropdownButton<String>)), Size.zero);
-  });
-
-  testWidgets('DropdownButtonFormField does not crash at zero area', (WidgetTester tester) async {
-    await tester.pumpWidget(
-      MaterialApp(
-        home: Scaffold(
-          body: Center(
-            child: SizedBox.shrink(
-              child: DropdownButtonFormField<String>(
-                onChanged: (_) {},
-                items: const <DropdownMenuItem<String>>[
-                  DropdownMenuItem<String>(value: 'a', child: Text('a')),
-                ],
-              ),
-            ),
-          ),
-        ),
-      ),
-    );
-    expect(tester.getSize(find.byType(DropdownButtonFormField<String>)), Size.zero);
   });
 
   testWidgets('DropdownMenuItem does not crash at zero area', (WidgetTester tester) async {
@@ -4932,56 +4712,4 @@ void main() {
     ).style;
     expect(labelStyle.color, labelColor);
   });
-
-  testWidgets('DropdownButton selectedItemBuilder length must match items length', (
-    WidgetTester tester,
-  ) async {
-    // Regression test for https://github.com/flutter/flutter/issues/92773
-    final List<DropdownMenuItem<String>> items = <String>['a', 'b']
-        .map<DropdownMenuItem<String>>(
-          (String value) => DropdownMenuItem<String>(value: value, child: Text(value)),
-        )
-        .toList();
-
-    await tester.pumpWidget(
-      MaterialApp(
-        home: Scaffold(
-          body: Center(
-            child: SizedBox.shrink(
-              child: DropdownButtonFormField<String>(
-                onChanged: (_) {},
-                items: items,
-                selectedItemBuilder: (BuildContext context) {
-                  return <Widget>[const Text('a')];
-                },
-              ),
-            ),
-          ),
-        ),
-      ),
-    );
-
-    expect(
-      (tester.takeException() as AssertionError).message,
-      'The selectedItemBuilder must return a list of widgets with the same length as the items list.\n'
-      'Currently, selectedItemBuilder returns a list of length 1, but items has length 2.',
-    );
-  });
-
-  testWidgets(
-    'DropdownButtonFormField asserts when both errorBuilder and decoration.errorText are provided',
-    (WidgetTester tester) async {
-      expect(
-        () => DropdownButtonFormField<String>(
-          items: const <DropdownMenuItem<String>>[],
-          onChanged: (String? value) {},
-          decoration: const InputDecoration(errorText: 'Decoration error'),
-          errorBuilder: (BuildContext context, String errorText) {
-            return Text(errorText);
-          },
-        ),
-        throwsAssertionError,
-      );
-    },
-  );
 }

--- a/packages/material_ui/test/dropdown_test.dart
+++ b/packages/material_ui/test/dropdown_test.dart
@@ -477,66 +477,6 @@ void main() {
     expect(value, equals('two'));
   });
 
-  testWidgets('DropdownButton does not allow duplicate item values', (WidgetTester tester) async {
-    final List<DropdownMenuItem<String>> itemsWithDuplicateValues = <String>['a', 'b', 'c', 'c']
-        .map<DropdownMenuItem<String>>((String value) {
-          return DropdownMenuItem<String>(value: value, child: Text(value));
-        })
-        .toList();
-
-    await expectLater(
-      () => tester.pumpWidget(
-        MaterialApp(
-          home: Scaffold(
-            body: DropdownButton<String>(
-              value: 'c',
-              onChanged: (String? newValue) {},
-              items: itemsWithDuplicateValues,
-            ),
-          ),
-        ),
-      ),
-      throwsA(
-        isAssertionError.having(
-          (AssertionError error) => error.toString(),
-          '.toString()',
-          contains("There should be exactly one item with [DropdownButton]'s value"),
-        ),
-      ),
-    );
-  });
-
-  testWidgets('DropdownButton value should only appear in one menu item', (
-    WidgetTester tester,
-  ) async {
-    final List<DropdownMenuItem<String>> itemsWithDuplicateValues = <String>['a', 'b', 'c', 'd']
-        .map<DropdownMenuItem<String>>((String value) {
-          return DropdownMenuItem<String>(value: value, child: Text(value));
-        })
-        .toList();
-
-    await expectLater(
-      () => tester.pumpWidget(
-        MaterialApp(
-          home: Scaffold(
-            body: DropdownButton<String>(
-              value: 'e',
-              onChanged: (String? newValue) {},
-              items: itemsWithDuplicateValues,
-            ),
-          ),
-        ),
-      ),
-      throwsA(
-        isAssertionError.having(
-          (AssertionError error) => error.toString(),
-          '.toString()',
-          contains("There should be exactly one item with [DropdownButton]'s value"),
-        ),
-      ),
-    );
-  });
-
   testWidgets('Dropdown menu can position correctly inside a nested navigator', (
     WidgetTester tester,
   ) async {


### PR DESCRIPTION
This PR reorganizes some tests for `DropdownButton`, `DropdownButtonFormField` and `DropdownMenuItem`, to be in test files specific to those widgets.

The `dropdown_test.dart` file has been deleted, since all tests have moved to new files.
I also consolidated the utilities into a new `dropdown_tester.dart`.

Fixes https://github.com/flutter/flutter/issues/192412

For reviewers: The tests are largely moved over verbatim, except for the setup phases (pumping DropdownButton and the like). Some tests also had their test names adjusted.

I did not specifically preserve the tests order as in the original file, but I can restore that as best effort if needed for review.

See https://github.com/flutter/flutter/issues/192412 for context (I need dropdown_button_form_field_test.dart so I can move a different test there from flutter/widgets)

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under[^1].
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[the version and CHANGELOG instructions]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version-and-changelog-updates
[semantic versioning]: https://dart.dev/tools/pub/versioning#semantic-versions
[repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
