### PR TITLE
[tool] Adopt `platform` 3.2.0

### DIFF
--- a/script/tool/CHANGELOG.md
+++ b/script/tool/CHANGELOG.md
@@ -1,7 +1,9 @@
-## NEXT
+## 0.14.4+1
 
 * Adds support for batch release of pre-1.0 packages.
 * Exempts `AGENTS.md` from requiring version and changelog changes.
+* Updates to support `platform` 3.2.0, to account for upstream breaking changes
+  to mocking.
 
 ## 0.14.4
 

--- a/script/tool/lib/src/common/cmake.dart
+++ b/script/tool/lib/src/common/cmake.dart
@@ -19,7 +19,7 @@ class CMakeProject {
     this.flutterProject, {
     required this.buildMode,
     this.processRunner = const ProcessRunner(),
-    this.platform = const LocalPlatform(),
+    required this.platform,
     required this.arch,
   });
 
@@ -30,7 +30,7 @@ class CMakeProject {
   final ProcessRunner processRunner;
 
   /// The platform that commands are being run on.
-  final Platform platform;
+  final NativePlatform platform;
 
   /// The architecture subdirectory of the build.
   final String arch;

--- a/script/tool/lib/src/common/core.dart
+++ b/script/tool/lib/src/common/core.dart
@@ -160,7 +160,7 @@ Directory toolCacheDirectory(Directory repoRoot) {
 }
 
 /// The directory to which to write logs and other artifacts, if set in CI.
-Directory? ciLogsDirectory(Platform platform, FileSystem fileSystem) {
+Directory? ciLogsDirectory(NativePlatform platform, FileSystem fileSystem) {
   final String? logsDirectoryPath = platform.environment['FLUTTER_LOGS_DIR'];
   Directory? logsDirectory;
   if (logsDirectoryPath != null) {

--- a/script/tool/lib/src/common/flutter_command_utils.dart
+++ b/script/tool/lib/src/common/flutter_command_utils.dart
@@ -16,7 +16,7 @@ import 'repository_package.dart';
 Future<bool> runConfigOnlyBuild(
   RepositoryPackage package,
   ProcessRunner processRunner,
-  Platform platform,
+  NativePlatform platform,
   FlutterPlatform targetPlatform, {
   bool buildDebug = false,
   List<String> extraArgs = const <String>[],

--- a/script/tool/lib/src/common/gradle.dart
+++ b/script/tool/lib/src/common/gradle.dart
@@ -17,8 +17,8 @@ class GradleProject {
   /// [processRunner].
   GradleProject(
     this.flutterProject, {
+    required this.platform,
     this.processRunner = const ProcessRunner(),
-    this.platform = const LocalPlatform(),
   });
 
   /// The directory of a Flutter project to run Gradle commands in.
@@ -28,7 +28,7 @@ class GradleProject {
   final ProcessRunner processRunner;
 
   /// The platform that commands are being run on.
-  final Platform platform;
+  final NativePlatform platform;
 
   /// The project's 'android' directory.
   Directory get androidDirectory => flutterProject.platformDirectory(FlutterPlatform.android);

--- a/script/tool/lib/src/common/package_command.dart
+++ b/script/tool/lib/src/common/package_command.dart
@@ -40,9 +40,10 @@ abstract class PackageCommand extends Command<void> {
   PackageCommand(
     this.packagesDir, {
     this.processRunner = const ProcessRunner(),
-    this.platform = const LocalPlatform(),
+    NativePlatform? platform,
     GitDir? gitDir,
   }) : _gitDir = gitDir {
+    this.platform = platform ?? NativePlatform.current!;
     thirdPartyPackagesDir = rootDir.childDirectory('third_party').childDirectory('packages');
 
     argParser.addMultiOption(
@@ -206,7 +207,7 @@ abstract class PackageCommand extends Command<void> {
   /// The current platform.
   ///
   /// This can be overridden for testing.
-  final Platform platform;
+  late final NativePlatform platform;
 
   /// The git directory to use. If unset, [gitDir] populates it from the
   /// packages directory's enclosing repository.

--- a/script/tool/lib/src/common/pub_utils.dart
+++ b/script/tool/lib/src/common/pub_utils.dart
@@ -17,7 +17,7 @@ import 'repository_package.dart';
 Future<bool> runPubGet(
   RepositoryPackage package,
   ProcessRunner processRunner,
-  Platform platform, {
+  NativePlatform platform, {
   bool streamOutput = true,
 }) async {
   return runPubCommand(
@@ -39,7 +39,7 @@ Future<bool> runPubCommand(
   List<String> commandArgs,
   RepositoryPackage package,
   ProcessRunner processRunner,
-  Platform platform, {
+  NativePlatform platform, {
   bool streamOutput = true,
   String? dartSdkPathOverride,
   bool recursiveFlutterCheck = false,
@@ -77,7 +77,7 @@ Future<io.Process> startPubCommand(
   List<String> commandArgs,
   RepositoryPackage package,
   ProcessRunner processRunner,
-  Platform platform,
+  NativePlatform platform,
 ) async {
   return processRunner.start(_pubCommand(package, platform), <String>[
     'pub',
@@ -87,7 +87,7 @@ Future<io.Process> startPubCommand(
 
 String _pubCommand(
   RepositoryPackage package,
-  Platform platform, {
+  NativePlatform platform, {
   String? dartSdkPathOverride,
   bool recursiveFlutterCheck = false,
 }) {

--- a/script/tool/lib/src/common/xcode.dart
+++ b/script/tool/lib/src/common/xcode.dart
@@ -38,7 +38,7 @@ class Xcode {
     required String scheme,
     String? configuration,
     List<String> extraFlags = const <String>[],
-    required Platform hostPlatform,
+    required NativePlatform hostPlatform,
   }) async {
     final FileSystem fileSystem = exampleDirectory.fileSystem;
     String? resultBundlePath;

--- a/script/tool/lib/src/publish_command.dart
+++ b/script/tool/lib/src/publish_command.dart
@@ -531,7 +531,7 @@ If running this command on CI, you can set the pub credential content in the $_p
 }
 
 /// The path in which pub expects to find its credentials file.
-String _getCredentialsPath({required Platform platform, required p.Context path}) {
+String _getCredentialsPath({required NativePlatform platform, required p.Context path}) {
   // See https://github.com/dart-lang/pub/blob/master/doc/cache_layout.md#layout
   String? configDir;
   if (platform.isLinux) {

--- a/script/tool/pubspec.yaml
+++ b/script/tool/pubspec.yaml
@@ -1,7 +1,7 @@
 name: flutter_plugin_tools
 description: Productivity and CI utils for Flutter team package repositories.
 repository: https://github.com/flutter/packages/tree/main/script/tool
-version: 0.14.4
+version: 0.14.4+1
 
 dependencies:
   args: ^2.1.0
@@ -15,7 +15,7 @@ dependencies:
   http_multi_server: ^3.0.1
   meta: ^1.10.0
   path: ^1.8.3
-  platform: ^3.0.2
+  platform: ^3.2.0
   pub_semver: ^2.0.0
   pubspec_parse: ^1.4.0
   quiver: ^3.0.1

--- a/script/tool/test/analyze_command_test.dart
+++ b/script/tool/test/analyze_command_test.dart
@@ -8,20 +8,21 @@ import 'package:flutter_plugin_tools/src/analyze_command.dart';
 import 'package:flutter_plugin_tools/src/common/core.dart';
 import 'package:flutter_plugin_tools/src/common/plugin_utils.dart';
 import 'package:git/git.dart';
+import 'package:platform/platform.dart';
 import 'package:test/test.dart';
 
 import 'mocks.dart';
 import 'util.dart';
 
 void main() {
-  late MockPlatform mockPlatform;
+  late NativePlatform mockPlatform;
   late Directory packagesDir;
   late RecordingProcessRunner processRunner;
   late RecordingProcessRunner gitProcessRunner;
   late CommandRunner<void> runner;
 
   setUp(() {
-    mockPlatform = MockPlatform();
+    mockPlatform = createMockPlatform();
     final GitDir gitDir;
     (:packagesDir, :processRunner, :gitProcessRunner, :gitDir) = configureBaseCommandMocks(
       platform: mockPlatform,

--- a/script/tool/test/branches_for_batch_release_command_test.dart
+++ b/script/tool/test/branches_for_batch_release_command_test.dart
@@ -7,6 +7,7 @@ import 'package:file/file.dart';
 import 'package:flutter_plugin_tools/src/branches_for_batch_release_command.dart';
 import 'package:flutter_plugin_tools/src/common/core.dart';
 import 'package:git/git.dart';
+import 'package:platform/platform.dart';
 import 'package:test/test.dart';
 
 import 'mocks.dart';
@@ -14,7 +15,7 @@ import 'mocks.dart';
 import 'util.dart';
 
 void main() {
-  late MockPlatform mockPlatform;
+  late NativePlatform mockPlatform;
   late Directory packagesDir;
   late RecordingProcessRunner processRunner;
   late RecordingProcessRunner gitProcessRunner;
@@ -78,7 +79,7 @@ void main() {
   }
 
   setUp(() {
-    mockPlatform = MockPlatform();
+    mockPlatform = createMockPlatform();
     final GitDir gitDir;
     (:packagesDir, :processRunner, :gitProcessRunner, :gitDir) = configureBaseCommandMocks(
       platform: mockPlatform,

--- a/script/tool/test/build_examples_command_test.dart
+++ b/script/tool/test/build_examples_command_test.dart
@@ -8,6 +8,7 @@ import 'package:flutter_plugin_tools/src/build_examples_command.dart';
 import 'package:flutter_plugin_tools/src/common/core.dart';
 import 'package:flutter_plugin_tools/src/common/plugin_utils.dart';
 import 'package:git/git.dart';
+import 'package:platform/platform.dart';
 import 'package:test/test.dart';
 
 import 'mocks.dart';
@@ -15,14 +16,14 @@ import 'util.dart';
 
 void main() {
   group('build-example', () {
-    late MockPlatform mockPlatform;
+    late NativePlatform mockPlatform;
     late Directory packagesDir;
     late CommandRunner<void> runner;
     late RecordingProcessRunner processRunner;
     late RecordingProcessRunner gitProcessRunner;
 
     setUp(() {
-      mockPlatform = MockPlatform();
+      mockPlatform = createMockPlatform();
       final GitDir gitDir;
       (:packagesDir, :processRunner, :gitProcessRunner, :gitDir) = configureBaseCommandMocks(
         platform: mockPlatform,
@@ -127,7 +128,6 @@ void main() {
     });
 
     test('building for iOS when plugin is not set up for iOS results in no-op', () async {
-      mockPlatform.isMacOS = true;
       createFakePlugin('plugin', packagesDir);
 
       final List<String> output = await runCapturingPrint(runner, <String>[
@@ -149,7 +149,6 @@ void main() {
     });
 
     test('building for iOS', () async {
-      mockPlatform.isMacOS = true;
       final RepositoryPackage plugin = createFakePlugin(
         'plugin',
         packagesDir,
@@ -182,8 +181,6 @@ void main() {
     });
 
     test('building for iOS with CocoaPods', () async {
-      mockPlatform.isMacOS = true;
-
       final RepositoryPackage plugin = createFakePlugin(
         'plugin',
         packagesDir,
@@ -230,8 +227,6 @@ void main() {
     });
 
     test('building for iOS with Swift Package Manager', () async {
-      mockPlatform.isMacOS = true;
-
       final RepositoryPackage plugin = createFakePlugin(
         'plugin',
         packagesDir,
@@ -278,8 +273,6 @@ void main() {
     });
 
     test('building non-plugin package for iOS with Swift Package Manager', () async {
-      mockPlatform.isMacOS = true;
-
       final RepositoryPackage package = createFakePackage(
         'a_package',
         packagesDir,
@@ -310,7 +303,6 @@ void main() {
     });
 
     test('building for Linux when plugin is not set up for Linux results in no-op', () async {
-      mockPlatform.isLinux = true;
       createFakePlugin('plugin', packagesDir);
 
       final List<String> output = await runCapturingPrint(runner, <String>[
@@ -332,7 +324,6 @@ void main() {
     });
 
     test('building for Linux', () async {
-      mockPlatform.isLinux = true;
       final RepositoryPackage plugin = createFakePlugin(
         'plugin',
         packagesDir,
@@ -362,7 +353,6 @@ void main() {
     });
 
     test('building for macOS with no implementation results in no-op', () async {
-      mockPlatform.isMacOS = true;
       createFakePlugin('plugin', packagesDir);
 
       final List<String> output = await runCapturingPrint(runner, <String>[
@@ -384,7 +374,6 @@ void main() {
     });
 
     test('building for macOS', () async {
-      mockPlatform.isMacOS = true;
       final RepositoryPackage plugin = createFakePlugin(
         'plugin',
         packagesDir,
@@ -414,8 +403,6 @@ void main() {
     });
 
     test('building for macOS with CocoaPods', () async {
-      mockPlatform.isMacOS = true;
-
       final RepositoryPackage plugin = createFakePlugin(
         'plugin',
         packagesDir,
@@ -459,8 +446,6 @@ void main() {
     });
 
     test('building for macOS with Swift Package Manager', () async {
-      mockPlatform.isMacOS = true;
-
       final RepositoryPackage plugin = createFakePlugin(
         'plugin',
         packagesDir,
@@ -554,7 +539,6 @@ void main() {
     });
 
     test('building for Windows when plugin is not set up for Windows results in no-op', () async {
-      mockPlatform.isWindows = true;
       createFakePlugin('plugin', packagesDir);
 
       final List<String> output = await runCapturingPrint(runner, <String>[
@@ -576,7 +560,6 @@ void main() {
     });
 
     test('building for Windows', () async {
-      mockPlatform.isWindows = true;
       final RepositoryPackage plugin = createFakePlugin(
         'plugin',
         packagesDir,
@@ -897,7 +880,6 @@ void main() {
     });
 
     test('The .pluginToolsConfig.yaml file', () async {
-      mockPlatform.isLinux = true;
       final RepositoryPackage plugin = createFakePlugin(
         'plugin',
         packagesDir,

--- a/script/tool/test/common/gradle_test.dart
+++ b/script/tool/test/common/gradle_test.dart
@@ -27,7 +27,7 @@ void main() {
       final project = GradleProject(
         plugin,
         processRunner: processRunner,
-        platform: MockPlatform(isWindows: true),
+        platform: createMockPlatform(isWindows: true),
       );
 
       expect(project.isConfigured(), true);
@@ -42,7 +42,7 @@ void main() {
       final project = GradleProject(
         plugin,
         processRunner: processRunner,
-        platform: MockPlatform(isMacOS: true),
+        platform: createMockPlatform(isMacOS: true),
       );
 
       expect(project.isConfigured(), true);
@@ -57,7 +57,7 @@ void main() {
       final project = GradleProject(
         plugin,
         processRunner: processRunner,
-        platform: MockPlatform(isWindows: true),
+        platform: createMockPlatform(isWindows: true),
       );
 
       expect(project.isConfigured(), false);
@@ -72,7 +72,7 @@ void main() {
       final project = GradleProject(
         plugin,
         processRunner: processRunner,
-        platform: MockPlatform(isMacOS: true),
+        platform: createMockPlatform(isMacOS: true),
       );
 
       expect(project.isConfigured(), false);
@@ -89,7 +89,7 @@ void main() {
       final project = GradleProject(
         plugin,
         processRunner: processRunner,
-        platform: MockPlatform(isMacOS: true),
+        platform: createMockPlatform(isMacOS: true),
       );
 
       final int exitCode = await project.runCommand('foo');
@@ -116,7 +116,7 @@ void main() {
       final project = GradleProject(
         plugin,
         processRunner: processRunner,
-        platform: MockPlatform(isMacOS: true),
+        platform: createMockPlatform(isMacOS: true),
       );
 
       final int exitCode = await project.runCommand('foo', arguments: <String>['--bar', '--baz']);
@@ -143,7 +143,7 @@ void main() {
       final project = GradleProject(
         plugin,
         processRunner: processRunner,
-        platform: MockPlatform(isWindows: true),
+        platform: createMockPlatform(isWindows: true),
       );
 
       final int exitCode = await project.runCommand('foo');
@@ -170,7 +170,7 @@ void main() {
       final project = GradleProject(
         plugin,
         processRunner: processRunner,
-        platform: MockPlatform(isWindows: true),
+        platform: createMockPlatform(isWindows: true),
       );
 
       processRunner.mockProcessesForExecutable[project.gradleWrapper.path] = <FakeProcessInfo>[

--- a/script/tool/test/common/package_command_test.dart
+++ b/script/tool/test/common/package_command_test.dart
@@ -8,6 +8,7 @@ import 'package:flutter_plugin_tools/src/common/core.dart';
 import 'package:flutter_plugin_tools/src/common/package_command.dart';
 import 'package:git/git.dart';
 import 'package:mockito/annotations.dart';
+import 'package:platform/platform.dart';
 import 'package:test/test.dart';
 
 import '../mocks.dart';
@@ -20,7 +21,7 @@ void main() {
   late RecordingProcessRunner gitProcessRunner;
   late SamplePackageCommand command;
   late CommandRunner<void> runner;
-  late MockPlatform mockPlatform;
+  late NativePlatform mockPlatform;
   late Directory packagesDir;
   late Directory thirdPartyPackagesDir;
 
@@ -36,7 +37,7 @@ void main() {
   }
 
   setUp(() {
-    mockPlatform = MockPlatform();
+    mockPlatform = createMockPlatform();
     (:packagesDir, :processRunner, :gitProcessRunner, :gitDir) = configureBaseCommandMocks(
       platform: mockPlatform,
     );

--- a/script/tool/test/common/package_looping_command_test.dart
+++ b/script/tool/test/common/package_looping_command_test.dart
@@ -11,6 +11,7 @@ import 'package:flutter_plugin_tools/src/common/core.dart';
 import 'package:flutter_plugin_tools/src/common/output_utils.dart';
 import 'package:flutter_plugin_tools/src/common/package_looping_command.dart';
 import 'package:git/git.dart';
+import 'package:platform/platform.dart';
 import 'package:test/test.dart';
 
 import '../mocks.dart';
@@ -74,14 +75,14 @@ String _filenameForType(_ResultFileType type) {
 }
 
 void main() {
-  late MockPlatform mockPlatform;
+  late NativePlatform mockPlatform;
   late Directory packagesDir;
   late Directory thirdPartyPackagesDir;
   late GitDir gitDir;
   late RecordingProcessRunner gitProcessRunner;
 
   setUp(() {
-    mockPlatform = MockPlatform();
+    mockPlatform = createMockPlatform();
     (:packagesDir, processRunner: _, :gitProcessRunner, :gitDir) = configureBaseCommandMocks(
       platform: mockPlatform,
     );

--- a/script/tool/test/common/pub_utils_test.dart
+++ b/script/tool/test/common/pub_utils_test.dart
@@ -4,6 +4,7 @@
 
 import 'package:file/file.dart';
 import 'package:flutter_plugin_tools/src/common/pub_utils.dart';
+import 'package:platform/platform.dart';
 import 'package:test/test.dart';
 
 import '../mocks.dart';
@@ -19,7 +20,7 @@ void main() {
 
   test('runs with Dart for a non-Flutter package', () async {
     final RepositoryPackage package = createFakePackage('a_package', packagesDir);
-    final platform = MockPlatform();
+    final NativePlatform platform = createMockPlatform();
 
     await runPubGet(package, processRunner, platform);
 
@@ -33,7 +34,7 @@ void main() {
 
   test('runs with Flutter for a Flutter package', () async {
     final RepositoryPackage package = createFakePackage('a_package', packagesDir, isFlutter: true);
-    final platform = MockPlatform();
+    final NativePlatform platform = createMockPlatform();
 
     await runPubGet(package, processRunner, platform);
 
@@ -48,7 +49,7 @@ void main() {
   test('runs with Flutter for a non-Flutter package with a Flutter example', () async {
     final RepositoryPackage package = createFakePackage('a_package', packagesDir, examples: []);
     createFakePackage('example', package.directory, examples: [], isFlutter: true);
-    final platform = MockPlatform();
+    final NativePlatform platform = createMockPlatform();
 
     await runPubGet(package, processRunner, platform);
 
@@ -62,7 +63,7 @@ void main() {
 
   test('uses the correct Flutter command on Windows', () async {
     final RepositoryPackage package = createFakePackage('a_package', packagesDir, isFlutter: true);
-    final platform = MockPlatform(isWindows: true);
+    final NativePlatform platform = createMockPlatform(isWindows: true);
 
     await runPubGet(package, processRunner, platform);
 
@@ -76,7 +77,7 @@ void main() {
 
   test('reports success', () async {
     final RepositoryPackage package = createFakePackage('a_package', packagesDir);
-    final platform = MockPlatform();
+    final NativePlatform platform = createMockPlatform();
 
     final bool result = await runPubGet(package, processRunner, platform);
 
@@ -85,7 +86,7 @@ void main() {
 
   test('reports failure', () async {
     final RepositoryPackage package = createFakePackage('a_package', packagesDir);
-    final platform = MockPlatform();
+    final NativePlatform platform = createMockPlatform();
 
     processRunner.mockProcessesForExecutable['dart'] = <FakeProcessInfo>[
       FakeProcessInfo(MockProcess(exitCode: 1), <String>['pub', 'get']),

--- a/script/tool/test/common/xcode_test.dart
+++ b/script/tool/test/common/xcode_test.dart
@@ -157,7 +157,7 @@ void main() {
         'ios',
         workspace: 'A.xcworkspace',
         scheme: 'AScheme',
-        hostPlatform: MockPlatform(),
+        hostPlatform: createMockPlatform(),
       );
 
       expect(exitCode, 0);
@@ -186,7 +186,7 @@ void main() {
         workspace: 'A.xcworkspace',
         scheme: 'AScheme',
         configuration: 'Debug',
-        hostPlatform: MockPlatform(),
+        hostPlatform: createMockPlatform(),
         extraFlags: <String>['-a', '-b', 'c=d'],
       );
 
@@ -223,7 +223,7 @@ void main() {
         'ios',
         workspace: 'A.xcworkspace',
         scheme: 'AScheme',
-        hostPlatform: MockPlatform(),
+        hostPlatform: createMockPlatform(),
       );
 
       expect(exitCode, 1);
@@ -256,7 +256,7 @@ void main() {
         'macos',
         workspace: 'A.xcworkspace',
         scheme: 'AScheme',
-        hostPlatform: MockPlatform(),
+        hostPlatform: createMockPlatform(),
         actions: <String>['test'],
       );
 

--- a/script/tool/test/coverage_check_command_test.dart
+++ b/script/tool/test/coverage_check_command_test.dart
@@ -15,14 +15,14 @@ import 'util.dart';
 
 void main() {
   group('CoverageCheckCommand', () {
-    late Platform mockPlatform;
+    late NativePlatform mockPlatform;
     late Directory packagesDir;
     late CommandRunner<void> runner;
     late RecordingProcessRunner processRunner;
     late CoverageCheckCommand command;
 
     setUp(() {
-      mockPlatform = MockPlatform();
+      mockPlatform = createMockPlatform();
       late GitDir gitDir;
       (:packagesDir, :processRunner, gitProcessRunner: _, :gitDir) = configureBaseCommandMocks(
         platform: mockPlatform,

--- a/script/tool/test/create_all_packages_app_command_test.dart
+++ b/script/tool/test/create_all_packages_app_command_test.dart
@@ -19,13 +19,13 @@ import 'util.dart';
 void main() {
   late CommandRunner<void> runner;
   late CreateAllPackagesAppCommand command;
-  late Platform mockPlatform;
+  late NativePlatform mockPlatform;
   late Directory testRoot;
   late Directory packagesDir;
   late RecordingProcessRunner processRunner;
 
   setUp(() {
-    mockPlatform = MockPlatform(isMacOS: true);
+    mockPlatform = createMockPlatform(isMacOS: true);
     (:packagesDir, :processRunner, gitProcessRunner: _, gitDir: _) = configureBaseCommandMocks(
       platform: mockPlatform,
     );
@@ -152,7 +152,7 @@ project 'Runner', {
 
   group('non-macOS host', () {
     setUp(() {
-      mockPlatform = MockPlatform(isLinux: true);
+      mockPlatform = createMockPlatform(isLinux: true);
       command = CreateAllPackagesAppCommand(
         packagesDir,
         processRunner: processRunner,
@@ -598,7 +598,7 @@ android {
       command = CreateAllPackagesAppCommand(
         packagesDir,
         processRunner: processRunner,
-        platform: MockPlatform(isMacOS: true),
+        platform: createMockPlatform(isMacOS: true),
       );
       runner = CommandRunner<void>('create_all_test', 'Test for $CreateAllPackagesAppCommand');
       runner.addCommand(command);

--- a/script/tool/test/custom_test_command_test.dart
+++ b/script/tool/test/custom_test_command_test.dart
@@ -7,20 +7,21 @@ import 'package:file/file.dart';
 import 'package:flutter_plugin_tools/src/common/core.dart';
 import 'package:flutter_plugin_tools/src/custom_test_command.dart';
 import 'package:git/git.dart';
+import 'package:platform/platform.dart';
 import 'package:test/test.dart';
 
 import 'mocks.dart';
 import 'util.dart';
 
 void main() {
-  late MockPlatform mockPlatform;
+  late NativePlatform mockPlatform;
   late Directory packagesDir;
   late RecordingProcessRunner processRunner;
   late CommandRunner<void> runner;
 
   group('posix', () {
     setUp(() {
-      mockPlatform = MockPlatform();
+      mockPlatform = createMockPlatform();
       final GitDir gitDir;
       (:packagesDir, :processRunner, gitProcessRunner: _, :gitDir) = configureBaseCommandMocks(
         platform: mockPlatform,
@@ -226,7 +227,7 @@ void main() {
 
   group('Windows', () {
     setUp(() {
-      mockPlatform = MockPlatform(isWindows: true);
+      mockPlatform = createMockPlatform(isWindows: true);
       final GitDir gitDir;
       (:packagesDir, :processRunner, gitProcessRunner: _, :gitDir) = configureBaseCommandMocks(
         platform: mockPlatform,

--- a/script/tool/test/dart_test_command_test.dart
+++ b/script/tool/test/dart_test_command_test.dart
@@ -16,14 +16,14 @@ import 'util.dart';
 
 void main() {
   group('TestCommand', () {
-    late Platform mockPlatform;
+    late NativePlatform mockPlatform;
     late Directory packagesDir;
     late CommandRunner<void> runner;
     late RecordingProcessRunner processRunner;
     late RecordingProcessRunner gitProcessRunner;
 
     setUp(() {
-      mockPlatform = MockPlatform();
+      mockPlatform = createMockPlatform();
       final GitDir gitDir;
       (:packagesDir, :processRunner, :gitProcessRunner, :gitDir) = configureBaseCommandMocks(
         platform: mockPlatform,

--- a/script/tool/test/drive_examples_command_test.dart
+++ b/script/tool/test/drive_examples_command_test.dart
@@ -13,6 +13,7 @@ import 'package:flutter_plugin_tools/src/common/plugin_utils.dart';
 import 'package:flutter_plugin_tools/src/drive_examples_command.dart';
 import 'package:git/git.dart';
 import 'package:mockito/mockito.dart';
+import 'package:platform/platform.dart';
 import 'package:test/test.dart';
 
 import 'mocks.dart';
@@ -38,14 +39,14 @@ const List<String> _defaultWebBrowserFlags = <String>[
 
 void main() {
   group('test drive_example_command', () {
-    late MockPlatform mockPlatform;
+    late NativePlatform mockPlatform;
     late Directory packagesDir;
     late CommandRunner<void> runner;
     late RecordingProcessRunner processRunner;
     late RecordingProcessRunner gitProcessRunner;
 
     setUp(() {
-      mockPlatform = MockPlatform();
+      mockPlatform = createMockPlatform();
       final GitDir gitDir;
       (:packagesDir, :processRunner, :gitProcessRunner, :gitDir) = configureBaseCommandMocks(
         platform: mockPlatform,
@@ -946,55 +947,6 @@ void main() {
       );
     });
 
-    test('drives a web plugin on macOS with mock keychain', () async {
-      final RepositoryPackage plugin = createFakePlugin(
-        'plugin',
-        packagesDir,
-        extraFiles: <String>[
-          'example/integration_test/plugin_test.dart',
-          'example/test_driver/integration_test.dart',
-          'example/web/index.html',
-        ],
-        platformSupport: <String, PlatformDetails>{
-          platformWeb: const PlatformDetails(PlatformSupport.inline),
-        },
-      );
-
-      final Directory pluginExampleDirectory = getExampleDir(plugin);
-
-      mockPlatform.isMacOS = true;
-
-      final List<String> output = await runCapturingPrint(runner, <String>[
-        'drive-examples',
-        '--web',
-      ]);
-
-      expect(
-        output,
-        containsAllInOrder(<Matcher>[contains('Running for plugin'), contains('No issues found!')]),
-      );
-
-      expect(
-        processRunner.recordedCalls,
-        orderedEquals(<ProcessCall>[
-          ProcessCall(getFlutterCommand(mockPlatform), const <String>[
-            'drive',
-            '-d',
-            'web-server',
-            '--web-port=7357',
-            '--browser-name=chrome',
-            ..._defaultWebBrowserFlags,
-            '--web-browser-flag=--use-mock-keychain',
-            '--screenshot=/path/to/logs/plugin_example-drive',
-            '--driver',
-            'test_driver/integration_test.dart',
-            '--target',
-            'integration_test/plugin_test.dart',
-          ], pluginExampleDirectory.path),
-        ]),
-      );
-    });
-
     test('driving when plugin does not suppport Windows is a no-op', () async {
       createFakePlugin(
         'plugin',
@@ -1786,6 +1738,79 @@ packages/package_a/CHANGELOG.md
         expect(output, isNot(containsAllInOrder(<Matcher>[contains('Running for package_a')])));
         expect(output, containsAllInOrder(<Matcher>[contains('SKIPPING ALL PACKAGES')]));
       });
+    });
+  });
+
+  group('on macOS', () {
+    late NativePlatform mockPlatform;
+    late Directory packagesDir;
+    late CommandRunner<void> runner;
+    late RecordingProcessRunner processRunner;
+
+    setUp(() {
+      mockPlatform = createMockPlatform(isMacOS: true);
+      final GitDir gitDir;
+      (:packagesDir, :processRunner, gitProcessRunner: _, :gitDir) = configureBaseCommandMocks(
+        platform: mockPlatform,
+      );
+      final command = DriveExamplesCommand(
+        packagesDir,
+        processRunner: processRunner,
+        platform: mockPlatform,
+        gitDir: gitDir,
+      );
+
+      runner = CommandRunner<void>('drive_examples_command', 'Test for drive_example_command');
+      runner.addCommand(command);
+
+      mockPlatform.environment['FLUTTER_LOGS_DIR'] = '/path/to/logs';
+    });
+
+    test('drives a web plugin on macOS with mock keychain', () async {
+      final RepositoryPackage plugin = createFakePlugin(
+        'plugin',
+        packagesDir,
+        extraFiles: <String>[
+          'example/integration_test/plugin_test.dart',
+          'example/test_driver/integration_test.dart',
+          'example/web/index.html',
+        ],
+        platformSupport: <String, PlatformDetails>{
+          platformWeb: const PlatformDetails(PlatformSupport.inline),
+        },
+      );
+
+      final Directory pluginExampleDirectory = getExampleDir(plugin);
+
+      final List<String> output = await runCapturingPrint(runner, <String>[
+        'drive-examples',
+        '--web',
+      ]);
+
+      expect(
+        output,
+        containsAllInOrder(<Matcher>[contains('Running for plugin'), contains('No issues found!')]),
+      );
+
+      expect(
+        processRunner.recordedCalls,
+        orderedEquals(<ProcessCall>[
+          ProcessCall(getFlutterCommand(mockPlatform), const <String>[
+            'drive',
+            '-d',
+            'web-server',
+            '--web-port=7357',
+            '--browser-name=chrome',
+            ..._defaultWebBrowserFlags,
+            '--web-browser-flag=--use-mock-keychain',
+            '--screenshot=/path/to/logs/plugin_example-drive',
+            '--driver',
+            'test_driver/integration_test.dart',
+            '--target',
+            'integration_test/plugin_test.dart',
+          ], pluginExampleDirectory.path),
+        ]),
+      );
     });
   });
 }

--- a/script/tool/test/federation_safety_check_command_test.dart
+++ b/script/tool/test/federation_safety_check_command_test.dart
@@ -7,19 +7,20 @@ import 'package:file/file.dart';
 import 'package:flutter_plugin_tools/src/common/core.dart';
 import 'package:flutter_plugin_tools/src/federation_safety_check_command.dart';
 import 'package:git/git.dart';
+import 'package:platform/platform.dart';
 import 'package:test/test.dart';
 
 import 'mocks.dart';
 import 'util.dart';
 
 void main() {
-  late MockPlatform mockPlatform;
+  late NativePlatform mockPlatform;
   late Directory packagesDir;
   late CommandRunner<void> runner;
   late RecordingProcessRunner gitProcessRunner;
 
   setUp(() {
-    mockPlatform = MockPlatform();
+    mockPlatform = createMockPlatform();
     final GitDir gitDir;
     final RecordingProcessRunner processRunner;
     (:packagesDir, :processRunner, :gitProcessRunner, :gitDir) = configureBaseCommandMocks(

--- a/script/tool/test/fetch_deps_command_test.dart
+++ b/script/tool/test/fetch_deps_command_test.dart
@@ -8,6 +8,7 @@ import 'package:flutter_plugin_tools/src/common/core.dart';
 import 'package:flutter_plugin_tools/src/common/plugin_utils.dart';
 import 'package:flutter_plugin_tools/src/fetch_deps_command.dart';
 import 'package:git/git.dart';
+import 'package:platform/platform.dart';
 import 'package:test/test.dart';
 
 import 'mocks.dart';
@@ -17,11 +18,11 @@ void main() {
   group('FetchDepsCommand', () {
     late Directory packagesDir;
     late CommandRunner<void> runner;
-    late MockPlatform mockPlatform;
+    late NativePlatform mockPlatform;
     late RecordingProcessRunner processRunner;
 
     setUp(() {
-      mockPlatform = MockPlatform();
+      mockPlatform = createMockPlatform();
       final GitDir gitDir;
       (:packagesDir, :processRunner, gitProcessRunner: _, :gitDir) = configureBaseCommandMocks(
         platform: mockPlatform,
@@ -657,7 +658,6 @@ void main() {
       for (final platformName in <String>[platformIOS, platformMacOS]) {
         group(platformName, () {
           test('is not set by default', () async {
-            mockPlatform.isMacOS = true;
             final RepositoryPackage plugin = createFakePlugin(
               'plugin1',
               packagesDir,
@@ -686,7 +686,6 @@ void main() {
           });
 
           test('can be enabled', () async {
-            mockPlatform.isMacOS = true;
             final RepositoryPackage plugin = createFakePlugin(
               'plugin1',
               packagesDir,
@@ -720,7 +719,6 @@ void main() {
           });
 
           test('can be disabled', () async {
-            mockPlatform.isMacOS = true;
             final RepositoryPackage plugin = createFakePlugin(
               'plugin1',
               packagesDir,
@@ -755,7 +753,6 @@ void main() {
           });
 
           test('is set before running pub get, and includes the plugin package', () async {
-            mockPlatform.isMacOS = true;
             final RepositoryPackage plugin = createFakePlugin(
               'plugin1',
               packagesDir,

--- a/script/tool/test/firebase_test_lab_command_test.dart
+++ b/script/tool/test/firebase_test_lab_command_test.dart
@@ -9,6 +9,7 @@ import 'package:flutter_plugin_tools/src/common/file_utils.dart';
 import 'package:flutter_plugin_tools/src/firebase_test_lab_command.dart';
 import 'package:git/git.dart';
 import 'package:path/path.dart' as p;
+import 'package:platform/platform.dart';
 import 'package:test/test.dart';
 
 import 'mocks.dart';
@@ -16,14 +17,14 @@ import 'util.dart';
 
 void main() {
   group('FirebaseTestLabCommand', () {
-    late MockPlatform mockPlatform;
+    late NativePlatform mockPlatform;
     late Directory packagesDir;
     late CommandRunner<void> runner;
     late RecordingProcessRunner processRunner;
     late RecordingProcessRunner gitProcessRunner;
 
     setUp(() {
-      mockPlatform = MockPlatform();
+      mockPlatform = createMockPlatform();
       final GitDir gitDir;
       (:packagesDir, :processRunner, :gitProcessRunner, :gitDir) = configureBaseCommandMocks(
         platform: mockPlatform,

--- a/script/tool/test/fix_command_test.dart
+++ b/script/tool/test/fix_command_test.dart
@@ -7,19 +7,20 @@ import 'package:file/file.dart';
 import 'package:flutter_plugin_tools/src/common/core.dart';
 import 'package:flutter_plugin_tools/src/fix_command.dart';
 import 'package:git/git.dart';
+import 'package:platform/platform.dart';
 import 'package:test/test.dart';
 
 import 'mocks.dart';
 import 'util.dart';
 
 void main() {
-  late MockPlatform mockPlatform;
+  late NativePlatform mockPlatform;
   late Directory packagesDir;
   late RecordingProcessRunner processRunner;
   late CommandRunner<void> runner;
 
   setUp(() {
-    mockPlatform = MockPlatform();
+    mockPlatform = createMockPlatform();
     final GitDir gitDir;
     (:packagesDir, :processRunner, gitProcessRunner: _, :gitDir) = configureBaseCommandMocks(
       platform: mockPlatform,

--- a/script/tool/test/format_command_test.dart
+++ b/script/tool/test/format_command_test.dart
@@ -9,6 +9,7 @@ import 'package:flutter_plugin_tools/src/common/file_utils.dart';
 import 'package:flutter_plugin_tools/src/format_command.dart';
 import 'package:git/git.dart';
 import 'package:path/path.dart' as p;
+import 'package:platform/platform.dart';
 import 'package:test/test.dart';
 
 import 'mocks.dart';
@@ -18,39 +19,6 @@ const String _languageVersion = '3.8';
 const String _dartConstraint = '^$_languageVersion.0';
 
 void main() {
-  late MockPlatform mockPlatform;
-  late Directory packagesDir;
-  late RecordingProcessRunner processRunner;
-  late RecordingProcessRunner gitProcessRunner;
-  late FormatCommand analyzeCommand;
-  late CommandRunner<void> runner;
-  late String javaFormatPath;
-  late String kotlinFormatPath;
-
-  setUp(() {
-    mockPlatform = MockPlatform();
-    final GitDir gitDir;
-    (:packagesDir, :processRunner, :gitProcessRunner, :gitDir) = configureBaseCommandMocks(
-      platform: mockPlatform,
-    );
-    analyzeCommand = FormatCommand(
-      packagesDir,
-      processRunner: processRunner,
-      platform: mockPlatform,
-      gitDir: gitDir,
-    );
-
-    // Create the Java and Kotlin formatter files that the command checks for,
-    // to avoid a download.
-    javaFormatPath = analyzeCommand.javaFormatterFile.path;
-    packagesDir.fileSystem.file(javaFormatPath).createSync(recursive: true);
-    kotlinFormatPath = analyzeCommand.kotlinFormatterFile.path;
-    packagesDir.fileSystem.file(kotlinFormatPath).createSync(recursive: true);
-
-    runner = CommandRunner<void>('format_command', 'Test for format_command');
-    runner.addCommand(analyzeCommand);
-  });
-
   /// Creates the .dart_tool directory for [package] to simulate (as much as
   /// this command requires) `pub get` having been run.
   void fakePubGet(RepositoryPackage package, {String languageVersion = _languageVersion}) {
@@ -74,44 +42,413 @@ void main() {
 ''');
   }
 
-  /// Returns a modified version of a list of [relativePaths] that are relative
-  /// to [package] to instead be relative to [packagesDir].
-  List<String> getPackagesDirRelativePaths(RepositoryPackage package, List<String> relativePaths) {
-    final p.Context path = analyzeCommand.path;
-    final String relativeBase = path.relative(package.path, from: packagesDir.path);
-    return relativePaths
-        .map((String relativePath) => path.join(relativeBase, relativePath))
-        .toList();
-  }
+  group('non-Windows', () {
+    late NativePlatform mockPlatform;
+    late Directory packagesDir;
+    late RecordingProcessRunner processRunner;
+    late RecordingProcessRunner gitProcessRunner;
+    late FormatCommand analyzeCommand;
+    late CommandRunner<void> runner;
+    late String javaFormatPath;
+    late String kotlinFormatPath;
 
-  /// Returns a list of [count] relative paths to pass to [createFakePlugin]
-  /// or [createFakePackage] such that each path will be 99 characters long
-  /// relative to the package directory.
-  ///
-  /// This is for each of testing batching, since it means each file will
-  /// consume 100 characters of the batch length.
-  List<String> get99CharacterPathExtraFiles(int count) {
-    const int padding =
-        99 -
-        1 - // the path separator after the padding
-        10; // the file name
-    const filenameBase = 10000;
-
-    final p.Context path = analyzeCommand.path;
-    return <String>[
-      for (int i = filenameBase; i < filenameBase + count; ++i) path.join('a' * padding, '$i.dart'),
-    ];
-  }
-
-  group('dart format', () {
-    test('formats .dart files', () async {
-      const files = <String>['lib/a.dart', 'lib/src/b.dart', 'lib/src/c.dart'];
-      final RepositoryPackage plugin = createFakePlugin(
-        'a_plugin',
-        packagesDir,
-        extraFiles: files,
-        dartConstraint: _dartConstraint,
+    setUp(() {
+      mockPlatform = createMockPlatform();
+      final GitDir gitDir;
+      (:packagesDir, :processRunner, :gitProcessRunner, :gitDir) = configureBaseCommandMocks(
+        platform: mockPlatform,
       );
+      analyzeCommand = FormatCommand(
+        packagesDir,
+        processRunner: processRunner,
+        platform: mockPlatform,
+        gitDir: gitDir,
+      );
+
+      // Create the Java and Kotlin formatter files that the command checks for,
+      // to avoid a download.
+      javaFormatPath = analyzeCommand.javaFormatterFile.path;
+      packagesDir.fileSystem.file(javaFormatPath).createSync(recursive: true);
+      kotlinFormatPath = analyzeCommand.kotlinFormatterFile.path;
+      packagesDir.fileSystem.file(kotlinFormatPath).createSync(recursive: true);
+
+      runner = CommandRunner<void>('format_command', 'Test for format_command');
+      runner.addCommand(analyzeCommand);
+    });
+
+    /// Convenience wrapper for [_getPackagesDirRelativePaths], passing the correct context.
+    List<String> getPackagesDirRelativePaths(
+      RepositoryPackage package,
+      List<String> relativePaths,
+    ) {
+      return _getPackagesDirRelativePaths(
+        package,
+        relativePaths,
+        path: analyzeCommand.path,
+        packagesDir: packagesDir,
+      );
+    }
+
+    /// Convenience wrapper for [_get99CharacterPathExtraFiles], passing the correct context.
+    List<String> get99CharacterPathExtraFiles(int count) {
+      return _get99CharacterPathExtraFiles(count, path: analyzeCommand.path);
+    }
+
+    group('dart format', () {
+      test('formats .dart files', () async {
+        const files = <String>['lib/a.dart', 'lib/src/b.dart', 'lib/src/c.dart'];
+        final RepositoryPackage plugin = createFakePlugin(
+          'a_plugin',
+          packagesDir,
+          extraFiles: files,
+          dartConstraint: _dartConstraint,
+        );
+        fakePubGet(plugin);
+
+        await runCapturingPrint(runner, <String>['format']);
+
+        expect(
+          processRunner.recordedCalls,
+          orderedEquals(<ProcessCall>[
+            ProcessCall('dart', const <String>['format', ...files], plugin.path),
+          ]),
+        );
+      });
+
+      test('does not format .dart files with pragma', () async {
+        const formattedFiles = <String>['lib/a.dart', 'lib/src/b.dart', 'lib/src/c.dart'];
+        const unformattedFile = 'lib/src/d.dart';
+        final RepositoryPackage plugin = createFakePlugin(
+          'a_plugin',
+          packagesDir,
+          extraFiles: <String>[...formattedFiles, unformattedFile],
+          dartConstraint: _dartConstraint,
+        );
+        fakePubGet(plugin);
+
+        final p.Context posixContext = p.posix;
+        childFileWithSubcomponents(
+          plugin.directory,
+          posixContext.split(unformattedFile),
+        ).writeAsStringSync('// copyright bla bla\n// This file is hand-formatted.\ncode...');
+
+        await runCapturingPrint(runner, <String>['format']);
+
+        expect(
+          processRunner.recordedCalls,
+          orderedEquals(<ProcessCall>[
+            ProcessCall('dart', const <String>['format', ...formattedFiles], plugin.path),
+          ]),
+        );
+      });
+
+      test('fails if dart format fails', () async {
+        const files = <String>['lib/a.dart', 'lib/src/b.dart', 'lib/src/c.dart'];
+        final RepositoryPackage plugin = createFakePlugin(
+          'a_plugin',
+          packagesDir,
+          extraFiles: files,
+          dartConstraint: _dartConstraint,
+        );
+        fakePubGet(plugin);
+
+        processRunner.mockProcessesForExecutable['dart'] = <FakeProcessInfo>[
+          FakeProcessInfo(MockProcess(exitCode: 1), <String>['format']),
+        ];
+        Error? commandError;
+        final List<String> output = await runCapturingPrint(
+          runner,
+          <String>['format'],
+          errorHandler: (Error e) {
+            commandError = e;
+          },
+        );
+
+        expect(commandError, isA<ToolExit>());
+        expect(
+          output,
+          containsAllInOrder(<Matcher>[contains('Failed to format Dart files: exit code 1.')]),
+        );
+      });
+
+      test('formats only staged files when --run-on-staged-packages is used', () async {
+        const files = <String>['lib/a.dart', 'lib/src/b.dart', 'lib/src/c.dart'];
+        final RepositoryPackage plugin = createFakePlugin(
+          'a_plugin',
+          packagesDir,
+          extraFiles: files,
+          dartConstraint: _dartConstraint,
+        );
+        fakePubGet(plugin);
+
+        // Mock git diff --cached to return only lib/src/b.dart (called three times)
+        const stagedFilePath = 'packages/a_plugin/lib/src/b.dart';
+        gitProcessRunner.mockProcessesForExecutable['git-diff'] = List<FakeProcessInfo>.generate(
+          3,
+          (_) => FakeProcessInfo(MockProcess(stdout: stagedFilePath)),
+        );
+
+        await runCapturingPrint(runner, <String>['format', '--run-on-staged-packages']);
+
+        expect(
+          processRunner.recordedCalls,
+          orderedEquals(<ProcessCall>[
+            ProcessCall('dart', const <String>['format', 'lib/src/b.dart'], plugin.path),
+          ]),
+        );
+      });
+
+      test('skips formatting when there are no staged packages', () async {
+        final RepositoryPackage plugin = createFakePlugin(
+          'a_plugin',
+          packagesDir,
+          dartConstraint: _dartConstraint,
+        );
+        fakePubGet(plugin);
+
+        gitProcessRunner.mockProcessesForExecutable['git-diff'] = List<FakeProcessInfo>.generate(
+          3,
+          (_) => FakeProcessInfo(MockProcess(stdout: '')),
+        );
+
+        await runCapturingPrint(runner, <String>['format', '--run-on-staged-packages']);
+
+        expect(processRunner.recordedCalls, isEmpty);
+      });
+
+      test('formats only staged files across multiple packages', () async {
+        final RepositoryPackage pluginA = createFakePlugin(
+          'plugin_a',
+          packagesDir,
+          extraFiles: <String>['lib/a.dart', 'lib/src/unused_a.dart'],
+          dartConstraint: _dartConstraint,
+        );
+        fakePubGet(pluginA);
+
+        final RepositoryPackage pluginB = createFakePlugin(
+          'plugin_b',
+          packagesDir,
+          extraFiles: <String>['lib/b.dart', 'lib/src/unused_b.dart'],
+          dartConstraint: _dartConstraint,
+        );
+        fakePubGet(pluginB);
+
+        // Mock git diff to return both staged files (called three times)
+        const stagedFiles = 'packages/plugin_a/lib/a.dart\npackages/plugin_b/lib/b.dart\n';
+        gitProcessRunner.mockProcessesForExecutable['git-diff'] = List<FakeProcessInfo>.generate(
+          3,
+          (_) => FakeProcessInfo(MockProcess(stdout: stagedFiles)),
+        );
+
+        await runCapturingPrint(runner, <String>['format', '--run-on-staged-packages']);
+
+        expect(
+          processRunner.recordedCalls,
+          unorderedEquals(<ProcessCall>[
+            ProcessCall('dart', const <String>['format', 'lib/a.dart'], pluginA.path),
+            ProcessCall('dart', const <String>['format', 'lib/b.dart'], pluginB.path),
+          ]),
+        );
+      });
+
+      test(
+        'does not format staged files that are hand-formatted or in excluded directories when --run-on-staged-packages is used',
+        () async {
+          const files = <String>[
+            'lib/a.dart',
+            'lib/src/b.dart',
+            'example/build/a.dart',
+            '.dart_tool/a.dart',
+          ];
+          final RepositoryPackage plugin = createFakePlugin(
+            'a_plugin',
+            packagesDir,
+            extraFiles: files,
+            dartConstraint: _dartConstraint,
+          );
+          fakePubGet(plugin);
+
+          // Write pragma to lib/src/b.dart
+          final p.Context posixContext = p.posix;
+          childFileWithSubcomponents(
+            plugin.directory,
+            posixContext.split('lib/src/b.dart'),
+          ).writeAsStringSync('// This file is hand-formatted.\ncode...');
+
+          // Mock git diff to return all of them
+          final String stagedFiles = files.map((String f) => 'packages/a_plugin/$f').join('\n');
+          gitProcessRunner.mockProcessesForExecutable['git-diff'] = List<FakeProcessInfo>.generate(
+            3,
+            (_) => FakeProcessInfo(MockProcess(stdout: stagedFiles)),
+          );
+
+          await runCapturingPrint(runner, <String>['format', '--run-on-staged-packages']);
+
+          // Only lib/a.dart should be formatted.
+          // lib/src/b.dart is hand-formatted.
+          // example/build/a.dart is in excluded dir.
+          // .dart_tool/a.dart is in excluded dir.
+          expect(
+            processRunner.recordedCalls,
+            orderedEquals(<ProcessCall>[
+              ProcessCall('dart', const <String>['format', 'lib/a.dart'], plugin.path),
+            ]),
+          );
+        },
+      );
+
+      test('skips Java and Kotlin formatting when no Java or Kotlin files are staged', () async {
+        final RepositoryPackage plugin = createFakePlugin(
+          'a_plugin',
+          packagesDir,
+          extraFiles: <String>[
+            'lib/a.dart',
+            'android/src/main/java/io/flutter/plugins/a_plugin/a.java',
+            'android/src/main/kotlin/io/flutter/plugins/a_plugin/b.kt',
+          ],
+          dartConstraint: _dartConstraint,
+        );
+        fakePubGet(plugin);
+
+        // Mock git diff to return only the Dart file
+        const stagedFilePath = 'packages/a_plugin/lib/a.dart';
+        gitProcessRunner.mockProcessesForExecutable['git-diff'] = List<FakeProcessInfo>.generate(
+          3,
+          (_) => FakeProcessInfo(MockProcess(stdout: stagedFilePath)),
+        );
+
+        await runCapturingPrint(runner, <String>['format', '--run-on-staged-packages']);
+
+        // Should only run dart format, no java format
+        expect(
+          processRunner.recordedCalls,
+          orderedEquals(<ProcessCall>[
+            ProcessCall('dart', const <String>['format', 'lib/a.dart'], plugin.path),
+          ]),
+        );
+      });
+
+      test('formats only staged Java files and skips Dart when only Java is staged', () async {
+        const javaFile = 'android/src/main/java/io/flutter/plugins/a_plugin/a.java';
+        final RepositoryPackage plugin = createFakePlugin(
+          'a_plugin',
+          packagesDir,
+          extraFiles: <String>['lib/a.dart', javaFile],
+          dartConstraint: _dartConstraint,
+        );
+        fakePubGet(plugin);
+
+        // Mock git diff to return only the Java file
+        const stagedFilePath = 'packages/a_plugin/$javaFile';
+        gitProcessRunner.mockProcessesForExecutable['git-diff'] = List<FakeProcessInfo>.generate(
+          3,
+          (_) => FakeProcessInfo(MockProcess(stdout: stagedFilePath)),
+        );
+
+        await runCapturingPrint(runner, <String>['format', '--run-on-staged-packages']);
+
+        // Should only run java format, no dart format
+        expect(
+          processRunner.recordedCalls,
+          orderedEquals(<ProcessCall>[
+            const ProcessCall('java', <String>['-version'], null),
+            ProcessCall('java', <String>[
+              '-jar',
+              javaFormatPath,
+              '--replace',
+              ...getPackagesDirRelativePaths(plugin, <String>[javaFile]),
+            ], packagesDir.path),
+          ]),
+        );
+      });
+
+      test('skips dart if --no-dart flag is provided', () async {
+        const files = <String>['lib/a.dart'];
+        final RepositoryPackage plugin = createFakePlugin(
+          'a_plugin',
+          packagesDir,
+          extraFiles: files,
+          dartConstraint: _dartConstraint,
+        );
+        fakePubGet(plugin);
+
+        await runCapturingPrint(runner, <String>['format', '--no-dart']);
+        expect(processRunner.recordedCalls, orderedEquals(<ProcessCall>[]));
+      });
+
+      test('runs pub get if it has not been run', () async {
+        const files = <String>['lib/a.dart', 'lib/src/b.dart', 'lib/src/c.dart'];
+        final RepositoryPackage plugin = createFakePlugin(
+          'a_plugin',
+          packagesDir,
+          extraFiles: files,
+          dartConstraint: _dartConstraint,
+        );
+
+        await runCapturingPrint(runner, <String>['format']);
+
+        expect(
+          processRunner.recordedCalls,
+          orderedEquals(<ProcessCall>[
+            ProcessCall('flutter', const <String>['pub', 'get'], plugin.directory.path),
+            ProcessCall('dart', const <String>['format', ...files], plugin.path),
+          ]),
+        );
+      });
+
+      test('runs pub get in subpackages if it has not been run', () async {
+        const files = <String>['lib/a.dart', 'lib/src/b.dart', 'lib/src/c.dart'];
+        final RepositoryPackage plugin = createFakePlugin(
+          'a_plugin',
+          packagesDir,
+          extraFiles: files,
+          dartConstraint: _dartConstraint,
+        );
+        final RepositoryPackage subpackage = createFakePackage(
+          'subpackage',
+          plugin.directory.childDirectory('extras'),
+        );
+
+        await runCapturingPrint(runner, <String>['format']);
+
+        expect(
+          processRunner.recordedCalls,
+          orderedEquals(<ProcessCall>[
+            ProcessCall('flutter', const <String>['pub', 'get'], plugin.directory.path),
+            ProcessCall('dart', const <String>['pub', 'get'], subpackage.directory.path),
+            ProcessCall('dart', const <String>['format', ...files], plugin.path),
+          ]),
+        );
+      });
+
+      test('runs pub get if the resolved language version is stale', () async {
+        const files = <String>['lib/a.dart', 'lib/src/b.dart', 'lib/src/c.dart'];
+        final RepositoryPackage plugin = createFakePlugin(
+          'a_plugin',
+          packagesDir,
+          extraFiles: files,
+          dartConstraint: _dartConstraint,
+        );
+        fakePubGet(plugin, languageVersion: '3.0');
+
+        await runCapturingPrint(runner, <String>['format']);
+
+        expect(
+          processRunner.recordedCalls,
+          orderedEquals(<ProcessCall>[
+            ProcessCall('flutter', const <String>['pub', 'get'], plugin.directory.path),
+            ProcessCall('dart', const <String>['format', ...files], plugin.path),
+          ]),
+        );
+      });
+    });
+
+    test('formats .java files', () async {
+      const files = <String>[
+        'android/src/main/java/io/flutter/plugins/a_plugin/a.java',
+        'android/src/main/java/io/flutter/plugins/a_plugin/b.java',
+      ];
+      final RepositoryPackage plugin = createFakePlugin('a_plugin', packagesDir, extraFiles: files);
       fakePubGet(plugin);
 
       await runCapturingPrint(runner, <String>['format']);
@@ -119,50 +456,27 @@ void main() {
       expect(
         processRunner.recordedCalls,
         orderedEquals(<ProcessCall>[
-          ProcessCall('dart', const <String>['format', ...files], plugin.path),
+          const ProcessCall('java', <String>['-version'], null),
+          ProcessCall('java', <String>[
+            '-jar',
+            javaFormatPath,
+            '--replace',
+            ...getPackagesDirRelativePaths(plugin, files),
+          ], packagesDir.path),
         ]),
       );
     });
 
-    test('does not format .dart files with pragma', () async {
-      const formattedFiles = <String>['lib/a.dart', 'lib/src/b.dart', 'lib/src/c.dart'];
-      const unformattedFile = 'lib/src/d.dart';
-      final RepositoryPackage plugin = createFakePlugin(
-        'a_plugin',
-        packagesDir,
-        extraFiles: <String>[...formattedFiles, unformattedFile],
-        dartConstraint: _dartConstraint,
-      );
+    test('fails with a clear message if Java is not in the path', () async {
+      const files = <String>[
+        'android/src/main/java/io/flutter/plugins/a_plugin/a.java',
+        'android/src/main/java/io/flutter/plugins/a_plugin/b.java',
+      ];
+      final RepositoryPackage plugin = createFakePlugin('a_plugin', packagesDir, extraFiles: files);
       fakePubGet(plugin);
 
-      final p.Context posixContext = p.posix;
-      childFileWithSubcomponents(
-        plugin.directory,
-        posixContext.split(unformattedFile),
-      ).writeAsStringSync('// copyright bla bla\n// This file is hand-formatted.\ncode...');
-
-      await runCapturingPrint(runner, <String>['format']);
-
-      expect(
-        processRunner.recordedCalls,
-        orderedEquals(<ProcessCall>[
-          ProcessCall('dart', const <String>['format', ...formattedFiles], plugin.path),
-        ]),
-      );
-    });
-
-    test('fails if dart format fails', () async {
-      const files = <String>['lib/a.dart', 'lib/src/b.dart', 'lib/src/c.dart'];
-      final RepositoryPackage plugin = createFakePlugin(
-        'a_plugin',
-        packagesDir,
-        extraFiles: files,
-        dartConstraint: _dartConstraint,
-      );
-      fakePubGet(plugin);
-
-      processRunner.mockProcessesForExecutable['dart'] = <FakeProcessInfo>[
-        FakeProcessInfo(MockProcess(exitCode: 1), <String>['format']),
+      processRunner.mockProcessesForExecutable['java'] = <FakeProcessInfo>[
+        FakeProcessInfo(MockProcess(exitCode: 1), <String>['-version']),
       ];
       Error? commandError;
       final List<String> output = await runCapturingPrint(
@@ -176,574 +490,19 @@ void main() {
       expect(commandError, isA<ToolExit>());
       expect(
         output,
-        containsAllInOrder(<Matcher>[contains('Failed to format Dart files: exit code 1.')]),
-      );
-    });
-
-    test('formats only staged files when --run-on-staged-packages is used', () async {
-      const files = <String>['lib/a.dart', 'lib/src/b.dart', 'lib/src/c.dart'];
-      final RepositoryPackage plugin = createFakePlugin(
-        'a_plugin',
-        packagesDir,
-        extraFiles: files,
-        dartConstraint: _dartConstraint,
-      );
-      fakePubGet(plugin);
-
-      // Mock git diff --cached to return only lib/src/b.dart (called three times)
-      const stagedFilePath = 'packages/a_plugin/lib/src/b.dart';
-      gitProcessRunner.mockProcessesForExecutable['git-diff'] = List<FakeProcessInfo>.generate(
-        3,
-        (_) => FakeProcessInfo(MockProcess(stdout: stagedFilePath)),
-      );
-
-      await runCapturingPrint(runner, <String>['format', '--run-on-staged-packages']);
-
-      expect(
-        processRunner.recordedCalls,
-        orderedEquals(<ProcessCall>[
-          ProcessCall('dart', const <String>['format', 'lib/src/b.dart'], plugin.path),
+        containsAllInOrder(<Matcher>[
+          contains(
+            'Unable to run "java". Make sure that it is in your path, or '
+            'provide a full path with --java-path.',
+          ),
         ]),
       );
     });
 
-    test('skips formatting when there are no staged packages', () async {
-      final RepositoryPackage plugin = createFakePlugin(
-        'a_plugin',
-        packagesDir,
-        dartConstraint: _dartConstraint,
-      );
-      fakePubGet(plugin);
-
-      gitProcessRunner.mockProcessesForExecutable['git-diff'] = List<FakeProcessInfo>.generate(
-        3,
-        (_) => FakeProcessInfo(MockProcess(stdout: '')),
-      );
-
-      await runCapturingPrint(runner, <String>['format', '--run-on-staged-packages']);
-
-      expect(processRunner.recordedCalls, isEmpty);
-    });
-
-    test('formats only staged files across multiple packages', () async {
-      final RepositoryPackage pluginA = createFakePlugin(
-        'plugin_a',
-        packagesDir,
-        extraFiles: <String>['lib/a.dart', 'lib/src/unused_a.dart'],
-        dartConstraint: _dartConstraint,
-      );
-      fakePubGet(pluginA);
-
-      final RepositoryPackage pluginB = createFakePlugin(
-        'plugin_b',
-        packagesDir,
-        extraFiles: <String>['lib/b.dart', 'lib/src/unused_b.dart'],
-        dartConstraint: _dartConstraint,
-      );
-      fakePubGet(pluginB);
-
-      // Mock git diff to return both staged files (called three times)
-      const stagedFiles = 'packages/plugin_a/lib/a.dart\npackages/plugin_b/lib/b.dart\n';
-      gitProcessRunner.mockProcessesForExecutable['git-diff'] = List<FakeProcessInfo>.generate(
-        3,
-        (_) => FakeProcessInfo(MockProcess(stdout: stagedFiles)),
-      );
-
-      await runCapturingPrint(runner, <String>['format', '--run-on-staged-packages']);
-
-      expect(
-        processRunner.recordedCalls,
-        unorderedEquals(<ProcessCall>[
-          ProcessCall('dart', const <String>['format', 'lib/a.dart'], pluginA.path),
-          ProcessCall('dart', const <String>['format', 'lib/b.dart'], pluginB.path),
-        ]),
-      );
-    });
-
-    test(
-      'does not format staged files that are hand-formatted or in excluded directories when --run-on-staged-packages is used',
-      () async {
-        const files = <String>[
-          'lib/a.dart',
-          'lib/src/b.dart',
-          'example/build/a.dart',
-          '.dart_tool/a.dart',
-        ];
-        final RepositoryPackage plugin = createFakePlugin(
-          'a_plugin',
-          packagesDir,
-          extraFiles: files,
-          dartConstraint: _dartConstraint,
-        );
-        fakePubGet(plugin);
-
-        // Write pragma to lib/src/b.dart
-        final p.Context posixContext = p.posix;
-        childFileWithSubcomponents(
-          plugin.directory,
-          posixContext.split('lib/src/b.dart'),
-        ).writeAsStringSync('// This file is hand-formatted.\ncode...');
-
-        // Mock git diff to return all of them
-        final String stagedFiles = files.map((String f) => 'packages/a_plugin/$f').join('\n');
-        gitProcessRunner.mockProcessesForExecutable['git-diff'] = List<FakeProcessInfo>.generate(
-          3,
-          (_) => FakeProcessInfo(MockProcess(stdout: stagedFiles)),
-        );
-
-        await runCapturingPrint(runner, <String>['format', '--run-on-staged-packages']);
-
-        // Only lib/a.dart should be formatted.
-        // lib/src/b.dart is hand-formatted.
-        // example/build/a.dart is in excluded dir.
-        // .dart_tool/a.dart is in excluded dir.
-        expect(
-          processRunner.recordedCalls,
-          orderedEquals(<ProcessCall>[
-            ProcessCall('dart', const <String>['format', 'lib/a.dart'], plugin.path),
-          ]),
-        );
-      },
-    );
-
-    test('skips Java and Kotlin formatting when no Java or Kotlin files are staged', () async {
-      final RepositoryPackage plugin = createFakePlugin(
-        'a_plugin',
-        packagesDir,
-        extraFiles: <String>[
-          'lib/a.dart',
-          'android/src/main/java/io/flutter/plugins/a_plugin/a.java',
-          'android/src/main/kotlin/io/flutter/plugins/a_plugin/b.kt',
-        ],
-        dartConstraint: _dartConstraint,
-      );
-      fakePubGet(plugin);
-
-      // Mock git diff to return only the Dart file
-      const stagedFilePath = 'packages/a_plugin/lib/a.dart';
-      gitProcessRunner.mockProcessesForExecutable['git-diff'] = List<FakeProcessInfo>.generate(
-        3,
-        (_) => FakeProcessInfo(MockProcess(stdout: stagedFilePath)),
-      );
-
-      await runCapturingPrint(runner, <String>['format', '--run-on-staged-packages']);
-
-      // Should only run dart format, no java format
-      expect(
-        processRunner.recordedCalls,
-        orderedEquals(<ProcessCall>[
-          ProcessCall('dart', const <String>['format', 'lib/a.dart'], plugin.path),
-        ]),
-      );
-    });
-
-    test('formats only staged Java files and skips Dart when only Java is staged', () async {
-      const javaFile = 'android/src/main/java/io/flutter/plugins/a_plugin/a.java';
-      final RepositoryPackage plugin = createFakePlugin(
-        'a_plugin',
-        packagesDir,
-        extraFiles: <String>['lib/a.dart', javaFile],
-        dartConstraint: _dartConstraint,
-      );
-      fakePubGet(plugin);
-
-      // Mock git diff to return only the Java file
-      const stagedFilePath = 'packages/a_plugin/$javaFile';
-      gitProcessRunner.mockProcessesForExecutable['git-diff'] = List<FakeProcessInfo>.generate(
-        3,
-        (_) => FakeProcessInfo(MockProcess(stdout: stagedFilePath)),
-      );
-
-      await runCapturingPrint(runner, <String>['format', '--run-on-staged-packages']);
-
-      // Should only run java format, no dart format
-      expect(
-        processRunner.recordedCalls,
-        orderedEquals(<ProcessCall>[
-          const ProcessCall('java', <String>['-version'], null),
-          ProcessCall('java', <String>[
-            '-jar',
-            javaFormatPath,
-            '--replace',
-            ...getPackagesDirRelativePaths(plugin, <String>[javaFile]),
-          ], packagesDir.path),
-        ]),
-      );
-    });
-
-    test('skips dart if --no-dart flag is provided', () async {
-      const files = <String>['lib/a.dart'];
-      final RepositoryPackage plugin = createFakePlugin(
-        'a_plugin',
-        packagesDir,
-        extraFiles: files,
-        dartConstraint: _dartConstraint,
-      );
-      fakePubGet(plugin);
-
-      await runCapturingPrint(runner, <String>['format', '--no-dart']);
-      expect(processRunner.recordedCalls, orderedEquals(<ProcessCall>[]));
-    });
-
-    test('runs pub get if it has not been run', () async {
-      const files = <String>['lib/a.dart', 'lib/src/b.dart', 'lib/src/c.dart'];
-      final RepositoryPackage plugin = createFakePlugin(
-        'a_plugin',
-        packagesDir,
-        extraFiles: files,
-        dartConstraint: _dartConstraint,
-      );
-
-      await runCapturingPrint(runner, <String>['format']);
-
-      expect(
-        processRunner.recordedCalls,
-        orderedEquals(<ProcessCall>[
-          ProcessCall('flutter', const <String>['pub', 'get'], plugin.directory.path),
-          ProcessCall('dart', const <String>['format', ...files], plugin.path),
-        ]),
-      );
-    });
-
-    test('runs pub get in subpackages if it has not been run', () async {
-      const files = <String>['lib/a.dart', 'lib/src/b.dart', 'lib/src/c.dart'];
-      final RepositoryPackage plugin = createFakePlugin(
-        'a_plugin',
-        packagesDir,
-        extraFiles: files,
-        dartConstraint: _dartConstraint,
-      );
-      final RepositoryPackage subpackage = createFakePackage(
-        'subpackage',
-        plugin.directory.childDirectory('extras'),
-      );
-
-      await runCapturingPrint(runner, <String>['format']);
-
-      expect(
-        processRunner.recordedCalls,
-        orderedEquals(<ProcessCall>[
-          ProcessCall('flutter', const <String>['pub', 'get'], plugin.directory.path),
-          ProcessCall('dart', const <String>['pub', 'get'], subpackage.directory.path),
-          ProcessCall('dart', const <String>['format', ...files], plugin.path),
-        ]),
-      );
-    });
-
-    test('runs pub get if the resolved language version is stale', () async {
-      const files = <String>['lib/a.dart', 'lib/src/b.dart', 'lib/src/c.dart'];
-      final RepositoryPackage plugin = createFakePlugin(
-        'a_plugin',
-        packagesDir,
-        extraFiles: files,
-        dartConstraint: _dartConstraint,
-      );
-      fakePubGet(plugin, languageVersion: '3.0');
-
-      await runCapturingPrint(runner, <String>['format']);
-
-      expect(
-        processRunner.recordedCalls,
-        orderedEquals(<ProcessCall>[
-          ProcessCall('flutter', const <String>['pub', 'get'], plugin.directory.path),
-          ProcessCall('dart', const <String>['format', ...files], plugin.path),
-        ]),
-      );
-    });
-  });
-
-  test('formats .java files', () async {
-    const files = <String>[
-      'android/src/main/java/io/flutter/plugins/a_plugin/a.java',
-      'android/src/main/java/io/flutter/plugins/a_plugin/b.java',
-    ];
-    final RepositoryPackage plugin = createFakePlugin('a_plugin', packagesDir, extraFiles: files);
-    fakePubGet(plugin);
-
-    await runCapturingPrint(runner, <String>['format']);
-
-    expect(
-      processRunner.recordedCalls,
-      orderedEquals(<ProcessCall>[
-        const ProcessCall('java', <String>['-version'], null),
-        ProcessCall('java', <String>[
-          '-jar',
-          javaFormatPath,
-          '--replace',
-          ...getPackagesDirRelativePaths(plugin, files),
-        ], packagesDir.path),
-      ]),
-    );
-  });
-
-  test('fails with a clear message if Java is not in the path', () async {
-    const files = <String>[
-      'android/src/main/java/io/flutter/plugins/a_plugin/a.java',
-      'android/src/main/java/io/flutter/plugins/a_plugin/b.java',
-    ];
-    final RepositoryPackage plugin = createFakePlugin('a_plugin', packagesDir, extraFiles: files);
-    fakePubGet(plugin);
-
-    processRunner.mockProcessesForExecutable['java'] = <FakeProcessInfo>[
-      FakeProcessInfo(MockProcess(exitCode: 1), <String>['-version']),
-    ];
-    Error? commandError;
-    final List<String> output = await runCapturingPrint(
-      runner,
-      <String>['format'],
-      errorHandler: (Error e) {
-        commandError = e;
-      },
-    );
-
-    expect(commandError, isA<ToolExit>());
-    expect(
-      output,
-      containsAllInOrder(<Matcher>[
-        contains(
-          'Unable to run "java". Make sure that it is in your path, or '
-          'provide a full path with --java-path.',
-        ),
-      ]),
-    );
-  });
-
-  test('fails if Java formatter fails', () async {
-    const files = <String>[
-      'android/src/main/java/io/flutter/plugins/a_plugin/a.java',
-      'android/src/main/java/io/flutter/plugins/a_plugin/b.java',
-    ];
-    final RepositoryPackage plugin = createFakePlugin('a_plugin', packagesDir, extraFiles: files);
-    fakePubGet(plugin);
-
-    processRunner.mockProcessesForExecutable['java'] = <FakeProcessInfo>[
-      FakeProcessInfo(MockProcess(), <String>['-version']), // check for working java
-      FakeProcessInfo(MockProcess(exitCode: 1), <String>['-jar']), // format
-    ];
-    Error? commandError;
-    final List<String> output = await runCapturingPrint(
-      runner,
-      <String>['format'],
-      errorHandler: (Error e) {
-        commandError = e;
-      },
-    );
-
-    expect(commandError, isA<ToolExit>());
-    expect(
-      output,
-      containsAllInOrder(<Matcher>[contains('Failed to format Java files: exit code 1.')]),
-    );
-  });
-
-  test('honors --java-path flag', () async {
-    const files = <String>[
-      'android/src/main/java/io/flutter/plugins/a_plugin/a.java',
-      'android/src/main/java/io/flutter/plugins/a_plugin/b.java',
-    ];
-    final RepositoryPackage plugin = createFakePlugin('a_plugin', packagesDir, extraFiles: files);
-    fakePubGet(plugin);
-
-    await runCapturingPrint(runner, <String>['format', '--java-path=/path/to/java']);
-
-    expect(
-      processRunner.recordedCalls,
-      orderedEquals(<ProcessCall>[
-        const ProcessCall('/path/to/java', <String>['--version'], null),
-        ProcessCall('/path/to/java', <String>[
-          '-jar',
-          javaFormatPath,
-          '--replace',
-          ...getPackagesDirRelativePaths(plugin, files),
-        ], packagesDir.path),
-      ]),
-    );
-  });
-
-  test('skips Java if --no-java flag is provided', () async {
-    const files = <String>['android/src/main/java/io/flutter/plugins/a_plugin/a.java'];
-    final RepositoryPackage plugin = createFakePlugin('a_plugin', packagesDir, extraFiles: files);
-    fakePubGet(plugin);
-
-    await runCapturingPrint(runner, <String>['format', '--no-java']);
-    expect(processRunner.recordedCalls, orderedEquals(<ProcessCall>[]));
-  });
-
-  test('formats c-ish files', () async {
-    const files = <String>[
-      'ios/Classes/Foo.h',
-      'ios/Classes/Foo.m',
-      'linux/foo_plugin.cc',
-      'macos/Classes/Foo.h',
-      'macos/Classes/Foo.mm',
-      'windows/foo_plugin.cpp',
-    ];
-    final RepositoryPackage plugin = createFakePlugin('a_plugin', packagesDir, extraFiles: files);
-    fakePubGet(plugin);
-
-    await runCapturingPrint(runner, <String>['format']);
-
-    expect(
-      processRunner.recordedCalls,
-      orderedEquals(<ProcessCall>[
-        const ProcessCall('clang-format', <String>['--version'], null),
-        ProcessCall('clang-format', <String>[
-          '-i',
-          '--style=file',
-          ...getPackagesDirRelativePaths(plugin, files),
-        ], packagesDir.path),
-      ]),
-    );
-  });
-
-  test('fails with a clear message if clang-format is not in the path', () async {
-    const files = <String>['linux/foo_plugin.cc', 'macos/Classes/Foo.h'];
-    final RepositoryPackage plugin = createFakePlugin('a_plugin', packagesDir, extraFiles: files);
-    fakePubGet(plugin);
-
-    processRunner.mockProcessesForExecutable['clang-format'] = <FakeProcessInfo>[
-      FakeProcessInfo(MockProcess(exitCode: 1)),
-    ];
-    Error? commandError;
-    final List<String> output = await runCapturingPrint(
-      runner,
-      <String>['format'],
-      errorHandler: (Error e) {
-        commandError = e;
-      },
-    );
-
-    expect(commandError, isA<ToolExit>());
-    expect(
-      output,
-      containsAllInOrder(<Matcher>[
-        contains(
-          'Unable to run "clang-format". Make sure that it is in your '
-          'path, or provide a full path with --clang-format-path.',
-        ),
-      ]),
-    );
-  });
-
-  test('falls back to working clang-format in the path', () async {
-    const files = <String>['linux/foo_plugin.cc', 'macos/Classes/Foo.h'];
-    final RepositoryPackage plugin = createFakePlugin('a_plugin', packagesDir, extraFiles: files);
-    fakePubGet(plugin);
-
-    processRunner.mockProcessesForExecutable['clang-format'] = <FakeProcessInfo>[
-      FakeProcessInfo(MockProcess(exitCode: 1)),
-    ];
-    processRunner.mockProcessesForExecutable['which'] = <FakeProcessInfo>[
-      FakeProcessInfo(
-        MockProcess(stdout: '/usr/local/bin/clang-format\n/path/to/working-clang-format'),
-        <String>['-a', 'clang-format'],
-      ),
-    ];
-    processRunner.mockProcessesForExecutable['/usr/local/bin/clang-format'] = <FakeProcessInfo>[
-      FakeProcessInfo(MockProcess(exitCode: 1)),
-    ];
-    await runCapturingPrint(runner, <String>['format']);
-
-    expect(
-      processRunner.recordedCalls,
-      containsAll(<ProcessCall>[
-        const ProcessCall('/path/to/working-clang-format', <String>['--version'], null),
-        ProcessCall('/path/to/working-clang-format', <String>[
-          '-i',
-          '--style=file',
-          ...getPackagesDirRelativePaths(plugin, files),
-        ], packagesDir.path),
-      ]),
-    );
-  });
-
-  test('honors --clang-format-path flag', () async {
-    const files = <String>['windows/foo_plugin.cpp'];
-    final RepositoryPackage plugin = createFakePlugin('a_plugin', packagesDir, extraFiles: files);
-    fakePubGet(plugin);
-
-    await runCapturingPrint(runner, <String>[
-      'format',
-      '--clang-format-path=/path/to/clang-format',
-    ]);
-
-    expect(
-      processRunner.recordedCalls,
-      orderedEquals(<ProcessCall>[
-        const ProcessCall('/path/to/clang-format', <String>['--version'], null),
-        ProcessCall('/path/to/clang-format', <String>[
-          '-i',
-          '--style=file',
-          ...getPackagesDirRelativePaths(plugin, files),
-        ], packagesDir.path),
-      ]),
-    );
-  });
-
-  test('fails if clang-format fails', () async {
-    const files = <String>['linux/foo_plugin.cc', 'macos/Classes/Foo.h'];
-    final RepositoryPackage plugin = createFakePlugin('a_plugin', packagesDir, extraFiles: files);
-    fakePubGet(plugin);
-
-    processRunner.mockProcessesForExecutable['clang-format'] = <FakeProcessInfo>[
-      FakeProcessInfo(MockProcess(), <String>['--version']), // check for working clang-format
-      FakeProcessInfo(MockProcess(exitCode: 1), <String>['-i']), // format
-    ];
-    Error? commandError;
-    final List<String> output = await runCapturingPrint(
-      runner,
-      <String>['format'],
-      errorHandler: (Error e) {
-        commandError = e;
-      },
-    );
-
-    expect(commandError, isA<ToolExit>());
-    expect(
-      output,
-      containsAllInOrder(<Matcher>[
-        contains('Failed to format C, C++, and Objective-C files: exit code 1.'),
-      ]),
-    );
-  });
-
-  test('skips clang-format if --no-clang-format flag is provided', () async {
-    const files = <String>['linux/foo_plugin.cc'];
-    final RepositoryPackage plugin = createFakePlugin('a_plugin', packagesDir, extraFiles: files);
-    fakePubGet(plugin);
-
-    await runCapturingPrint(runner, <String>['format', '--no-clang-format']);
-    expect(processRunner.recordedCalls, orderedEquals(<ProcessCall>[]));
-  });
-
-  group('kotlin-format', () {
-    test('formats .kt files', () async {
+    test('fails if Java formatter fails', () async {
       const files = <String>[
-        'android/src/main/kotlin/io/flutter/plugins/a_plugin/a.kt',
-        'android/src/main/kotlin/io/flutter/plugins/a_plugin/b.kt',
-      ];
-      final RepositoryPackage plugin = createFakePlugin('a_plugin', packagesDir, extraFiles: files);
-      fakePubGet(plugin);
-
-      await runCapturingPrint(runner, <String>['format']);
-
-      expect(
-        processRunner.recordedCalls,
-        orderedEquals(<ProcessCall>[
-          const ProcessCall('java', <String>['-version'], null),
-          ProcessCall('java', <String>[
-            '-jar',
-            kotlinFormatPath,
-            ...getPackagesDirRelativePaths(plugin, files),
-          ], packagesDir.path),
-        ]),
-      );
-    });
-
-    test('fails if Kotlin formatter fails', () async {
-      const files = <String>[
-        'android/src/main/kotlin/io/flutter/plugins/a_plugin/a.kt',
-        'android/src/main/kotlin/io/flutter/plugins/a_plugin/b.kt',
+        'android/src/main/java/io/flutter/plugins/a_plugin/a.java',
+        'android/src/main/java/io/flutter/plugins/a_plugin/b.java',
       ];
       final RepositoryPackage plugin = createFakePlugin('a_plugin', packagesDir, extraFiles: files);
       fakePubGet(plugin);
@@ -764,26 +523,461 @@ void main() {
       expect(commandError, isA<ToolExit>());
       expect(
         output,
-        containsAllInOrder(<Matcher>[contains('Failed to format Kotlin files: exit code 1.')]),
+        containsAllInOrder(<Matcher>[contains('Failed to format Java files: exit code 1.')]),
       );
     });
 
-    test('skips Kotlin if --no-kotlin flag is provided', () async {
-      const files = <String>['android/src/main/kotlin/io/flutter/plugins/a_plugin/a.kt'];
+    test('honors --java-path flag', () async {
+      const files = <String>[
+        'android/src/main/java/io/flutter/plugins/a_plugin/a.java',
+        'android/src/main/java/io/flutter/plugins/a_plugin/b.java',
+      ];
       final RepositoryPackage plugin = createFakePlugin('a_plugin', packagesDir, extraFiles: files);
       fakePubGet(plugin);
 
-      await runCapturingPrint(runner, <String>['format', '--no-kotlin']);
+      await runCapturingPrint(runner, <String>['format', '--java-path=/path/to/java']);
+
+      expect(
+        processRunner.recordedCalls,
+        orderedEquals(<ProcessCall>[
+          const ProcessCall('/path/to/java', <String>['--version'], null),
+          ProcessCall('/path/to/java', <String>[
+            '-jar',
+            javaFormatPath,
+            '--replace',
+            ...getPackagesDirRelativePaths(plugin, files),
+          ], packagesDir.path),
+        ]),
+      );
+    });
+
+    test('skips Java if --no-java flag is provided', () async {
+      const files = <String>['android/src/main/java/io/flutter/plugins/a_plugin/a.java'];
+      final RepositoryPackage plugin = createFakePlugin('a_plugin', packagesDir, extraFiles: files);
+      fakePubGet(plugin);
+
+      await runCapturingPrint(runner, <String>['format', '--no-java']);
       expect(processRunner.recordedCalls, orderedEquals(<ProcessCall>[]));
     });
-  });
 
-  group('swift-format', () {
-    test('formats Swift if --swift flag is provided', () async {
-      mockPlatform.isMacOS = false;
-
-      const files = <String>['macos/foo.swift'];
+    test('formats c-ish files', () async {
+      const files = <String>[
+        'ios/Classes/Foo.h',
+        'ios/Classes/Foo.m',
+        'linux/foo_plugin.cc',
+        'macos/Classes/Foo.h',
+        'macos/Classes/Foo.mm',
+        'windows/foo_plugin.cpp',
+      ];
       final RepositoryPackage plugin = createFakePlugin('a_plugin', packagesDir, extraFiles: files);
+      fakePubGet(plugin);
+
+      await runCapturingPrint(runner, <String>['format']);
+
+      expect(
+        processRunner.recordedCalls,
+        orderedEquals(<ProcessCall>[
+          const ProcessCall('clang-format', <String>['--version'], null),
+          ProcessCall('clang-format', <String>[
+            '-i',
+            '--style=file',
+            ...getPackagesDirRelativePaths(plugin, files),
+          ], packagesDir.path),
+        ]),
+      );
+    });
+
+    test('fails with a clear message if clang-format is not in the path', () async {
+      const files = <String>['linux/foo_plugin.cc', 'macos/Classes/Foo.h'];
+      final RepositoryPackage plugin = createFakePlugin('a_plugin', packagesDir, extraFiles: files);
+      fakePubGet(plugin);
+
+      processRunner.mockProcessesForExecutable['clang-format'] = <FakeProcessInfo>[
+        FakeProcessInfo(MockProcess(exitCode: 1)),
+      ];
+      Error? commandError;
+      final List<String> output = await runCapturingPrint(
+        runner,
+        <String>['format'],
+        errorHandler: (Error e) {
+          commandError = e;
+        },
+      );
+
+      expect(commandError, isA<ToolExit>());
+      expect(
+        output,
+        containsAllInOrder(<Matcher>[
+          contains(
+            'Unable to run "clang-format". Make sure that it is in your '
+            'path, or provide a full path with --clang-format-path.',
+          ),
+        ]),
+      );
+    });
+
+    test('falls back to working clang-format in the path', () async {
+      const files = <String>['linux/foo_plugin.cc', 'macos/Classes/Foo.h'];
+      final RepositoryPackage plugin = createFakePlugin('a_plugin', packagesDir, extraFiles: files);
+      fakePubGet(plugin);
+
+      processRunner.mockProcessesForExecutable['clang-format'] = <FakeProcessInfo>[
+        FakeProcessInfo(MockProcess(exitCode: 1)),
+      ];
+      processRunner.mockProcessesForExecutable['which'] = <FakeProcessInfo>[
+        FakeProcessInfo(
+          MockProcess(stdout: '/usr/local/bin/clang-format\n/path/to/working-clang-format'),
+          <String>['-a', 'clang-format'],
+        ),
+      ];
+      processRunner.mockProcessesForExecutable['/usr/local/bin/clang-format'] = <FakeProcessInfo>[
+        FakeProcessInfo(MockProcess(exitCode: 1)),
+      ];
+      await runCapturingPrint(runner, <String>['format']);
+
+      expect(
+        processRunner.recordedCalls,
+        containsAll(<ProcessCall>[
+          const ProcessCall('/path/to/working-clang-format', <String>['--version'], null),
+          ProcessCall('/path/to/working-clang-format', <String>[
+            '-i',
+            '--style=file',
+            ...getPackagesDirRelativePaths(plugin, files),
+          ], packagesDir.path),
+        ]),
+      );
+    });
+
+    test('honors --clang-format-path flag', () async {
+      const files = <String>['windows/foo_plugin.cpp'];
+      final RepositoryPackage plugin = createFakePlugin('a_plugin', packagesDir, extraFiles: files);
+      fakePubGet(plugin);
+
+      await runCapturingPrint(runner, <String>[
+        'format',
+        '--clang-format-path=/path/to/clang-format',
+      ]);
+
+      expect(
+        processRunner.recordedCalls,
+        orderedEquals(<ProcessCall>[
+          const ProcessCall('/path/to/clang-format', <String>['--version'], null),
+          ProcessCall('/path/to/clang-format', <String>[
+            '-i',
+            '--style=file',
+            ...getPackagesDirRelativePaths(plugin, files),
+          ], packagesDir.path),
+        ]),
+      );
+    });
+
+    test('fails if clang-format fails', () async {
+      const files = <String>['linux/foo_plugin.cc', 'macos/Classes/Foo.h'];
+      final RepositoryPackage plugin = createFakePlugin('a_plugin', packagesDir, extraFiles: files);
+      fakePubGet(plugin);
+
+      processRunner.mockProcessesForExecutable['clang-format'] = <FakeProcessInfo>[
+        FakeProcessInfo(MockProcess(), <String>['--version']), // check for working clang-format
+        FakeProcessInfo(MockProcess(exitCode: 1), <String>['-i']), // format
+      ];
+      Error? commandError;
+      final List<String> output = await runCapturingPrint(
+        runner,
+        <String>['format'],
+        errorHandler: (Error e) {
+          commandError = e;
+        },
+      );
+
+      expect(commandError, isA<ToolExit>());
+      expect(
+        output,
+        containsAllInOrder(<Matcher>[
+          contains('Failed to format C, C++, and Objective-C files: exit code 1.'),
+        ]),
+      );
+    });
+
+    test('skips clang-format if --no-clang-format flag is provided', () async {
+      const files = <String>['linux/foo_plugin.cc'];
+      final RepositoryPackage plugin = createFakePlugin('a_plugin', packagesDir, extraFiles: files);
+      fakePubGet(plugin);
+
+      await runCapturingPrint(runner, <String>['format', '--no-clang-format']);
+      expect(processRunner.recordedCalls, orderedEquals(<ProcessCall>[]));
+    });
+
+    group('kotlin-format', () {
+      test('formats .kt files', () async {
+        const files = <String>[
+          'android/src/main/kotlin/io/flutter/plugins/a_plugin/a.kt',
+          'android/src/main/kotlin/io/flutter/plugins/a_plugin/b.kt',
+        ];
+        final RepositoryPackage plugin = createFakePlugin(
+          'a_plugin',
+          packagesDir,
+          extraFiles: files,
+        );
+        fakePubGet(plugin);
+
+        await runCapturingPrint(runner, <String>['format']);
+
+        expect(
+          processRunner.recordedCalls,
+          orderedEquals(<ProcessCall>[
+            const ProcessCall('java', <String>['-version'], null),
+            ProcessCall('java', <String>[
+              '-jar',
+              kotlinFormatPath,
+              ...getPackagesDirRelativePaths(plugin, files),
+            ], packagesDir.path),
+          ]),
+        );
+      });
+
+      test('fails if Kotlin formatter fails', () async {
+        const files = <String>[
+          'android/src/main/kotlin/io/flutter/plugins/a_plugin/a.kt',
+          'android/src/main/kotlin/io/flutter/plugins/a_plugin/b.kt',
+        ];
+        final RepositoryPackage plugin = createFakePlugin(
+          'a_plugin',
+          packagesDir,
+          extraFiles: files,
+        );
+        fakePubGet(plugin);
+
+        processRunner.mockProcessesForExecutable['java'] = <FakeProcessInfo>[
+          FakeProcessInfo(MockProcess(), <String>['-version']), // check for working java
+          FakeProcessInfo(MockProcess(exitCode: 1), <String>['-jar']), // format
+        ];
+        Error? commandError;
+        final List<String> output = await runCapturingPrint(
+          runner,
+          <String>['format'],
+          errorHandler: (Error e) {
+            commandError = e;
+          },
+        );
+
+        expect(commandError, isA<ToolExit>());
+        expect(
+          output,
+          containsAllInOrder(<Matcher>[contains('Failed to format Kotlin files: exit code 1.')]),
+        );
+      });
+
+      test('skips Kotlin if --no-kotlin flag is provided', () async {
+        const files = <String>['android/src/main/kotlin/io/flutter/plugins/a_plugin/a.kt'];
+        final RepositoryPackage plugin = createFakePlugin(
+          'a_plugin',
+          packagesDir,
+          extraFiles: files,
+        );
+        fakePubGet(plugin);
+
+        await runCapturingPrint(runner, <String>['format', '--no-kotlin']);
+        expect(processRunner.recordedCalls, orderedEquals(<ProcessCall>[]));
+      });
+    });
+
+    group('swift-format', () {
+      test('formats Swift if --swift flag is provided', () async {
+        const files = <String>['macos/foo.swift'];
+        final RepositoryPackage plugin = createFakePlugin(
+          'a_plugin',
+          packagesDir,
+          extraFiles: files,
+        );
+        fakePubGet(plugin);
+
+        await runCapturingPrint(runner, <String>['format', '--swift']);
+
+        expect(
+          processRunner.recordedCalls,
+          orderedEquals(<ProcessCall>[
+            ProcessCall('xcrun', <String>[
+              'swift-format',
+              '-i',
+              ...getPackagesDirRelativePaths(plugin, files),
+            ], packagesDir.path),
+            ProcessCall('xcrun', <String>[
+              'swift-format',
+              'lint',
+              '--parallel',
+              '--strict',
+              ...getPackagesDirRelativePaths(plugin, files),
+            ], packagesDir.path),
+          ]),
+        );
+      });
+
+      test('skips Swift if --no-swift flag is provided', () async {
+        const files = <String>['macos/foo.swift'];
+        final RepositoryPackage plugin = createFakePlugin(
+          'a_plugin',
+          packagesDir,
+          extraFiles: files,
+        );
+        fakePubGet(plugin);
+
+        await runCapturingPrint(runner, <String>['format', '--no-swift']);
+
+        expect(processRunner.recordedCalls, orderedEquals(<ProcessCall>[]));
+      });
+
+      test('fails if swift-format lint finds issues', () async {
+        const files = <String>['macos/foo.swift'];
+        final RepositoryPackage plugin = createFakePlugin(
+          'a_plugin',
+          packagesDir,
+          extraFiles: files,
+        );
+        fakePubGet(plugin);
+
+        processRunner.mockProcessesForExecutable['xcrun'] = <FakeProcessInfo>[
+          FakeProcessInfo(MockProcess(), <String>['swift-format', '-i']),
+          FakeProcessInfo(MockProcess(exitCode: 1), <String>[
+            'swift-format',
+            'lint',
+            '--parallel',
+            '--strict',
+          ]),
+        ];
+        Error? commandError;
+        final List<String> output = await runCapturingPrint(
+          runner,
+          <String>['format', '--swift'],
+          errorHandler: (Error e) {
+            commandError = e;
+          },
+        );
+
+        expect(commandError, isA<ToolExit>());
+        expect(
+          output,
+          containsAllInOrder(<Matcher>[
+            contains('Swift linter found issues. See above for linter output.'),
+          ]),
+        );
+      });
+
+      test('fails if swift-format lint fails', () async {
+        const files = <String>['macos/foo.swift'];
+        final RepositoryPackage plugin = createFakePlugin(
+          'a_plugin',
+          packagesDir,
+          extraFiles: files,
+        );
+        fakePubGet(plugin);
+
+        processRunner.mockProcessesForExecutable['xcrun'] = <FakeProcessInfo>[
+          FakeProcessInfo(MockProcess(), <String>['swift-format', '-i']),
+          FakeProcessInfo(MockProcess(exitCode: 99), <String>[
+            'swift-format',
+            'lint',
+            '--parallel',
+            '--strict',
+          ]),
+        ];
+        Error? commandError;
+        final List<String> output = await runCapturingPrint(
+          runner,
+          <String>['format', '--swift'],
+          errorHandler: (Error e) {
+            commandError = e;
+          },
+        );
+
+        expect(commandError, isA<ToolExit>());
+        expect(
+          output,
+          containsAllInOrder(<Matcher>[contains('Failed to lint Swift files: exit code 99.')]),
+        );
+      });
+
+      test('fails if swift-format fails', () async {
+        const files = <String>['macos/foo.swift'];
+        final RepositoryPackage plugin = createFakePlugin(
+          'a_plugin',
+          packagesDir,
+          extraFiles: files,
+        );
+        fakePubGet(plugin);
+
+        processRunner.mockProcessesForExecutable['xcrun'] = <FakeProcessInfo>[
+          FakeProcessInfo(MockProcess(exitCode: 1), <String>['swift-format', '-i']),
+        ];
+        Error? commandError;
+        final List<String> output = await runCapturingPrint(
+          runner,
+          <String>['format', '--swift'],
+          errorHandler: (Error e) {
+            commandError = e;
+          },
+        );
+
+        expect(commandError, isA<ToolExit>());
+        expect(
+          output,
+          containsAllInOrder(<Matcher>[contains('Failed to format Swift files: exit code 1.')]),
+        );
+      });
+    });
+
+    test('skips known non-repo files', () async {
+      const skipFiles = <String>[
+        '/example/build/SomeFramework.framework/Headers/SomeFramework.h',
+        '/example/Pods/APod.framework/Headers/APod.h',
+        '.dart_tool/internals/foo.cc',
+        '.dart_tool/internals/Bar.java',
+        '.dart_tool/internals/baz.dart',
+      ];
+      const clangFiles = <String>['ios/Classes/Foo.h'];
+      const dartFiles = <String>['lib/a.dart'];
+      const javaFiles = <String>['android/src/main/java/io/flutter/plugins/a_plugin/a.java'];
+      final RepositoryPackage plugin = createFakePlugin(
+        'a_plugin',
+        packagesDir,
+        extraFiles: <String>[
+          ...skipFiles,
+          // Include some files that should be formatted to validate that it's
+          // correctly filtering even when running the commands.
+          ...clangFiles,
+          ...dartFiles,
+          ...javaFiles,
+        ],
+      );
+      fakePubGet(plugin);
+
+      await runCapturingPrint(runner, <String>['format']);
+
+      expect(
+        processRunner.recordedCalls,
+        containsAll(<ProcessCall>[
+          ProcessCall('clang-format', <String>[
+            '-i',
+            '--style=file',
+            ...getPackagesDirRelativePaths(plugin, clangFiles),
+          ], packagesDir.path),
+          ProcessCall('dart', const <String>['format', ...dartFiles], plugin.path),
+          ProcessCall('java', <String>[
+            '-jar',
+            javaFormatPath,
+            '--replace',
+            ...getPackagesDirRelativePaths(plugin, javaFiles),
+          ], packagesDir.path),
+        ]),
+      );
+    });
+
+    test('skips GeneratedPluginRegistrant.swift', () async {
+      const sourceFile = 'macos/Classes/Foo.swift';
+      final RepositoryPackage plugin = createFakePlugin(
+        'a_plugin',
+        packagesDir,
+        extraFiles: <String>[sourceFile, 'example/macos/Flutter/GeneratedPluginRegistrant.swift'],
+      );
       fakePubGet(plugin);
 
       await runCapturingPrint(runner, <String>['format', '--swift']);
@@ -794,49 +988,33 @@ void main() {
           ProcessCall('xcrun', <String>[
             'swift-format',
             '-i',
-            ...getPackagesDirRelativePaths(plugin, files),
+            ...getPackagesDirRelativePaths(plugin, <String>[sourceFile]),
           ], packagesDir.path),
           ProcessCall('xcrun', <String>[
             'swift-format',
             'lint',
             '--parallel',
             '--strict',
-            ...getPackagesDirRelativePaths(plugin, files),
+            ...getPackagesDirRelativePaths(plugin, <String>[sourceFile]),
           ], packagesDir.path),
         ]),
       );
     });
 
-    test('skips Swift if --no-swift flag is provided', () async {
-      mockPlatform.isMacOS = true;
-
-      const files = <String>['macos/foo.swift'];
+    test('fails if files are changed with --fail-on-change', () async {
+      const files = <String>['linux/foo_plugin.cc', 'macos/Classes/Foo.h'];
       final RepositoryPackage plugin = createFakePlugin('a_plugin', packagesDir, extraFiles: files);
       fakePubGet(plugin);
 
-      await runCapturingPrint(runner, <String>['format', '--no-swift']);
-
-      expect(processRunner.recordedCalls, orderedEquals(<ProcessCall>[]));
-    });
-
-    test('fails if swift-format lint finds issues', () async {
-      const files = <String>['macos/foo.swift'];
-      final RepositoryPackage plugin = createFakePlugin('a_plugin', packagesDir, extraFiles: files);
-      fakePubGet(plugin);
-
-      processRunner.mockProcessesForExecutable['xcrun'] = <FakeProcessInfo>[
-        FakeProcessInfo(MockProcess(), <String>['swift-format', '-i']),
-        FakeProcessInfo(MockProcess(exitCode: 1), <String>[
-          'swift-format',
-          'lint',
-          '--parallel',
-          '--strict',
-        ]),
+      const changedFilePath = 'packages/a_plugin/linux/foo_plugin.cc';
+      processRunner.mockProcessesForExecutable['git'] = <FakeProcessInfo>[
+        FakeProcessInfo(MockProcess(stdout: changedFilePath), <String>['ls-files']),
       ];
+
       Error? commandError;
       final List<String> output = await runCapturingPrint(
         runner,
-        <String>['format', '--swift'],
+        <String>['format', '--fail-on-change'],
         errorHandler: (Error e) {
           commandError = e;
         },
@@ -846,29 +1024,67 @@ void main() {
       expect(
         output,
         containsAllInOrder(<Matcher>[
-          contains('Swift linter found issues. See above for linter output.'),
+          contains('These files are not formatted correctly'),
+          contains(changedFilePath),
+          // Ensure the error message links to instructions.
+          contains('$toolDocsUrl#format-code'),
+          contains('patch -p1 <<DONE'),
+        ]),
+      );
+
+      // Ensure that both packages and third_party/packages are checked.
+      final Directory thirdPartyDir = packagesDir.parent
+          .childDirectory('third_party')
+          .childDirectory('packages');
+      expect(
+        processRunner.recordedCalls,
+        containsAllInOrder(<ProcessCall>[
+          ProcessCall('git', <String>[
+            'ls-files',
+            '--modified',
+            packagesDir.path,
+            thirdPartyDir.path,
+          ], packagesDir.parent.path),
         ]),
       );
     });
 
-    test('fails if swift-format lint fails', () async {
-      const files = <String>['macos/foo.swift'];
+    test('fails if git ls-files fails', () async {
+      const files = <String>['linux/foo_plugin.cc', 'macos/Classes/Foo.h'];
       final RepositoryPackage plugin = createFakePlugin('a_plugin', packagesDir, extraFiles: files);
       fakePubGet(plugin);
 
-      processRunner.mockProcessesForExecutable['xcrun'] = <FakeProcessInfo>[
-        FakeProcessInfo(MockProcess(), <String>['swift-format', '-i']),
-        FakeProcessInfo(MockProcess(exitCode: 99), <String>[
-          'swift-format',
-          'lint',
-          '--parallel',
-          '--strict',
-        ]),
+      processRunner.mockProcessesForExecutable['git'] = <FakeProcessInfo>[
+        FakeProcessInfo(MockProcess(exitCode: 1), <String>['ls-files']),
       ];
       Error? commandError;
       final List<String> output = await runCapturingPrint(
         runner,
-        <String>['format', '--swift'],
+        <String>['format', '--fail-on-change'],
+        errorHandler: (Error e) {
+          commandError = e;
+        },
+      );
+
+      expect(commandError, isA<ToolExit>());
+      expect(output, containsAllInOrder(<Matcher>[contains('Unable to determine changed files.')]));
+    });
+
+    test('reports git diff failures', () async {
+      const files = <String>['linux/foo_plugin.cc', 'macos/Classes/Foo.h'];
+      final RepositoryPackage plugin = createFakePlugin('a_plugin', packagesDir, extraFiles: files);
+      fakePubGet(plugin);
+
+      const changedFilePath = 'packages/a_plugin/linux/foo_plugin.cc';
+      processRunner.mockProcessesForExecutable['git'] = <FakeProcessInfo>[
+        FakeProcessInfo(MockProcess(stdout: changedFilePath), <String>['ls-files']),
+        FakeProcessInfo(MockProcess(exitCode: 1), <String>['diff']),
+      ];
+
+      Error? commandError;
+      final List<String> output = await runCapturingPrint(
+        runner,
+        <String>['format', '--fail-on-change'],
         errorHandler: (Error e) {
           commandError = e;
         },
@@ -877,290 +1093,159 @@ void main() {
       expect(commandError, isA<ToolExit>());
       expect(
         output,
-        containsAllInOrder(<Matcher>[contains('Failed to lint Swift files: exit code 99.')]),
+        containsAllInOrder(<Matcher>[
+          contains('These files are not formatted correctly'),
+          contains(changedFilePath),
+          contains('Unable to determine diff.'),
+        ]),
       );
     });
 
-    test('fails if swift-format fails', () async {
-      const files = <String>['macos/foo.swift'];
-      final RepositoryPackage plugin = createFakePlugin('a_plugin', packagesDir, extraFiles: files);
+    // Validates that the Windows limit--which is much lower than the limit on
+    // other platforms--isn't being used on all platforms, as that would make
+    // formatting slower on Linux and macOS.
+    test('Does not batch moderately long file lists on non-Windows', () async {
+      const pluginName = 'a_plugin';
+      // -1 since the command itself takes some length.
+      const int batchSize = (windowsCommandLineMax ~/ 100) - 1;
+
+      // Make the file list one file longer than would fit in a Windows batch.
+      final List<String> batch = get99CharacterPathExtraFiles(batchSize + 1);
+
+      final RepositoryPackage plugin = createFakePlugin(
+        pluginName,
+        packagesDir,
+        extraFiles: batch,
+        dartConstraint: _dartConstraint,
+      );
       fakePubGet(plugin);
 
-      processRunner.mockProcessesForExecutable['xcrun'] = <FakeProcessInfo>[
-        FakeProcessInfo(MockProcess(exitCode: 1), <String>['swift-format', '-i']),
-      ];
-      Error? commandError;
-      final List<String> output = await runCapturingPrint(
-        runner,
-        <String>['format', '--swift'],
-        errorHandler: (Error e) {
-          commandError = e;
-        },
-      );
+      await runCapturingPrint(runner, <String>['format']);
 
-      expect(commandError, isA<ToolExit>());
+      expect(processRunner.recordedCalls.length, 1);
+    });
+
+    test('Batches extremely long file lists on non-Windows', () async {
+      const pluginName = 'a_plugin';
+      // -1 since the command itself takes some length.
+      const int batchSize = (nonWindowsCommandLineMax ~/ 100) - 1;
+
+      // Make the file list one file longer than would fit in the batch.
+      final List<String> batch1 = get99CharacterPathExtraFiles(batchSize + 1);
+      final String extraFile = batch1.removeLast();
+
+      final RepositoryPackage package = createFakePlugin(
+        pluginName,
+        packagesDir,
+        extraFiles: <String>[...batch1, extraFile],
+        dartConstraint: _dartConstraint,
+      );
+      fakePubGet(package);
+
+      await runCapturingPrint(runner, <String>['format']);
+
+      // Ensure that it was batched...
+      expect(processRunner.recordedCalls.length, 2);
+      // ... and that the spillover into the second batch was only one file.
       expect(
-        output,
-        containsAllInOrder(<Matcher>[contains('Failed to format Swift files: exit code 1.')]),
+        processRunner.recordedCalls,
+        contains(ProcessCall('dart', <String>['format', extraFile], package.path)),
       );
     });
   });
 
-  test('skips known non-repo files', () async {
-    const skipFiles = <String>[
-      '/example/build/SomeFramework.framework/Headers/SomeFramework.h',
-      '/example/Pods/APod.framework/Headers/APod.h',
-      '.dart_tool/internals/foo.cc',
-      '.dart_tool/internals/Bar.java',
-      '.dart_tool/internals/baz.dart',
-    ];
-    const clangFiles = <String>['ios/Classes/Foo.h'];
-    const dartFiles = <String>['lib/a.dart'];
-    const javaFiles = <String>['android/src/main/java/io/flutter/plugins/a_plugin/a.java'];
-    final RepositoryPackage plugin = createFakePlugin(
-      'a_plugin',
-      packagesDir,
-      extraFiles: <String>[
-        ...skipFiles,
-        // Include some files that should be formatted to validate that it's
-        // correctly filtering even when running the commands.
-        ...clangFiles,
-        ...dartFiles,
-        ...javaFiles,
-      ],
-    );
-    fakePubGet(plugin);
+  group('windows', () {
+    late NativePlatform mockPlatform;
+    late Directory packagesDir;
+    late RecordingProcessRunner processRunner;
+    late FormatCommand analyzeCommand;
+    late CommandRunner<void> runner;
+    late String javaFormatPath;
+    late String kotlinFormatPath;
 
-    await runCapturingPrint(runner, <String>['format']);
+    setUp(() {
+      mockPlatform = createMockPlatform(isWindows: true);
+      final GitDir gitDir;
+      (:packagesDir, :processRunner, gitProcessRunner: _, :gitDir) = configureBaseCommandMocks(
+        platform: mockPlatform,
+      );
+      analyzeCommand = FormatCommand(
+        packagesDir,
+        processRunner: processRunner,
+        platform: mockPlatform,
+        gitDir: gitDir,
+      );
 
-    expect(
-      processRunner.recordedCalls,
-      containsAll(<ProcessCall>[
-        ProcessCall('clang-format', <String>[
-          '-i',
-          '--style=file',
-          ...getPackagesDirRelativePaths(plugin, clangFiles),
-        ], packagesDir.path),
-        ProcessCall('dart', const <String>['format', ...dartFiles], plugin.path),
-        ProcessCall('java', <String>[
-          '-jar',
-          javaFormatPath,
-          '--replace',
-          ...getPackagesDirRelativePaths(plugin, javaFiles),
-        ], packagesDir.path),
-      ]),
-    );
+      // Create the Java and Kotlin formatter files that the command checks for,
+      // to avoid a download.
+      javaFormatPath = analyzeCommand.javaFormatterFile.path;
+      packagesDir.fileSystem.file(javaFormatPath).createSync(recursive: true);
+      kotlinFormatPath = analyzeCommand.kotlinFormatterFile.path;
+      packagesDir.fileSystem.file(kotlinFormatPath).createSync(recursive: true);
+
+      runner = CommandRunner<void>('format_command', 'Test for format_command');
+      runner.addCommand(analyzeCommand);
+    });
+
+    test('Batches moderately long file lists on Windows', () async {
+      const pluginName = 'a_plugin';
+      // -1 since the command itself takes some length.
+      const int batchSize = (windowsCommandLineMax ~/ 100) - 1;
+
+      // Make the file list one file longer than would fit in the batch.
+      final List<String> batch1 = _get99CharacterPathExtraFiles(
+        batchSize + 1,
+        path: analyzeCommand.path,
+      );
+      final String extraFile = batch1.removeLast();
+
+      final RepositoryPackage package = createFakePlugin(
+        pluginName,
+        packagesDir,
+        extraFiles: <String>[...batch1, extraFile],
+        dartConstraint: _dartConstraint,
+      );
+      fakePubGet(package);
+
+      await runCapturingPrint(runner, <String>['format']);
+
+      // Ensure that it was batched...
+      expect(processRunner.recordedCalls.length, 2);
+      // ... and that the spillover into the second batch was only one file.
+      expect(
+        processRunner.recordedCalls,
+        contains(ProcessCall('dart', <String>['format', extraFile], package.path)),
+      );
+    });
   });
+}
 
-  test('skips GeneratedPluginRegistrant.swift', () async {
-    const sourceFile = 'macos/Classes/Foo.swift';
-    final RepositoryPackage plugin = createFakePlugin(
-      'a_plugin',
-      packagesDir,
-      extraFiles: <String>[sourceFile, 'example/macos/Flutter/GeneratedPluginRegistrant.swift'],
-    );
-    fakePubGet(plugin);
+/// Returns a modified version of a list of [relativePaths] that are relative
+/// to [package] to instead be relative to [packagesDir].
+List<String> _getPackagesDirRelativePaths(
+  RepositoryPackage package,
+  List<String> relativePaths, {
+  required p.Context path,
+  required Directory packagesDir,
+}) {
+  final String relativeBase = path.relative(package.path, from: packagesDir.path);
+  return relativePaths.map((String relativePath) => path.join(relativeBase, relativePath)).toList();
+}
 
-    await runCapturingPrint(runner, <String>['format', '--swift']);
+/// Returns a list of [count] relative paths to pass to [createFakePlugin]
+/// or [createFakePackage] such that each path will be 99 characters long
+/// relative to the package directory.
+///
+/// This is for each of testing batching, since it means each file will
+/// consume 100 characters of the batch length.
+List<String> _get99CharacterPathExtraFiles(int count, {required p.Context path}) {
+  const int padding =
+      99 -
+      1 - // the path separator after the padding
+      10; // the file name
+  const filenameBase = 10000;
 
-    expect(
-      processRunner.recordedCalls,
-      orderedEquals(<ProcessCall>[
-        ProcessCall('xcrun', <String>[
-          'swift-format',
-          '-i',
-          ...getPackagesDirRelativePaths(plugin, <String>[sourceFile]),
-        ], packagesDir.path),
-        ProcessCall('xcrun', <String>[
-          'swift-format',
-          'lint',
-          '--parallel',
-          '--strict',
-          ...getPackagesDirRelativePaths(plugin, <String>[sourceFile]),
-        ], packagesDir.path),
-      ]),
-    );
-  });
-
-  test('fails if files are changed with --fail-on-change', () async {
-    const files = <String>['linux/foo_plugin.cc', 'macos/Classes/Foo.h'];
-    final RepositoryPackage plugin = createFakePlugin('a_plugin', packagesDir, extraFiles: files);
-    fakePubGet(plugin);
-
-    const changedFilePath = 'packages/a_plugin/linux/foo_plugin.cc';
-    processRunner.mockProcessesForExecutable['git'] = <FakeProcessInfo>[
-      FakeProcessInfo(MockProcess(stdout: changedFilePath), <String>['ls-files']),
-    ];
-
-    Error? commandError;
-    final List<String> output = await runCapturingPrint(
-      runner,
-      <String>['format', '--fail-on-change'],
-      errorHandler: (Error e) {
-        commandError = e;
-      },
-    );
-
-    expect(commandError, isA<ToolExit>());
-    expect(
-      output,
-      containsAllInOrder(<Matcher>[
-        contains('These files are not formatted correctly'),
-        contains(changedFilePath),
-        // Ensure the error message links to instructions.
-        contains('$toolDocsUrl#format-code'),
-        contains('patch -p1 <<DONE'),
-      ]),
-    );
-
-    // Ensure that both packages and third_party/packages are checked.
-    final Directory thirdPartyDir = packagesDir.parent
-        .childDirectory('third_party')
-        .childDirectory('packages');
-    expect(
-      processRunner.recordedCalls,
-      containsAllInOrder(<ProcessCall>[
-        ProcessCall('git', <String>[
-          'ls-files',
-          '--modified',
-          packagesDir.path,
-          thirdPartyDir.path,
-        ], packagesDir.parent.path),
-      ]),
-    );
-  });
-
-  test('fails if git ls-files fails', () async {
-    const files = <String>['linux/foo_plugin.cc', 'macos/Classes/Foo.h'];
-    final RepositoryPackage plugin = createFakePlugin('a_plugin', packagesDir, extraFiles: files);
-    fakePubGet(plugin);
-
-    processRunner.mockProcessesForExecutable['git'] = <FakeProcessInfo>[
-      FakeProcessInfo(MockProcess(exitCode: 1), <String>['ls-files']),
-    ];
-    Error? commandError;
-    final List<String> output = await runCapturingPrint(
-      runner,
-      <String>['format', '--fail-on-change'],
-      errorHandler: (Error e) {
-        commandError = e;
-      },
-    );
-
-    expect(commandError, isA<ToolExit>());
-    expect(output, containsAllInOrder(<Matcher>[contains('Unable to determine changed files.')]));
-  });
-
-  test('reports git diff failures', () async {
-    const files = <String>['linux/foo_plugin.cc', 'macos/Classes/Foo.h'];
-    final RepositoryPackage plugin = createFakePlugin('a_plugin', packagesDir, extraFiles: files);
-    fakePubGet(plugin);
-
-    const changedFilePath = 'packages/a_plugin/linux/foo_plugin.cc';
-    processRunner.mockProcessesForExecutable['git'] = <FakeProcessInfo>[
-      FakeProcessInfo(MockProcess(stdout: changedFilePath), <String>['ls-files']),
-      FakeProcessInfo(MockProcess(exitCode: 1), <String>['diff']),
-    ];
-
-    Error? commandError;
-    final List<String> output = await runCapturingPrint(
-      runner,
-      <String>['format', '--fail-on-change'],
-      errorHandler: (Error e) {
-        commandError = e;
-      },
-    );
-
-    expect(commandError, isA<ToolExit>());
-    expect(
-      output,
-      containsAllInOrder(<Matcher>[
-        contains('These files are not formatted correctly'),
-        contains(changedFilePath),
-        contains('Unable to determine diff.'),
-      ]),
-    );
-  });
-
-  test('Batches moderately long file lists on Windows', () async {
-    mockPlatform.isWindows = true;
-
-    const pluginName = 'a_plugin';
-    // -1 since the command itself takes some length.
-    const int batchSize = (windowsCommandLineMax ~/ 100) - 1;
-
-    // Make the file list one file longer than would fit in the batch.
-    final List<String> batch1 = get99CharacterPathExtraFiles(batchSize + 1);
-    final String extraFile = batch1.removeLast();
-
-    final RepositoryPackage package = createFakePlugin(
-      pluginName,
-      packagesDir,
-      extraFiles: <String>[...batch1, extraFile],
-      dartConstraint: _dartConstraint,
-    );
-    fakePubGet(package);
-
-    await runCapturingPrint(runner, <String>['format']);
-
-    // Ensure that it was batched...
-    expect(processRunner.recordedCalls.length, 2);
-    // ... and that the spillover into the second batch was only one file.
-    expect(
-      processRunner.recordedCalls,
-      contains(ProcessCall('dart', <String>['format', extraFile], package.path)),
-    );
-  });
-
-  // Validates that the Windows limit--which is much lower than the limit on
-  // other platforms--isn't being used on all platforms, as that would make
-  // formatting slower on Linux and macOS.
-  test('Does not batch moderately long file lists on non-Windows', () async {
-    const pluginName = 'a_plugin';
-    // -1 since the command itself takes some length.
-    const int batchSize = (windowsCommandLineMax ~/ 100) - 1;
-
-    // Make the file list one file longer than would fit in a Windows batch.
-    final List<String> batch = get99CharacterPathExtraFiles(batchSize + 1);
-
-    final RepositoryPackage plugin = createFakePlugin(
-      pluginName,
-      packagesDir,
-      extraFiles: batch,
-      dartConstraint: _dartConstraint,
-    );
-    fakePubGet(plugin);
-
-    await runCapturingPrint(runner, <String>['format']);
-
-    expect(processRunner.recordedCalls.length, 1);
-  });
-
-  test('Batches extremely long file lists on non-Windows', () async {
-    const pluginName = 'a_plugin';
-    // -1 since the command itself takes some length.
-    const int batchSize = (nonWindowsCommandLineMax ~/ 100) - 1;
-
-    // Make the file list one file longer than would fit in the batch.
-    final List<String> batch1 = get99CharacterPathExtraFiles(batchSize + 1);
-    final String extraFile = batch1.removeLast();
-
-    final RepositoryPackage package = createFakePlugin(
-      pluginName,
-      packagesDir,
-      extraFiles: <String>[...batch1, extraFile],
-      dartConstraint: _dartConstraint,
-    );
-    fakePubGet(package);
-
-    await runCapturingPrint(runner, <String>['format']);
-
-    // Ensure that it was batched...
-    expect(processRunner.recordedCalls.length, 2);
-    // ... and that the spillover into the second batch was only one file.
-    expect(
-      processRunner.recordedCalls,
-      contains(ProcessCall('dart', <String>['format', extraFile], package.path)),
-    );
-  });
+  return <String>[
+    for (int i = filenameBase; i < filenameBase + count; ++i) path.join('a' * padding, '$i.dart'),
+  ];
 }

--- a/script/tool/test/license_check_command_test.dart
+++ b/script/tool/test/license_check_command_test.dart
@@ -18,13 +18,13 @@ import 'util.dart';
 void main() {
   group('LicenseCheckCommand', () {
     late CommandRunner<void> runner;
-    late Platform platform;
+    late NativePlatform platform;
     late RecordingProcessRunner gitProcessRunner;
     late Directory packagesDir;
     late Directory root;
 
     setUp(() {
-      platform = MockPlatformWithSeparator();
+      platform = createMockPlatform();
       final GitDir gitDir;
       (:packagesDir, processRunner: _, :gitProcessRunner, :gitDir) = configureBaseCommandMocks(
         platform: platform,
@@ -673,11 +673,6 @@ furnished to do so, subject to the following conditions:''',
       );
     });
   });
-}
-
-class MockPlatformWithSeparator extends MockPlatform {
-  @override
-  String get pathSeparator => isWindows ? r'\' : '/';
 }
 
 const String _correctLicenseFileText = '''

--- a/script/tool/test/list_command_test.dart
+++ b/script/tool/test/list_command_test.dart
@@ -5,6 +5,7 @@
 import 'package:args/command_runner.dart';
 import 'package:file/file.dart';
 import 'package:flutter_plugin_tools/src/list_command.dart';
+import 'package:platform/platform.dart';
 import 'package:test/test.dart';
 
 import 'mocks.dart';
@@ -12,12 +13,12 @@ import 'util.dart';
 
 void main() {
   group('ListCommand', () {
-    late MockPlatform mockPlatform;
+    late NativePlatform mockPlatform;
     late Directory packagesDir;
     late CommandRunner<void> runner;
 
     setUp(() {
-      mockPlatform = MockPlatform();
+      mockPlatform = createMockPlatform();
       (:packagesDir, processRunner: _, gitProcessRunner: _, gitDir: _) = configureBaseCommandMocks(
         platform: mockPlatform,
       );

--- a/script/tool/test/mocks.dart
+++ b/script/tool/test/mocks.dart
@@ -9,31 +9,38 @@ import 'dart:io' as io;
 import 'package:file/file.dart';
 import 'package:flutter_plugin_tools/src/common/process_runner.dart';
 import 'package:mockito/mockito.dart';
-import 'package:platform/platform.dart';
+import 'package:platform/testing.dart';
 
 import 'common/package_command_test.mocks.dart';
 
-class MockPlatform extends Mock implements Platform {
-  MockPlatform({this.isLinux = false, this.isMacOS = false, this.isWindows = false});
-
-  @override
-  bool isLinux;
-
-  @override
-  bool isMacOS;
-
-  @override
-  bool isWindows;
-
-  @override
-  Uri get script =>
-      isWindows ? Uri.file(r'C:\foo\bar', windows: true) : Uri.file('/foo/bar', windows: false);
-
-  @override
-  Map<String, String> environment = <String, String>{};
-
-  @override
-  String get pathSeparator => isWindows ? r'\' : '/';
+// TODO(stuartmorgan): Consider updating call sites to use TestNativePlatform directly; this is a
+// shim from the previous implementation, which mocked Platform directly, to fix tests when the
+// ability to mock Platform was removed.
+NativePlatform createMockPlatform({
+  bool isLinux = false,
+  bool isMacOS = false,
+  bool isWindows = false,
+}) {
+  assert(
+    !(isLinux && isMacOS) && !(isLinux && isWindows) && !(isMacOS && isWindows),
+    'Only one platform can be selected.',
+  );
+  final String platform;
+  if (isMacOS) {
+    platform = NativePlatform.macOS;
+  } else if (isWindows) {
+    platform = NativePlatform.windows;
+  } else {
+    platform = NativePlatform.linux;
+  }
+  return TestNativePlatform(
+    operatingSystem: platform,
+    script: isWindows
+        ? Uri.file(r'C:\foo\bar', windows: true)
+        : Uri.file('/foo/bar', windows: false),
+    environment: <String, String>{},
+    pathSeparator: isWindows ? r'\' : '/',
+  );
 }
 
 class MockProcess extends Mock implements io.Process {

--- a/script/tool/test/native_test_command_test.dart
+++ b/script/tool/test/native_test_command_test.dart
@@ -61,7 +61,7 @@ const String _fakeCmakeCommand = 'path/to/cmake';
 const String _archDirX64 = 'x64';
 const String _archDirArm64 = 'arm64';
 
-void _createFakeCMakeCache(RepositoryPackage plugin, Platform platform, String archDir) {
+void _createFakeCMakeCache(RepositoryPackage plugin, NativePlatform platform, String archDir) {
   final project = CMakeProject(
     getExampleDir(plugin),
     platform: platform,
@@ -79,17 +79,16 @@ void main() {
   const kDestination = '--ios-destination';
 
   group('test native_test_command on Posix', () {
-    late MockPlatform mockPlatform;
+    late NativePlatform mockPlatform;
     late Directory packagesDir;
     late CommandRunner<void> runner;
     late RecordingProcessRunner processRunner;
     late RecordingProcessRunner gitProcessRunner;
 
     setUp(() {
-      // iOS and macOS tests expect macOS, Linux tests expect Linux; nothing
-      // needs to distinguish between Linux and macOS, so set both to true to
-      // allow them to share a setup group.
-      mockPlatform = MockPlatform(isMacOS: true, isLinux: true);
+      // Currently nothing in the logic specifically checks for isMacOS, so just use Linux for both
+      // test groups.
+      mockPlatform = createMockPlatform(isLinux: true);
       final GitDir gitDir;
       (:packagesDir, :processRunner, :gitProcessRunner, :gitDir) = configureBaseCommandMocks(
         platform: mockPlatform,
@@ -1961,14 +1960,14 @@ public class FlutterActivityTest {
   });
 
   group('test native_test_command on Windows', () {
-    late MockPlatform mockPlatform;
+    late NativePlatform mockPlatform;
     late Directory packagesDir;
     late CommandRunner<void> runner;
     late RecordingProcessRunner processRunner;
     late GitDir gitDir;
 
     setUp(() {
-      mockPlatform = MockPlatform(isWindows: true);
+      mockPlatform = createMockPlatform(isWindows: true);
       (:packagesDir, :processRunner, gitProcessRunner: _, :gitDir) = configureBaseCommandMocks(
         platform: mockPlatform,
       );

--- a/script/tool/test/podspec_check_command_test.dart
+++ b/script/tool/test/podspec_check_command_test.dart
@@ -74,14 +74,13 @@ end
 }
 
 void main() {
-  group('PodspecCheckCommand', () {
+  group('non-macOS', () {
     late Directory packagesDir;
     late CommandRunner<void> runner;
-    late MockPlatform mockPlatform;
     late RecordingProcessRunner processRunner;
 
     setUp(() {
-      mockPlatform = MockPlatform(isMacOS: true);
+      final NativePlatform mockPlatform = createMockPlatform(isLinux: true);
       final GitDir gitDir;
       (:packagesDir, :processRunner, gitProcessRunner: _, :gitDir) = configureBaseCommandMocks(
         platform: mockPlatform,
@@ -97,9 +96,8 @@ void main() {
       runner.addCommand(command);
     });
 
-    test('only runs on macOS', () async {
+    test('fails when not on macOS', () async {
       createFakePlugin('plugin1', packagesDir, extraFiles: <String>['plugin1.podspec']);
-      mockPlatform.isMacOS = false;
 
       Error? commandError;
       final List<String> output = await runCapturingPrint(
@@ -115,6 +113,29 @@ void main() {
       expect(processRunner.recordedCalls, equals(<ProcessCall>[]));
 
       expect(output, containsAllInOrder(<Matcher>[contains('only supported on macOS')]));
+    });
+  });
+
+  group('macOS', () {
+    late Directory packagesDir;
+    late CommandRunner<void> runner;
+    late RecordingProcessRunner processRunner;
+
+    setUp(() {
+      final NativePlatform mockPlatform = createMockPlatform(isMacOS: true);
+      final GitDir gitDir;
+      (:packagesDir, :processRunner, gitProcessRunner: _, :gitDir) = configureBaseCommandMocks(
+        platform: mockPlatform,
+      );
+      final command = PodspecCheckCommand(
+        packagesDir,
+        processRunner: processRunner,
+        platform: mockPlatform,
+        gitDir: gitDir,
+      );
+
+      runner = CommandRunner<void>('podspec_test', 'Test for $PodspecCheckCommand');
+      runner.addCommand(command);
     });
 
     test('runs pod lib lint on a podspec', () async {

--- a/script/tool/test/publish_check_command_test.dart
+++ b/script/tool/test/publish_check_command_test.dart
@@ -11,6 +11,7 @@ import 'package:flutter_plugin_tools/src/publish_check_command.dart';
 import 'package:git/git.dart';
 import 'package:http/http.dart' as http;
 import 'package:http/testing.dart';
+import 'package:platform/platform.dart';
 import 'package:test/test.dart';
 
 import 'mocks.dart';
@@ -18,7 +19,7 @@ import 'util.dart';
 
 void main() {
   group('PublishCheckCommand tests', () {
-    late MockPlatform mockPlatform;
+    late NativePlatform mockPlatform;
     late Directory packagesDir;
     late RecordingProcessRunner processRunner;
     // Separate process runner for the mock gitDir to make asserting the
@@ -41,7 +42,7 @@ void main() {
     }
 
     setUp(() {
-      mockPlatform = MockPlatform();
+      mockPlatform = createMockPlatform();
       (:packagesDir, :processRunner, gitProcessRunner: _, :gitDir) = configureBaseCommandMocks(
         platform: mockPlatform,
       );

--- a/script/tool/test/publish_command_test.dart
+++ b/script/tool/test/publish_command_test.dart
@@ -14,13 +14,14 @@ import 'package:git/git.dart';
 import 'package:http/http.dart' as http;
 import 'package:http/testing.dart';
 import 'package:mockito/mockito.dart';
+import 'package:platform/platform.dart';
 import 'package:test/test.dart';
 
 import 'mocks.dart';
 import 'util.dart';
 
 void main() {
-  late MockPlatform platform;
+  late NativePlatform platform;
   late Directory packagesDir;
   late TestProcessRunner processRunner;
   late PublishCommand command;
@@ -36,7 +37,7 @@ void main() {
   }
 
   setUp(() async {
-    platform = MockPlatform(isLinux: true);
+    platform = createMockPlatform(isLinux: true);
     processRunner = TestProcessRunner();
     final GitDir gitDir;
     (:packagesDir, processRunner: _, gitProcessRunner: _, :gitDir) = configureBaseCommandMocks(
@@ -1338,7 +1339,7 @@ void main() {
 
   group('credential location', () {
     test('Linux with XDG', () async {
-      platform = MockPlatform(isLinux: true);
+      platform = createMockPlatform(isLinux: true);
       platform.environment['XDG_CONFIG_HOME'] = '/xdghome/config';
       command = PublishCommand(packagesDir, platform: platform);
 
@@ -1346,7 +1347,7 @@ void main() {
     });
 
     test('Linux without XDG', () async {
-      platform = MockPlatform(isLinux: true);
+      platform = createMockPlatform(isLinux: true);
       platform.environment['HOME'] = '/home';
       command = PublishCommand(packagesDir, platform: platform);
 
@@ -1354,7 +1355,7 @@ void main() {
     });
 
     test('macOS', () async {
-      platform = MockPlatform(isMacOS: true);
+      platform = createMockPlatform(isMacOS: true);
       platform.environment['HOME'] = '/Users/someuser';
       command = PublishCommand(packagesDir, platform: platform);
 
@@ -1365,7 +1366,7 @@ void main() {
     });
 
     test('Windows', () async {
-      platform = MockPlatform(isWindows: true);
+      platform = createMockPlatform(isWindows: true);
       platform.environment['APPDATA'] = r'C:\Users\SomeUser\AppData';
       command = PublishCommand(packagesDir, platform: platform);
 

--- a/script/tool/test/test_dart_fixes_command_test.dart
+++ b/script/tool/test/test_dart_fixes_command_test.dart
@@ -15,14 +15,14 @@ import 'util.dart';
 
 void main() {
   group('TestDartFixesCommand', () {
-    late Platform mockPlatform;
+    late NativePlatform mockPlatform;
     late Directory packagesDir;
     late CommandRunner<void> runner;
     late RecordingProcessRunner processRunner;
     late TestDartFixesCommand command;
 
     setUp(() {
-      mockPlatform = MockPlatform();
+      mockPlatform = createMockPlatform();
       final GitDir gitDir;
       (:packagesDir, :processRunner, gitProcessRunner: _, :gitDir) = configureBaseCommandMocks(
         platform: mockPlatform,

--- a/script/tool/test/update_excerpts_command_test.dart
+++ b/script/tool/test/update_excerpts_command_test.dart
@@ -7,12 +7,13 @@ import 'package:file/file.dart';
 import 'package:flutter_plugin_tools/src/common/core.dart';
 import 'package:flutter_plugin_tools/src/update_excerpts_command.dart';
 import 'package:git/git.dart';
+import 'package:platform/platform.dart';
 import 'package:test/test.dart';
 
 import 'mocks.dart';
 import 'util.dart';
 
-void runAllTests(MockPlatform platform) {
+void runAllTests(NativePlatform platform) {
   late Directory packagesDir;
   late CommandRunner<void> runner;
 
@@ -538,6 +539,6 @@ A B C
 }
 
 void main() {
-  runAllTests(MockPlatform());
-  runAllTests(MockPlatform(isWindows: true));
+  runAllTests(createMockPlatform());
+  runAllTests(createMockPlatform(isWindows: true));
 }

--- a/script/tool/test/util.dart
+++ b/script/tool/test/util.dart
@@ -32,7 +32,7 @@ const String _defaultFlutterConstraint = '>=2.5.0';
 
 /// Returns the exe name that command will use when running Flutter on
 /// [platform].
-String getFlutterCommand(Platform platform) => platform.isWindows ? 'flutter.bat' : 'flutter';
+String getFlutterCommand(NativePlatform platform) => platform.isWindows ? 'flutter.bat' : 'flutter';
 
 /// Creates a packages directory at an arbitrary location in the given
 /// filesystem.
@@ -530,7 +530,7 @@ class ProcessCall {
   GitDir gitDir,
 })
 configureBaseCommandMocks({
-  Platform? platform,
+  NativePlatform? platform,
   RecordingProcessRunner? customProcessRunner,
   RecordingProcessRunner? customGitProcessRunner,
 }) {

--- a/script/tool/test/validate_command_pubignore_test.dart
+++ b/script/tool/test/validate_command_pubignore_test.dart
@@ -6,6 +6,7 @@ import 'package:args/command_runner.dart';
 import 'package:file/file.dart';
 import 'package:flutter_plugin_tools/src/validate_command.dart';
 import 'package:git/git.dart';
+import 'package:platform/platform.dart';
 import 'package:test/test.dart';
 
 import 'mocks.dart';
@@ -18,7 +19,7 @@ void main() {
     late Directory packagesDir;
 
     setUp(() {
-      final mockPlatform = MockPlatform();
+      final NativePlatform mockPlatform = createMockPlatform();
       final ({
         Directory packagesDir,
         RecordingProcessRunner processRunner,

--- a/script/tool/test/validate_command_pubspec_test.dart
+++ b/script/tool/test/validate_command_pubspec_test.dart
@@ -7,6 +7,7 @@ import 'package:file/file.dart';
 import 'package:flutter_plugin_tools/src/common/core.dart';
 import 'package:flutter_plugin_tools/src/validate_command.dart';
 import 'package:git/git.dart';
+import 'package:platform/platform.dart';
 import 'package:test/test.dart';
 
 import 'mocks.dart';
@@ -136,11 +137,11 @@ false_secrets:
 void main() {
   group('test pubspec_check_command', () {
     late CommandRunner<void> runner;
-    late MockPlatform mockPlatform;
+    late NativePlatform mockPlatform;
     late Directory packagesDir;
     late Directory repoRoot;
     setUp(() {
-      mockPlatform = MockPlatform();
+      mockPlatform = createMockPlatform();
       final RecordingProcessRunner processRunner;
       final GitDir gitDir;
       (:packagesDir, :processRunner, gitProcessRunner: _, :gitDir) = configureBaseCommandMocks(
@@ -2127,11 +2128,11 @@ ${_topicsSection()}
 
   group('test pubspec_check_command on Windows', () {
     late CommandRunner<void> runner;
-    late MockPlatform mockPlatform;
+    late NativePlatform mockPlatform;
     late Directory packagesDir;
 
     setUp(() {
-      mockPlatform = MockPlatform(isWindows: true);
+      mockPlatform = createMockPlatform(isWindows: true);
       final RecordingProcessRunner processRunner;
       final GitDir gitDir;
       (:packagesDir, :processRunner, gitProcessRunner: _, :gitDir) = configureBaseCommandMocks(

--- a/script/tool/test/validate_command_readme_test.dart
+++ b/script/tool/test/validate_command_readme_test.dart
@@ -8,6 +8,7 @@ import 'package:flutter_plugin_tools/src/common/core.dart';
 import 'package:flutter_plugin_tools/src/common/plugin_utils.dart';
 import 'package:flutter_plugin_tools/src/validate_command.dart';
 import 'package:git/git.dart';
+import 'package:platform/platform.dart';
 import 'package:test/test.dart';
 
 import 'mocks.dart';
@@ -15,11 +16,11 @@ import 'util.dart';
 
 void main() {
   late CommandRunner<void> runner;
-  late MockPlatform mockPlatform;
+  late NativePlatform mockPlatform;
   late Directory packagesDir;
 
   setUp(() {
-    mockPlatform = MockPlatform();
+    mockPlatform = createMockPlatform();
     final RecordingProcessRunner processRunner;
     final GitDir gitDir;
     (:packagesDir, :processRunner, gitProcessRunner: _, :gitDir) = configureBaseCommandMocks(

--- a/script/tool/test/validate_command_version_test.dart
+++ b/script/tool/test/validate_command_version_test.dart
@@ -8,6 +8,7 @@ import 'package:flutter_plugin_tools/src/common/core.dart';
 import 'package:flutter_plugin_tools/src/validate_command.dart';
 import 'package:flutter_plugin_tools/src/validators/version_and_changelog_validator.dart';
 import 'package:git/git.dart';
+import 'package:platform/platform.dart';
 import 'package:pub_semver/pub_semver.dart';
 import 'package:test/test.dart';
 
@@ -38,13 +39,13 @@ void testAllowedVersion(
 
 void main() {
   group('VersionCheckCommand', () {
-    late MockPlatform mockPlatform;
+    late NativePlatform mockPlatform;
     late Directory packagesDir;
     late CommandRunner<void> runner;
     late RecordingProcessRunner gitProcessRunner;
 
     setUp(() {
-      mockPlatform = MockPlatform();
+      mockPlatform = createMockPlatform();
       final RecordingProcessRunner processRunner;
       final GitDir gitDir;
       (:packagesDir, :processRunner, :gitProcessRunner, :gitDir) = configureBaseCommandMocks(


### PR DESCRIPTION
`platform` 3.2.0 added new APIs, and broke the ability to mock the old APIs. This updates all code to expect `NativePlatform` instead of `Platform`, and replaces `MockPlatform` with the upstream `TestNativePlatform`.

Fixes https://github.com/flutter/flutter/issues/192420