### PR TITLE
[material_ui] Port PR (#187366) from flutter/flutter to material_ui

### DIFF
--- a/packages/material_ui/lib/src/dropdown.dart
+++ b/packages/material_ui/lib/src/dropdown.dart
@@ -15,6 +15,7 @@ import 'dart:ui';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/rendering.dart';
+import 'package:flutter/scheduler.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 
@@ -1588,8 +1589,23 @@ class _DropdownButtonState<T> extends State<DropdownButton<T>> with WidgetsBindi
     final Orientation newOrientation = _getOrientation(context);
     _lastOrientation ??= newOrientation;
     if (newOrientation != _lastOrientation) {
-      _removeDropdownRoute();
       _lastOrientation = newOrientation;
+      // The open menu's layout is computed for the previous orientation, so it
+      // must be dismissed. Removing the route mutates the Navigator, which is
+      // not allowed during build, so defer the dismissal until after the
+      // current frame when we are in the persistent callbacks phase.
+      // See https://github.com/flutter/flutter/issues/171011
+      if (_dropdownRoute != null) {
+        if (SchedulerBinding.instance.schedulerPhase == SchedulerPhase.persistentCallbacks) {
+          WidgetsBinding.instance.addPostFrameCallback((Duration timeStamp) {
+            if (mounted) {
+              _removeDropdownRoute();
+            }
+          }, debugLabel: 'DropdownButton.dismissOnOrientationChange');
+        } else {
+          _removeDropdownRoute();
+        }
+      }
     }
 
     // The width of the button and the menu are defined by the widest

--- a/packages/material_ui/pending_changelogs/change_187366_dropdown_orientation_crash.yaml
+++ b/packages/material_ui/pending_changelogs/change_187366_dropdown_orientation_crash.yaml
@@ -1,0 +1,3 @@
+changelog: |
+  - Fixes a crash when a DropdownButton menu is open inside a dialog and the device orientation changes.
+version: patch

--- a/packages/material_ui/test/dropdown_test.dart
+++ b/packages/material_ui/test/dropdown_test.dart
@@ -1375,6 +1375,65 @@ void main() {
     },
   );
 
+  testWidgets(
+    'Dropdown menu opened inside a dialog is dismissed on orientation change without throwing',
+    (WidgetTester tester) async {
+      // Regression test for https://github.com/flutter/flutter/issues/171011
+      addTearDown(tester.view.reset);
+      tester.view.devicePixelRatio = 1.0;
+      tester.view.physicalSize = const Size(800, 600);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Builder(
+              builder: (BuildContext context) {
+                return Center(
+                  child: ElevatedButton(
+                    onPressed: () {
+                      showDialog<void>(
+                        context: context,
+                        builder: (BuildContext context) {
+                          return AlertDialog(
+                            content: DropdownButton<int>(
+                              value: 1,
+                              onChanged: (int? value) {},
+                              items: const <DropdownMenuItem<int>>[
+                                DropdownMenuItem<int>(value: 1, child: Text('1')),
+                                DropdownMenuItem<int>(value: 2, child: Text('2')),
+                                DropdownMenuItem<int>(value: 3, child: Text('3')),
+                              ],
+                            ),
+                          );
+                        },
+                      );
+                    },
+                    child: const Text('Open dialog'),
+                  ),
+                );
+              },
+            ),
+          ),
+        ),
+      );
+
+      // Open the dialog, then open the dropdown menu inside it.
+      await tester.tap(find.text('Open dialog'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.byType(DropdownButton<int>));
+      await tester.pumpAndSettle();
+      expect(find.byType(ListView), findsOneWidget);
+
+      // Rotate the device (simulate by swapping the physical size dimensions).
+      tester.view.physicalSize = const Size(600, 800);
+      await tester.pumpAndSettle();
+
+      // The route should be dismissed without mutating the Navigator during build.
+      expect(tester.takeException(), isNull);
+      expect(find.byType(ListView), findsNothing);
+    },
+  );
+
   testWidgets('Semantics Tree contains only selected element', (WidgetTester tester) async {
     final semantics = SemanticsTester(tester);
     await tester.pumpWidget(buildFrame(onChanged: onChanged));


### PR DESCRIPTION
This PR ports https://github.com/flutter/flutter/pull/187366 to `material_ui`.

When a `DropdownButton` menu is open (especially inside a dialog) and the device orientation changes, `_DropdownButtonState.build()` dismissed the route with `Navigator.removeRoute()` during build. That triggers `setState() or markNeedsBuild() called during build`.

The route is now removed synchronously unless we are in `SchedulerPhase.persistentCallbacks`, in which case removal is deferred to a post-frame callback.

Fixes https://github.com/flutter/flutter/issues/171011
Follows https://github.com/flutter/flutter/issues/188444

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under[^1].
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [x] All existing and new tests are passing.

