### PR TITLE
[go_router] Fix redirect zone async error handling

### DIFF
--- a/packages/go_router/lib/src/configuration.dart
+++ b/packages/go_router/lib/src/configuration.dart
@@ -622,30 +622,9 @@ class RouteConfiguration {
       return callback();
     }
 
-    T? result;
-    var errorOccurred = false;
-
-    runZonedGuarded<void>(
-      () {
-        result = callback();
-      },
-      (Object error, StackTrace stack) {
-        errorOccurred = true;
-        // Convert any exception during redirect to a GoException and rethrow
-        final GoException goException = error is GoException
-            ? error
-            : GoException('Exception during redirect: $error');
-        throw goException;
-      },
-      zoneValues: <Object?, Object?>{currentRouterKey: router},
-    );
-
-    if (errorOccurred) {
-      // This should not be reached since we rethrow in the error handler
-      throw GoException('Unexpected error in router zone');
-    }
-
-    return result as T;
+    return Zone.current
+        .fork(zoneValues: <Object?, Object?>{currentRouterKey: router})
+        .run<T>(callback);
   }
 
   /// Get the location for the provided route.

--- a/packages/go_router/pending_changelogs/fix_redirect_zone_async_error_handling.yaml
+++ b/packages/go_router/pending_changelogs/fix_redirect_zone_async_error_handling.yaml
@@ -1,0 +1,3 @@
+changelog: |
+  - Fixes unrelated async errors started during redirects being wrapped as `GoException`.
+version: patch

--- a/packages/go_router/test/go_router_test.dart
+++ b/packages/go_router/test/go_router_test.dart
@@ -2063,6 +2063,38 @@ void main() {
       expect(find.text('should not reach here'), findsNothing);
     });
 
+    testWidgets('unrelated async errors started during redirect are not wrapped', (
+      WidgetTester tester,
+    ) async {
+      final Object expectedError = StateError('background failure');
+      Object? caughtError;
+
+      await runZonedGuarded<Future<void>>(
+        () async {
+          await createRouter(
+            <RouteBase>[
+              GoRoute(
+                path: '/',
+                builder: (BuildContext context, GoRouterState state) => const HomeScreen(),
+              ),
+            ],
+            tester,
+            redirect: (BuildContext context, GoRouterState state) {
+              Future<void>.error(expectedError);
+              return null;
+            },
+          );
+
+          await tester.pump();
+        },
+        (Object error, StackTrace stackTrace) {
+          caughtError = error;
+        },
+      );
+
+      expect(caughtError, same(expectedError));
+    });
+
     testWidgets('context extension methods work in redirects', (WidgetTester tester) async {
       String? capturedNamedLocation;
       final routes = <GoRoute>[


### PR DESCRIPTION
Fixes flutter/flutter#192066

  ## Summary

  Replaces the guarded redirect zone with a value-only zone when running redirect callbacks.

  Redirect callbacks still have access to the current router through zone values, so APIs such as `GoRouter.of(context)` and `context.namedLocation(...)`
  continue to work during redirects. However, unrelated unawaited async errors started during a redirect are no longer caught by go_router and wrapped as
  `GoException`.

  ## Tests

  - `fvm dart run ../../script/tool/bin/flutter_plugin_tools.dart format --packages go_router`
  - `fvm dart run ../../script/tool/bin/flutter_plugin_tools.dart analyze --packages go_router`
  - `fvm dart run ../../script/tool/bin/flutter_plugin_tools.dart dart-test --packages go_router`
  - `fvm dart run ../../script/tool/bin/flutter_plugin_tools.dart validate --packages go_router`
  - `fvm flutter test test/go_router_test.dart`
  - `fvm flutter test test/redirect_chain_test.dart`

  For the checklist, check the ones that are true:

  - [x] I read the Contributor Guide...
  - [x] I read the AI contribution guidelines...
  - [x] I read the Tree Hygiene page...
  - [x] I read and followed the relevant style guides and ran the auto-formatter.
  - [x] I signed the CLA.
  - [x] The title of the PR starts with the name of the package surrounded by square brackets...
  - [x] I linked to at least one issue that this PR fixes in the description above.
  - [x] I followed the version and CHANGELOG instructions...
  - [ ] I updated/added any relevant documentation...
  - [x] I added new tests to check the change I am making...
  - [x] All existing and new tests are passing.