### PR TITLE
[pointer_interceptor] Remove unnecessary Material and Cupertino imports

### DIFF
--- a/packages/pointer_interceptor/pointer_interceptor/CHANGELOG.md
+++ b/packages/pointer_interceptor/pointer_interceptor/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## NEXT
 
+* Removes unnecessary Material and Cupertino imports.
 * Updates minimum supported SDK version to Flutter 3.38/Dart 3.10.
 * Updates README to reflect currently supported OS versions for the latest
   versions of the endorsed platform implementations.

--- a/packages/pointer_interceptor/pointer_interceptor/example/lib/platforms/native_widget_ios.dart
+++ b/packages/pointer_interceptor/pointer_interceptor/example/lib/platforms/native_widget_ios.dart
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart';
 
 /// A widget representing an underlying platform view.
 class NativeWidget extends StatelessWidget {

--- a/packages/pointer_interceptor/pointer_interceptor/example/lib/platforms/native_widget_web.dart
+++ b/packages/pointer_interceptor/pointer_interceptor/example/lib/platforms/native_widget_web.dart
@@ -4,7 +4,7 @@
 
 import 'dart:ui_web' as ui_web;
 
-import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 import 'package:web/web.dart' as web;
 
 /// The web.HTMLElement that will be rendered underneath the flutter UI.

--- a/packages/pointer_interceptor/pointer_interceptor_ios/CHANGELOG.md
+++ b/packages/pointer_interceptor/pointer_interceptor_ios/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## NEXT
 
+* Removes unnecessary Material imports.
 * Updates minimum supported SDK version to Flutter 3.38/Dart 3.10.
 
 ## 0.10.1+1

--- a/packages/pointer_interceptor/pointer_interceptor_ios/test/pointer_interceptor_ios_test.dart
+++ b/packages/pointer_interceptor/pointer_interceptor_ios/test/pointer_interceptor_ios_test.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:pointer_interceptor_ios/pointer_interceptor_ios.dart';
 
@@ -20,18 +20,15 @@ class TestAppState extends State<TestApp> {
 
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
-      home: Scaffold(
-        body: const Text('Body'),
-        floatingActionButton: FloatingActionButton(
-          onPressed: () {},
-          child: PointerInterceptorIOS().buildWidget(
-            child: TextButton(
-              onPressed: () => setState(() {
-                _buttonText = 'Clicked';
-              }),
-              child: Text(_buttonText),
-            ),
+    return Directionality(
+      textDirection: TextDirection.ltr,
+      child: Center(
+        child: PointerInterceptorIOS().buildWidget(
+          child: GestureDetector(
+            onTap: () => setState(() {
+              _buttonText = 'Clicked';
+            }),
+            child: Text(_buttonText),
           ),
         ),
       ),

--- a/packages/pointer_interceptor/pointer_interceptor_platform_interface/test/default_pointer_interceptor_test.dart
+++ b/packages/pointer_interceptor/pointer_interceptor_platform_interface/test/default_pointer_interceptor_test.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:flutter/cupertino.dart';
+import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:pointer_interceptor_platform_interface/pointer_interceptor_platform_interface.dart';
 

--- a/packages/pointer_interceptor/pointer_interceptor_platform_interface/test/pointer_interceptor_platform_test.dart
+++ b/packages/pointer_interceptor/pointer_interceptor_platform_interface/test/pointer_interceptor_platform_test.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:flutter/cupertino.dart';
+import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:pointer_interceptor_platform_interface/pointer_interceptor_platform_interface.dart';
 


### PR DESCRIPTION
Removes unnecessary `material` and `cupertino` imports from `pointer_interceptor`.

Part of: https://github.com/flutter/flutter/issues/191322

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR does not need version changes.
- [x] I updated `CHANGELOG.md` for this package.
- [x] I added new tests to check the change I am making, or this PR is test-exempt.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://claude.google.com/claude/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://discord.gg/flutter
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/master/docs/contributing/AI-Contribution-Guidelines.md
