### PR TITLE
[material_ui] Port flutter/flutter #185475 "Accessibility: Add semanticLabel to MenuAnchor"

### DIFF
--- a/packages/material_ui/example/lib/menu_anchor/menu_anchor.0.dart
+++ b/packages/material_ui/example/lib/menu_anchor/menu_anchor.0.dart
@@ -112,6 +112,7 @@ class _MyCascadingMenuState extends State<MyCascadingMenu> {
       children: <Widget>[
         MenuAnchor(
           animated: true,
+          semanticLabel: 'Cascading application menu',
           onAnimationStatusChanged: (AnimationStatus status) {
             // Store the animation status so that it can be used to determine
             // whether the menu is opening or closing when the button is

--- a/packages/material_ui/lib/src/menu_anchor.dart
+++ b/packages/material_ui/lib/src/menu_anchor.dart
@@ -476,7 +476,7 @@ class MenuAnchor extends StatefulWidget {
   /// closed.
   final MenuAnchorChildBuilder? builder;
 
-  /// The semantic label of the dialog used by this menu.
+  /// The semantic label of the menu.
   ///
   /// Defaults to null.
   final String? semanticLabel;
@@ -720,6 +720,27 @@ class _MenuAnchorState extends State<MenuAnchor> with SingleTickerProviderStateM
   }
 
   Widget _buildOverlay(BuildContext context, RawMenuOverlayInfo position) {
+    Widget submenu = _Submenu(
+      fadeAnimation: opacityAnimation,
+      heightAnimation: heightAnimation,
+      layerLink: widget.layerLink,
+      consumeOutsideTaps: widget.consumeOutsideTap,
+      menuScopeNode: _menuScopeNode,
+      menuStyle: widget.style,
+      clipBehavior: widget.clipBehavior,
+      menuChildren: _menuChildren,
+      crossAxisUnconstrained: widget.crossAxisUnconstrained,
+      menuPosition: position,
+      anchor: this,
+      alignmentOffset: widget.alignmentOffset ?? Offset.zero,
+      reservedPadding: widget.reservedPadding ?? const EdgeInsets.all(_kMenuViewPadding),
+    );
+
+    // Only inject the semantics node if a label is provided
+    if (widget.semanticLabel != null) {
+      submenu = Semantics(container: true, label: widget.semanticLabel, child: submenu);
+    }
+
     // ExcludeSemantics, ExcludeFocus, and IgnorePointer are used to effectively
     // disable all interactions with the menu while it is closing.
     //
@@ -730,27 +751,7 @@ class _MenuAnchorState extends State<MenuAnchor> with SingleTickerProviderStateM
       excluding: isClosingOrClosed,
       child: IgnorePointer(
         ignoring: isClosingOrClosed,
-        child: ExcludeFocus(
-          excluding: isClosingOrClosed,
-          child: Semantics(
-            label: widget.semanticLabel,
-            child: _Submenu(
-              fadeAnimation: opacityAnimation,
-              heightAnimation: heightAnimation,
-              layerLink: widget.layerLink,
-              consumeOutsideTaps: widget.consumeOutsideTap,
-              menuScopeNode: _menuScopeNode,
-              menuStyle: widget.style,
-              clipBehavior: widget.clipBehavior,
-              menuChildren: _menuChildren,
-              crossAxisUnconstrained: widget.crossAxisUnconstrained,
-              menuPosition: position,
-              anchor: this,
-              alignmentOffset: widget.alignmentOffset ?? Offset.zero,
-              reservedPadding: widget.reservedPadding ?? const EdgeInsets.all(_kMenuViewPadding),
-            ),
-          ),
-        ),
+        child: ExcludeFocus(excluding: isClosingOrClosed, child: submenu),
       ),
     );
   }

--- a/packages/material_ui/lib/src/menu_anchor.dart
+++ b/packages/material_ui/lib/src/menu_anchor.dart
@@ -282,6 +282,7 @@ class MenuAnchor extends StatefulWidget {
     this.onAnimationStatusChanged,
     required this.menuChildren,
     this.builder,
+    this.semanticLabel,
     this.child,
   });
 
@@ -474,6 +475,11 @@ class MenuAnchor extends StatefulWidget {
   /// If provided, the builder will be called each time the menu is opened or
   /// closed.
   final MenuAnchorChildBuilder? builder;
+
+  /// The semantic label of the dialog used by this menu.
+  ///
+  /// Defaults to null.
+  final String? semanticLabel;
 
   /// The optional child to be passed to the [builder].
   ///
@@ -726,20 +732,23 @@ class _MenuAnchorState extends State<MenuAnchor> with SingleTickerProviderStateM
         ignoring: isClosingOrClosed,
         child: ExcludeFocus(
           excluding: isClosingOrClosed,
-          child: _Submenu(
-            fadeAnimation: opacityAnimation,
-            heightAnimation: heightAnimation,
-            layerLink: widget.layerLink,
-            consumeOutsideTaps: widget.consumeOutsideTap,
-            menuScopeNode: _menuScopeNode,
-            menuStyle: widget.style,
-            clipBehavior: widget.clipBehavior,
-            menuChildren: _menuChildren,
-            crossAxisUnconstrained: widget.crossAxisUnconstrained,
-            menuPosition: position,
-            anchor: this,
-            alignmentOffset: widget.alignmentOffset ?? Offset.zero,
-            reservedPadding: widget.reservedPadding ?? const EdgeInsets.all(_kMenuViewPadding),
+          child: Semantics(
+            label: widget.semanticLabel,
+            child: _Submenu(
+              fadeAnimation: opacityAnimation,
+              heightAnimation: heightAnimation,
+              layerLink: widget.layerLink,
+              consumeOutsideTaps: widget.consumeOutsideTap,
+              menuScopeNode: _menuScopeNode,
+              menuStyle: widget.style,
+              clipBehavior: widget.clipBehavior,
+              menuChildren: _menuChildren,
+              crossAxisUnconstrained: widget.crossAxisUnconstrained,
+              menuPosition: position,
+              anchor: this,
+              alignmentOffset: widget.alignmentOffset ?? Offset.zero,
+              reservedPadding: widget.reservedPadding ?? const EdgeInsets.all(_kMenuViewPadding),
+            ),
           ),
         ),
       ),

--- a/packages/material_ui/lib/src/menu_anchor.dart
+++ b/packages/material_ui/lib/src/menu_anchor.dart
@@ -677,10 +677,6 @@ class _MenuAnchorState extends State<MenuAnchor> with SingleTickerProviderStateM
 
     showOverlay();
 
-    if (widget.semanticLabel != null) {
-      SemanticsService.announce(widget.semanticLabel!, Directionality.of(context));
-    }
-
     if (_animationController.isForwardOrCompleted) {
       return;
     }

--- a/packages/material_ui/lib/src/menu_anchor.dart
+++ b/packages/material_ui/lib/src/menu_anchor.dart
@@ -677,6 +677,10 @@ class _MenuAnchorState extends State<MenuAnchor> with SingleTickerProviderStateM
 
     showOverlay();
 
+    if (widget.semanticLabel != null) {
+      SemanticsService.announce(widget.semanticLabel!, Directionality.of(context));
+    }
+
     if (_animationController.isForwardOrCompleted) {
       return;
     }

--- a/packages/material_ui/lib/src/menu_anchor.dart
+++ b/packages/material_ui/lib/src/menu_anchor.dart
@@ -738,7 +738,12 @@ class _MenuAnchorState extends State<MenuAnchor> with SingleTickerProviderStateM
 
     // Only inject the semantics node if a label is provided
     if (widget.semanticLabel != null) {
-      submenu = Semantics(container: true, label: widget.semanticLabel, child: submenu);
+      submenu = Semantics(
+        container: true,
+        explicitChildNodes: true,
+        label: widget.semanticLabel,
+        child: submenu,
+      );
     }
 
     // ExcludeSemantics, ExcludeFocus, and IgnorePointer are used to effectively

--- a/packages/material_ui/pending_changelogs/change_2026_09_09_1788954923085.yaml
+++ b/packages/material_ui/pending_changelogs/change_2026_09_09_1788954923085.yaml
@@ -1,0 +1,3 @@
+changelog: |
+  - Adds a semanticLabel to MenuAnchor for the expanded menu overlay.
+version: minor

--- a/packages/material_ui/test/menu_anchor_test.dart
+++ b/packages/material_ui/test/menu_anchor_test.dart
@@ -7004,6 +7004,36 @@ void main() {
     await tester.pump();
     expect(find.text('X'), findsOne);
   });
+
+  testWidgets('MenuAnchor applies semanticLabel to the expanded menu overlay', (
+    WidgetTester tester,
+  ) async {
+    final SemanticsHandle handle = tester.ensureSemantics();
+    final controller = MenuController();
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Material(
+          child: Center(
+            child: MenuAnchor(
+              controller: controller,
+              semanticLabel: 'Custom Menu Label',
+              menuChildren: const <Widget>[Text('Menu Item')],
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(find.bySemanticsLabel('Custom Menu Label'), findsNothing);
+
+    controller.open();
+    await tester.pumpAndSettle();
+
+    expect(find.bySemanticsLabel('Custom Menu Label'), findsOneWidget);
+
+    handle.dispose();
+  });
 }
 
 List<Widget> createTestMenus({


### PR DESCRIPTION
Ports flutter/flutter#185475 to `material_ui`, following the instructions in flutter/flutter#188444. The commits were cherry-picked from the original PR, with only file paths adjusted for this repo.

`MenuAnchor` had no way to label the expanded menu overlay, so screen readers announced nothing useful when a menu opened. This adds a `semanticLabel` property, applied to a `Semantics` node wrapping the submenu in `_buildOverlay`, and only when a label is provided.

The original PR also announced the label with `SemanticsService.announce` when the menu opened. Following @chunhtai's review feedback on flutter/flutter#185475, that part is dropped here: a semantics label should not double as announcement text, and anyone who wants an announcement can call `SemanticsService.announce` from `onOpen`. The last commit on this branch removes it.

## Tests

New test `MenuAnchor applies semanticLabel to the expanded menu overlay` in `packages/material_ui/test/menu_anchor_test.dart`, checking that the label is absent before the menu opens and present once it expands. The `menu_anchor.0` API example now sets a `semanticLabel`, and its example test still passes.

Fixes flutter/flutter#184876

Supersedes flutter/flutter#185475, which will be closed with a pointer to this PR.

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under[^1].
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[the version and CHANGELOG instructions]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version-and-changelog-updates
[semantic versioning]: https://dart.dev/tools/pub/versioning#semantic-versions
[repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
