### PR TITLE
[cupertino_ui]Add awaitNotRequired to Future-returning callsites without await

### DIFF
--- a/packages/cupertino_ui/lib/src/route.dart
+++ b/packages/cupertino_ui/lib/src/route.dart
@@ -1344,6 +1344,7 @@ class CupertinoModalPopupRoute<T> extends PopupRoute<T> {
 ///  * [CupertinoActionSheet], which is the widget usually returned by the
 ///    `builder` argument to [showCupertinoModalPopup].
 ///  * <https://developer.apple.com/design/human-interface-guidelines/ios/views/action-sheets/>
+@awaitNotRequired
 Future<T?> showCupertinoModalPopup<T>({
   required BuildContext context,
   required WidgetBuilder builder,
@@ -1447,6 +1448,7 @@ Widget _buildCupertinoDialogTransitions(
 ///  * [DisplayFeatureSubScreen], which documents the specifics of how
 ///    [DisplayFeature]s can split the screen into sub-screens.
 ///  * <https://developer.apple.com/design/human-interface-guidelines/alerts/>
+@awaitNotRequired
 Future<T?> showCupertinoDialog<T>({
   required BuildContext context,
   required WidgetBuilder builder,

--- a/packages/cupertino_ui/pending_changelogs/change_2026_09_09_1788989701571.yaml
+++ b/packages/cupertino_ui/pending_changelogs/change_2026_09_09_1788989701571.yaml
@@ -1,0 +1,3 @@
+changelog: |
+  - Adds awaitNotRequired annotation to showCupertinoModalPopup and showCupertinoDialog.
+version: patch


### PR DESCRIPTION
cupertino_ui split of [Add awaitNotRequired annotation to Material/Cupertino libraries](https://github.com/flutter/flutter/pull/185446)

Part of [Use @awaitNotRequired in Flutter SDK](https://github.com/flutter/flutter/issues/168555)
