### PR TITLE
[material_ui] 1.2.0 sync back clean up

### DIFF
--- a/packages/material_ui/CHANGELOG.md
+++ b/packages/material_ui/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.2.0
+
+- Adds the `StyleVariant` enum defining the Material 3 and Material 3 Expressive style variants.
+
 ## 1.1.1
 
 - Constrains Slider and RangeSlider value indicator labels to the screen width, truncating with an ellipsis instead of clipping.

--- a/packages/material_ui/pending_changelogs/change_2026_09_01_1788300011018.yaml
+++ b/packages/material_ui/pending_changelogs/change_2026_09_01_1788300011018.yaml
@@ -1,3 +1,0 @@
-changelog: |
-  - Adds the `StyleVariant` enum defining the Material 3 and Material 3 Expressive style variants.
-version: minor

--- a/packages/material_ui/pubspec.yaml
+++ b/packages/material_ui/pubspec.yaml
@@ -1,6 +1,6 @@
 name: material_ui
 description: The official Flutter Material UI Library, implementing Google's Material Design design system.
-version: 1.1.1
+version: 1.2.0
 repository: https://github.com/flutter/packages/tree/main/packages/material_ui
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A%20material_ui%22
 


### PR DESCRIPTION

The previous sync back for 1.1.1 is landed after the 1.2.0 batch release is triggered. so 1.2.0 went out as if 1.1.1 is not there, you can see the changelog of 1.2.0 swallow the change log item from 1.1.1, while the 1.1.1's section is completely missing
<img width="1371" height="728" alt="image" src="https://github.com/user-attachments/assets/0278041c-1fa2-49aa-8cba-9bedd9db9c00" />

This pr cleans it up and restore the correct change log order 

## Pre-Review Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [ ] I read the [Tree Hygiene] page, which explains my responsibilities.
- [ ] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [ ] I signed the [CLA].
- [ ] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I [linked to at least one issue that this PR fixes] in the description above.
- [ ] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under[^1].
- [ ] I updated/added any relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[the version and CHANGELOG instructions]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version-and-changelog-updates
[semantic versioning]: https://dart.dev/tools/pub/versioning#semantic-versions
[repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
