### PR TITLE
[material_ui] Keep ExpansionPanelList dividers when expanded with 0 materialGapSize (#183974)

### DIFF
--- a/packages/material_ui/example/lib/expansion_panel/expansion_panel_list.2.dart
+++ b/packages/material_ui/example/lib/expansion_panel/expansion_panel_list.2.dart
@@ -1,0 +1,96 @@
+// Copyright 2013 The Flutter Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// #region body
+import 'package:material_ui/material_ui.dart';
+
+/// Flutter code sample for a flat [ExpansionPanelList] with divider separators.
+
+void main() => runApp(const FlatExpansionPanelListExampleApp());
+
+class FlatExpansionPanelListExampleApp extends StatelessWidget {
+  const FlatExpansionPanelListExampleApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      home: Scaffold(
+        appBar: AppBar(title: const Text('Flat ExpansionPanelList Sample')),
+        body: const Center(child: FlatExpansionPanelListExample()),
+      ),
+    );
+  }
+}
+
+class FlatExpansionPanelListExample extends StatefulWidget {
+  const FlatExpansionPanelListExample({super.key});
+
+  @override
+  State<FlatExpansionPanelListExample> createState() =>
+      _FlatExpansionPanelListExampleState();
+}
+
+class _FlatExpansionPanelListExampleState
+    extends State<FlatExpansionPanelListExample> {
+  final List<bool> _isExpanded = <bool>[false, false, false];
+
+  @override
+  Widget build(BuildContext context) {
+    return SingleChildScrollView(
+      child: Padding(
+        padding: const .all(16.0),
+        child: Column(
+          children: <Widget>[
+            const Padding(
+              padding: .only(bottom: 16.0),
+              child: Text(
+                'With materialGapSize set to 0, dividers between expanded panels are '
+                'preserved, creating a flat list appearance.',
+                textAlign: .center,
+              ),
+            ),
+            Card(
+              child: ExpansionPanelList(
+                materialGapSize: 0,
+                expandedHeaderPadding: .zero,
+                expansionCallback: (int index, bool isExpanded) {
+                  setState(() {
+                    _isExpanded[index] = isExpanded;
+                  });
+                },
+                children: <ExpansionPanel>[
+                  ExpansionPanel(
+                    headerBuilder: (BuildContext context, bool isExpanded) {
+                      return const ListTile(title: Text('Panel A'));
+                    },
+                    body: const ListTile(title: Text('Content for Panel A')),
+                    isExpanded: _isExpanded[0],
+                    canTapOnHeader: true,
+                  ),
+                  ExpansionPanel(
+                    headerBuilder: (BuildContext context, bool isExpanded) {
+                      return const ListTile(title: Text('Panel B'));
+                    },
+                    body: const ListTile(title: Text('Content for Panel B')),
+                    isExpanded: _isExpanded[1],
+                    canTapOnHeader: true,
+                  ),
+                  ExpansionPanel(
+                    headerBuilder: (BuildContext context, bool isExpanded) {
+                      return const ListTile(title: Text('Panel C'));
+                    },
+                    body: const ListTile(title: Text('Content for Panel C')),
+                    isExpanded: _isExpanded[2],
+                    canTapOnHeader: true,
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+// #endregion body

--- a/packages/material_ui/example/test/expansion_panel/expansion_panel_list.2_test.dart
+++ b/packages/material_ui/example/test/expansion_panel/expansion_panel_list.2_test.dart
@@ -1,0 +1,26 @@
+// Copyright 2013 The Flutter Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:material_ui/material_ui.dart';
+import 'package:material_ui_examples/expansion_panel/expansion_panel_list.2.dart'
+    as example;
+
+void main() {
+  testWidgets(
+    'Flat ExpansionPanelList preserves dividers with no MaterialGap',
+    (WidgetTester tester) async {
+      await tester.pumpWidget(const example.FlatExpansionPanelListExampleApp());
+
+      await tester.tap(find.text('Panel A'));
+      await tester.pumpAndSettle();
+
+      final MergeableMaterial mergeableMaterial = tester.widget(
+        find.byType(MergeableMaterial),
+      );
+      expect(mergeableMaterial.children.whereType<MaterialGap>().length, 0);
+      expect(mergeableMaterial.hasDividers, true);
+    },
+  );
+}

--- a/packages/material_ui/lib/src/expansion_panel.dart
+++ b/packages/material_ui/lib/src/expansion_panel.dart
@@ -292,6 +292,19 @@ class ExpansionPanelList extends StatefulWidget {
   /// Defines the [MaterialGap.size] of the [MaterialGap] which is placed
   /// between the [ExpansionPanelList.children] when they're expanded.
   ///
+  /// When set to zero, no [MaterialGap] is inserted between expanded panels
+  /// and dividers are preserved, allowing a flat, divider-separated appearance.
+  ///
+  /// <callout-box>
+  ///
+  /// Here is an example with [materialGapSize] set to zero.
+  ///
+  /// {@macro material_ui.dartpad_guide}
+  ///
+  /// {@example /example/lib/expansion_panel/expansion_panel_list.2.dart#body}
+  ///
+  /// </callout-box>
+  ///
   /// Defaults to `16.0`.
   final double materialGapSize;
 
@@ -392,9 +405,13 @@ class _ExpansionPanelListState extends State<ExpansionPanelList> {
     );
 
     final items = <MergeableMaterialItem>[];
+    final bool shouldInsertMaterialGap = widget.materialGapSize > 0;
 
     for (var index = 0; index < widget.children.length; index += 1) {
-      if (_isChildExpanded(index) && index != 0 && !_isChildExpanded(index - 1)) {
+      if (_isChildExpanded(index) &&
+          index != 0 &&
+          !_isChildExpanded(index - 1) &&
+          shouldInsertMaterialGap) {
         items.add(
           MaterialGap(
             key: _SaltedKey<BuildContext, int>(context, index * 2 - 1),
@@ -483,7 +500,9 @@ class _ExpansionPanelListState extends State<ExpansionPanelList> {
         ),
       );
 
-      if (_isChildExpanded(index) && index != widget.children.length - 1) {
+      if (_isChildExpanded(index) &&
+          index != widget.children.length - 1 &&
+          shouldInsertMaterialGap) {
         items.add(
           MaterialGap(
             key: _SaltedKey<BuildContext, int>(context, index * 2 + 1),

--- a/packages/material_ui/pending_changelogs/expansion_panel_retain_dividers.yaml
+++ b/packages/material_ui/pending_changelogs/expansion_panel_retain_dividers.yaml
@@ -1,0 +1,4 @@
+changelog: |
+  - Keeps `ExpansionPanelList` dividers when expanded if `materialGapSize` is 0.
+version: minor
+

--- a/packages/material_ui/test/expansion_panel_test.dart
+++ b/packages/material_ui/test/expansion_panel_test.dart
@@ -1938,14 +1938,9 @@ void main() {
     await tester.pumpWidget(buildWidgetForTest(materialGapSize: 0));
     await tester.pumpAndSettle();
     final MergeableMaterial mergeableMaterial = tester.widget(find.byType(MergeableMaterial));
-    expect(mergeableMaterial.children.length, 3);
-    expect(mergeableMaterial.children.whereType<MaterialGap>().length, 1);
+    expect(mergeableMaterial.children.length, 2);
+    expect(mergeableMaterial.children.whereType<MaterialGap>().length, 0);
     expect(mergeableMaterial.children.whereType<MaterialSlice>().length, 2);
-    for (final MergeableMaterialItem e in mergeableMaterial.children) {
-      if (e is MaterialGap) {
-        expect(e.size, 0);
-      }
-    }
 
     await tester.pumpWidget(buildWidgetForTest(materialGapSize: 20));
     await tester.pumpAndSettle();
@@ -1970,6 +1965,56 @@ void main() {
         expect(e.size, 16);
       }
     }
+  });
+
+  Future<void> pumpExpansionPanelListAndVerifyGaps(
+    WidgetTester tester, {
+    required double materialGapSize,
+    required int expectedGapCount,
+  }) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: SingleChildScrollView(
+          child: ExpansionPanelList(
+            materialGapSize: materialGapSize,
+            children: <ExpansionPanel>[
+              ExpansionPanel(
+                isExpanded: true,
+                canTapOnHeader: true,
+                body: const SizedBox.shrink(),
+                headerBuilder: (BuildContext context, bool isExpanded) {
+                  return const SizedBox.shrink();
+                },
+              ),
+              ExpansionPanel(
+                canTapOnHeader: true,
+                body: const SizedBox.shrink(),
+                headerBuilder: (BuildContext context, bool isExpanded) {
+                  return const SizedBox.shrink();
+                },
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final MergeableMaterial mergeableMaterial = tester.widget(find.byType(MergeableMaterial));
+    expect(mergeableMaterial.children.whereType<MaterialGap>().length, expectedGapCount);
+    expect(mergeableMaterial.children.whereType<MaterialSlice>().length, 2);
+  }
+
+  testWidgets('ExpansionPanelList does not insert MaterialGap when materialGapSize is 0', (
+    WidgetTester tester,
+  ) async {
+    await pumpExpansionPanelListAndVerifyGaps(tester, materialGapSize: 0, expectedGapCount: 0);
+  });
+
+  testWidgets('ExpansionPanelList inserts MaterialGap when materialGapSize is greater than 0', (
+    WidgetTester tester,
+  ) async {
+    await pumpExpansionPanelListAndVerifyGaps(tester, materialGapSize: 16, expectedGapCount: 1);
   });
 
   testWidgets(


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/183974
Supersedes https://github.com/flutter/flutter/pull/183975

Ports the change originally submitted in https://github.com/flutter/flutter/pull/183975 to `packages/material_ui`.

cc @dkwingsmt @victorsanni who previously reviewed and approved the original PR in https://github.com/flutter/flutter/pull/183975.

### Description
When `ExpansionPanelList.materialGapSize` is set to `0`, `MaterialGap` is no longer inserted between expanded panels. This allows `MergeableMaterial` to preserve the dividers between adjacent expanded panels, creating a clean flat list appearance (ideal for nested lists or panels within cards).

This is the end result of the PR (before it, the dividers between panels were absent):
<img width="2210" height="1260" alt="CleanShot 2026-09-10 at 17 17 05@2x" src="https://github.com/user-attachments/assets/73a91b4e-edaf-4d21-afa4-43709b2e25af" />


- Guarded `MaterialGap` insertion in `ExpansionPanelList` with `materialGapSize > 0`.
- Documented zero-gap behavior in `materialGapSize` with a `<callout-box>`.
- Added example sample (`expansion_panel_list.2.dart`) and widget tests.
- Updated `expansion_panel_test.dart` to verify gap insertion and zero-gap divider retention.
- Added pending changelog entry.

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under[^1].
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[the version and CHANGELOG instructions]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version-and-changelog-updates
[semantic versioning]: https://dart.dev/tools/pub/versioning#semantic-versions
[repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests