### PR TITLE
[material_ui] Stop MenuAnchor from covering its anchor

### DIFF
--- a/packages/material_ui/lib/src/menu_anchor.dart
+++ b/packages/material_ui/lib/src/menu_anchor.dart
@@ -3466,7 +3466,32 @@ class _MenuLayout extends SingleChildLayoutDelegate {
   BoxConstraints getConstraintsForChild(BoxConstraints constraints) {
     // The menu can be at most the size of the overlay minus the view padding
     // in each direction.
-    return BoxConstraints.loose(constraints.biggest).deflate(reservedPadding);
+    final BoxConstraints result = BoxConstraints.loose(
+      constraints.biggest,
+    ).deflate(reservedPadding);
+    if (menuPosition != null || orientation == Axis.horizontal) {
+      return result;
+    }
+    // A vertical menu is placed either above or below the anchor, so it can
+    // only ever occupy the space on one of those two sides. Capping its height
+    // to the larger of the two keeps a tall menu from growing past the anchor
+    // and covering it; the menu scrolls instead.
+    //
+    // This uses the same bounds as the positioning logic below, so that the cap
+    // matches the space the menu is actually allowed to be placed in.
+    final Rect overlayRect = mediaQueryData.padding.deflateRect(
+      mediaQueryData.viewInsets.deflateRect(Offset.zero & constraints.biggest),
+    );
+    final double availableHeight = math.max(
+      anchorRect.top - overlayRect.top,
+      overlayRect.bottom - anchorRect.bottom,
+    );
+    if (availableHeight <= 0.0) {
+      // The anchor leaves no room on either side, so there is nothing to cap
+      // the menu to. Leave it to the positioning logic to fit what it can.
+      return result;
+    }
+    return result.copyWith(maxHeight: math.min(availableHeight, result.maxHeight));
   }
 
   @override

--- a/packages/material_ui/pending_changelogs/change_2026_09_12_menu_anchor_overlap.yaml
+++ b/packages/material_ui/pending_changelogs/change_2026_09_12_menu_anchor_overlap.yaml
@@ -1,0 +1,3 @@
+changelog: |
+  - Fixes `MenuAnchor` covering its anchor when the menu is too tall to fit above it.
+version: patch

--- a/packages/material_ui/test/menu_anchor_test.dart
+++ b/packages/material_ui/test/menu_anchor_test.dart
@@ -4114,6 +4114,55 @@ void main() {
       );
     });
 
+    // Regression test for https://github.com/flutter/flutter/issues/161474
+    testWidgets('Menu does not cover the anchor when it does not fit above it', (
+      WidgetTester tester,
+    ) async {
+      tester.view.physicalSize = const Size(400, 200);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.reset);
+
+      final controller = MenuController();
+      final anchorKey = UniqueKey();
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Column(
+              mainAxisAlignment: MainAxisAlignment.end,
+              children: <Widget>[
+                MenuAnchor(
+                  controller: controller,
+                  menuChildren: List<MenuItemButton>.generate(
+                    3,
+                    (int index) =>
+                        MenuItemButton(onPressed: () {}, child: Text('Item ${index + 1}')),
+                  ),
+                  builder: (BuildContext context, MenuController controller, Widget? child) {
+                    return SizedBox(key: anchorKey, width: 56, height: 56);
+                  },
+                ),
+              ],
+            ),
+          ),
+        ),
+      );
+
+      controller.open();
+      await tester.pumpAndSettle();
+
+      final Rect anchorRect = tester.getRect(find.byKey(anchorKey));
+      final Rect menuRect = tester.getRect(findMenuPanels());
+      // There is not enough room above the anchor to show the whole menu, so
+      // the menu is shortened rather than being pushed down over the anchor.
+      expect(
+        menuRect.bottom,
+        lessThanOrEqualTo(anchorRect.top),
+        reason:
+            'Menu bottom (${menuRect.bottom}) should not cover the anchor top (${anchorRect.top})',
+      );
+    });
+
     testWidgets(
       'Menu is correctly offset when a LayerLink is provided and alignmentOffset is set',
       (WidgetTester tester) async {


### PR DESCRIPTION
When a menu opens upwards and it is too tall to fit above its button, the menu is pushed down to the bottom edge of the screen and covers the button completely. You cannot see the button you just tapped.

The reason is that `MenuAnchor` only limited the menu height to the size of the whole screen. But a menu can only use the space above the button or the space below it, never both. So when the menu did not fit above, the positioning code ran out of options and pinned it to the bottom edge, right on top of the button.

Now the menu height is limited to the bigger of those two spaces. A menu that is taller than that becomes shorter and scrolls, instead of growing over the button.

Addresses flutter/flutter#161474

before:
<img width="800" height="400" alt="before" src="https://raw.githubusercontent.com/RootHex200/packages/assets-161474/issue-161474/before.png" />

after:
<img width="800" height="400" alt="after" src="https://raw.githubusercontent.com/RootHex200/packages/assets-161474/issue-161474/after.png" />

I added a test in `test/menu_anchor_test.dart` that puts a menu at the bottom of a short screen and checks that the bottom of the menu never goes past the top of the button.

## Pre-Review Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [AI contribution guidelines] and understand my responsibilities, or I am not using AI tools.
- [x] I read the [Tree Hygiene] page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the package surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I [linked to at least one issue that this PR fixes] in the description above.
- [x] I followed [the version and CHANGELOG instructions], using [semantic versioning] and the [repository CHANGELOG style], or I have commented below to indicate which documented exception this PR falls under[^1].
- [x] I updated/added any relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or I have commented below to indicate which [test exemption] this PR falls under[^1].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.


<!-- Links -->
[Contributor Guide]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md
[AI contribution guidelines]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#ai-contribution-guidelines
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[relevant style guides]: https://github.com/flutter/packages/blob/main/CONTRIBUTING.md#style
[the auto-formatter]: https://github.com/flutter/packages/blob/main/script/tool/README.md#format-code
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[linked to at least one issue that this PR fixes]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[the version and CHANGELOG instructions]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#version-and-changelog-updates
[semantic versioning]: https://dart.dev/tools/pub/versioning#semantic-versions
[repository CHANGELOG style]: https://github.com/flutter/flutter/blob/master/docs/ecosystem/contributing/README.md#changelog-style
[test exemption]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
