### PR TITLE
[flutter_svg] Remove unnecessary Material imports

### DIFF
--- a/third_party/packages/flutter_svg/CHANGELOG.md
+++ b/third_party/packages/flutter_svg/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## NEXT
 
+* Removes unnecessary Material imports.
 * Updates minimum supported SDK version to Flutter 3.38/Dart 3.10.
 
 ## 2.3.0

--- a/third_party/packages/flutter_svg/example/test/readme_excerpts_test.dart
+++ b/third_party/packages/flutter_svg/example/test/readme_excerpts_test.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 import 'package:flutter_svg_example/readme_excerpts.dart' as excerpts;
 import 'package:flutter_test/flutter_test.dart';
 

--- a/third_party/packages/flutter_svg/test/no_width_height_test.dart
+++ b/third_party/packages/flutter_svg/test/no_width_height_test.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 
 import 'package:flutter_test/flutter_test.dart';
@@ -64,7 +64,7 @@ class ImageWithText extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final Widget image = SvgPicture.string(circleSvg);
-    final Widget imageContainer = ColoredBox(color: Colors.amber, child: image);
+    final Widget imageContainer = ColoredBox(color: const Color(0xFFFFC107), child: image);
     const Widget text = Text('Hello');
     final Widget column = Column(children: <Widget>[imageContainer, text]);
     return Expanded(child: column);


### PR DESCRIPTION
Removes unnecessary `material` imports from `flutter_svg`.

Part of: https://github.com/flutter/flutter/issues/191322

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR does not need version changes.
- [x] I updated `CHANGELOG.md` for this package.
- [x] I added new tests to check the change I am making, or this PR is test-exempt.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[CLA]: https://claude.google.com/claude/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://discord.gg/flutter
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/master/docs/contributing/AI-Contribution-Guidelines.md
