### PR TITLE
[xdg_directories] Parse user-dirs.dirs in pure Dart instead of using runSync

### DIFF
--- a/packages/xdg_directories/CHANGELOG.md
+++ b/packages/xdg_directories/CHANGELOG.md
@@ -1,5 +1,6 @@
-## NEXT
+## 1.1.1
 
+* Parses `user-dirs.dirs` in pure Dart instead of spawning the external `xdg-user-dir` binary via `Process.runSync`.
 * Updates minimum supported SDK version to Flutter 3.38/Dart 3.10.
 
 ## 1.1.0

--- a/packages/xdg_directories/lib/xdg_directories.dart
+++ b/packages/xdg_directories/lib/xdg_directories.dart
@@ -58,22 +58,54 @@ class _DefaultProcessRunner implements XdgProcessRunner {
     Encoding? stdoutEncoding = systemEncoding,
     Encoding? stderrEncoding = systemEncoding,
   }) {
-    return Process.runSync(
+    if (executable == 'xdg-user-dir' && arguments.isNotEmpty) {
+      final String dirName = arguments.first;
+      final File configFile = File(
+        path.join(configHome.path, 'user-dirs.dirs'),
+      );
+      try {
+        final List<String> contents = configFile.readAsLinesSync();
+        final RegExp dirRegExp = RegExp(
+          r'^\s*XDG_' + RegExp.escape(dirName) + r'_DIR\s*=\s*(?<dir>.*)\s*$',
+        );
+        for (final String line in contents) {
+          final RegExpMatch? match = dirRegExp.firstMatch(line);
+          if (match != null) {
+            String dir = match.namedGroup('dir')!.trim();
+            if (dir.startsWith('"') && dir.endsWith('"') && dir.length >= 2) {
+              dir = dir.substring(1, dir.length - 1);
+            }
+            final String homeDir = _getenv('HOME') ?? '';
+            dir = dir.replaceAll(r'$HOME', homeDir);
+            return ProcessResult(0, 0, '$dir\n', '');
+          }
+        }
+      } on FileSystemException {
+        // Fall through to standard xdg-user-dir fallback below.
+      }
+      final String homeDir = _getenv('HOME') ?? '';
+      final String fallback = dirName == 'DESKTOP'
+          ? '$homeDir/Desktop'
+          : homeDir;
+      return ProcessResult(0, 0, '$fallback\n', '');
+    }
+    throw ProcessException(
       executable,
       arguments,
-      stdoutEncoding: stdoutEncoding,
-      stderrEncoding: stderrEncoding,
+      'No such file or directory',
+      _noSuchFileError,
     );
   }
 }
 
 /// A testing function that replaces the process runner used to run
-/// xdg-user-path with the one supplied.
+/// xdg-user-path with the one supplied, or resets to the default runner if
+/// null is passed.
 ///
 /// Only available to tests.
 @visibleForTesting
-set xdgProcessRunner(XdgProcessRunner processRunner) {
-  _processRunner = processRunner;
+set xdgProcessRunner(XdgProcessRunner? processRunner) {
+  _processRunner = processRunner ?? const _DefaultProcessRunner();
 }
 
 XdgProcessRunner _processRunner = const _DefaultProcessRunner();

--- a/packages/xdg_directories/pubspec.yaml
+++ b/packages/xdg_directories/pubspec.yaml
@@ -2,7 +2,7 @@ name: xdg_directories
 description: A Dart package for reading XDG directory configuration information on Linux.
 repository: https://github.com/flutter/packages/tree/main/packages/xdg_directories
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+xdg_directories%22
-version: 1.1.0
+version: 1.1.1
 
 environment:
   sdk: ^3.10.0

--- a/packages/xdg_directories/test/xdg_directories_test.dart
+++ b/packages/xdg_directories/test/xdg_directories_test.dart
@@ -127,6 +127,15 @@ XDG_VIDEOS_DIR="$HOME/Videos"
     );
   });
 
+  test('Default process runner parses user-dirs.dirs and falls back to HOME', () {
+    xdg.xdgProcessRunner = null;
+    expect(xdg.getUserDirectory('DOWNLOAD')!.path, equals(testPath('Downloads')));
+    expect(xdg.getUserDirectory('DESKTOP')!.path, equals(testPath('Desktop')));
+
+    // When a key is omitted from user-dirs.dirs, falls back to HOME.
+    expect(xdg.getUserDirectory('UNKNOWN_DIR')!.path, equals(testRootPath()));
+  });
+
   test('Throws StateError when HOME not set', () {
     fakeEnv.clear();
     expect(() {


### PR DESCRIPTION
## Description

Replaces the `Process.runSync('xdg-user-dir', ...)` call in `_DefaultProcessRunner` with pure-Dart parsing of `${XDG_CONFIG_HOME}/user-dirs.dirs`.

Previously, getUserDirectory shelled out to the external 'xdg-user-dir' binary via Process.runSync to read ~/.config/user-dirs.dirs, while getUserDirectoryNames parsed the same file directly in pure Dart.

This replaces the Process.runSync call in _DefaultProcessRunner with pure-Dart parsing of user-dirs.dirs, preserving the standard xdg-user-dir fallback (/usr/local/google/home/cepadilla/Desktop for DESKTOP and /usr/local/google/home/cepadilla otherwise) when the file or variable is missing.

This eliminates synchronous subprocess execution on the UI thread, removes the shell evaluation surface in xdg-user-dir, and allows getUserDirectory to work on minimal Linux distributions and container environments where the xdg-user-dirs package is not installed.

*Replace this paragraph with a description of what this PR is changing or adding, and why. Consider including before/after screenshots.*

*List which issues are fixed by this PR. You must list at least one issue.*

Fixes https://github.com/flutter/flutter/issues/192430

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under[^1].
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[the version and CHANGELOG instructions]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version-and-changelog-updates
[semantic versioning]: https://dart.dev/tools/pub/versioning#semantic-versions
[repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests