### PR TITLE
[video_player] Fix crash when videoTrack has zero-duration minFrameDuration

### DIFF
--- a/packages/video_player/video_player_avfoundation/CHANGELOG.md
+++ b/packages/video_player/video_player_avfoundation/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.12.1
+
+* Fixes a crash caused by a videoTrack that has a zero-duration minFrameDuration when creating a AVMutableVideoComposition.
+
 ## 2.12.0
 
 * Routes video over AirPlay when an external screen is active, by setting

--- a/packages/video_player/video_player_avfoundation/darwin/RunnerTests/VideoPlayerTests.swift
+++ b/packages/video_player/video_player_avfoundation/darwin/RunnerTests/VideoPlayerTests.swift
@@ -1016,6 +1016,24 @@ private let hlsAudioTestURI =
     player.disposeWithError(&error)
   }
 
+  @Test func validFrameDurationWithPositiveTime() {
+    let duration = CMTimeMake(value: 1, timescale: 30)
+    #expect(FVPIsValidFrameDuration(duration))
+  }
+
+  @Test func validFrameDurationWithZeroTime() {
+    #expect(!FVPIsValidFrameDuration(CMTime.zero))
+  }
+
+  @Test func validFrameDurationWithInvalidTime() {
+    #expect(!FVPIsValidFrameDuration(CMTime.invalid))
+  }
+
+  @Test func validFrameDurationWithNegativeTime() {
+    let duration = CMTimeMake(value: -1, timescale: 30)
+    #expect(!FVPIsValidFrameDuration(duration))
+  }
+
   // MARK: - Helper Methods
 
   /// Creates a plugin with the given dependencies, and default stubs for any that aren't provided,

--- a/packages/video_player/video_player_avfoundation/darwin/video_player_avfoundation/Sources/video_player_avfoundation_objc/FVPVideoPlayer.m
+++ b/packages/video_player/video_player_avfoundation/darwin/video_player_avfoundation/Sources/video_player_avfoundation_objc/FVPVideoPlayer.m
@@ -286,7 +286,8 @@ NS_INLINE CGFloat radiansToDegrees(CGFloat radians) {
   videoComposition.renderSize = CGSizeMake(width, height);
 
   videoComposition.sourceTrackIDForFrameTiming = videoTrack.trackID;
-  if (CMTIME_IS_VALID(videoTrack.minFrameDuration)) {
+  if (CMTIME_IS_VALID(videoTrack.minFrameDuration) &&
+      CMTimeCompare(videoTrack.minFrameDuration, kCMTimeZero) > 0) {
     videoComposition.frameDuration = videoTrack.minFrameDuration;
   } else {
     NSLog(@"Warning: videoTrack.minFrameDuration for input video is invalid, please report this to "

--- a/packages/video_player/video_player_avfoundation/darwin/video_player_avfoundation/Sources/video_player_avfoundation_objc/FVPVideoPlayer.m
+++ b/packages/video_player/video_player_avfoundation/darwin/video_player_avfoundation/Sources/video_player_avfoundation_objc/FVPVideoPlayer.m
@@ -259,6 +259,10 @@ NS_INLINE CGFloat radiansToDegrees(CGFloat radians) {
   return degrees;
 };
 
+BOOL FVPIsValidFrameDuration(CMTime frameDuration) {
+  return CMTIME_IS_VALID(frameDuration) && CMTimeCompare(frameDuration, kCMTimeZero) > 0;
+}
+
 - (AVMutableVideoComposition *)videoCompositionWithTransform:(CGAffineTransform)transform
                                                        asset:(NSObject<FVPAVAsset> *)asset
                                                   videoTrack:(AVAssetTrack *)videoTrack {
@@ -286,8 +290,7 @@ NS_INLINE CGFloat radiansToDegrees(CGFloat radians) {
   videoComposition.renderSize = CGSizeMake(width, height);
 
   videoComposition.sourceTrackIDForFrameTiming = videoTrack.trackID;
-  if (CMTIME_IS_VALID(videoTrack.minFrameDuration) &&
-      CMTimeCompare(videoTrack.minFrameDuration, kCMTimeZero) > 0) {
+  if (FVPIsValidFrameDuration(videoTrack.minFrameDuration)) {
     videoComposition.frameDuration = videoTrack.minFrameDuration;
   } else {
     NSLog(@"Warning: videoTrack.minFrameDuration for input video is invalid, please report this to "

--- a/packages/video_player/video_player_avfoundation/darwin/video_player_avfoundation/Sources/video_player_avfoundation_objc/include/video_player_avfoundation_objc/FVPVideoPlayer.h
+++ b/packages/video_player/video_player_avfoundation/darwin/video_player_avfoundation/Sources/video_player_avfoundation_objc/include/video_player_avfoundation_objc/FVPVideoPlayer.h
@@ -44,4 +44,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
+/// Returns true if the given CMTime is valid and strictly positive,
+BOOL FVPIsValidFrameDuration(CMTime frameDuration);
+
 NS_ASSUME_NONNULL_END

--- a/packages/video_player/video_player_avfoundation/pubspec.yaml
+++ b/packages/video_player/video_player_avfoundation/pubspec.yaml
@@ -2,7 +2,7 @@ name: video_player_avfoundation
 description: iOS and macOS implementation of the video_player plugin.
 repository: https://github.com/flutter/packages/tree/main/packages/video_player/video_player_avfoundation
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+video_player%22
-version: 2.12.0
+version: 2.12.1
 
 environment:
   sdk: ^3.10.0


### PR DESCRIPTION
Fixes a crash on iOS caused by a zero-duration frame duration. When creating the `AVMutableVideoComposition` a check is made against `CMTIME_IS_VALID` but this doesn't guard against a frame duration of 0. I just added one more check to make sure the frame duration is > 0.

Fixes https://github.com/flutter/flutter/issues/151031

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under[^1].
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[the version and CHANGELOG instructions]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version-and-changelog-updates
[semantic versioning]: https://dart.dev/tools/pub/versioning#semantic-versions
[repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
