### PR TITLE
[image_picker] Document that retrieving lost data is a one-time operation

### DIFF
--- a/packages/image_picker/image_picker/CHANGELOG.md
+++ b/packages/image_picker/image_picker/CHANGELOG.md
@@ -1,3 +1,8 @@
+## NEXT
+
+* Documents that `retrieveLostData` is a one-time operation that clears the
+  stored lost data once it is returned.
+
 ## 1.2.3
 
 * Fixes `pickMultiImage(limit: 1)` and `pickMultipleMedia(limit: 1)` throwing an `ArgumentError` by delegating to

--- a/packages/image_picker/image_picker/CHANGELOG.md
+++ b/packages/image_picker/image_picker/CHANGELOG.md
@@ -1,4 +1,4 @@
-## NEXT
+## 1.2.4
 
 * Documents that `retrieveLostData` is a one-time operation that clears the
   stored lost data once it is returned.

--- a/packages/image_picker/image_picker/lib/image_picker.dart
+++ b/packages/image_picker/image_picker/lib/image_picker.dart
@@ -353,6 +353,10 @@ class ImagePicker {
   /// Returns a [LostDataResponse] object if successfully retrieved the lost data. The [LostDataResponse] object can \
   /// represent either a successful image/video selection, or a failure.
   ///
+  /// Retrieving the lost data is a one-time operation: once it is returned, the
+  /// data is cleared, so subsequent calls return an empty [LostDataResponse]
+  /// rather than the same data again.
+  ///
   /// Calling this on a non-Android platform will throw [UnimplementedError] exception.
   ///
   /// See also:

--- a/packages/image_picker/image_picker/pubspec.yaml
+++ b/packages/image_picker/image_picker/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for selecting images from the Android and iOS image
   library, and taking new pictures with the camera.
 repository: https://github.com/flutter/packages/tree/main/packages/image_picker/image_picker
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+image_picker%22
-version: 1.2.3
+version: 1.2.4
 
 environment:
   sdk: ^3.10.0

--- a/packages/image_picker/image_picker_platform_interface/CHANGELOG.md
+++ b/packages/image_picker/image_picker_platform_interface/CHANGELOG.md
@@ -1,4 +1,4 @@
-## NEXT
+## 2.11.2
 
 * Updates minimum supported SDK version to Flutter 3.38/Dart 3.10.
 * Documents that `getLostData` must clear the stored lost data once it is

--- a/packages/image_picker/image_picker_platform_interface/CHANGELOG.md
+++ b/packages/image_picker/image_picker_platform_interface/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## NEXT
 
 * Updates minimum supported SDK version to Flutter 3.38/Dart 3.10.
+* Documents that `getLostData` must clear the stored lost data once it is
+  returned, so subsequent calls return an empty result.
 
 ## 2.11.1
 

--- a/packages/image_picker/image_picker_platform_interface/lib/src/platform_interface/image_picker_platform.dart
+++ b/packages/image_picker/image_picker_platform_interface/lib/src/platform_interface/image_picker_platform.dart
@@ -257,6 +257,10 @@ abstract class ImagePickerPlatform extends PlatformInterface {
   /// Returns a [LostDataResponse] object if successfully retrieved the lost data. The [LostDataResponse] object can
   /// represent either a successful image/video selection, or a failure.
   ///
+  /// Retrieving the lost data is a one-time operation: implementations must
+  /// clear the stored data once it has been returned, so that subsequent calls
+  /// return an empty [LostDataResponse] rather than the same data again.
+  ///
   /// Calling this on a non-Android platform will throw [UnimplementedError] exception.
   ///
   /// See also:

--- a/packages/image_picker/image_picker_platform_interface/pubspec.yaml
+++ b/packages/image_picker/image_picker_platform_interface/pubspec.yaml
@@ -4,7 +4,7 @@ repository: https://github.com/flutter/packages/tree/main/packages/image_picker/
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+image_picker%22
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 2.11.1
+version: 2.11.2
 
 environment:
   sdk: ^3.10.0


### PR DESCRIPTION
Documents that lost-data retrieval is destructive: once the lost data is
returned it is cleared, so subsequent calls return an empty result. Adds the
note at both the app-facing layer (`ImagePicker.retrieveLostData`) and the
platform interface (`ImagePickerPlatform.getLostData`), matching the intended
behavior described in the issue.

This is a documentation-only change (dartdoc plus CHANGELOG), so adds no tests
(test-exempt).

Fixes flutter/flutter#164223

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under[^1].
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[the version and CHANGELOG instructions]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version-and-changelog-updates
[semantic versioning]: https://dart.dev/tools/pub/versioning#semantic-versions
[repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
