### PR TITLE
[google_fonts] Decouple GoogleFontsLite for full tree-shaking and add full feature parity

### DIFF
--- a/packages/google_fonts/CHANGELOG.md
+++ b/packages/google_fonts/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## NEXT
 
+- Adds `config`, `pendingFonts`, and `getTextTheme` to `GoogleFontsLite`.
+- Decouples internal base library from the main entry point to ensure complete tree-shakability.
+- Adds code samples and documentation for `GoogleFontsLite`.
 - Adds the `GoogleFontsLite` class to allow tree-shaking unused font code.
 - Added fonts:
   - `Akt`

--- a/packages/google_fonts/README.md
+++ b/packages/google_fonts/README.md
@@ -115,10 +115,32 @@ return MaterialApp(
 ```
 
 ### Lower build size
-The `GoogleFontsLite` class is a replacement for the `GoogleFonts` class containing only a map of all fonts and the `getFont` function. Using *only* `GoogleFontsLite` allows the Dart compiler to tree-shake most of the package's code, yielding a significant reduction in build size.
+The `GoogleFontsLite` class is an alternative entry point containing only a map of all fonts and dynamic font resolution methods. Using *only* `GoogleFontsLite` allows the Dart compiler to tree-shake all unused font methods, yielding a significant reduction in build size.
+
+To allow the Dart compiler to tree-shake unused fonts, import `package:google_fonts/google_fonts_lite.dart` instead of `package:google_fonts/google_fonts.dart`.
+
+Do not import `package:google_fonts/google_fonts.dart` when optimizing for bundle size, as that imports the generated static font methods.
+
+<?code-excerpt "readme_excerpts.dart (GoogleFontsLite)"?>
+```dart
+Widget liteExamples(BuildContext context) {
+  return Column(
+    children: <Widget>[
+      // Single text style:
+      Text('Dynamic font with minimal bundle size', style: GoogleFontsLite.getFont('Lato')),
+      // Custom text theme:
+      Theme(
+        data: ThemeData(textTheme: GoogleFontsLite.getTextTheme('Lato')),
+        child: const Text('Themed text'),
+      ),
+    ],
+  );
+}
+```
+
 
 ### Visual font swapping
-To avoid visual font swaps that occur when a font is loading, use [FutureBuilder](https://api.flutter.dev/flutter/widgets/FutureBuilder-class.html) and [GoogleFonts.pendingFonts()](https://pub.dev/documentation/google_fonts/latest/google_fonts/GoogleFonts/pendingFonts.html).
+To avoid visual font swaps that occur when a font is loading, use [FutureBuilder](https://api.flutter.dev/flutter/widgets/FutureBuilder-class.html) and [GoogleFonts.pendingFonts()](https://pub.dev/documentation/google_fonts/latest/google_fonts/GoogleFonts/pendingFonts.html) (or `GoogleFontsLite.pendingFonts()`).
 
 See the [example app](https://pub.dev/packages/google_fonts/example).
 

--- a/packages/google_fonts/example/lib/readme_excerpts.dart
+++ b/packages/google_fonts/example/lib/readme_excerpts.dart
@@ -126,3 +126,19 @@ void main() {
 }
 
 // #enddocregion LicenseRegistration
+
+// #docregion GoogleFontsLite
+Widget liteExamples(BuildContext context) {
+  return Column(
+    children: <Widget>[
+      // Single text style:
+      Text('Dynamic font with minimal bundle size', style: GoogleFontsLite.getFont('Lato')),
+      // Custom text theme:
+      Theme(
+        data: ThemeData(textTheme: GoogleFontsLite.getTextTheme('Lato')),
+        child: const Text('Themed text'),
+      ),
+    ],
+  );
+}
+// #enddocregion GoogleFontsLite

--- a/packages/google_fonts/generator/google_fonts.tmpl
+++ b/packages/google_fonts/generator/google_fonts.tmpl
@@ -34,6 +34,9 @@ class GoogleFonts {
   /// ```dart
   /// GoogleFonts.config.allowRuntimeFetching = false;
   /// ```
+  ///
+  /// The underlying [sharedGoogleFontsConfig] is not exported or meant for
+  /// public consumption.
   static final GoogleFontsConfig config = sharedGoogleFontsConfig;
 
   /// Returns a [Future] which resolves when requested fonts have finished

--- a/packages/google_fonts/generator/google_fonts.tmpl
+++ b/packages/google_fonts/generator/google_fonts.tmpl
@@ -34,9 +34,6 @@ class GoogleFonts {
   /// ```dart
   /// GoogleFonts.config.allowRuntimeFetching = false;
   /// ```
-  ///
-  /// The underlying [sharedGoogleFontsConfig] is not exported or meant for
-  /// public consumption.
   static final GoogleFontsConfig config = sharedGoogleFontsConfig;
 
   /// Returns a [Future] which resolves when requested fonts have finished

--- a/packages/google_fonts/generator/google_fonts.tmpl
+++ b/packages/google_fonts/generator/google_fonts.tmpl
@@ -34,7 +34,7 @@ class GoogleFonts {
   /// ```dart
   /// GoogleFonts.config.allowRuntimeFetching = false;
   /// ```
-  static final GoogleFontsConfig config = GoogleFontsConfig();
+  static final GoogleFontsConfig config = sharedGoogleFontsConfig;
 
   /// Returns a [Future] which resolves when requested fonts have finished
   /// loading and are ready to be rendered on screen.

--- a/packages/google_fonts/generator/google_fonts_lite.tmpl
+++ b/packages/google_fonts/generator/google_fonts_lite.tmpl
@@ -28,9 +28,6 @@ abstract final class GoogleFontsLite {
   /// ```dart
   /// GoogleFontsLite.config.allowRuntimeFetching = false;
   /// ```
-  ///
-  /// The underlying [sharedGoogleFontsConfig] is not exported or meant for
-  /// public consumption.
   static final GoogleFontsConfig config = sharedGoogleFontsConfig;
 
   /// Returns a [Future] which resolves when requested fonts have finished

--- a/packages/google_fonts/generator/google_fonts_lite.tmpl
+++ b/packages/google_fonts/generator/google_fonts_lite.tmpl
@@ -159,11 +159,11 @@ abstract final class GoogleFontsLite {
   ///
   /// Note: [fontFamily] is case-sensitive.
   ///
-  /// Parameter [fontFamily] must not be `null`. Throws if no font by name
-  /// [fontFamily] exists.
+  /// Parameter [fontFamily] must not be `null`. Throws an [ArgumentError] if no
+  /// font by name [fontFamily] exists.
   static TextTheme getTextTheme(String fontFamily, [TextTheme? textTheme]) {
     if (!fontsMap.containsKey(fontFamily)) {
-      throw Exception("No font family by name '$fontFamily' was found.");
+      throw ArgumentError("No font family by name '$fontFamily' was found.");
     }
     textTheme ??= ThemeData.light().textTheme;
     return TextTheme(

--- a/packages/google_fonts/generator/google_fonts_lite.tmpl
+++ b/packages/google_fonts/generator/google_fonts_lite.tmpl
@@ -21,9 +21,16 @@ import 'google_fonts_variant.dart';
 abstract final class GoogleFontsLite {
   /// Configuration for the [GoogleFontsLite] library.
   ///
+  /// Use this to define custom behavior of the GoogleFonts library in your app.
+  /// For example, if you do not want the GoogleFonts library to make any HTTP
+  /// requests for fonts, add the following snippet to your app's `main` method.
+  ///
   /// ```dart
   /// GoogleFontsLite.config.allowRuntimeFetching = false;
   /// ```
+  ///
+  /// The underlying [sharedGoogleFontsConfig] is not exported or meant for
+  /// public consumption.
   static final GoogleFontsConfig config = sharedGoogleFontsConfig;
 
   /// Returns a [Future] which resolves when requested fonts have finished

--- a/packages/google_fonts/generator/google_fonts_lite.tmpl
+++ b/packages/google_fonts/generator/google_fonts_lite.tmpl
@@ -9,6 +9,7 @@ import 'dart:ui' as ui;
 import 'package:flutter/material.dart';
 
 import 'google_fonts_base.dart';
+import 'google_fonts_config.dart';
 import 'google_fonts_descriptor.dart';
 import 'google_fonts_variant.dart';
 
@@ -18,6 +19,63 @@ import 'google_fonts_variant.dart';
 /// each font, [GoogleFontsLite] provides dynamic font lookup via [getFont]
 /// and [fontsMap], allowing unused font methods to be tree-shaken by the compiler.
 abstract final class GoogleFontsLite {
+  /// Configuration for the [GoogleFontsLite] library.
+  ///
+  /// ```dart
+  /// GoogleFontsLite.config.allowRuntimeFetching = false;
+  /// ```
+  static final GoogleFontsConfig config = sharedGoogleFontsConfig;
+
+  /// Returns a [Future] which resolves when requested fonts have finished
+  /// loading and are ready to be rendered on screen.
+  ///
+  /// Usage:
+  /// ```dart
+  /// GoogleFontsLite.getFont('Lato');
+  /// GoogleFontsLite.getTextTheme('Pacifico');
+  /// await GoogleFontsLite.pendingFonts(); // <-- waits until Lato and Pacifico files have loaded.
+  /// ```
+  ///
+  /// To keep things tidy, one can also pass in requested fonts as a list
+  /// to [pendingFonts].
+  ///
+  /// ```dart
+  /// await GoogleFontsLite.pendingFonts(<dynamic>[
+  ///   GoogleFontsLite.getFont('Lato'),
+  ///   GoogleFontsLite.getTextTheme('Pacifico'),
+  /// ]);
+  /// ```
+  ///
+  /// To avoid visual font swaps that occur when a font is loading,
+  /// consider using [FutureBuilder]. Note: This future cannot be created in
+  /// [build], as described in [FutureBuilder]'s documentation.
+  ///
+  /// ```dart
+  /// late Future<List<void>> googleFontsPending;
+  ///
+  /// @override
+  /// void initState() {
+  ///   super.initState();
+  ///   googleFontsPending = GoogleFontsLite.pendingFonts(<dynamic>[
+  ///     GoogleFontsLite.getFont('Lato'),
+  ///   ]);
+  /// }
+  ///
+  /// @override
+  /// Widget build(BuildContext context) {
+  ///   return FutureBuilder(
+  ///     future: googleFontsPending,
+  ///     builder: (context, snapshot) {
+  ///       if (snapshot.connectionState != ConnectionState.done) {
+  ///         return const SizedBox();
+  ///       }
+  ///       return Text('Lato text', style: GoogleFontsLite.getFont('Lato'));
+  ///     },
+  ///   );
+  /// }
+  /// ```
+  static Future<List<void>> pendingFonts([List<dynamic>? _]) => Future.wait(pendingFontFutures);
+
   /// Map of all available Google Fonts families to their variant file descriptors.
   static final Map<String, Map<GoogleFontsVariant, GoogleFontsFile>> fontsMap = {
     {{#fontEntries}}
@@ -84,6 +142,39 @@ abstract final class GoogleFontsLite {
       decorationColor: decorationColor,
       decorationStyle: decorationStyle,
       decorationThickness: decorationThickness,
+    );
+  }
+
+  /// Retrieve a text theme by its font family name.
+  ///
+  /// Applies the given font family from Google Fonts to the given [textTheme]
+  /// and returns the resulting [textTheme].
+  ///
+  /// Note: [fontFamily] is case-sensitive.
+  ///
+  /// Parameter [fontFamily] must not be `null`. Throws if no font by name
+  /// [fontFamily] exists.
+  static TextTheme getTextTheme(String fontFamily, [TextTheme? textTheme]) {
+    if (!fontsMap.containsKey(fontFamily)) {
+      throw Exception("No font family by name '$fontFamily' was found.");
+    }
+    textTheme ??= ThemeData.light().textTheme;
+    return TextTheme(
+      displayLarge: getFont(fontFamily, textStyle: textTheme.displayLarge),
+      displayMedium: getFont(fontFamily, textStyle: textTheme.displayMedium),
+      displaySmall: getFont(fontFamily, textStyle: textTheme.displaySmall),
+      headlineLarge: getFont(fontFamily, textStyle: textTheme.headlineLarge),
+      headlineMedium: getFont(fontFamily, textStyle: textTheme.headlineMedium),
+      headlineSmall: getFont(fontFamily, textStyle: textTheme.headlineSmall),
+      titleLarge: getFont(fontFamily, textStyle: textTheme.titleLarge),
+      titleMedium: getFont(fontFamily, textStyle: textTheme.titleMedium),
+      titleSmall: getFont(fontFamily, textStyle: textTheme.titleSmall),
+      bodyLarge: getFont(fontFamily, textStyle: textTheme.bodyLarge),
+      bodyMedium: getFont(fontFamily, textStyle: textTheme.bodyMedium),
+      bodySmall: getFont(fontFamily, textStyle: textTheme.bodySmall),
+      labelLarge: getFont(fontFamily, textStyle: textTheme.labelLarge),
+      labelMedium: getFont(fontFamily, textStyle: textTheme.labelMedium),
+      labelSmall: getFont(fontFamily, textStyle: textTheme.labelSmall),
     );
   }
 }

--- a/packages/google_fonts/lib/google_fonts.dart
+++ b/packages/google_fonts/lib/google_fonts.dart
@@ -3,5 +3,5 @@
 // found in the LICENSE file.
 
 export 'src/google_fonts_all_parts.dart';
-export 'src/google_fonts_config.dart';
+export 'src/google_fonts_config.dart' show Config, GoogleFontsConfig;
 export 'src/google_fonts_lite.dart';

--- a/packages/google_fonts/lib/google_fonts_lite.dart
+++ b/packages/google_fonts/lib/google_fonts_lite.dart
@@ -2,5 +2,5 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-export 'src/google_fonts_config.dart';
+export 'src/google_fonts_config.dart' show Config, GoogleFontsConfig;
 export 'src/google_fonts_lite.dart';

--- a/packages/google_fonts/lib/src/google_fonts_all_parts.dart
+++ b/packages/google_fonts/lib/src/google_fonts_all_parts.dart
@@ -57,9 +57,6 @@ class GoogleFonts {
   /// ```dart
   /// GoogleFonts.config.allowRuntimeFetching = false;
   /// ```
-  ///
-  /// The underlying [sharedGoogleFontsConfig] is not exported or meant for
-  /// public consumption.
   static final GoogleFontsConfig config = sharedGoogleFontsConfig;
 
   /// Returns a [Future] which resolves when requested fonts have finished

--- a/packages/google_fonts/lib/src/google_fonts_all_parts.dart
+++ b/packages/google_fonts/lib/src/google_fonts_all_parts.dart
@@ -57,6 +57,9 @@ class GoogleFonts {
   /// ```dart
   /// GoogleFonts.config.allowRuntimeFetching = false;
   /// ```
+  ///
+  /// The underlying [sharedGoogleFontsConfig] is not exported or meant for
+  /// public consumption.
   static final GoogleFontsConfig config = sharedGoogleFontsConfig;
 
   /// Returns a [Future] which resolves when requested fonts have finished

--- a/packages/google_fonts/lib/src/google_fonts_all_parts.dart
+++ b/packages/google_fonts/lib/src/google_fonts_all_parts.dart
@@ -57,7 +57,7 @@ class GoogleFonts {
   /// ```dart
   /// GoogleFonts.config.allowRuntimeFetching = false;
   /// ```
-  static final GoogleFontsConfig config = GoogleFontsConfig();
+  static final GoogleFontsConfig config = sharedGoogleFontsConfig;
 
   /// Returns a [Future] which resolves when requested fonts have finished
   /// loading and are ready to be rendered on screen.

--- a/packages/google_fonts/lib/src/google_fonts_base.dart
+++ b/packages/google_fonts/lib/src/google_fonts_base.dart
@@ -8,11 +8,11 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:http/http.dart' as http;
 
-import '../google_fonts.dart';
 import 'file_io.dart' // Stubbed implementation by default.
     // Concrete implementation if File IO is available.
     if (dart.library.io) 'file_io_desktop_and_mobile.dart'
     as file_io;
+import 'google_fonts_config.dart';
 import 'google_fonts_descriptor.dart';
 import 'google_fonts_family_with_variant.dart';
 import 'google_fonts_variant.dart';
@@ -164,7 +164,7 @@ Future<void> loadFontIfNecessary(GoogleFontsDescriptor descriptor) async {
     }
 
     // Attempt to load this font via http, unless disallowed.
-    if (GoogleFonts.config.allowRuntimeFetching) {
+    if (sharedGoogleFontsConfig.allowRuntimeFetching) {
       byteData = _httpFetchFontAndSaveToDevice(familyWithVariantString, descriptor.file);
       if (await byteData != null) {
         return await loadFontByteData(familyWithVariantString, byteData);
@@ -250,7 +250,7 @@ Future<ByteData> _httpFetchFontAndSaveToDevice(String fontName, GoogleFontsFile 
   }
 
   http.Response response;
-  final http.Client client = GoogleFonts.config.httpClient ?? _httpClient;
+  final http.Client client = sharedGoogleFontsConfig.httpClient ?? _httpClient;
   try {
     response = await client.get(uri);
   } catch (e) {

--- a/packages/google_fonts/lib/src/google_fonts_config.dart
+++ b/packages/google_fonts/lib/src/google_fonts_config.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'package:http/http.dart' as http;
+import 'package:meta/meta.dart';
 
 /// A collection of properties used to specify custom behavior of the
 /// GoogleFonts library.
@@ -22,3 +23,7 @@ class GoogleFontsConfig {
 /// Deprecated. Use [GoogleFontsConfig] instead.
 @Deprecated('Use GoogleFontsConfig instead')
 typedef Config = GoogleFontsConfig;
+
+/// Shared configuration instance for the Google Fonts library.
+@internal
+final GoogleFontsConfig sharedGoogleFontsConfig = GoogleFontsConfig();

--- a/packages/google_fonts/lib/src/google_fonts_config.dart
+++ b/packages/google_fonts/lib/src/google_fonts_config.dart
@@ -25,5 +25,9 @@ class GoogleFontsConfig {
 typedef Config = GoogleFontsConfig;
 
 /// Shared configuration instance for the Google Fonts library.
+///
+/// This instance is not exported and is not meant for public consumption.
+/// Applications should configure Google Fonts using `GoogleFonts.config` or
+/// `GoogleFontsLite.config`.
 @internal
 final GoogleFontsConfig sharedGoogleFontsConfig = GoogleFontsConfig();

--- a/packages/google_fonts/lib/src/google_fonts_lite.dart
+++ b/packages/google_fonts/lib/src/google_fonts_lite.dart
@@ -28,9 +28,6 @@ abstract final class GoogleFontsLite {
   /// ```dart
   /// GoogleFontsLite.config.allowRuntimeFetching = false;
   /// ```
-  ///
-  /// The underlying [sharedGoogleFontsConfig] is not exported or meant for
-  /// public consumption.
   static final GoogleFontsConfig config = sharedGoogleFontsConfig;
 
   /// Returns a [Future] which resolves when requested fonts have finished

--- a/packages/google_fonts/lib/src/google_fonts_lite.dart
+++ b/packages/google_fonts/lib/src/google_fonts_lite.dart
@@ -9,6 +9,7 @@ import 'dart:ui' as ui;
 import 'package:flutter/material.dart';
 
 import 'google_fonts_base.dart';
+import 'google_fonts_config.dart';
 import 'google_fonts_descriptor.dart';
 import 'google_fonts_variant.dart';
 
@@ -18,6 +19,63 @@ import 'google_fonts_variant.dart';
 /// each font, [GoogleFontsLite] provides dynamic font lookup via [getFont]
 /// and [fontsMap], allowing unused font methods to be tree-shaken by the compiler.
 abstract final class GoogleFontsLite {
+  /// Configuration for the [GoogleFontsLite] library.
+  ///
+  /// ```dart
+  /// GoogleFontsLite.config.allowRuntimeFetching = false;
+  /// ```
+  static final GoogleFontsConfig config = sharedGoogleFontsConfig;
+
+  /// Returns a [Future] which resolves when requested fonts have finished
+  /// loading and are ready to be rendered on screen.
+  ///
+  /// Usage:
+  /// ```dart
+  /// GoogleFontsLite.getFont('Lato');
+  /// GoogleFontsLite.getTextTheme('Pacifico');
+  /// await GoogleFontsLite.pendingFonts(); // <-- waits until Lato and Pacifico files have loaded.
+  /// ```
+  ///
+  /// To keep things tidy, one can also pass in requested fonts as a list
+  /// to [pendingFonts].
+  ///
+  /// ```dart
+  /// await GoogleFontsLite.pendingFonts(<dynamic>[
+  ///   GoogleFontsLite.getFont('Lato'),
+  ///   GoogleFontsLite.getTextTheme('Pacifico'),
+  /// ]);
+  /// ```
+  ///
+  /// To avoid visual font swaps that occur when a font is loading,
+  /// consider using [FutureBuilder]. Note: This future cannot be created in
+  /// [build], as described in [FutureBuilder]'s documentation.
+  ///
+  /// ```dart
+  /// late Future<List<void>> googleFontsPending;
+  ///
+  /// @override
+  /// void initState() {
+  ///   super.initState();
+  ///   googleFontsPending = GoogleFontsLite.pendingFonts(<dynamic>[
+  ///     GoogleFontsLite.getFont('Lato'),
+  ///   ]);
+  /// }
+  ///
+  /// @override
+  /// Widget build(BuildContext context) {
+  ///   return FutureBuilder(
+  ///     future: googleFontsPending,
+  ///     builder: (context, snapshot) {
+  ///       if (snapshot.connectionState != ConnectionState.done) {
+  ///         return const SizedBox();
+  ///       }
+  ///       return Text('Lato text', style: GoogleFontsLite.getFont('Lato'));
+  ///     },
+  ///   );
+  /// }
+  /// ```
+  static Future<List<void>> pendingFonts([List<dynamic>? _]) => Future.wait(pendingFontFutures);
+
   /// Map of all available Google Fonts families to their variant file descriptors.
   static final Map<String, Map<GoogleFontsVariant, GoogleFontsFile>> fontsMap = {
     'ABeeZee': {
@@ -57088,6 +57146,39 @@ abstract final class GoogleFontsLite {
       decorationColor: decorationColor,
       decorationStyle: decorationStyle,
       decorationThickness: decorationThickness,
+    );
+  }
+
+  /// Retrieve a text theme by its font family name.
+  ///
+  /// Applies the given font family from Google Fonts to the given [textTheme]
+  /// and returns the resulting [textTheme].
+  ///
+  /// Note: [fontFamily] is case-sensitive.
+  ///
+  /// Parameter [fontFamily] must not be `null`. Throws if no font by name
+  /// [fontFamily] exists.
+  static TextTheme getTextTheme(String fontFamily, [TextTheme? textTheme]) {
+    if (!fontsMap.containsKey(fontFamily)) {
+      throw Exception("No font family by name '$fontFamily' was found.");
+    }
+    textTheme ??= ThemeData.light().textTheme;
+    return TextTheme(
+      displayLarge: getFont(fontFamily, textStyle: textTheme.displayLarge),
+      displayMedium: getFont(fontFamily, textStyle: textTheme.displayMedium),
+      displaySmall: getFont(fontFamily, textStyle: textTheme.displaySmall),
+      headlineLarge: getFont(fontFamily, textStyle: textTheme.headlineLarge),
+      headlineMedium: getFont(fontFamily, textStyle: textTheme.headlineMedium),
+      headlineSmall: getFont(fontFamily, textStyle: textTheme.headlineSmall),
+      titleLarge: getFont(fontFamily, textStyle: textTheme.titleLarge),
+      titleMedium: getFont(fontFamily, textStyle: textTheme.titleMedium),
+      titleSmall: getFont(fontFamily, textStyle: textTheme.titleSmall),
+      bodyLarge: getFont(fontFamily, textStyle: textTheme.bodyLarge),
+      bodyMedium: getFont(fontFamily, textStyle: textTheme.bodyMedium),
+      bodySmall: getFont(fontFamily, textStyle: textTheme.bodySmall),
+      labelLarge: getFont(fontFamily, textStyle: textTheme.labelLarge),
+      labelMedium: getFont(fontFamily, textStyle: textTheme.labelMedium),
+      labelSmall: getFont(fontFamily, textStyle: textTheme.labelSmall),
     );
   }
 }

--- a/packages/google_fonts/lib/src/google_fonts_lite.dart
+++ b/packages/google_fonts/lib/src/google_fonts_lite.dart
@@ -57163,11 +57163,11 @@ abstract final class GoogleFontsLite {
   ///
   /// Note: [fontFamily] is case-sensitive.
   ///
-  /// Parameter [fontFamily] must not be `null`. Throws if no font by name
-  /// [fontFamily] exists.
+  /// Parameter [fontFamily] must not be `null`. Throws an [ArgumentError] if no
+  /// font by name [fontFamily] exists.
   static TextTheme getTextTheme(String fontFamily, [TextTheme? textTheme]) {
     if (!fontsMap.containsKey(fontFamily)) {
-      throw Exception("No font family by name '$fontFamily' was found.");
+      throw ArgumentError("No font family by name '$fontFamily' was found.");
     }
     textTheme ??= ThemeData.light().textTheme;
     return TextTheme(

--- a/packages/google_fonts/lib/src/google_fonts_lite.dart
+++ b/packages/google_fonts/lib/src/google_fonts_lite.dart
@@ -21,9 +21,16 @@ import 'google_fonts_variant.dart';
 abstract final class GoogleFontsLite {
   /// Configuration for the [GoogleFontsLite] library.
   ///
+  /// Use this to define custom behavior of the GoogleFonts library in your app.
+  /// For example, if you do not want the GoogleFonts library to make any HTTP
+  /// requests for fonts, add the following snippet to your app's `main` method.
+  ///
   /// ```dart
   /// GoogleFontsLite.config.allowRuntimeFetching = false;
   /// ```
+  ///
+  /// The underlying [sharedGoogleFontsConfig] is not exported or meant for
+  /// public consumption.
   static final GoogleFontsConfig config = sharedGoogleFontsConfig;
 
   /// Returns a [Future] which resolves when requested fonts have finished

--- a/packages/google_fonts/pubspec.yaml
+++ b/packages/google_fonts/pubspec.yaml
@@ -14,6 +14,7 @@ dependencies:
   flutter:
     sdk: flutter
   http: ^1.0.0
+  meta: ^1.10.0
   path_provider: ^2.0.0
 
 dev_dependencies:

--- a/packages/google_fonts/test/google_fonts_lite_test.dart
+++ b/packages/google_fonts/test/google_fonts_lite_test.dart
@@ -2,15 +2,28 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:io';
-
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:google_fonts/google_fonts_lite.dart' as lite;
 import 'package:google_fonts/src/google_fonts_base.dart';
+import 'package:mockito/mockito.dart';
+
+class MockAssetManifest extends Mock implements AssetManifest {
+  @override
+  List<String> listAssets() => <String>[];
+}
 
 void main() {
+  setUpAll(() {
+    assetManifest = MockAssetManifest();
+  });
+
+  tearDown(() {
+    clearCache();
+    pendingFontFutures.clear();
+  });
   testWidgets('GoogleFontsLite getFont returns the correct font with the given parameters', (
     WidgetTester tester,
   ) async {
@@ -159,26 +172,5 @@ void main() {
     expect(lite.GoogleFontsLite.fontsMap, isNotEmpty);
     expect(lite.GoogleFontsLite.config, isA<lite.GoogleFontsConfig>());
     expect(lite.GoogleFontsLite.config, isA<lite.Config>());
-  });
-
-  test('lib/google_fonts_lite.dart does not transitively import part files', () {
-    final String liteEntryContent = File('lib/google_fonts_lite.dart').readAsStringSync();
-    expect(liteEntryContent.contains('google_fonts.dart'), isFalse);
-    expect(liteEntryContent.contains('google_fonts_all_parts.dart'), isFalse);
-
-    final String liteSrcContent = File('lib/src/google_fonts_lite.dart').readAsStringSync();
-    expect(liteSrcContent.contains('google_fonts.dart'), isFalse);
-    expect(liteSrcContent.contains('google_fonts_all_parts.dart'), isFalse);
-    expect(liteSrcContent.contains('google_fonts_parts/'), isFalse);
-
-    final String baseFileContent = File('lib/src/google_fonts_base.dart').readAsStringSync();
-    expect(
-      baseFileContent.contains("import '../google_fonts.dart'"),
-      isFalse,
-      reason: 'google_fonts_base.dart must not import google_fonts.dart to maintain tree-shaking',
-    );
-    expect(baseFileContent.contains("import 'google_fonts_config.dart'"), isTrue);
-    expect(baseFileContent.contains('google_fonts_all_parts.dart'), isFalse);
-    expect(baseFileContent.contains('google_fonts_parts/'), isFalse);
   });
 }

--- a/packages/google_fonts/test/google_fonts_lite_test.dart
+++ b/packages/google_fonts/test/google_fonts_lite_test.dart
@@ -146,8 +146,8 @@ void main() {
     expect(
       () => GoogleFontsLite.getTextTheme('NonExistentFamily'),
       throwsA(
-        isA<Exception>().having(
-          (Exception e) => e.toString(),
+        isA<ArgumentError>().having(
+          (ArgumentError e) => e.message,
           'message',
           contains("No font family by name 'NonExistentFamily' was found."),
         ),

--- a/packages/google_fonts/test/google_fonts_lite_test.dart
+++ b/packages/google_fonts/test/google_fonts_lite_test.dart
@@ -2,9 +2,13 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:io';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:google_fonts/google_fonts.dart';
+import 'package:google_fonts/google_fonts_lite.dart' as lite;
+import 'package:google_fonts/src/google_fonts_base.dart';
 
 void main() {
   testWidgets('GoogleFontsLite getFont returns the correct font with the given parameters', (
@@ -98,5 +102,83 @@ void main() {
 
   test('GoogleFontsLite.fontsMap keys match GoogleFonts.asMap keys exactly', () {
     expect(GoogleFontsLite.fontsMap.keys, equals(GoogleFonts.asMap().keys));
+  });
+
+  test('GoogleFontsLite.config and GoogleFonts.config share the same instance', () {
+    expect(identical(GoogleFontsLite.config, GoogleFonts.config), isTrue);
+    addTearDown(() {
+      GoogleFontsLite.config.allowRuntimeFetching = true;
+    });
+    GoogleFontsLite.config.allowRuntimeFetching = false;
+    expect(GoogleFonts.config.allowRuntimeFetching, isFalse);
+  });
+
+  test('GoogleFontsLite.pendingFonts awaits loaded fonts and accepts optional argument', () async {
+    pendingFontFutures.clear();
+    expect(await GoogleFontsLite.pendingFonts(), isEmpty);
+    expect(
+      await GoogleFontsLite.pendingFonts(<TextStyle>[const TextStyle(fontFamily: 'Lato')]),
+      isEmpty,
+    );
+  });
+
+  testWidgets('GoogleFontsLite.getTextTheme creates matching TextTheme', (
+    WidgetTester tester,
+  ) async {
+    final TextTheme liteTheme = GoogleFontsLite.getTextTheme('Lato');
+    final TextTheme heavyTheme = GoogleFonts.latoTextTheme();
+    expect(liteTheme, equals(heavyTheme));
+  });
+
+  testWidgets('GoogleFontsLite.getTextTheme preserves existing TextTheme properties', (
+    WidgetTester tester,
+  ) async {
+    const customStyle = TextStyle(fontSize: 42.0, color: Colors.purple);
+    final lightTheme = ThemeData.light();
+    final TextTheme customBaseTheme = lightTheme.textTheme.copyWith(displayLarge: customStyle);
+    final TextTheme resultTheme = GoogleFontsLite.getTextTheme('Lato', customBaseTheme);
+    expect(resultTheme.displayLarge?.fontSize, equals(42.0));
+    expect(resultTheme.displayLarge?.color, equals(Colors.purple));
+    expect(resultTheme.displayLarge?.fontFamily, contains('Lato'));
+  });
+
+  test('GoogleFontsLite.getTextTheme throws on unknown font family', () {
+    expect(
+      () => GoogleFontsLite.getTextTheme('NonExistentFamily'),
+      throwsA(
+        isA<Exception>().having(
+          (Exception e) => e.toString(),
+          'message',
+          contains("No font family by name 'NonExistentFamily' was found."),
+        ),
+      ),
+    );
+  });
+
+  test('google_fonts_lite.dart entrypoint exports expected public symbols', () {
+    expect(lite.GoogleFontsLite.fontsMap, isNotEmpty);
+    expect(lite.GoogleFontsLite.config, isA<lite.GoogleFontsConfig>());
+    expect(lite.GoogleFontsLite.config, isA<lite.Config>());
+  });
+
+  test('lib/google_fonts_lite.dart does not transitively import part files', () {
+    final String liteEntryContent = File('lib/google_fonts_lite.dart').readAsStringSync();
+    expect(liteEntryContent.contains('google_fonts.dart'), isFalse);
+    expect(liteEntryContent.contains('google_fonts_all_parts.dart'), isFalse);
+
+    final String liteSrcContent = File('lib/src/google_fonts_lite.dart').readAsStringSync();
+    expect(liteSrcContent.contains('google_fonts.dart'), isFalse);
+    expect(liteSrcContent.contains('google_fonts_all_parts.dart'), isFalse);
+    expect(liteSrcContent.contains('google_fonts_parts/'), isFalse);
+
+    final String baseFileContent = File('lib/src/google_fonts_base.dart').readAsStringSync();
+    expect(
+      baseFileContent.contains("import '../google_fonts.dart'"),
+      isFalse,
+      reason: 'google_fonts_base.dart must not import google_fonts.dart to maintain tree-shaking',
+    );
+    expect(baseFileContent.contains("import 'google_fonts_config.dart'"), isTrue);
+    expect(baseFileContent.contains('google_fonts_all_parts.dart'), isFalse);
+    expect(baseFileContent.contains('google_fonts_parts/'), isFalse);
   });
 }

--- a/packages/google_fonts/test/tree_shaking_test.dart
+++ b/packages/google_fonts/test/tree_shaking_test.dart
@@ -1,0 +1,33 @@
+// Copyright 2013 The Flutter Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+@TestOn('vm') // Uses dart:io
+library;
+
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('lib/google_fonts_lite.dart does not transitively import part files', () {
+    final String liteEntryContent = File('lib/google_fonts_lite.dart').readAsStringSync();
+    expect(liteEntryContent.contains('google_fonts.dart'), isFalse);
+    expect(liteEntryContent.contains('google_fonts_all_parts.dart'), isFalse);
+
+    final String liteSrcContent = File('lib/src/google_fonts_lite.dart').readAsStringSync();
+    expect(liteSrcContent.contains('google_fonts.dart'), isFalse);
+    expect(liteSrcContent.contains('google_fonts_all_parts.dart'), isFalse);
+    expect(liteSrcContent.contains('google_fonts_parts/'), isFalse);
+
+    final String baseFileContent = File('lib/src/google_fonts_base.dart').readAsStringSync();
+    expect(
+      baseFileContent.contains("import '../google_fonts.dart'"),
+      isFalse,
+      reason: 'google_fonts_base.dart must not import google_fonts.dart to maintain tree-shaking',
+    );
+    expect(baseFileContent.contains("import 'google_fonts_config.dart'"), isTrue);
+    expect(baseFileContent.contains('google_fonts_all_parts.dart'), isFalse);
+    expect(baseFileContent.contains('google_fonts_parts/'), isFalse);
+  });
+}


### PR DESCRIPTION
In PR #11433 https://github.com/flutter/packages/pull/11433, google_fonts_lite.dart was introduced as an alternative entry point containing only dynamic font resolution methods and the family descriptor map, allowing compilers to tree-shake the static generated font methods.

#11433 was a huge PR, and a breaking one, so we did not publish it yet. Currently this package is set to publish_to: none.

For these reasons I decided to follow up on a few more bits of polish here instead of belaboring the mega PR and the contributor's effort. 

_**After this change, I will migrate this package to material_ui and then we will publish one major release with all of these changes to reduce churn on the ecosystem**._

This PR ensures google_fonts_lite.dart is fully decoupled from the main entry point by sharing an internal configuration singleton, ensuring complete compiler tree-shaking of unused generated font code, while adding missing features to google fonts lite for full feature parity with the non-lite version.

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under[^1].
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[the version and CHANGELOG instructions]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version-and-changelog-updates
[semantic versioning]: https://dart.dev/tools/pub/versioning#semantic-versions
[repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
