### PR TITLE
[video_player_android] Enable ExoPlayer decoder fallback

### DIFF
--- a/packages/video_player/video_player_android/CHANGELOG.md
+++ b/packages/video_player/video_player_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.12.3
+
+* Enables ExoPlayer decoder fallback so that playback continues on a lower-priority decoder when the preferred decoder fails to initialize.
+
 ## 2.12.2
 
 * Fixes a [bug](https://github.com/flutter/flutter/issues/132934) where videos with a pixel aspect ratio other than 1.0 (anamorphic content) reported their coded size instead of their display size, causing them to be rendered stretched.

--- a/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/platformview/PlatformViewVideoPlayer.java
+++ b/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/platformview/PlatformViewVideoPlayer.java
@@ -11,6 +11,7 @@ import androidx.annotation.VisibleForTesting;
 import androidx.media3.common.MediaItem;
 import androidx.media3.common.util.UnstableApi;
 import androidx.media3.exoplayer.DefaultLoadControl;
+import androidx.media3.exoplayer.DefaultRenderersFactory;
 import androidx.media3.exoplayer.ExoPlayer;
 import io.flutter.plugins.videoplayer.ExoPlayerEventListener;
 import io.flutter.plugins.videoplayer.VideoAsset;
@@ -57,7 +58,9 @@ public class PlatformViewVideoPlayer extends VideoPlayer {
         asset.getMediaItem(),
         options,
         () -> {
-          ExoPlayer.Builder builder = new ExoPlayer.Builder(context);
+          ExoPlayer.Builder builder =
+              new ExoPlayer.Builder(
+                  context, new DefaultRenderersFactory(context).setEnableDecoderFallback(true));
           if (options.backBufferDurationMs != null) {
             if (options.backBufferDurationMs < 0) {
               throw new IllegalArgumentException("backBufferDurationMs must be at least 0");

--- a/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/texture/TextureVideoPlayer.java
+++ b/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/texture/TextureVideoPlayer.java
@@ -13,6 +13,7 @@ import androidx.annotation.VisibleForTesting;
 import androidx.media3.common.MediaItem;
 import androidx.media3.common.util.UnstableApi;
 import androidx.media3.exoplayer.DefaultLoadControl;
+import androidx.media3.exoplayer.DefaultRenderersFactory;
 import androidx.media3.exoplayer.ExoPlayer;
 import io.flutter.plugins.videoplayer.ExoPlayerEventListener;
 import io.flutter.plugins.videoplayer.VideoAsset;
@@ -57,7 +58,9 @@ public final class TextureVideoPlayer extends VideoPlayer implements SurfaceProd
         asset.getMediaItem(),
         options,
         () -> {
-          ExoPlayer.Builder builder = new ExoPlayer.Builder(context);
+          ExoPlayer.Builder builder =
+              new ExoPlayer.Builder(
+                  context, new DefaultRenderersFactory(context).setEnableDecoderFallback(true));
           if (options.backBufferDurationMs != null) {
             if (options.backBufferDurationMs < 0) {
               throw new IllegalArgumentException("backBufferDurationMs must be at least 0");

--- a/packages/video_player/video_player_android/android/src/test/java/io/flutter/plugins/videoplayer/TextureVideoPlayerTest.java
+++ b/packages/video_player/video_player_android/android/src/test/java/io/flutter/plugins/videoplayer/TextureVideoPlayerTest.java
@@ -6,6 +6,7 @@ package io.flutter.plugins.videoplayer;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.*;
 
 import android.view.Surface;
@@ -14,6 +15,7 @@ import androidx.media3.common.C;
 import androidx.media3.common.PlaybackParameters;
 import androidx.media3.common.Player;
 import androidx.media3.common.VideoSize;
+import androidx.media3.exoplayer.DefaultRenderersFactory;
 import androidx.media3.exoplayer.ExoPlayer;
 import io.flutter.plugins.videoplayer.texture.TextureVideoPlayer;
 import io.flutter.view.TextureRegistry;
@@ -224,6 +226,36 @@ public final class TextureVideoPlayerTest {
       assertEquals(1, mockedBuilder.constructed().size());
       ExoPlayer.Builder builderMock = mockedBuilder.constructed().get(0);
       verify(builderMock).setLoadControl(any());
+      player.dispose();
+    }
+  }
+
+  @Test
+  public void create_enablesDecoderFallback() {
+    android.content.Context mockContext = mock(android.content.Context.class);
+    VideoPlayerOptions options = new VideoPlayerOptions();
+
+    try (MockedConstruction<DefaultRenderersFactory> mockedFactory =
+            mockConstruction(
+                DefaultRenderersFactory.class,
+                (mock, context) ->
+                    when(mock.setEnableDecoderFallback(anyBoolean())).thenReturn(mock));
+        MockedConstruction<ExoPlayer.Builder> mockedBuilder =
+            mockConstruction(
+                ExoPlayer.Builder.class,
+                (mock, context) -> {
+                  when(mock.setLoadControl(any())).thenReturn(mock);
+                  when(mock.setTrackSelector(any())).thenReturn(mock);
+                  when(mock.setMediaSourceFactory(any())).thenReturn(mock);
+                  when(mock.build()).thenReturn(mockExoPlayer);
+                })) {
+
+      TextureVideoPlayer player =
+          TextureVideoPlayer.create(mockContext, mockEvents, mockProducer, fakeVideoAsset, options);
+
+      assertEquals(1, mockedBuilder.constructed().size());
+      assertEquals(1, mockedFactory.constructed().size());
+      verify(mockedFactory.constructed().get(0)).setEnableDecoderFallback(true);
       player.dispose();
     }
   }

--- a/packages/video_player/video_player_android/pubspec.yaml
+++ b/packages/video_player/video_player_android/pubspec.yaml
@@ -2,7 +2,7 @@ name: video_player_android
 description: Android implementation of the video_player plugin.
 repository: https://github.com/flutter/packages/tree/main/packages/video_player/video_player_android
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+video_player%22
-version: 2.12.2
+version: 2.12.3
 
 environment:
   sdk: ^3.12.0


### PR DESCRIPTION
Enables `setEnableDecoderFallback` on the `DefaultRenderersFactory` backing the `ExoPlayer` instance, so playback falls back to a lower-priority decoder when the preferred one fails to initialize, instead of surfacing an `ExoPlaybackException`.

On some devices `MediaCodecUtil` reports a format as supported, the hardware decoder is selected, and initialization fails anyway. Playback then aborts even though a working software decoder is present on the device.

Reproduced on a Lenovo Tab M10 FHD Plus (MediaTek mt6765, Android 10). ExoPlayer selects `OMX.MTK.VIDEO.DECODER.AVC`, and `ACodec` cannot raise the output buffer count past the value the decoder declares:

```
[OUTPUT] nBufferCountActual(7)
setParameter(ParamPortDefinition) ERROR: BadParameter(0x80001005)
setting nBufferCountActual to 14 failed: -22
setting nBufferCountActual to 13 failed: -22
setting nBufferCountActual to 12 failed: -22
setting nBufferCountActual to 11 failed: -22
E/ACodec: Failed to allocate buffers after transitioning to IDLE state (0xffffffea)
E/MediaCodec: Codec reported err 0xffffffea, actionCode 0, while in state 5
```

The failure is in buffer negotiation rather than codec capability, which is why the error carries `format_supported=YES` and reproduces at any resolution or profile — verified from 480p Main@3.1 to 1080p High@4.0. With the flag enabled, playback proceeds on `c2.android.avc.decoder`.

Verified by building the same application twice, differing only in this flag: playback fails every time without it and succeeds every time with it, on the same device and the same videos.

Fallback only engages after the preferred decoder has already failed to initialize, so the trade-off is a possibly slower decoder rather than no playback at all.

Related to https://github.com/flutter/flutter/issues/185674 — same error signature, reported there on Huawei hardware. The device used here is a MediaTek tablet, so the underlying vendor failure may differ, but the fallback path is the same.

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under[^1].
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

[^1]: Regular contributors who have demonstrated familiarity with the repository guidelines only need to comment if the PR is not auto-exempted by repo tooling.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[the version and CHANGELOG instructions]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version-and-changelog-updates
[semantic versioning]: https://dart.dev/tools/pub/versioning#semantic-versions
[repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
