### PR TITLE
[material_ui] Add trailingIconVisibility to ExpansionPanel (#179167)

### DIFF
--- a/packages/material_ui/example/lib/expansion_panel/expansion_panel_list.1.dart
+++ b/packages/material_ui/example/lib/expansion_panel/expansion_panel_list.1.dart
@@ -1,0 +1,128 @@
+// Copyright 2013 The Flutter Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// #region body
+import 'package:material_ui/material_ui.dart';
+
+/// Flutter code sample for [ExpansionPanel.trailingIconVisibility].
+
+void main() => runApp(const ExpansionPanelIconVisibilityExampleApp());
+
+class ExpansionPanelIconVisibilityExampleApp extends StatelessWidget {
+  const ExpansionPanelIconVisibilityExampleApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      home: Scaffold(
+        appBar: AppBar(title: const Text('ExpansionPanel Icon Visibility')),
+        body: const ExpansionPanelIconVisibilityExample(),
+      ),
+    );
+  }
+}
+
+class ExpansionPanelIconVisibilityExample extends StatefulWidget {
+  const ExpansionPanelIconVisibilityExample({super.key});
+
+  @override
+  State<ExpansionPanelIconVisibilityExample> createState() =>
+      _ExpansionPanelIconVisibilityExampleState();
+}
+
+class _ExpansionPanelIconVisibilityExampleState
+    extends State<ExpansionPanelIconVisibilityExample> {
+  ExpansionPanelIconVisibility _visibility = .visible;
+  bool _canTapOnHeader = false;
+  final List<bool> _isExpanded = <bool>[false, false, false];
+
+  @override
+  Widget build(BuildContext context) {
+    return SingleChildScrollView(
+      child: Column(
+        children: <Widget>[
+          const SizedBox(height: 24),
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16),
+            child: Column(
+              children: <Widget>[
+                SegmentedButton<ExpansionPanelIconVisibility>(
+                  segments: const <ButtonSegment<ExpansionPanelIconVisibility>>[
+                    ButtonSegment<ExpansionPanelIconVisibility>(
+                      value: .visible,
+                      label: Text('Visible'),
+                    ),
+                    ButtonSegment<ExpansionPanelIconVisibility>(
+                      value: .hidden,
+                      label: Text('Hidden'),
+                    ),
+                    ButtonSegment<ExpansionPanelIconVisibility>(
+                      value: .gone,
+                      label: Text('Gone'),
+                    ),
+                  ],
+                  selected: <ExpansionPanelIconVisibility>{_visibility},
+                  onSelectionChanged:
+                      (Set<ExpansionPanelIconVisibility> selected) {
+                        setState(() {
+                          _visibility = selected.first;
+                        });
+                      },
+                ),
+                const SizedBox(height: 12),
+                SwitchListTile(
+                  title: const Text('canTapOnHeader'),
+                  value: _canTapOnHeader,
+                  onChanged: (bool value) {
+                    setState(() {
+                      _canTapOnHeader = value;
+                    });
+                  },
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(height: 24),
+          ExpansionPanelList(
+            expansionCallback: (int index, bool isExpanded) {
+              setState(() {
+                _isExpanded[index] = isExpanded;
+              });
+            },
+            children: <ExpansionPanel>[
+              for (int i = 0; i < 3; i++)
+                ExpansionPanel(
+                  trailingIconVisibility: _visibility,
+                  canTapOnHeader: _canTapOnHeader,
+                  headerBuilder: (BuildContext context, bool isExpanded) {
+                    return ListTile(
+                      title: Text('Panel ${i + 1}'),
+                      trailing: Container(
+                        width: 8,
+                        height: 8,
+                        decoration: BoxDecoration(
+                          color: Theme.of(context).colorScheme.primary,
+                          shape: BoxShape.circle,
+                        ),
+                      ),
+                    );
+                  },
+                  body: ListTile(
+                    title: Text('Panel ${i + 1} content'),
+                    subtitle: const Text(
+                      'When the icon visibility is hidden, the space is preserved. '
+                      'When gone, the space is removed.',
+                    ),
+                  ),
+                  isExpanded: _isExpanded[i],
+                ),
+            ],
+          ),
+          const SizedBox(height: 24),
+        ],
+      ),
+    );
+  }
+}
+// #endregion body

--- a/packages/material_ui/example/test/expansion_panel/expansion_panel_list.1_test.dart
+++ b/packages/material_ui/example/test/expansion_panel/expansion_panel_list.1_test.dart
@@ -1,0 +1,42 @@
+// Copyright 2013 The Flutter Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:material_ui/material_ui.dart';
+import 'package:material_ui_examples/expansion_panel/expansion_panel_list.1.dart'
+    as example;
+
+void main() {
+  testWidgets('ExpansionPanel icon visibility can be toggled', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(
+      const example.ExpansionPanelIconVisibilityExampleApp(),
+    );
+
+    expect(find.byType(ExpandIcon), findsNWidgets(3));
+
+    final Finder visibilityFinder = find
+        .ancestor(
+          of: find.byType(ExpandIcon).first,
+          matching: find.byType(Visibility),
+        )
+        .first;
+
+    Visibility visibility = tester.widget(visibilityFinder);
+    expect(visibility.visible, isTrue);
+
+    await tester.tap(find.text('Hidden'));
+    await tester.pumpAndSettle();
+
+    visibility = tester.widget(visibilityFinder);
+    expect(visibility.visible, isFalse);
+    expect(visibility.maintainSize, isTrue);
+
+    await tester.tap(find.text('Gone'));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(ExpandIcon), findsNothing);
+  });
+}

--- a/packages/material_ui/lib/src/expansion_panel.dart
+++ b/packages/material_ui/lib/src/expansion_panel.dart
@@ -58,6 +58,20 @@ typedef ExpansionPanelCallback = void Function(int panelIndex, bool isExpanded);
 /// [ExpansionPanel] needs to rebuild.
 typedef ExpansionPanelHeaderBuilder = Widget Function(BuildContext context, bool isExpanded);
 
+/// Controls the visibility of the trailing expand/collapse icon in an
+/// [ExpansionPanel].
+enum ExpansionPanelIconVisibility {
+  /// The icon is visible and interactive.
+  visible,
+
+  /// The icon is hidden, but its layout space is preserved to maintain
+  /// alignment with other panels.
+  hidden,
+
+  /// The icon is hidden and its layout space is removed.
+  gone,
+}
+
 /// A material expansion panel. It has a header and a body and can be either
 /// expanded or collapsed. The body of the panel is only visible when it is
 /// expanded.
@@ -68,6 +82,17 @@ typedef ExpansionPanelHeaderBuilder = Widget Function(BuildContext context, bool
 /// [ExpansionPanelList].
 ///
 /// See [ExpansionPanelList] for a sample implementation.
+///
+/// <callout-box>
+///
+/// This example demonstrates how to use [trailingIconVisibility] to control
+/// the visibility of the expand/collapse icon.
+///
+/// {@macro material_ui.dartpad_guide}
+///
+/// {@example /example/lib/expansion_panel/expansion_panel_list.1.dart#body}
+///
+/// </callout-box>
 ///
 /// See also:
 ///
@@ -84,6 +109,7 @@ class ExpansionPanel {
     this.backgroundColor,
     this.splashColor,
     this.highlightColor,
+    this.trailingIconVisibility = ExpansionPanelIconVisibility.visible,
   });
 
   /// The widget builder that builds the expansion panels' header.
@@ -130,6 +156,16 @@ class ExpansionPanel {
   ///
   /// Defaults to [ThemeData.cardColor].
   final Color? backgroundColor;
+
+  /// Controls the visibility of the trailing expand/collapse icon.
+  ///
+  /// When set to [ExpansionPanelIconVisibility.hidden], the icon is not
+  /// rendered but its layout space is preserved for alignment. When set to
+  /// [ExpansionPanelIconVisibility.gone], both the icon and its space are
+  /// removed.
+  ///
+  /// Defaults to [ExpansionPanelIconVisibility.visible].
+  final ExpansionPanelIconVisibility trailingIconVisibility;
 }
 
 /// An expansion panel that allows for radio-like functionality.
@@ -153,6 +189,7 @@ class ExpansionPanelRadio extends ExpansionPanel {
     super.backgroundColor,
     super.splashColor,
     super.highlightColor,
+    super.trailingIconVisibility,
   });
 
   /// The value that uniquely identifies a radio panel so that the currently
@@ -406,22 +443,31 @@ class _ExpansionPanelListState extends State<ExpansionPanelList> {
       final ExpansionPanel child = widget.children[index];
       final Widget headerWidget = child.headerBuilder(context, _isChildExpanded(index));
 
-      Widget expandIconPadded = Padding(
-        padding: const EdgeInsetsDirectional.only(end: 8.0),
-        child: IgnorePointer(
-          ignoring: child.canTapOnHeader,
-          child: ExpandIcon(
-            color: widget.expandIconColor,
-            isExpanded: _isChildExpanded(index),
-            padding: _kExpandIconPadding,
-            splashColor: child.splashColor,
-            highlightColor: child.highlightColor,
-            onPressed: (bool isExpanded) => _handlePressed(isExpanded, index),
+      final iconVisible = child.trailingIconVisibility == .visible;
+      final iconMaintainSize = child.trailingIconVisibility == .hidden;
+
+      Widget expandIconPadded = Visibility(
+        visible: iconVisible,
+        maintainSize: iconMaintainSize,
+        maintainAnimation: iconMaintainSize,
+        maintainState: iconMaintainSize,
+        child: Padding(
+          padding: const EdgeInsetsDirectional.only(end: 8.0),
+          child: IgnorePointer(
+            ignoring: child.canTapOnHeader,
+            child: ExpandIcon(
+              color: widget.expandIconColor,
+              isExpanded: _isChildExpanded(index),
+              padding: _kExpandIconPadding,
+              splashColor: child.splashColor,
+              highlightColor: child.highlightColor,
+              onPressed: (bool isExpanded) => _handlePressed(isExpanded, index),
+            ),
           ),
         ),
       );
 
-      if (!child.canTapOnHeader) {
+      if (!child.canTapOnHeader && iconVisible) {
         final MaterialLocalizations localizations = MaterialLocalizations.of(context);
         expandIconPadded = Semantics(
           label: _isChildExpanded(index)

--- a/packages/material_ui/pending_changelogs/expansion_panel_trailing_icon_visibility.yaml
+++ b/packages/material_ui/pending_changelogs/expansion_panel_trailing_icon_visibility.yaml
@@ -1,0 +1,3 @@
+changelog: |
+  - Adds `ExpansionPanel.trailingIconVisibility` to control expand/collapse icon visibility.
+version: minor

--- a/packages/material_ui/test/expansion_panel_test.dart
+++ b/packages/material_ui/test/expansion_panel_test.dart
@@ -2087,4 +2087,154 @@ void main() {
     final IgnorePointer ignorePointerTrue = tester.widget(ignorePointerFinder);
     expect(ignorePointerTrue.ignoring, isTrue);
   });
+
+  testWidgets('ExpansionPanel hides icon but preserves space with trailingIconVisibility.hidden', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: SingleChildScrollView(
+          child: ExpansionPanelList(
+            children: <ExpansionPanel>[
+              ExpansionPanel(
+                trailingIconVisibility: ExpansionPanelIconVisibility.hidden,
+                headerBuilder: (BuildContext context, bool isExpanded) {
+                  return const ListTile(title: Text('Panel'));
+                },
+                body: const ListTile(title: Text('Content')),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    final Finder visibilityFinder = find
+        .ancestor(of: find.byType(ExpandIcon), matching: find.byType(Visibility))
+        .first;
+
+    final Visibility visibility = tester.widget(visibilityFinder);
+    expect(visibility.visible, isFalse);
+    expect(visibility.maintainSize, isTrue);
+    expect(visibility.maintainAnimation, isTrue);
+    expect(visibility.maintainState, isTrue);
+
+    expect(find.byType(ExpandIcon), findsOneWidget);
+  });
+
+  testWidgets('ExpansionPanel removes icon and space with trailingIconVisibility.gone', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: SingleChildScrollView(
+          child: ExpansionPanelList(
+            children: <ExpansionPanel>[
+              ExpansionPanel(
+                trailingIconVisibility: ExpansionPanelIconVisibility.gone,
+                headerBuilder: (BuildContext context, bool isExpanded) {
+                  return const ListTile(title: Text('Panel'));
+                },
+                body: const ListTile(title: Text('Content')),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    expect(find.byType(ExpandIcon), findsNothing);
+  });
+
+  testWidgets('ExpansionPanel shows icon by default with trailingIconVisibility.visible', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: SingleChildScrollView(
+          child: ExpansionPanelList(
+            children: <ExpansionPanel>[
+              ExpansionPanel(
+                headerBuilder: (BuildContext context, bool isExpanded) {
+                  return const ListTile(title: Text('Panel'));
+                },
+                body: const ListTile(title: Text('Content')),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    final Finder visibilityFinder = find
+        .ancestor(of: find.byType(ExpandIcon), matching: find.byType(Visibility))
+        .first;
+
+    final Visibility visibility = tester.widget(visibilityFinder);
+    expect(visibility.visible, isTrue);
+  });
+
+  testWidgets('ExpansionPanel icon has semantics label when visible and canTapOnHeader is false', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: SingleChildScrollView(
+          child: ExpansionPanelList(
+            children: <ExpansionPanel>[
+              ExpansionPanel(
+                headerBuilder: (BuildContext context, bool isExpanded) {
+                  return const ListTile(title: Text('Panel'));
+                },
+                body: const ListTile(title: Text('Content')),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    final Finder semanticsFinder = find.ancestor(
+      of: find.byType(ExpandIcon),
+      matching: find.byType(Semantics),
+    );
+    expect(semanticsFinder, findsWidgets);
+
+    final Semantics semantics = tester
+        .widgetList<Semantics>(semanticsFinder)
+        .firstWhere((Semantics s) => s.properties.label != null && s.properties.label!.isNotEmpty);
+    expect(semantics.properties.label, isNotNull);
+  });
+
+  testWidgets('ExpansionPanel icon has no semantics label when hidden', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: SingleChildScrollView(
+          child: ExpansionPanelList(
+            children: <ExpansionPanel>[
+              ExpansionPanel(
+                trailingIconVisibility: ExpansionPanelIconVisibility.hidden,
+                headerBuilder: (BuildContext context, bool isExpanded) {
+                  return const ListTile(title: Text('Panel'));
+                },
+                body: const ListTile(title: Text('Content')),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    final Finder semanticsFinder = find.ancestor(
+      of: find.byType(ExpandIcon),
+      matching: find.byType(Semantics),
+    );
+    final Iterable<Semantics> semanticsList = tester.widgetList<Semantics>(semanticsFinder);
+    final bool hasExpandCollapseLabel = semanticsList.any(
+      (Semantics s) => s.properties.label != null && s.properties.label!.isNotEmpty,
+    );
+    expect(hasExpandCollapseLabel, isFalse);
+  });
 }


### PR DESCRIPTION
Ports https://github.com/flutter/flutter/pull/183951 to `material_ui`, following the instructions in flutter/flutter#188444.

## Description

Introduces the `ExpansionPanelIconVisibility` enum (`visible`, `hidden`, `gone`) to `ExpansionPanel.trailingIconVisibility`. 

This allows controlling whether the trailing expand/collapse icon is visible, hidden (preserving its layout space for alignment), or gone (removed from layout completely).

Fixes https://github.com/flutter/flutter/issues/179167
Supersedes https://github.com/flutter/flutter/pull/183951

cc @dkwingsmt @victorsanni  who previously reviewed and approved the original PR in flutter/flutter#183951.

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under[^1].
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[the version and CHANGELOG instructions]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version-and-changelog-updates
[semantic versioning]: https://dart.dev/tools/pub/versioning#semantic-versions
[repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests