### PR TITLE
[material_ui] Update gen_defaults color helper

### DIFF
--- a/packages/material_ui/tool/gen_defaults/templates/template.dart
+++ b/packages/material_ui/tool/gen_defaults/templates/template.dart
@@ -102,14 +102,27 @@ abstract class TokenTemplate {
   String number(num value) => value.toString();
 
   /// Generates a [ColorScheme] color expression for the given token.
-  String color(TokenColorRole role, String prefix) => '$prefix.${role.name}';
+  String color(TokenColorRole role, String prefix) {
+    final String colorName = switch (role) {
+      TokenColorRole.inverseOnSurface => 'onInverseSurface',
+      _ => role.name,
+    };
+    return '$prefix.$colorName';
+  }
 
   /// Generates a color expression with opacity applied.
   String colorWithOpacity(TokenColorRole role, double opacity, String prefix) {
+    final String colorExpression = color(role, prefix);
     if (opacity == 1.0) {
-      return color(role, prefix);
+      return colorExpression;
     }
-    return '${color(role, prefix)}.withOpacity(${number(opacity)})';
+    final String opacityValue = number(opacity);
+    return switch (_version) {
+      // TODO(QuncCccccc): Update M3 defaults to use withValues(alpha:) once
+      // all existing M3 templates have migrated to the new generator.
+      _MaterialVersion.material3 => '$colorExpression.withOpacity($opacityValue)',
+      _MaterialVersion.material3Expressive => '$colorExpression.withValues(alpha: $opacityValue)',
+    };
   }
 
   /// Generate a [BorderSide] for the given component.

--- a/packages/material_ui/tool/gen_defaults/test/gen_defaults_test.dart
+++ b/packages/material_ui/tool/gen_defaults/test/gen_defaults_test.dart
@@ -133,7 +133,9 @@ void main() {
       );
     });
 
-    test('colorWithOpacity generates color expression with opacity', () {
+    // M3 templates intentionally keep the deprecated withOpacity output until
+    // all existing M3 templates have migrated to the new generator.
+    test('M3 colorWithOpacity generates color expression with opacity', () {
       final template = IconButtonTemplateM3(testPath());
       expect(
         template.colorWithOpacity(TokenColorRole.onSurface, 0.12, '_colors'),

--- a/packages/material_ui/tool/gen_defaults/test/gen_defaults_test.dart
+++ b/packages/material_ui/tool/gen_defaults/test/gen_defaults_test.dart
@@ -115,6 +115,10 @@ void main() {
     test('color generates color expression', () {
       final template = IconButtonTemplateM3(testPath());
       expect(template.color(TokenColorRole.onSurface, '_colors'), '_colors.onSurface');
+      expect(
+        template.color(TokenColorRole.inverseOnSurface, '_colors'),
+        '_colors.onInverseSurface',
+      );
     });
 
     test('textStyle generates text name', () {
@@ -136,8 +140,28 @@ void main() {
         '_colors.onSurface.withOpacity(0.12)',
       );
       expect(
+        template.colorWithOpacity(TokenColorRole.inverseOnSurface, 0.12, '_colors'),
+        '_colors.onInverseSurface.withOpacity(0.12)',
+      );
+      expect(
         template.colorWithOpacity(TokenColorRole.onSurface, 1.0, '_colors'),
         '_colors.onSurface',
+      );
+    });
+
+    test('M3E colorWithOpacity uses withValues', () {
+      final template = IconButtonTemplateM3E(testPath());
+      expect(
+        template.colorWithOpacity(TokenColorRole.onSurface, 0.12, '_colors'),
+        '_colors.onSurface.withValues(alpha: 0.12)',
+      );
+      expect(
+        template.colorWithOpacity(TokenColorRole.inverseOnSurface, 0.12, '_colors'),
+        '_colors.onInverseSurface.withValues(alpha: 0.12)',
+      );
+      expect(
+        template.colorWithOpacity(TokenColorRole.inverseOnSurface, 1.0, '_colors'),
+        '_colors.onInverseSurface',
       );
     });
 


### PR DESCRIPTION
Work toward flutter/flutter#187899.

This PR is to update the `colorWithOpacity` helper to preserve existing Material 3 generated defaults by continuing to emit `withOpacity(...)`, while Material 3 Expressive generated defaults emit `withValues(alpha: ...)` to avoid introducing new deprecated `Color.withOpacity` usages.

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under[^1].
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [x] All existing and new tests are passing.
