### PR TITLE
[material_ui] Fix ExpansionTile TalkBack double-swipe on Android

### DIFF
--- a/packages/material_ui/lib/src/expansion_tile.dart
+++ b/packages/material_ui/lib/src/expansion_tile.dart
@@ -691,13 +691,13 @@ class _ExpansionTileState extends State<ExpansionTile> {
 
     if (defaultTargetPlatform == TargetPlatform.android) {
       return Semantics(
-        // Live region used to announce state changes (e.g., "expanded" or "collapsed")
-        // without taking focus.
-        // blockNode prevents this node from being part of the focus traversal.
-        label: semanticsHint,
+        // Live region announces expand/collapse without a separate focusable
+        // wrapper node. Nesting a liveRegion+label Semantics over the hint node
+        // caused TalkBack to stop twice on the same tile (flutter/flutter#190601).
         liveRegion: true,
-        accessibilityFocusBlockType: AccessibilityFocusBlockType.blockNode,
-        child: Semantics(hint: semanticsHint, onTapHint: onTapHint, child: child),
+        hint: semanticsHint,
+        onTapHint: onTapHint,
+        child: child,
       );
     }
     return Semantics(hint: semanticsHint, onTapHint: onTapHint, child: child);

--- a/packages/material_ui/pending_changelogs/change_2026_09_11_1789108674488.yaml
+++ b/packages/material_ui/pending_changelogs/change_2026_09_11_1789108674488.yaml
@@ -1,0 +1,3 @@
+changelog: |
+  - Fixes ExpansionTile TalkBack requiring two swipes on Android by combining the live-region announcement into a single semantics node.
+version: skip

--- a/packages/material_ui/test/expansion_tile_test.dart
+++ b/packages/material_ui/test/expansion_tile_test.dart
@@ -2243,7 +2243,7 @@ void main() {
         ),
       );
 
-      // Initially collapsed - live region label is "Collapsed".
+      // Initially collapsed - live region hint is "Collapsed".
 
       SemanticsNode liveRegionSemantics = tester.getSemantics(
         find.ancestor(
@@ -2253,7 +2253,7 @@ void main() {
           ),
         ),
       );
-      expect(liveRegionSemantics.label, localizations.expandedHint);
+      expect(liveRegionSemantics.hint, localizations.expandedHint);
 
       // Tap to expand.
       await tester.tap(find.text('Test Tile'));
@@ -2268,7 +2268,7 @@ void main() {
           ),
         ),
       );
-      expect(liveRegionSemantics.label, localizations.collapsedHint);
+      expect(liveRegionSemantics.hint, localizations.collapsedHint);
 
       // Tap to collapse.
       await tester.tap(find.text('Test Tile'));
@@ -2283,7 +2283,35 @@ void main() {
           ),
         ),
       );
-      expect(liveRegionSemantics.label, localizations.expandedHint);
+      expect(liveRegionSemantics.hint, localizations.expandedHint);
+
+      handle.dispose();
+    }, variant: const TargetPlatformVariant(<TargetPlatform>{TargetPlatform.android}));
+
+    // Regression test for https://github.com/flutter/flutter/issues/190601.
+    testWidgets('Android header uses a single live-region Semantics node', (
+      WidgetTester tester,
+    ) async {
+      final SemanticsHandle handle = tester.ensureSemantics();
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Material(
+            child: ExpansionTile(title: Text('Filter'), children: <Widget>[Text('Child')]),
+          ),
+        ),
+      );
+
+      final Finder liveRegionSemantics = find.ancestor(
+        of: find.byType(ListTile),
+        matching: find.byWidgetPredicate(
+          (Widget widget) => widget is Semantics && (widget.properties.liveRegion ?? false),
+        ),
+      );
+      expect(liveRegionSemantics, findsOneWidget);
+
+      final Semantics widget = tester.widget<Semantics>(liveRegionSemantics);
+      expect(widget.properties.hint, isNotNull);
+      expect(widget.properties.accessibilityFocusBlockType, isNull);
 
       handle.dispose();
     }, variant: const TargetPlatformVariant(<TargetPlatform>{TargetPlatform.android}));


### PR DESCRIPTION
Combine the Android live-region announcement into the same Semantics node as the header hint so TalkBack no longer stops twice on one `ExpansionTile`.

Fixes https://github.com/flutter/flutter/issues/190601

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under[^1].
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [x] All existing and new tests are passing.

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[the version and CHANGELOG instructions]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version-and-changelog-updates
[semantic versioning]: https://dart.dev/tools/pub/versioning#semantic-versions
[repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests