### PR TITLE
[web_benchmarks] Migrate test_app to material_ui

### DIFF
--- a/packages/web_benchmarks/testing/test_app/benchmark/test_infra/automator.dart
+++ b/packages/web_benchmarks/testing/test_app/benchmark/test_infra/automator.dart
@@ -7,8 +7,8 @@
 import 'dart:async';
 
 import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:test_app/home_page.dart' show aboutPageKey, textKey;
 import 'package:test_app/main.dart';
 import 'package:web/web.dart';

--- a/packages/web_benchmarks/testing/test_app/benchmark/test_infra/recorder.dart
+++ b/packages/web_benchmarks/testing/test_app/benchmark/test_infra/recorder.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:web_benchmarks/client.dart';
 
 import 'automator.dart';

--- a/packages/web_benchmarks/testing/test_app/lib/about_page.dart
+++ b/packages/web_benchmarks/testing/test_app/lib/about_page.dart
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
+import 'package:material_ui/material_ui.dart';
 
 class AboutPage extends StatelessWidget {
   const AboutPage({super.key});

--- a/packages/web_benchmarks/testing/test_app/lib/home_page.dart
+++ b/packages/web_benchmarks/testing/test_app/lib/home_page.dart
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
+import 'package:material_ui/material_ui.dart';
 
 const ValueKey<String> textKey = ValueKey<String>('textKey');
 const ValueKey<String> aboutPageKey = ValueKey<String>('aboutPageKey');

--- a/packages/web_benchmarks/testing/test_app/lib/main.dart
+++ b/packages/web_benchmarks/testing/test_app/lib/main.dart
@@ -2,9 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:flutter/material.dart';
 import 'package:flutter_web_plugins/url_strategy.dart';
 import 'package:go_router/go_router.dart';
+import 'package:material_ui/material_ui.dart';
 
 import 'about_page.dart';
 import 'home_page.dart';

--- a/packages/web_benchmarks/testing/test_app/pubspec.yaml
+++ b/packages/web_benchmarks/testing/test_app/pubspec.yaml
@@ -6,7 +6,8 @@ publish_to: 'none'
 version: 1.0.0+1
 
 environment:
-  sdk: ^3.10.0
+  sdk: ^3.12.0
+  flutter: ">=3.44.0"
 
 dependencies:
   flutter:
@@ -14,6 +15,7 @@ dependencies:
   flutter_web_plugins:
     sdk: flutter
   go_router: ^14.2.7
+  material_ui: ^1.0.0
 
 dev_dependencies:
   flutter_lints: ^4.0.0


### PR DESCRIPTION
Migrates `web_benchmarks/testing/test_app` to use `package:material_ui` and updates minimum supported SDK version to Flutter 3.44/Dart 3.12.

Part of: https://github.com/flutter/flutter/issues/191322

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under[^1].
- [ ] I updated/added any relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[the version and CHANGELOG instructions]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version-and-changelog-updates
[semantic versioning]: https://dart.dev/tools/pub/versioning#semantic-versions
[repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests